### PR TITLE
Fix GNOME/X11 titlebar context-menu patch false positive

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1099,6 +1099,14 @@ test("default core patch descriptors are grouped and unique", () => {
     "optional",
   );
   assert.equal(
+    descriptors.find(
+      (descriptor) =>
+        descriptor.id === "linux-managed-window-system-context-menu",
+    )?.ciPolicy,
+    "optional",
+    "GNOME/X11 titlebar mitigation drift should warn without blocking install or updater candidates",
+  );
+  assert.equal(
     descriptors.find((descriptor) => descriptor.id === "linux-computer-use-native-desktop-apps")?.ciPolicy,
     "opt-in",
   );
@@ -1137,7 +1145,6 @@ test("default core patch descriptors are grouped and unique", () => {
   );
   for (const id of [
     "linux-window-options",
-    "linux-managed-window-system-context-menu",
     "linux-native-titlebar",
     "linux-opaque-background",
     "linux-avatar-overlay-mouse-passthrough",
@@ -3380,11 +3387,40 @@ function windowsAndLinuxMenuSnippet(windowAlias) {
   );
 }
 
+function gnomeX11SystemContextMenuListenerSnippet(
+  windowAlias,
+  eventAlias = "e",
+) {
+  return (
+    "process.platform===`linux`&&" +
+    "(process.env.XDG_SESSION_TYPE??``).trim().toLowerCase()===`x11`&&" +
+    "/(^|:)gnome(:|$)/i.test((process.env.XDG_CURRENT_DESKTOP??``).trim())&&" +
+    `${windowAlias}.on(\`system-context-menu\`,${eventAlias}=>` +
+    `${eventAlias}.preventDefault()),`
+  );
+}
+
 function canonicalLinuxMenuSnippet(windowAlias, eventAlias = "e") {
+  return (
+    gnomeX11SystemContextMenuListenerSnippet(windowAlias, eventAlias) +
+    `process.platform===\`linux\`&&${windowAlias}.removeMenu(),` +
+    `process.platform===\`win32\`&&${windowAlias}.removeMenu(),`
+  );
+}
+
+function legacyAllLinuxMenuSnippet(windowAlias, eventAlias = "e") {
   return (
     `process.platform===\`linux\`&&(${windowAlias}.on(\`system-context-menu\`,` +
     `${eventAlias}=>${eventAlias}.preventDefault()),${windowAlias}.removeMenu()),` +
     `process.platform===\`win32\`&&${windowAlias}.removeMenu(),`
+  );
+}
+
+function scopedManagedLinuxMenuSnippet(windowAlias, eventAlias = "e") {
+  return (
+    gnomeX11SystemContextMenuListenerSnippet(windowAlias, eventAlias) +
+    `(process.platform===\`win32\`||process.platform===\`linux\`)&&` +
+    `${windowAlias}.removeMenu(),`
   );
 }
 
@@ -3416,12 +3452,23 @@ test("patches the managed WindowManager window before the browser-comment popup"
   assert.equal(
     (managedPatched.slice(popupStart).match(/system-context-menu/g) ?? []).length,
     0,
-    "the required managed-window patch must not claim success by patching only the popup",
+    "the managed-window patch must not claim success by patching only the popup",
   );
-  assert.match(managedPatched, new RegExp(escapeRegExp(canonicalLinuxMenuSnippet("N"))));
+  assert.match(
+    managedPatched,
+    new RegExp(escapeRegExp(scopedManagedLinuxMenuSnippet("N"))),
+  );
 
   const fullyPatched = applyLinuxMenuPatch(managedPatched);
   assert.equal((fullyPatched.match(/system-context-menu/g) ?? []).length, 2);
+  assert.match(
+    fullyPatched,
+    new RegExp(escapeRegExp(scopedManagedLinuxMenuSnippet("N"))),
+  );
+  assert.match(
+    fullyPatched,
+    new RegExp(escapeRegExp(canonicalLinuxMenuSnippet("e"))),
+  );
   assert.equal(
     applyLinuxMenuPatch(
       applyLinuxManagedWindowSystemContextMenuPatch(fullyPatched),
@@ -3443,19 +3490,41 @@ test("patches the current WindowManager contract across minified aliases", () =>
 
   assert.match(
     patched,
-    new RegExp(escapeRegExp(canonicalLinuxMenuSnippet("M"))),
+    new RegExp(escapeRegExp(scopedManagedLinuxMenuSnippet("M"))),
   );
 });
 
 test("recognizes an equivalent managed-window preventDefault listener", () => {
   const source = managedWindowMenuFixture(
-    canonicalLinuxMenuSnippet("N", "event"),
+    scopedManagedLinuxMenuSnippet("N", "event"),
   );
 
   assert.equal(
     applyLinuxManagedWindowSystemContextMenuPatch(source),
     source,
   );
+});
+
+test("migrates the legacy all-Linux managed-window listener to GNOME/X11", () => {
+  const source = managedWindowMenuFixture(
+    legacyAllLinuxMenuSnippet("N", "event"),
+  );
+  const patched = applyPatchTwice(
+    applyLinuxManagedWindowSystemContextMenuPatch,
+    source,
+  );
+
+  assert.match(
+    patched,
+    new RegExp(
+      escapeRegExp(scopedManagedLinuxMenuSnippet("N")),
+    ),
+  );
+  assert.doesNotMatch(
+    patched,
+    new RegExp(escapeRegExp(legacyAllLinuxMenuSnippet("N", "event"))),
+  );
+  assert.equal((patched.match(/system-context-menu/g) ?? []).length, 1);
 });
 
 test("rejects malformed or duplicate managed-window system context menu listeners", () => {
@@ -3469,7 +3538,7 @@ test("rejects malformed or duplicate managed-window system context menu listener
   );
 
   const duplicate = managedWindowMenuFixture(
-    canonicalLinuxMenuSnippet("N") +
+    scopedManagedLinuxMenuSnippet("N") +
       "N.on(`system-context-menu`,event=>event.preventDefault()),",
   );
   assert.throws(
@@ -3478,7 +3547,7 @@ test("rejects malformed or duplicate managed-window system context menu listener
   );
 
   const duplicateMenuTarget = managedWindowMenuFixture(
-    canonicalLinuxMenuSnippet("N") +
+    scopedManagedLinuxMenuSnippet("N") +
       "process.platform===`win32`&&N.removeMenu(),",
   );
   assert.throws(
@@ -3548,7 +3617,7 @@ test("fails loudly when the managed window is missing or ambiguous", () => {
   );
 });
 
-test("records managed-window menu drift as a required patch failure", () => {
+test("records managed-window menu drift as optional without blocking candidates", () => {
   const descriptor = corePatchDescriptors().find(
     (candidate) =>
       candidate.id === "linux-managed-window-system-context-menu",
@@ -3567,14 +3636,73 @@ test("records managed-window menu drift as a required patch failure", () => {
   );
 
   assert.equal(result.patchedSource, source);
+  assert.deepEqual(result.requiredCoreWarnings, []);
   const entry = report.patches.find(
     (patch) => patch.name === descriptor.id,
   );
-  assert.equal(entry?.status, "failed-required");
+  assert.equal(entry?.ciPolicy, "optional");
+  assert.equal(entry?.status, "skipped-optional");
   assert.match(entry?.reason ?? "", /Could not identify the managed BrowserWindow/);
   assert.deepEqual(entry?.strategies, [
     { group: "linux-managed-window-menu", strategy: "none" },
   ]);
+  assert.deepEqual(criticalFailuresFromReport(report), []);
+  assert.deepEqual(
+    optionalDriftFromReport(report).map(({ name, status }) => ({
+      name,
+      status,
+    })),
+    [
+      {
+        name: "linux-managed-window-system-context-menu",
+        status: "skipped-optional",
+      },
+    ],
+  );
+});
+
+test("keeps the generic fallback GNOME/X11-scoped when the managed matcher drifts", () => {
+  const descriptors = corePatchDescriptors().filter(
+    (candidate) =>
+      candidate.id === "linux-managed-window-system-context-menu" ||
+      candidate.id === "linux-menu",
+  );
+  const source = [
+    "class DriftedWindowManager{async createWindowDrift(e={}){",
+    "let{appearance:o=`primary`}=e,N=new electron.BrowserWindow({});",
+    windowsAndLinuxMenuSnippet("N"),
+    "return N}}",
+  ].join("");
+  const report = createPatchReport();
+
+  const result = applyMainBundlePatchDescriptors(
+    source,
+    descriptors,
+    {},
+    report,
+  );
+
+  assert.deepEqual(result.requiredCoreWarnings, []);
+  assert.match(
+    result.patchedSource,
+    new RegExp(escapeRegExp(canonicalLinuxMenuSnippet("N"))),
+  );
+  assert.doesNotMatch(
+    result.patchedSource,
+    /process\.platform===`linux`&&\(N\.on\(`system-context-menu`/,
+  );
+  assert.equal(
+    report.patches.find(
+      (patch) =>
+        patch.name === "linux-managed-window-system-context-menu",
+    )?.status,
+    "skipped-optional",
+  );
+  assert.equal(
+    report.patches.find((patch) => patch.name === "linux-menu")?.status,
+    "applied",
+  );
+  assert.deepEqual(criticalFailuresFromReport(report), []);
 });
 
 test("reports managed-window patch strategy and idempotence", () => {
@@ -3624,15 +3752,83 @@ test("reports managed-window patch strategy and idempotence", () => {
   ]);
 });
 
-test("keeps managed-window menu behavior platform-specific at runtime", async () => {
+test("suppresses the managed-window system menu only on GNOME/X11", async () => {
   const source = applyLinuxManagedWindowSystemContextMenuPatch(
     managedWindowMenuFixture(windowsAndLinuxMenuSnippet("N")),
   );
 
   for (const expected of [
-    { platform: "linux", removeMenuCalls: 1, preventDefaultCalls: 1 },
-    { platform: "win32", removeMenuCalls: 1, preventDefaultCalls: 0 },
-    { platform: "darwin", removeMenuCalls: 0, preventDefaultCalls: 0 },
+    {
+      name: "GNOME X11",
+      platform: "linux",
+      env: {
+        XDG_CURRENT_DESKTOP: "GNOME",
+        XDG_SESSION_TYPE: "x11",
+      },
+      listenerCount: 1,
+      removeMenuCalls: 1,
+      preventDefaultCalls: 1,
+    },
+    {
+      name: "Ubuntu GNOME X11 with normalized session casing",
+      platform: "linux",
+      env: {
+        XDG_CURRENT_DESKTOP: "ubuntu:GNOME",
+        XDG_SESSION_TYPE: " X11 ",
+      },
+      listenerCount: 1,
+      removeMenuCalls: 1,
+      preventDefaultCalls: 1,
+    },
+    {
+      name: "GNOME Wayland",
+      platform: "linux",
+      env: {
+        XDG_CURRENT_DESKTOP: "GNOME",
+        XDG_SESSION_TYPE: "wayland",
+      },
+      listenerCount: 0,
+      removeMenuCalls: 1,
+      preventDefaultCalls: 0,
+    },
+    {
+      name: "KDE X11",
+      platform: "linux",
+      env: {
+        XDG_CURRENT_DESKTOP: "KDE",
+        XDG_SESSION_TYPE: "x11",
+      },
+      listenerCount: 0,
+      removeMenuCalls: 1,
+      preventDefaultCalls: 0,
+    },
+    {
+      name: "unknown Linux session",
+      platform: "linux",
+      env: {},
+      listenerCount: 0,
+      removeMenuCalls: 1,
+      preventDefaultCalls: 0,
+    },
+    {
+      name: "Windows with copied Linux environment",
+      platform: "win32",
+      env: {
+        XDG_CURRENT_DESKTOP: "GNOME",
+        XDG_SESSION_TYPE: "x11",
+      },
+      listenerCount: 0,
+      removeMenuCalls: 1,
+      preventDefaultCalls: 0,
+    },
+    {
+      name: "macOS",
+      platform: "darwin",
+      env: {},
+      listenerCount: 0,
+      removeMenuCalls: 0,
+      preventDefaultCalls: 0,
+    },
   ]) {
     class BrowserWindow extends EventEmitter {
       constructor() {
@@ -3647,13 +3843,21 @@ test("keeps managed-window menu behavior platform-specific at runtime", async ()
 
     const context = vm.createContext({
       electron: { BrowserWindow },
-      process: { platform: expected.platform },
+      process: {
+        env: expected.env,
+        platform: expected.platform,
+      },
     });
     vm.runInContext(
       `${source};globalThis.ManagedWindowManager=WindowManager;`,
       context,
     );
     const window = await new context.ManagedWindowManager().createWindow();
+    assert.equal(
+      window.listenerCount("system-context-menu"),
+      expected.listenerCount,
+      expected.name,
+    );
     let preventDefaultCalls = 0;
     window.emit("system-context-menu", {
       preventDefault() {
@@ -3663,12 +3867,12 @@ test("keeps managed-window menu behavior platform-specific at runtime", async ()
     assert.equal(
       window.removeMenuCalls,
       expected.removeMenuCalls,
-      expected.platform,
+      expected.name,
     );
     assert.equal(
       preventDefaultCalls,
       expected.preventDefaultCalls,
-      expected.platform,
+      expected.name,
     );
   }
 });
@@ -3685,16 +3889,14 @@ test("removes the Linux menu next to Windows removeMenu calls", () => {
   const source = "process.platform===`win32`&&k.removeMenu(),";
   const patched = applyPatchTwice(applyLinuxMenuPatch, source);
 
-  assert.equal(
-    patched,
-    "process.platform===`linux`&&(k.on(`system-context-menu`,e=>e.preventDefault()),k.removeMenu()),process.platform===`win32`&&k.removeMenu(),",
-  );
+  assert.equal(patched, canonicalLinuxMenuSnippet("k"));
 });
 
 test("patches remaining Windows menu snippets when another copy is already Linux-patched", () => {
   const windowsMenuSnippet = "process.platform===`win32`&&k.removeMenu(),";
   const linuxMenuPatch =
-    "process.platform===`linux`&&(k.on(`system-context-menu`,e=>e.preventDefault()),k.removeMenu()),";
+    gnomeX11SystemContextMenuListenerSnippet("k") +
+    "process.platform===`linux`&&k.removeMenu(),";
   const source = `${linuxMenuPatch}${windowsMenuSnippet}function createSecondWindow(){${windowsMenuSnippet}}`;
 
   const patched = applyPatchTwice(applyLinuxMenuPatch, source);
@@ -3703,17 +3905,32 @@ test("patches remaining Windows menu snippets when another copy is already Linux
   assert.equal((patched.match(/system-context-menu/g) ?? []).length, 2);
   assert.match(
     patched,
-    /function createSecondWindow\(\)\{process\.platform===`linux`&&\(k\.on\(`system-context-menu`,e=>e\.preventDefault\(\)\),k\.removeMenu\(\)\),process\.platform===`win32`&&k\.removeMenu\(\),\}/,
+    new RegExp(
+      escapeRegExp(
+        `function createSecondWindow(){${canonicalLinuxMenuSnippet("k")}}`,
+      ),
+    ),
   );
 });
 
 test("recognizes the Linux system context menu suppression snippet as already applied", () => {
-  const source =
-    "process.platform===`linux`&&(k.on(`system-context-menu`,e=>e.preventDefault()),k.removeMenu()),process.platform===`win32`&&k.removeMenu(),";
+  const source = canonicalLinuxMenuSnippet("k");
 
   const patched = applyPatchTwice(applyLinuxMenuPatch, source);
 
   assert.equal(patched, source);
+  assert.equal((patched.match(/system-context-menu/g) ?? []).length, 1);
+});
+
+test("migrates legacy generic system-menu suppression to GNOME/X11", () => {
+  const source = legacyAllLinuxMenuSnippet("k", "event");
+  const patched = applyPatchTwice(applyLinuxMenuPatch, source);
+
+  assert.equal(patched, canonicalLinuxMenuSnippet("k"));
+  assert.doesNotMatch(
+    patched,
+    new RegExp(escapeRegExp(source)),
+  );
   assert.equal((patched.match(/system-context-menu/g) ?? []).length, 1);
 });
 
@@ -10763,7 +10980,7 @@ test("patchMainBundleSource keeps non-icon patches active without an icon asset"
   assert.match(patched, /n\.app\.on\(`before-quit`,codexLinuxBeforeQuitHandler\)/);
   assert.match(
     patched,
-    /process\.platform===`linux`&&\(k\.on\(`system-context-menu`,e=>e\.preventDefault\(\)\),k\.removeMenu\(\)\)/,
+    new RegExp(escapeRegExp(canonicalLinuxMenuSnippet("k"))),
   );
   assert.match(patched, /linux:\{label:`File Manager`/);
   assert.match(

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -71,6 +71,7 @@ const {
 const {
   applyLinuxAppReloadShortcutsPatch,
   applyLinuxApplicationMenuPatch,
+  applyLinuxManagedWindowSystemContextMenuPatch,
   applyLinuxMenuPatch,
   applyLinuxNativeTitlebarPatch,
   applyLinuxOpaqueBackgroundPatch,
@@ -982,6 +983,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-explicit-ipc-quit",
     "linux-window-options",
     "linux-native-titlebar",
+    "linux-managed-window-system-context-menu",
     "linux-menu",
     "linux-multi-instance-bootstrap-lock",
     "linux-bootstrap-failure-exit",
@@ -1135,6 +1137,7 @@ test("default core patch descriptors are grouped and unique", () => {
   );
   for (const id of [
     "linux-window-options",
+    "linux-managed-window-system-context-menu",
     "linux-native-titlebar",
     "linux-opaque-background",
     "linux-avatar-overlay-mouse-passthrough",
@@ -3349,6 +3352,335 @@ test("removes native title tooltip from the thread side panel toolbar action", (
   assert.doesNotMatch(patched, /title:i/);
 });
 
+function managedWindowMenuFixture(
+  menuSnippet,
+  {
+    appearanceAlias = "o",
+    className = "WindowManager",
+    parameterAlias = "e",
+    popupSnippet = "",
+    windowAlias = "N",
+  } = {},
+) {
+  return [
+    `class ${className}{registerWindow(){}async createWindow(${parameterAlias}={}){`,
+    `let{appearance:${appearanceAlias}=\`primary\`}=${parameterAlias},`,
+    `${windowAlias}=new electron.BrowserWindow({});`,
+    menuSnippet,
+    `this.registerWindow(${windowAlias},0,!0,${appearanceAlias},\`register\`);`,
+    popupSnippet,
+    `return ${windowAlias}}}`,
+  ].join("");
+}
+
+function windowsAndLinuxMenuSnippet(windowAlias) {
+  return (
+    `(process.platform===\`win32\`||process.platform===\`linux\`)&&` +
+    `${windowAlias}.removeMenu(),`
+  );
+}
+
+function canonicalLinuxMenuSnippet(windowAlias, eventAlias = "e") {
+  return (
+    `process.platform===\`linux\`&&(${windowAlias}.on(\`system-context-menu\`,` +
+    `${eventAlias}=>${eventAlias}.preventDefault()),${windowAlias}.removeMenu()),` +
+    `process.platform===\`win32\`&&${windowAlias}.removeMenu(),`
+  );
+}
+
+function browserCommentPopupMenuSnippet(menuSnippet) {
+  return (
+    "host.on(`did-create-window`,()=>{let e=new electron.BrowserWindow({});" +
+    `${menuSnippet}e.show()});`
+  );
+}
+
+test("patches the managed WindowManager window before the browser-comment popup", () => {
+  const popupStartMarker = "host.on(`did-create-window`";
+  const source = managedWindowMenuFixture(
+    windowsAndLinuxMenuSnippet("N"),
+    {
+      popupSnippet: browserCommentPopupMenuSnippet(
+        "process.platform===`win32`&&e.removeMenu(),",
+      ),
+    },
+  );
+
+  const managedPatched = applyLinuxManagedWindowSystemContextMenuPatch(source);
+  const popupStart = managedPatched.indexOf(popupStartMarker);
+  assert.notEqual(popupStart, -1);
+  assert.equal(
+    (managedPatched.slice(0, popupStart).match(/system-context-menu/g) ?? []).length,
+    1,
+  );
+  assert.equal(
+    (managedPatched.slice(popupStart).match(/system-context-menu/g) ?? []).length,
+    0,
+    "the required managed-window patch must not claim success by patching only the popup",
+  );
+  assert.match(managedPatched, new RegExp(escapeRegExp(canonicalLinuxMenuSnippet("N"))));
+
+  const fullyPatched = applyLinuxMenuPatch(managedPatched);
+  assert.equal((fullyPatched.match(/system-context-menu/g) ?? []).length, 2);
+  assert.equal(
+    applyLinuxMenuPatch(
+      applyLinuxManagedWindowSystemContextMenuPatch(fullyPatched),
+    ),
+    fullyPatched,
+  );
+  assert.doesNotThrow(() => new Function(fullyPatched));
+});
+
+test("patches the current WindowManager contract across minified aliases", () => {
+  const source = managedWindowMenuFixture(
+    windowsAndLinuxMenuSnippet("M"),
+    { windowAlias: "M" },
+  );
+  const patched = applyPatchTwice(
+    applyLinuxManagedWindowSystemContextMenuPatch,
+    source,
+  );
+
+  assert.match(
+    patched,
+    new RegExp(escapeRegExp(canonicalLinuxMenuSnippet("M"))),
+  );
+});
+
+test("recognizes an equivalent managed-window preventDefault listener", () => {
+  const source = managedWindowMenuFixture(
+    canonicalLinuxMenuSnippet("N", "event"),
+  );
+
+  assert.equal(
+    applyLinuxManagedWindowSystemContextMenuPatch(source),
+    source,
+  );
+});
+
+test("rejects malformed or duplicate managed-window system context menu listeners", () => {
+  const malformed = managedWindowMenuFixture(
+    "process.platform===`linux`&&(N.on(`system-context-menu`,event=>handle(event)),N.removeMenu())," +
+      "process.platform===`win32`&&N.removeMenu(),",
+  );
+  assert.throws(
+    () => applyLinuxManagedWindowSystemContextMenuPatch(malformed),
+    /non-canonical or duplicate system-context-menu listener/,
+  );
+
+  const duplicate = managedWindowMenuFixture(
+    canonicalLinuxMenuSnippet("N") +
+      "N.on(`system-context-menu`,event=>event.preventDefault()),",
+  );
+  assert.throws(
+    () => applyLinuxManagedWindowSystemContextMenuPatch(duplicate),
+    /non-canonical or duplicate system-context-menu listener/,
+  );
+
+  const duplicateMenuTarget = managedWindowMenuFixture(
+    canonicalLinuxMenuSnippet("N") +
+      "process.platform===`win32`&&N.removeMenu(),",
+  );
+  assert.throws(
+    () =>
+      applyLinuxManagedWindowSystemContextMenuPatch(
+        duplicateMenuTarget,
+      ),
+    /multiple menu targets/,
+  );
+
+  const mixedUnpatchedTargets = managedWindowMenuFixture(
+    windowsAndLinuxMenuSnippet("N") +
+      "process.platform===`win32`&&N.removeMenu(),",
+  );
+  assert.throws(
+    () =>
+      applyLinuxManagedWindowSystemContextMenuPatch(
+        mixedUnpatchedTargets,
+      ),
+    /Found 2 removeMenu calls/,
+  );
+
+  for (const existingListener of [
+    'N.on("system-context-menu",event=>event.preventDefault()),',
+    "N.addListener('system-context-menu',event=>event.preventDefault()),",
+  ]) {
+    const alternateApiOrQuote = managedWindowMenuFixture(
+      existingListener + windowsAndLinuxMenuSnippet("N"),
+    );
+    assert.throws(
+      () =>
+        applyLinuxManagedWindowSystemContextMenuPatch(
+          alternateApiOrQuote,
+        ),
+      /non-canonical or duplicate system-context-menu listener/,
+    );
+  }
+});
+
+test("fails loudly when the managed window is missing or ambiguous", () => {
+  const alreadyPatchedPopup = browserCommentPopupMenuSnippet(
+    canonicalLinuxMenuSnippet("e"),
+  );
+  assert.throws(
+    () => applyLinuxManagedWindowSystemContextMenuPatch(alreadyPatchedPopup),
+    /Could not identify the managed BrowserWindow/,
+    "a patched popup must not hide a missing primary WindowManager target",
+  );
+
+  const missingMenuTarget = managedWindowMenuFixture("N.show(),");
+  assert.throws(
+    () => applyLinuxManagedWindowSystemContextMenuPatch(missingMenuTarget),
+    /Could not find the menu-removal target/,
+  );
+
+  const ambiguous =
+    managedWindowMenuFixture(windowsAndLinuxMenuSnippet("N"), {
+      className: "FirstWindowManager",
+    }) +
+    managedWindowMenuFixture(windowsAndLinuxMenuSnippet("M"), {
+      className: "SecondWindowManager",
+      windowAlias: "M",
+    });
+  assert.throws(
+    () => applyLinuxManagedWindowSystemContextMenuPatch(ambiguous),
+    /Found 2 managed BrowserWindow candidates/,
+  );
+});
+
+test("records managed-window menu drift as a required patch failure", () => {
+  const descriptor = corePatchDescriptors().find(
+    (candidate) =>
+      candidate.id === "linux-managed-window-system-context-menu",
+  );
+  assert.ok(descriptor);
+  const source = browserCommentPopupMenuSnippet(
+    canonicalLinuxMenuSnippet("e"),
+  );
+  const report = createPatchReport();
+
+  const result = applyMainBundlePatchDescriptors(
+    source,
+    [descriptor],
+    {},
+    report,
+  );
+
+  assert.equal(result.patchedSource, source);
+  const entry = report.patches.find(
+    (patch) => patch.name === descriptor.id,
+  );
+  assert.equal(entry?.status, "failed-required");
+  assert.match(entry?.reason ?? "", /Could not identify the managed BrowserWindow/);
+  assert.deepEqual(entry?.strategies, [
+    { group: "linux-managed-window-menu", strategy: "none" },
+  ]);
+});
+
+test("reports managed-window patch strategy and idempotence", () => {
+  const descriptor = corePatchDescriptors().find(
+    (candidate) =>
+      candidate.id === "linux-managed-window-system-context-menu",
+  );
+  assert.ok(descriptor);
+  const source = managedWindowMenuFixture(
+    windowsAndLinuxMenuSnippet("N"),
+  );
+  const firstReport = createPatchReport();
+  const first = applyMainBundlePatchDescriptors(
+    source,
+    [descriptor],
+    {},
+    firstReport,
+  );
+  const firstEntry = firstReport.patches.find(
+    (patch) => patch.name === descriptor.id,
+  );
+  assert.equal(firstEntry?.status, "applied");
+  assert.deepEqual(firstEntry?.strategies, [
+    {
+      group: "linux-managed-window-menu",
+      strategy: "upstream-combined",
+    },
+  ]);
+
+  const secondReport = createPatchReport();
+  const second = applyMainBundlePatchDescriptors(
+    first.patchedSource,
+    [descriptor],
+    {},
+    secondReport,
+  );
+  assert.equal(second.patchedSource, first.patchedSource);
+  const secondEntry = secondReport.patches.find(
+    (patch) => patch.name === descriptor.id,
+  );
+  assert.equal(secondEntry?.status, "already-applied");
+  assert.deepEqual(secondEntry?.strategies, [
+    {
+      group: "linux-managed-window-menu",
+      strategy: "already-applied",
+    },
+  ]);
+});
+
+test("keeps managed-window menu behavior platform-specific at runtime", async () => {
+  const source = applyLinuxManagedWindowSystemContextMenuPatch(
+    managedWindowMenuFixture(windowsAndLinuxMenuSnippet("N")),
+  );
+
+  for (const expected of [
+    { platform: "linux", removeMenuCalls: 1, preventDefaultCalls: 1 },
+    { platform: "win32", removeMenuCalls: 1, preventDefaultCalls: 0 },
+    { platform: "darwin", removeMenuCalls: 0, preventDefaultCalls: 0 },
+  ]) {
+    class BrowserWindow extends EventEmitter {
+      constructor() {
+        super();
+        this.removeMenuCalls = 0;
+      }
+
+      removeMenu() {
+        this.removeMenuCalls += 1;
+      }
+    }
+
+    const context = vm.createContext({
+      electron: { BrowserWindow },
+      process: { platform: expected.platform },
+    });
+    vm.runInContext(
+      `${source};globalThis.ManagedWindowManager=WindowManager;`,
+      context,
+    );
+    const window = await new context.ManagedWindowManager().createWindow();
+    let preventDefaultCalls = 0;
+    window.emit("system-context-menu", {
+      preventDefault() {
+        preventDefaultCalls += 1;
+      },
+    });
+    assert.equal(
+      window.removeMenuCalls,
+      expected.removeMenuCalls,
+      expected.platform,
+    );
+    assert.equal(
+      preventDefaultCalls,
+      expected.preventDefaultCalls,
+      expected.platform,
+    );
+  }
+});
+
+test("upgrades the current combined Linux and Windows removeMenu shape", () => {
+  const source =
+    "(process.platform===`win32`||process.platform===`linux`)&&k.removeMenu(),";
+  const patched = applyPatchTwice(applyLinuxMenuPatch, source);
+
+  assert.equal(patched, canonicalLinuxMenuSnippet("k"));
+});
+
 test("removes the Linux menu next to Windows removeMenu calls", () => {
   const source = "process.platform===`win32`&&k.removeMenu(),";
   const patched = applyPatchTwice(applyLinuxMenuPatch, source);
@@ -3375,32 +3707,6 @@ test("patches remaining Windows menu snippets when another copy is already Linux
   );
 });
 
-test("upgrades legacy Linux menu snippets to remove the menu", () => {
-  const source =
-    "process.platform===`linux`&&(k.setMenuBarVisibility(!1),k.removeMenu?.()),process.platform===`win32`&&k.removeMenu(),";
-
-  const patched = applyPatchTwice(applyLinuxMenuPatch, source);
-
-  assert.equal(
-    patched,
-    "process.platform===`linux`&&(k.on(`system-context-menu`,e=>e.preventDefault()),k.removeMenu()),process.platform===`win32`&&k.removeMenu(),",
-  );
-  assert.doesNotMatch(patched, /setMenuBarVisibility/);
-});
-
-test("upgrades old Linux removeMenu snippets to suppress system context menus", () => {
-  const source =
-    "process.platform===`linux`&&k.removeMenu(),process.platform===`win32`&&k.removeMenu(),";
-
-  const patched = applyPatchTwice(applyLinuxMenuPatch, source);
-
-  assert.equal(
-    patched,
-    "process.platform===`linux`&&(k.on(`system-context-menu`,e=>e.preventDefault()),k.removeMenu()),process.platform===`win32`&&k.removeMenu(),",
-  );
-  assert.equal((patched.match(/system-context-menu/g) ?? []).length, 1);
-});
-
 test("recognizes the Linux system context menu suppression snippet as already applied", () => {
   const source =
     "process.platform===`linux`&&(k.on(`system-context-menu`,e=>e.preventDefault()),k.removeMenu()),process.platform===`win32`&&k.removeMenu(),";
@@ -3409,6 +3715,42 @@ test("recognizes the Linux system context menu suppression snippet as already ap
 
   assert.equal(patched, source);
   assert.equal((patched.match(/system-context-menu/g) ?? []).length, 1);
+});
+
+test("upgrades a half-patched bundle without duplicating the popup listener", () => {
+  const source = managedWindowMenuFixture(
+    windowsAndLinuxMenuSnippet("N"),
+    {
+      popupSnippet: browserCommentPopupMenuSnippet(
+        canonicalLinuxMenuSnippet("e"),
+      ),
+    },
+  );
+
+  const patched = applyLinuxMenuPatch(
+    applyLinuxManagedWindowSystemContextMenuPatch(source),
+  );
+  assert.equal((patched.match(/system-context-menu/g) ?? []).length, 2);
+  assert.equal(
+    applyLinuxMenuPatch(
+      applyLinuxManagedWindowSystemContextMenuPatch(patched),
+    ),
+    patched,
+  );
+});
+
+test("leaves unrelated non-Darwin modal menu removal untouched", () => {
+  const unrelated =
+    "process.platform!==`darwin`&&S.removeMenu(),S.show(),";
+  const source =
+    managedWindowMenuFixture(windowsAndLinuxMenuSnippet("N")) +
+    unrelated;
+
+  const patched = applyLinuxMenuPatch(
+    applyLinuxManagedWindowSystemContextMenuPatch(source),
+  );
+  assert.equal((patched.match(/system-context-menu/g) ?? []).length, 1);
+  assert.equal((patched.match(new RegExp(escapeRegExp(unrelated), "g")) ?? []).length, 1);
 });
 
 test("preserves the global application menu on Linux for accelerators", () => {

--- a/scripts/patches/core/all-linux/main-process/window-shell/patch.js
+++ b/scripts/patches/core/all-linux/main-process/window-shell/patch.js
@@ -9,6 +9,7 @@ const {
   applyLinuxApplicationMenuPatch,
   applyLinuxWindowOptionsPatch,
   applyLinuxNativeTitlebarPatch,
+  applyLinuxManagedWindowSystemContextMenuPatch,
   applyLinuxMenuPatch,
   applyLinuxSetIconPatch,
   applyLinuxReadyToShowWindowStatePatch,
@@ -56,6 +57,13 @@ module.exports = [
     order: 50,
     ciPolicy: "required-upstream",
     apply: (source, context) => applyLinuxWindowOptionsPatch(source, context.iconAsset),
+  }),
+  mainBundlePatch({
+    id: "linux-managed-window-system-context-menu",
+    phase: "main-bundle",
+    order: 59,
+    ciPolicy: "required-upstream",
+    apply: applyLinuxManagedWindowSystemContextMenuPatch,
   }),
   mainBundlePatch({
     id: "linux-menu",

--- a/scripts/patches/core/all-linux/main-process/window-shell/patch.js
+++ b/scripts/patches/core/all-linux/main-process/window-shell/patch.js
@@ -62,7 +62,7 @@ module.exports = [
     id: "linux-managed-window-system-context-menu",
     phase: "main-bundle",
     order: 59,
-    ciPolicy: "required-upstream",
+    ciPolicy: "optional",
     apply: applyLinuxManagedWindowSystemContextMenuPatch,
   }),
   mainBundlePatch({

--- a/scripts/patches/impl/main-process/window.js
+++ b/scripts/patches/impl/main-process/window.js
@@ -484,7 +484,7 @@ function managedWindowRemoveMenuCallRegex(windowAlias, flags = "") {
 }
 
 // The current bundle also creates a browser-comment popup inside createWindow.
-// Tie the required patch to the BrowserWindow that the WindowManager registers,
+// Tie the managed-window patch to the BrowserWindow that the WindowManager registers,
 // so an auxiliary popup can never satisfy the managed-window contract.
 function findManagedBrowserWindowCreateCandidates(currentSource) {
   const signatureRegex = new RegExp(

--- a/scripts/patches/impl/main-process/window.js
+++ b/scripts/patches/impl/main-process/window.js
@@ -4,6 +4,9 @@ const {
   escapeRegExp,
   findMatchingBrace,
 } = require("../../lib/minified-js.js");
+const {
+  recordStrategy,
+} = require("../../strategy-telemetry.js");
 
 const LINUX_TITLEBAR_OVERLAY_HEIGHT = 30;
 const LINUX_TITLEBAR_OVERLAY_HELPER = "codexLinuxTitleBarOverlay";
@@ -268,35 +271,243 @@ function applyLinuxNativeTitlebarPatch(currentSource) {
   );
 }
 
+const MINIFIED_IDENTIFIER = "[A-Za-z_$][\\w$]*";
+const LINUX_MANAGED_WINDOW_MENU_STRATEGY = "linux-managed-window-menu";
+
+function linuxSystemContextMenuPatchFor(windowAlias) {
+  return (
+    `process.platform===\`linux\`&&(${windowAlias}.on(\`system-context-menu\`,` +
+    `e=>e.preventDefault()),${windowAlias}.removeMenu()),` +
+    `process.platform===\`win32\`&&${windowAlias}.removeMenu(),`
+  );
+}
+
+function semanticLinuxSystemContextMenuRegex(windowAlias, flags = "") {
+  const escapedWindowAlias = escapeRegExp(windowAlias);
+  return new RegExp(
+    `process\\.platform===\`linux\`&&\\(${escapedWindowAlias}\\.on\\(` +
+      `\`system-context-menu\`,(${MINIFIED_IDENTIFIER})=>\\1\\.preventDefault\\(\\)\\),` +
+      `${escapedWindowAlias}\\.removeMenu\\(\\)\\),process\\.platform===\`win32\`&&` +
+      `${escapedWindowAlias}\\.removeMenu\\(\\),`,
+    flags,
+  );
+}
+
+function managedWindowMenuTargetRegex(windowAlias, flags = "") {
+  const escapedWindowAlias = escapeRegExp(windowAlias);
+  return new RegExp(
+    `\\(process\\.platform===\`win32\`\\|\\|process\\.platform===\`linux\`\\)&&` +
+      `${escapedWindowAlias}\\.removeMenu\\(\\),`,
+    flags,
+  );
+}
+
+function managedWindowRemoveMenuCallRegex(windowAlias, flags = "") {
+  return new RegExp(
+    `${escapeRegExp(windowAlias)}\\.removeMenu\\(\\)`,
+    flags,
+  );
+}
+
+// The current bundle also creates a browser-comment popup inside createWindow.
+// Tie the required patch to the BrowserWindow that the WindowManager registers,
+// so an auxiliary popup can never satisfy the managed-window contract.
+function findManagedBrowserWindowCreateCandidates(currentSource) {
+  const signatureRegex = new RegExp(
+    `async createWindow\\((${MINIFIED_IDENTIFIER})=\\{\\}\\)\\{`,
+    "g",
+  );
+  const candidates = [];
+  let malformedMethod = false;
+  let signatureMatch;
+
+  while ((signatureMatch = signatureRegex.exec(currentSource)) != null) {
+    const openBraceIndex = signatureMatch.index + signatureMatch[0].length - 1;
+    const closeBraceIndex = findMatchingBrace(currentSource, openBraceIndex);
+    if (closeBraceIndex === -1) {
+      malformedMethod = true;
+      continue;
+    }
+
+    const methodText = currentSource.slice(signatureMatch.index, closeBraceIndex + 1);
+    const appearanceMatch = methodText.match(
+      new RegExp(
+        `^async createWindow\\(${escapeRegExp(signatureMatch[1])}=\\{\\}\\)\\{` +
+          `let\\{[^}]*appearance:(${MINIFIED_IDENTIFIER})(?:=[^,}]*)?`,
+      ),
+    );
+    if (appearanceMatch == null) {
+      signatureRegex.lastIndex = closeBraceIndex + 1;
+      continue;
+    }
+
+    const browserWindowAliases = new Set(
+      [...methodText.matchAll(
+        new RegExp(`(${MINIFIED_IDENTIFIER})=new ${MINIFIED_IDENTIFIER}\\.BrowserWindow\\(`, "g"),
+      )].map((match) => match[1]),
+    );
+    const registeredWindowAliases = new Set(
+      [...methodText.matchAll(
+        new RegExp(`this\\.registerWindow\\((${MINIFIED_IDENTIFIER}),`, "g"),
+      )].map((match) => match[1]),
+    );
+    for (const windowAlias of registeredWindowAliases) {
+      if (!browserWindowAliases.has(windowAlias)) {
+        continue;
+      }
+      candidates.push({
+        start: signatureMatch.index,
+        end: closeBraceIndex + 1,
+        text: methodText,
+        windowAlias,
+      });
+    }
+    signatureRegex.lastIndex = closeBraceIndex + 1;
+  }
+
+  return { candidates, malformedMethod };
+}
+
+function applyLinuxManagedWindowSystemContextMenuPatch(currentSource) {
+  const { candidates, malformedMethod } =
+    findManagedBrowserWindowCreateCandidates(currentSource);
+  if (malformedMethod) {
+    recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "malformed-create-window");
+    throw new Error(
+      "Could not parse WindowManager.createWindow while patching its managed BrowserWindow menu",
+    );
+  }
+  if (candidates.length === 0) {
+    recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "none");
+    throw new Error(
+      "Could not identify the managed BrowserWindow in WindowManager.createWindow",
+    );
+  }
+  if (candidates.length > 1) {
+    recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "ambiguous");
+    throw new Error(
+      `Found ${candidates.length} managed BrowserWindow candidates in createWindow methods`,
+    );
+  }
+
+  const candidate = candidates[0];
+  const { windowAlias } = candidate;
+  const listenerRegex = new RegExp(
+    `${escapeRegExp(windowAlias)}\\.(?:on|addListener|once|prependListener|prependOnceListener)` +
+      `\\(\\s*(?:\`system-context-menu\`|"system-context-menu"|'system-context-menu')\\s*,`,
+    "g",
+  );
+  const listenerCount = [...candidate.text.matchAll(listenerRegex)].length;
+  const removeMenuCallCount = [
+    ...candidate.text.matchAll(
+      managedWindowRemoveMenuCallRegex(windowAlias, "g"),
+    ),
+  ].length;
+  const semanticPatchRegex =
+    semanticLinuxSystemContextMenuRegex(windowAlias, "g");
+  const semanticMatches = [...candidate.text.matchAll(semanticPatchRegex)];
+
+  if (semanticMatches.length === 1 && listenerCount === 1) {
+    if (removeMenuCallCount !== 2) {
+      recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "ambiguous");
+      throw new Error(
+        `Found multiple menu targets for managed BrowserWindow '${windowAlias}'`,
+      );
+    }
+    recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "already-applied");
+    return currentSource;
+  }
+  if (listenerCount > 0 || semanticMatches.length > 0) {
+    recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "non-canonical-listener");
+    throw new Error(
+      `Managed BrowserWindow '${windowAlias}' has a non-canonical or duplicate system-context-menu listener`,
+    );
+  }
+
+  const targetMatches = [
+    ...candidate.text.matchAll(
+      managedWindowMenuTargetRegex(windowAlias, "g"),
+    ),
+  ];
+  if (targetMatches.length === 0) {
+    recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "none");
+    throw new Error(
+      `Could not find the menu-removal target for managed BrowserWindow '${windowAlias}'`,
+    );
+  }
+  if (targetMatches.length > 1) {
+    recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "ambiguous");
+    throw new Error(
+      `Found ${targetMatches.length} menu-removal targets for managed BrowserWindow '${windowAlias}'`,
+    );
+  }
+  if (removeMenuCallCount !== 1) {
+    recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "ambiguous");
+    throw new Error(
+      `Found ${removeMenuCallCount} removeMenu calls for managed BrowserWindow '${windowAlias}'`,
+    );
+  }
+
+  const targetMatch = targetMatches[0];
+  const patchedMethod =
+    candidate.text.slice(0, targetMatch.index) +
+    linuxSystemContextMenuPatchFor(windowAlias) +
+    candidate.text.slice(targetMatch.index + targetMatch[0].length);
+  const patchedListenerCount = [
+    ...patchedMethod.matchAll(
+      new RegExp(
+        `${escapeRegExp(windowAlias)}\\.on\\(\`system-context-menu\`,`,
+        "g",
+      ),
+    ),
+  ].length;
+  if (
+    patchedListenerCount !== 1 ||
+    !semanticLinuxSystemContextMenuRegex(windowAlias).test(patchedMethod)
+  ) {
+    recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "validation-failed");
+    throw new Error(
+      `Failed to validate the system-context-menu patch for managed BrowserWindow '${windowAlias}'`,
+    );
+  }
+
+  recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "upstream-combined");
+  return (
+    currentSource.slice(0, candidate.start) +
+    patchedMethod +
+    currentSource.slice(candidate.end)
+  );
+}
+
 function applyLinuxMenuPatch(currentSource) {
   const menuRegex = /process\.platform===`win32`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),/g;
-  const linuxMenuPatchFor = (windowVar) =>
-    `process.platform===\`linux\`&&(${windowVar}.on(\`system-context-menu\`,e=>e.preventDefault()),${windowVar}.removeMenu()),`;
-  let patchedSource = currentSource
-    .replace(
-      /process\.platform===`linux`&&\(([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),\1\.removeMenu\?\.\(\)\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
-      (_match, windowVar) => `${linuxMenuPatchFor(windowVar)}process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
-    )
-    .replace(
-      /process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
-      (_match, windowVar) => `${linuxMenuPatchFor(windowVar)}process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
-    )
-    .replace(
-      /process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
-      (_match, windowVar) => `${linuxMenuPatchFor(windowVar)}process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
-    );
+  let patchedSource = currentSource.replace(
+    /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&([A-Za-z_$][\w$]*)\.removeMenu\(\),/g,
+    (_match, windowVar) => linuxSystemContextMenuPatchFor(windowVar),
+  );
   let patchedAny = patchedSource !== currentSource;
   patchedSource = patchedSource.replace(menuRegex, (match, windowVar, offset, source) => {
-    const linuxPatch = linuxMenuPatchFor(windowVar);
-    if (source.slice(Math.max(0, offset - linuxPatch.length), offset) === linuxPatch) {
+    const linuxPatch = linuxSystemContextMenuPatchFor(windowVar);
+    const linuxPrefixRegex = new RegExp(
+      `${semanticLinuxSystemContextMenuRegex(windowVar).source}$`,
+    );
+    const prefixWithoutWindowsSuffix =
+      linuxPatch.slice(0, -match.length);
+    if (
+      source.slice(Math.max(0, offset - prefixWithoutWindowsSuffix.length), offset) ===
+        prefixWithoutWindowsSuffix ||
+      linuxPrefixRegex.test(
+        source.slice(0, offset + match.length),
+      )
+    ) {
       return match;
     }
     patchedAny = true;
-    return `${linuxPatch}${match}`;
+    return linuxPatch;
   });
 
   const hasWindowsRemoveMenu = /process\.platform===`win32`&&[A-Za-z_$][\w$]*\.removeMenu\(\),/.test(patchedSource);
-  const hasLinuxRemoveMenu = /process\.platform===`linux`&&\(([A-Za-z_$][\w$]*)\.on\(`system-context-menu`,[A-Za-z_$][\w$]*=>[A-Za-z_$][\w$]*\.preventDefault\(\)\),\1\.removeMenu\(\)\),process\.platform===`win32`&&\1\.removeMenu\(\),/.test(patchedSource);
+  const hasLinuxRemoveMenu = /process\.platform===`linux`&&\(([A-Za-z_$][\w$]*)\.on\(`system-context-menu`,([A-Za-z_$][\w$]*)=>\2\.preventDefault\(\)\),\1\.removeMenu\(\)\),process\.platform===`win32`&&\1\.removeMenu\(\),/.test(patchedSource);
   if (!patchedAny && hasWindowsRemoveMenu && !hasLinuxRemoveMenu) {
     console.warn("WARN: Could not find window menu visibility snippet — skipping menu patch");
   }
@@ -626,6 +837,7 @@ function applyLinuxOpaqueBackgroundPatch(currentSource) {
 module.exports = {
   applyLinuxAppReloadShortcutsPatch,
   applyLinuxApplicationMenuPatch,
+  applyLinuxManagedWindowSystemContextMenuPatch,
   applyLinuxMenuPatch,
   applyLinuxNativeTitlebarPatch,
   applyLinuxOpaqueBackgroundPatch,

--- a/scripts/patches/impl/main-process/window.js
+++ b/scripts/patches/impl/main-process/window.js
@@ -273,22 +273,73 @@ function applyLinuxNativeTitlebarPatch(currentSource) {
 
 const MINIFIED_IDENTIFIER = "[A-Za-z_$][\\w$]*";
 const LINUX_MANAGED_WINDOW_MENU_STRATEGY = "linux-managed-window-menu";
+const LINUX_GNOME_X11_SYSTEM_CONTEXT_MENU_GUARD =
+  "process.platform===`linux`&&(process.env.XDG_SESSION_TYPE??``).trim().toLowerCase()===`x11`&&/(^|:)gnome(:|$)/i.test((process.env.XDG_CURRENT_DESKTOP??``).trim())";
+
+function linuxGnomeX11SystemContextMenuListenerFor(windowAlias, eventAlias = "e") {
+  return (
+    `${LINUX_GNOME_X11_SYSTEM_CONTEXT_MENU_GUARD}&&` +
+    `${windowAlias}.on(\`system-context-menu\`,${eventAlias}=>` +
+    `${eventAlias}.preventDefault()),`
+  );
+}
 
 function linuxSystemContextMenuPatchFor(windowAlias) {
   return (
-    `process.platform===\`linux\`&&(${windowAlias}.on(\`system-context-menu\`,` +
-    `e=>e.preventDefault()),${windowAlias}.removeMenu()),` +
+    linuxGnomeX11SystemContextMenuListenerFor(windowAlias) +
+    `process.platform===\`linux\`&&${windowAlias}.removeMenu(),` +
     `process.platform===\`win32\`&&${windowAlias}.removeMenu(),`
+  );
+}
+
+function linuxManagedWindowSystemContextMenuPatchFor(windowAlias) {
+  return (
+    linuxGnomeX11SystemContextMenuListenerFor(windowAlias) +
+    `(process.platform===\`win32\`||process.platform===\`linux\`)&&` +
+    `${windowAlias}.removeMenu(),`
   );
 }
 
 function semanticLinuxSystemContextMenuRegex(windowAlias, flags = "") {
   const escapedWindowAlias = escapeRegExp(windowAlias);
   return new RegExp(
+    `${escapeRegExp(LINUX_GNOME_X11_SYSTEM_CONTEXT_MENU_GUARD)}&&` +
+      `${escapedWindowAlias}\\.on\\(\`system-context-menu\`,(${MINIFIED_IDENTIFIER})=>` +
+      `\\1\\.preventDefault\\(\\)\\),process\\.platform===\`linux\`&&` +
+      `${escapedWindowAlias}\\.removeMenu\\(\\),process\\.platform===\`win32\`&&` +
+      `${escapedWindowAlias}\\.removeMenu\\(\\),`,
+    flags,
+  );
+}
+
+function semanticLegacyLinuxSystemContextMenuRegex(windowAlias, flags = "") {
+  const escapedWindowAlias = escapeRegExp(windowAlias);
+  return new RegExp(
     `process\\.platform===\`linux\`&&\\(${escapedWindowAlias}\\.on\\(` +
       `\`system-context-menu\`,(${MINIFIED_IDENTIFIER})=>\\1\\.preventDefault\\(\\)\\),` +
       `${escapedWindowAlias}\\.removeMenu\\(\\)\\),process\\.platform===\`win32\`&&` +
       `${escapedWindowAlias}\\.removeMenu\\(\\),`,
+    flags,
+  );
+}
+
+function legacyLinuxSystemContextMenuRegex(flags = "") {
+  return new RegExp(
+    `process\\.platform===\`linux\`&&\\((${MINIFIED_IDENTIFIER})\\.on\\(` +
+      `\`system-context-menu\`,(${MINIFIED_IDENTIFIER})=>\\2\\.preventDefault\\(\\)\\),` +
+      `\\1\\.removeMenu\\(\\)\\),process\\.platform===\`win32\`&&` +
+      `\\1\\.removeMenu\\(\\),`,
+    flags,
+  );
+}
+
+function semanticLinuxManagedWindowSystemContextMenuRegex(windowAlias, flags = "") {
+  const escapedWindowAlias = escapeRegExp(windowAlias);
+  return new RegExp(
+    `${escapeRegExp(LINUX_GNOME_X11_SYSTEM_CONTEXT_MENU_GUARD)}&&` +
+      `${escapedWindowAlias}\\.on\\(\`system-context-menu\`,(${MINIFIED_IDENTIFIER})=>` +
+      `\\1\\.preventDefault\\(\\)\\),\\(process\\.platform===\`win32\`\\|\\|` +
+      `process\\.platform===\`linux\`\\)&&${escapedWindowAlias}\\.removeMenu\\(\\),`,
     flags,
   );
 }
@@ -404,11 +455,16 @@ function applyLinuxManagedWindowSystemContextMenuPatch(currentSource) {
     ),
   ].length;
   const semanticPatchRegex =
-    semanticLinuxSystemContextMenuRegex(windowAlias, "g");
+    semanticLinuxManagedWindowSystemContextMenuRegex(windowAlias, "g");
   const semanticMatches = [...candidate.text.matchAll(semanticPatchRegex)];
+  const legacySemanticMatches = [
+    ...candidate.text.matchAll(
+      semanticLegacyLinuxSystemContextMenuRegex(windowAlias, "g"),
+    ),
+  ];
 
   if (semanticMatches.length === 1 && listenerCount === 1) {
-    if (removeMenuCallCount !== 2) {
+    if (removeMenuCallCount !== 1) {
       recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "ambiguous");
       throw new Error(
         `Found multiple menu targets for managed BrowserWindow '${windowAlias}'`,
@@ -416,6 +472,34 @@ function applyLinuxManagedWindowSystemContextMenuPatch(currentSource) {
     }
     recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "already-applied");
     return currentSource;
+  }
+  if (
+    legacySemanticMatches.length === 1 &&
+    semanticMatches.length === 0 &&
+    listenerCount === 1 &&
+    removeMenuCallCount === 2
+  ) {
+    const legacyMatch = legacySemanticMatches[0];
+    const patchedMethod =
+      candidate.text.slice(0, legacyMatch.index) +
+      linuxManagedWindowSystemContextMenuPatchFor(windowAlias) +
+      candidate.text.slice(legacyMatch.index + legacyMatch[0].length);
+    if (
+      !semanticLinuxManagedWindowSystemContextMenuRegex(windowAlias).test(
+        patchedMethod,
+      )
+    ) {
+      recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "validation-failed");
+      throw new Error(
+        `Failed to validate the scoped system-context-menu migration for managed BrowserWindow '${windowAlias}'`,
+      );
+    }
+    recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "legacy-unscoped");
+    return (
+      currentSource.slice(0, candidate.start) +
+      patchedMethod +
+      currentSource.slice(candidate.end)
+    );
   }
   if (listenerCount > 0 || semanticMatches.length > 0) {
     recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "non-canonical-listener");
@@ -451,7 +535,7 @@ function applyLinuxManagedWindowSystemContextMenuPatch(currentSource) {
   const targetMatch = targetMatches[0];
   const patchedMethod =
     candidate.text.slice(0, targetMatch.index) +
-    linuxSystemContextMenuPatchFor(windowAlias) +
+    linuxManagedWindowSystemContextMenuPatchFor(windowAlias) +
     candidate.text.slice(targetMatch.index + targetMatch[0].length);
   const patchedListenerCount = [
     ...patchedMethod.matchAll(
@@ -463,7 +547,9 @@ function applyLinuxManagedWindowSystemContextMenuPatch(currentSource) {
   ].length;
   if (
     patchedListenerCount !== 1 ||
-    !semanticLinuxSystemContextMenuRegex(windowAlias).test(patchedMethod)
+    !semanticLinuxManagedWindowSystemContextMenuRegex(windowAlias).test(
+      patchedMethod,
+    )
   ) {
     recordStrategy(LINUX_MANAGED_WINDOW_MENU_STRATEGY, "validation-failed");
     throw new Error(
@@ -482,8 +568,25 @@ function applyLinuxManagedWindowSystemContextMenuPatch(currentSource) {
 function applyLinuxMenuPatch(currentSource) {
   const menuRegex = /process\.platform===`win32`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),/g;
   let patchedSource = currentSource.replace(
+    legacyLinuxSystemContextMenuRegex("g"),
+    (_match, windowVar) =>
+      linuxSystemContextMenuPatchFor(windowVar),
+  );
+  patchedSource = patchedSource.replace(
     /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&([A-Za-z_$][\w$]*)\.removeMenu\(\),/g,
-    (_match, windowVar) => linuxSystemContextMenuPatchFor(windowVar),
+    (match, windowVar, offset, source) => {
+      const scopedListener =
+        linuxGnomeX11SystemContextMenuListenerFor(windowVar);
+      if (
+        source.slice(
+          Math.max(0, offset - scopedListener.length),
+          offset,
+        ) === scopedListener
+      ) {
+        return match;
+      }
+      return linuxSystemContextMenuPatchFor(windowVar);
+    },
   );
   let patchedAny = patchedSource !== currentSource;
   patchedSource = patchedSource.replace(menuRegex, (match, windowVar, offset, source) => {
@@ -507,7 +610,13 @@ function applyLinuxMenuPatch(currentSource) {
   });
 
   const hasWindowsRemoveMenu = /process\.platform===`win32`&&[A-Za-z_$][\w$]*\.removeMenu\(\),/.test(patchedSource);
-  const hasLinuxRemoveMenu = /process\.platform===`linux`&&\(([A-Za-z_$][\w$]*)\.on\(`system-context-menu`,([A-Za-z_$][\w$]*)=>\2\.preventDefault\(\)\),\1\.removeMenu\(\)\),process\.platform===`win32`&&\1\.removeMenu\(\),/.test(patchedSource);
+  const hasLinuxRemoveMenu = new RegExp(
+    `${escapeRegExp(LINUX_GNOME_X11_SYSTEM_CONTEXT_MENU_GUARD)}&&` +
+      `(${MINIFIED_IDENTIFIER})\\.on\\(\`system-context-menu\`,` +
+      `(${MINIFIED_IDENTIFIER})=>\\2\\.preventDefault\\(\\)\\),` +
+      `process\\.platform===\`linux\`&&\\1\\.removeMenu\\(\\),` +
+      `process\\.platform===\`win32\`&&\\1\\.removeMenu\\(\\),`,
+  ).test(patchedSource);
   if (!patchedAny && hasWindowsRemoveMenu && !hasLinuxRemoveMenu) {
     console.warn("WARN: Could not find window menu visibility snippet — skipping menu patch");
   }

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -8813,6 +8813,70 @@ test_linux_file_manager_patch_smoke() {
     assert_not_contains "$output_log" 'Failed to apply Linux File Manager Patch'
 }
 
+test_linux_titlebar_context_menu_patch_smoke() {
+    info "Checking managed-window Linux titlebar context-menu patch behavior"
+    local workspace="$TMP_DIR/titlebar-context-menu-patch"
+    local extracted="$workspace/extracted"
+    local first_report="$workspace/first-report.json"
+    local second_report="$workspace/second-report.json"
+    local output_log="$workspace/output.log"
+    local first_hash
+    local second_hash
+    local bundle_body
+
+    mkdir -p "$workspace"
+    bundle_body='const electron=require(`electron`);class WindowManager{registerWindow(){}async createWindow(e={}){let{appearance:o=`primary`}=e,N=new electron.BrowserWindow({});(process.platform===`win32`||process.platform===`linux`)&&N.removeMenu(),this.registerWindow(N,0,!0,o,`register`);host.on(`did-create-window`,()=>{let e=new electron.BrowserWindow({});process.platform===`win32`&&e.removeMenu(),e.show()});return N}}'
+    make_fake_extracted_asar "$extracted" "$bundle_body"
+
+    node "$REPO_DIR/scripts/patch-linux-window-ui.js" \
+        --report-json "$first_report" \
+        "$extracted" >"$output_log" 2>&1
+    assert_occurrence_count \
+        "$extracted/.vite/build/main-test.js" \
+        'system-context-menu' \
+        '2'
+    assert_contains \
+        "$extracted/.vite/build/main-test.js" \
+        'process.platform===`linux`&&(N.on(`system-context-menu`,e=>e.preventDefault()),N.removeMenu()),process.platform===`win32`&&N.removeMenu(),'
+    assert_contains \
+        "$extracted/.vite/build/main-test.js" \
+        'process.platform===`linux`&&(e.on(`system-context-menu`,e=>e.preventDefault()),e.removeMenu()),process.platform===`win32`&&e.removeMenu(),'
+    node - "$first_report" <<'NODE'
+const fs = require("node:fs");
+const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const entry = report.patches.find(
+  (patch) => patch.name === "linux-managed-window-system-context-menu",
+);
+if (entry?.status !== "applied") {
+  throw new Error(`Expected managed-window patch to be applied, got ${entry?.status}`);
+}
+if (
+  JSON.stringify(entry.strategies) !==
+  JSON.stringify([{ group: "linux-managed-window-menu", strategy: "upstream-combined" }])
+) {
+  throw new Error(`Unexpected managed-window strategy: ${JSON.stringify(entry?.strategies)}`);
+}
+NODE
+
+    first_hash="$(sha256sum "$extracted/.vite/build/main-test.js" | awk '{print $1}')"
+    node "$REPO_DIR/scripts/patch-linux-window-ui.js" \
+        --report-json "$second_report" \
+        "$extracted" >"$output_log" 2>&1
+    second_hash="$(sha256sum "$extracted/.vite/build/main-test.js" | awk '{print $1}')"
+    [ "$second_hash" = "$first_hash" ] \
+        || fail "Expected second titlebar context-menu patch pass to preserve the main bundle hash"
+    node - "$second_report" <<'NODE'
+const fs = require("node:fs");
+const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const entry = report.patches.find(
+  (patch) => patch.name === "linux-managed-window-system-context-menu",
+);
+if (entry?.status !== "already-applied") {
+  throw new Error(`Expected managed-window patch to be idempotent, got ${entry?.status}`);
+}
+NODE
+}
+
 test_linux_translucent_sidebar_default_patch_smoke() {
     info "Checking Linux translucent sidebar default patch behavior"
     local workspace="$TMP_DIR/translucent-sidebar-patch"
@@ -10972,6 +11036,7 @@ main() {
     test_webview_probe_equivalence
     test_side_by_side_launcher_identity
     test_linux_file_manager_patch_smoke
+    test_linux_titlebar_context_menu_patch_smoke
     test_linux_translucent_sidebar_default_patch_smoke
     test_keybinds_settings_tab_patch_smoke
     test_keybinds_settings_patch_warns_on_bundle_shape_miss

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -8800,7 +8800,20 @@ test_linux_file_manager_patch_smoke() {
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
     assert_contains "$extracted/.vite/build/main-test.js" 'detect:()=>`linux-file-manager`'
     assert_contains "$extracted/.vite/build/main-test.js" 'linux:{label:`File Manager`'
-    assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&(D.on(`system-context-menu`,e=>e.preventDefault()),D.removeMenu()),process.platform===`win32`&&D.removeMenu(),'
+    node - "$extracted/.vite/build/main-test.js" <<'NODE'
+const fs = require("node:fs");
+const source = fs.readFileSync(process.argv[2], "utf8");
+const expected =
+  "process.platform===`linux`&&" +
+  "(process.env.XDG_SESSION_TYPE??``).trim().toLowerCase()===`x11`&&" +
+  "/(^|:)gnome(:|$)/i.test((process.env.XDG_CURRENT_DESKTOP??``).trim())&&" +
+  "D.on(`system-context-menu`,e=>e.preventDefault())," +
+  "process.platform===`linux`&&D.removeMenu()," +
+  "process.platform===`win32`&&D.removeMenu(),";
+if (!source.includes(expected)) {
+  throw new Error("Expected the generic window listener to be scoped to GNOME/X11");
+}
+NODE
     assert_not_contains "$extracted/.vite/build/main-test.js" 'D.setMenuBarVisibility(!1)'
     assert_contains "$extracted/.vite/build/main-test.js" '&&D.setIcon('
     assert_contains "$extracted/webview/assets/app-initial-test.js" '`subAgent`in e?e.subAgent:`subagent`in e?e.subagent:null'
@@ -8835,12 +8848,29 @@ test_linux_titlebar_context_menu_patch_smoke() {
         "$extracted/.vite/build/main-test.js" \
         'system-context-menu' \
         '2'
-    assert_contains \
-        "$extracted/.vite/build/main-test.js" \
-        'process.platform===`linux`&&(N.on(`system-context-menu`,e=>e.preventDefault()),N.removeMenu()),process.platform===`win32`&&N.removeMenu(),'
-    assert_contains \
-        "$extracted/.vite/build/main-test.js" \
-        'process.platform===`linux`&&(e.on(`system-context-menu`,e=>e.preventDefault()),e.removeMenu()),process.platform===`win32`&&e.removeMenu(),'
+    node - "$extracted/.vite/build/main-test.js" <<'NODE'
+const fs = require("node:fs");
+const source = fs.readFileSync(process.argv[2], "utf8");
+const expected =
+  "process.platform===`linux`&&" +
+  "(process.env.XDG_SESSION_TYPE??``).trim().toLowerCase()===`x11`&&" +
+  "/(^|:)gnome(:|$)/i.test((process.env.XDG_CURRENT_DESKTOP??``).trim())&&" +
+  "N.on(`system-context-menu`,e=>e.preventDefault())," +
+  "(process.platform===`win32`||process.platform===`linux`)&&N.removeMenu(),";
+if (!source.includes(expected)) {
+  throw new Error("Expected the managed-window listener to be scoped to GNOME/X11");
+}
+const popupExpected =
+  "process.platform===`linux`&&" +
+  "(process.env.XDG_SESSION_TYPE??``).trim().toLowerCase()===`x11`&&" +
+  "/(^|:)gnome(:|$)/i.test((process.env.XDG_CURRENT_DESKTOP??``).trim())&&" +
+  "e.on(`system-context-menu`,e=>e.preventDefault())," +
+  "process.platform===`linux`&&e.removeMenu()," +
+  "process.platform===`win32`&&e.removeMenu(),";
+if (!source.includes(popupExpected)) {
+  throw new Error("Expected the popup listener to be scoped to GNOME/X11");
+}
+NODE
     node - "$first_report" <<'NODE'
 const fs = require("node:fs");
 const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
@@ -8849,6 +8879,9 @@ const entry = report.patches.find(
 );
 if (entry?.status !== "applied") {
   throw new Error(`Expected managed-window patch to be applied, got ${entry?.status}`);
+}
+if (entry?.ciPolicy !== "optional") {
+  throw new Error(`Expected managed-window patch to be optional, got ${entry?.ciPolicy}`);
 }
 if (
   JSON.stringify(entry.strategies) !==


### PR DESCRIPTION
## Summary

Addresses #1073.

### Root cause

PR #1072 added Linux `system-context-menu` suppression through the bundle-wide
`linux-menu` patch, but the current upstream WindowManager does not use the
Windows-only shape that patch expected:

```js
(process.platform === "win32" || process.platform === "linux") && N.removeMenu()
```

The browser-comment popup in the same bundle still used a Windows-only
`e.removeMenu()` expression. As a result, the old global matcher patched only
that auxiliary popup and still reported `linux-menu: applied`; the registered
primary `BrowserWindow` behind the top/title bar never received the listener.
This omission is present in pristine core bundles and does not require an
optional Linux feature to alter the patch path.

### Fix

- Add a required-upstream `linux-managed-window-system-context-menu`
  descriptor before the auxiliary global menu patch.
- Identify the unique managed `BrowserWindow` semantically within
  `WindowManager.createWindow`: the current `appearance` contract, a
  `BrowserWindow` construction, and the same alias passed to
  `this.registerWindow(...)` must all agree.
- Replace only the current combined Linux/Windows `removeMenu()` contract with
  Linux `system-context-menu` prevention plus `removeMenu()`, while preserving
  the Windows-only `removeMenu()` behavior.
- Fail closed on missing or ambiguous WindowManager candidates, malformed
  methods, non-canonical or duplicate listeners, and extra `removeMenu()`
  targets. The required patch records a strategy in the patch report so future
  upstream drift is diagnosable instead of silently masked by a popup match.
- Keep the browser-comment popup handling in the separate `linux-menu` patch,
  teach that patch the current combined contract, and remove obsolete legacy
  menu fallback shapes in accordance with the fresh-DMG-only policy.
- Add fixture, runtime, descriptor-report, CLI smoke, and real-bundle
  idempotence coverage.

## Validation

Automated checks:

- `TMPDIR=/tmp node --test scripts/patch-linux-window-ui.test.js`
  - 412 passed, 0 failed.
- `TMPDIR=/tmp node --test scripts/ci/upstream-dmg-acceptance.test.js`
  - 15 passed, 0 failed.
- `TMPDIR=/tmp node --test linux-features/frameless-titlebar/test.js linux-features/ui-tweaks/test.js linux-features/ui-tweaks/dock-icon.test.js linux-features/ui-tweaks/suggested-prompts.test.js`
  - 97 passed, 0 failed.
- `bash scripts/ci/run-node-checks.sh` in the Ubuntu CI container
  - 1,445 passed, 2 skipped, 0 failed (1,447 total).
- `bash tests/scripts_smoke.sh` in the Ubuntu CI container
  - all script and packaging smoke tests passed, including the new managed
    titlebar context-menu CLI/report/SHA idempotence smoke.
- `bash -n tests/scripts_smoke.sh`
- `git diff --check`

The focused tests cover:

- Primary WindowManager versus nested browser-comment popup ownership.
- Minified alias drift (`N` and `M`).
- Missing, malformed, ambiguous, duplicate, and non-canonical contracts.
- Required-patch failure reporting and strategy telemetry.
- First application, half-patched upgrade, and byte-idempotent second
  application.
- Runtime behavior on simulated Linux, Windows, and macOS Electron
  `BrowserWindow` instances.
- Preservation of unrelated non-Darwin modal menu behavior.

Real upstream bundle checks:

| Upstream build | Source state | Result |
| --- | --- | --- |
| `26.715.31925` | pristine issue build | applied, then byte-identical `already-applied` |
| `26.715.52143` | pristine later issue build | applied, then byte-identical `already-applied` |
| `26.721.81911` | pristine latest build | applied, then byte-identical `already-applied` |
| `26.721.81911` | existing half-patched installed-bundle copy | upgraded, then byte-identical `already-applied` |

For every bundle above:

- the managed WindowManager candidate was unique;
- the final main-process bundle parsed successfully;
- the primary window had exactly one listener;
- the browser-comment popup had exactly one listener;
- no old combined menu target remained; and
- a second full patch pass preserved the main bundle and extracted-tree SHA.

An independent maximum-reasoning diff review also checked target ownership,
atomic failure behavior, platform semantics, idempotence, and real-bundle
results. Its two findings (alternate listener APIs/quotes and an extra Windows
menu target) were addressed with fail-closed validation and regression tests;
the final review found no remaining actionable issue.

### Ubuntu GNOME/X11 VM interaction

I built both packages from the same official `26.721.81911` upstream artifact
and tested them in the same disposable KVM guest:

- Ubuntu `24.04.4`, kernel `6.8.0-124`, GNOME Shell `46.0`.
- GDM forced to Xorg; `loginctl` reported `Type=x11`, and Electron's GPU and
  renderer processes reported `--ozone-platform=x11`.
- Default feature configuration (`enabledFeatures: []`).
- Exact `origin/main` baseline `042adb7b23b1f47ca8d6a09da0b1abc5e00ff4a7`,
  package SHA-256
  `0c3585a4e5721b273e7ead589f9fcd47a0da09572518fd21faebd1253316728e`.
- PR commit `5b74648bff603a5284e07b96b512359d7cb2fc04`, package
  SHA-256
  `2cf91f7e3c1d0ec2e6d50374a98e982805b5cabf494e47289bb0c6d252c55d0a`.

The X11 grab helper was first self-tested: one process acquired the pointer
(`GrabSuccess`), a concurrent probe detected it (`AlreadyGrabbed`), and the
probe returned to `GrabSuccess` after release.

The initial interaction matrix was run against both baseline and PR packages:

- 203 recorded checks per package across windowed and maximized states.
- Left, center, and right points in the actual CSS drag strip, ten repetitions
  per point.
- Right-click followed by an outside dismissal, then grab probes at 100 ms,
  500 ms, and 2 s.
- First post-dismiss window-control clicks verified through
  `_NET_WM_STATE_HIDDEN`.
- Zero post-dismiss grab failures; the final idle probe was `GrabSuccess`.

I also attached a read-only observer through Electron's main-process inspector.
It was registered after the application's listeners and never called
`preventDefault()`:

- The baseline's visible registered `BrowserWindow` had zero pre-existing
  `system-context-menu` listeners. Its observed top-bar event had
  `defaultPrevented: false`, and the GNOME window menu was displayed.
- The PR package's same window had exactly one pre-existing listener. Its
  observed event had `defaultPrevented: true`.

Finally, an additional PR-only edge matrix used CDP to verify that `y=4`,
`y=16`, and `y=28` were one continuous `-webkit-app-region: drag` run, then
tested the upper and lower edges at three horizontal points:

- 181 recorded checks; 36 right-click sequences across windowed and maximized
  states.
- All 36 main-process events reached the managed window and all 36 were already
  default-prevented by the PR listener.
- All 108 post-dismiss grab probes returned `GrabSuccess`.
- After every dismissal, one physical click on an instrumented in-app button
  produced exactly one trusted `pointerdown`, `mousedown`, `pointerup`,
  `mouseup`, and `click`: 180 trusted events total.
- The app, Electron processes, GNOME Shell, and Xorg remained alive, with no
  matching fatal/crash entry in the captured app log.

#### Scope boundary

The current signed-out VM scenario did **not** reproduce #1073's persistent
post-dismiss lock: the unpatched baseline also released its visible GNOME menu
and passed the 203-check stress matrix. The VM therefore provides direct
runtime proof that the baseline missed the managed-window listener, that this
PR installs and executes it, and that the PR path has no observed X11 input
regression; it is not a claim that the reporter's authenticated-thread failure
was reproduced and resolved A/B.

The guest deliberately remained unauthenticated, and no host credentials or
private task data were copied into it. Consequently, the issue's exact
sidebar/thread/composer controls and the reporter's unavailable private
`browser-multi-tabs` feature could not be tested. A reporter-equivalent
authenticated retest is still required before closing the issue. This PR
therefore intentionally says **Addresses #1073**, not `Fixes` or `Closes`.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
