### PR TITLE
Add opt-in OpenAI dictation quality feature

### DIFF
--- a/linux-features/dictation-capture-quality/README.md
+++ b/linux-features/dictation-capture-quality/README.md
@@ -1,0 +1,91 @@
+# OpenAI Dictation Quality
+
+Opt-in Linux dictation that uses a verified clean capture path while keeping the
+user's OpenAI API key out of the renderer, source tree, package, environment,
+and logs.
+
+The feature changes only the existing Codex composer dictation path:
+
+- requests two-channel audio;
+- disables Chromium echo cancellation, noise suppression, and automatic gain
+  control;
+- disables Codex's built-in streaming transcription so it cannot bypass this
+  feature's OpenAI batch endpoint;
+- passes base64 WebM audio through Codex's trusted `vscode://codex` bridge;
+- accepts bridge calls only from primary Codex windows and permits one paid
+  transcription request at a time;
+- retrieves a Codex-owned key from the freedesktop.org Secret Service in the
+  Electron main process;
+- sends the unchanged WebM/Opus recording to OpenAI with
+  `model=gpt-4o-transcribe` and `language=en`.
+
+The key is never sent to the webview. Before opening Secret Service or making a
+network request, the bridge checks the caller, canonical base64 encoding,
+declared WebM/Opus MIME type, 25 MiB size limit, and WebM EBML signature. The
+OpenAI API performs final media validation. API errors report only their HTTP
+status, not response bodies.
+
+## Credential
+
+Debian and pacman packages declare the host package that supplies
+`/usr/bin/secret-tool`. RPM distributions use incompatible provider names
+(`libsecret` on Fedora and `secret-tool` on openSUSE), so RPM, AppImage, and
+other self-built installs must provide that command and an unlocked Secret
+Service implementation separately.
+
+The runtime reads this Secret Service item:
+
+```text
+service=codex-desktop-openai-transcription
+label=Codex Desktop OpenAI transcription key
+```
+
+Provision the item interactively; `secret-tool` reads the key from standard
+input:
+
+```bash
+secret-tool store \
+  --label='Codex Desktop OpenAI transcription key' \
+  service codex-desktop-openai-transcription
+```
+
+Never place the key in a command argument, environment variable, repository
+file, or feature configuration.
+
+## Privacy, billing, and support limits
+
+Each completed dictation uploads the recorded WebM/Opus audio to the OpenAI
+Audio Transcriptions API using the stored key. API usage is billed to that key
+independently of a ChatGPT or Codex subscription.
+
+This feature is English-only, batch-only, and intentionally conflicts with
+`conversation-mode`, whose microphone processing and streaming behavior are
+different. Text appears after recording stops and the upload completes.
+
+## Enable
+
+Add the feature id to `linux-features/features.json`:
+
+```json
+{
+  "enabled": ["dictation-capture-quality"]
+}
+```
+
+## Test
+
+```bash
+node --test linux-features/dictation-capture-quality/test.js
+```
+
+## Disable and remove
+
+Disabling the feature affects the next rebuild and removes both bundle patches.
+It intentionally leaves the Secret Service item in place. After the feature is
+disabled, remove only its credential with:
+
+```bash
+secret-tool clear service codex-desktop-openai-transcription
+```
+
+OpenWhispr is not a runtime dependency.

--- a/linux-features/dictation-capture-quality/feature.json
+++ b/linux-features/dictation-capture-quality/feature.json
@@ -1,0 +1,20 @@
+{
+  "id": "dictation-capture-quality",
+  "title": "OpenAI Dictation Quality",
+  "description": "Opt-in clean microphone capture routed through the user's Secret Service OpenAI key to gpt-4o-transcribe with an English language hint.",
+  "defaultEnabled": false,
+  "conflicts": [
+    "conversation-mode"
+  ],
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  },
+  "packageDependencies": {
+    "deb": [
+      "libsecret-tools"
+    ],
+    "pacman": [
+      "libsecret"
+    ]
+  }
+}

--- a/linux-features/dictation-capture-quality/patch.js
+++ b/linux-features/dictation-capture-quality/patch.js
@@ -1,0 +1,337 @@
+"use strict";
+
+const {
+  findMatchingBrace,
+  requireName,
+} = require("../../scripts/patches/lib/minified-js.js");
+
+const IDENT = "[A-Za-z_$][\\w$]*";
+const HANDLER_NAME = "linux-openai-dictation-transcribe";
+const SECRET_SERVICE = "codex-desktop-openai-transcription";
+const CAPTURE_MARKER = "codexLinuxDictationCaptureQuality";
+const RENDERER_MARKER = "codexLinuxOpenAITranscription";
+const STREAMING_MARKER = "codexLinuxDictationBatchOnly";
+const MAIN_HANDLER_MARKER = `"${HANDLER_NAME}":async`;
+const MAIN_COMPLETION_MARKER = "codexLinuxOpenAITranscriptionMainComplete";
+const CURRENT_APP_INITIAL_ASSET_PATTERN = /^app-initial-[A-Za-z0-9_-]+\.js$/;
+const OPENWHISPR_CONSTRAINTS =
+  "channelCount:2,echoCancellation:!1,noiseSuppression:!1,autoGainControl:!1";
+const MAX_AUDIO_BYTES = 25 * 1024 * 1024;
+const MAX_BASE64_LENGTH = Math.ceil(MAX_AUDIO_BYTES / 3) * 4;
+
+function warn(message, patchName) {
+  console.warn(`WARN: ${message} - skipping ${patchName}`);
+}
+
+function matches(source, pattern) {
+  return [...source.matchAll(new RegExp(
+    pattern.source,
+    pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`,
+  ))];
+}
+
+function countLiteral(source, literal) {
+  return source.split(literal).length - 1;
+}
+
+function applyEdits(source, edits) {
+  return edits
+    .sort((left, right) => right.start - left.start)
+    .reduce(
+      (current, edit) =>
+        `${current.slice(0, edit.start)}${edit.replacement}${current.slice(edit.end)}`,
+      source,
+    );
+}
+
+function resolveFallbackFunction(source) {
+  const startPattern = new RegExp(
+    `async function (${IDENT})\\(e,t=\\{\\}\\)\\{`,
+    "g",
+  );
+  const candidates = [];
+
+  for (const match of matches(source, startPattern)) {
+    const openIndex = match.index + match[0].length - 1;
+    const closeIndex = findMatchingBrace(source, openIndex);
+    if (closeIndex === -1) {
+      continue;
+    }
+    const body = source.slice(match.index, closeIndex + 1);
+    if (
+      !body.includes("post(`/transcribe`") ||
+      !body.includes("audio/webm")
+    ) {
+      continue;
+    }
+    const clientMatch = body.match(
+      /([A-Za-z_$][\w$]*)\.getInstance\(\)\.post\(`\/transcribe`/u,
+    );
+    const base64Match = body.match(
+      /=([A-Za-z_$][\w$]*)\(await [A-Za-z_$][\w$]*\(\{blob:e,/u,
+    );
+    if (clientMatch == null || base64Match == null) {
+      continue;
+    }
+    candidates.push({
+      start: match.index,
+      end: closeIndex + 1,
+      functionName: match[1],
+      clientVar: clientMatch[1],
+      base64Var: base64Match[1],
+    });
+  }
+
+  return candidates;
+}
+
+function rendererFallbackSource({ functionName, clientVar, base64Var }) {
+  return [
+    `async function ${functionName}(e,t={}){`,
+    "if(e==null||typeof e.arrayBuffer!==`function`||",
+    "!Number.isSafeInteger(e.size)||",
+    `e.size<=0||e.size>${MAX_AUDIO_BYTES})`,
+    "throw Error(`Dictation audio is invalid or too large.`);",
+    "let __codexContentType=t.contentType??",
+    "(e.type&&e.type.trim().length>0?e.type:`audio/webm`),",
+    `__codexAudioBase64=${base64Var}(new Uint8Array(await e.arrayBuffer()));`,
+    `return(await ${clientVar}.getInstance().post(`,
+    `\`vscode://codex/${HANDLER_NAME}\`,`,
+    "JSON.stringify({audioBase64:__codexAudioBase64,contentType:__codexContentType}),",
+    "{})).body.text",
+    `/*${RENDERER_MARKER}*/`,
+    "}",
+  ].join("");
+}
+
+function applyDictationCaptureQualityPatch(source) {
+  const patchName = "dictation capture and OpenAI transcription webview patch";
+  if (
+    !source.includes("global-dictation-record-history-item") ||
+    !source.includes("new MediaRecorder") ||
+    !source.includes("dictation-stream-connect-info")
+  ) {
+    warn("Could not resolve the current composer dictation contract", patchName);
+    return source;
+  }
+
+  const patchedConstraint =
+    `${OPENWHISPR_CONSTRAINTS}/*${CAPTURE_MARKER}*/`;
+  const patchedStreaming = `streamingEnabled:!1/*${STREAMING_MARKER}*/`;
+  const handlerRoute = `vscode://codex/${HANDLER_NAME}`;
+  const hasCapturePatch = source.includes(patchedConstraint);
+  const hasCaptureMarker = source.includes(CAPTURE_MARKER);
+  const hasRendererPatch =
+    source.includes(handlerRoute) && source.includes(RENDERER_MARKER);
+  const hasRendererMarker = source.includes(RENDERER_MARKER);
+  const hasStreamingPatch = source.includes(patchedStreaming);
+  const hasStreamingMarker = source.includes(STREAMING_MARKER);
+
+  if (hasCapturePatch && hasRendererPatch && hasStreamingPatch) {
+    return source;
+  }
+  if (
+    hasCaptureMarker !== hasCapturePatch ||
+    hasRendererMarker !== hasRendererPatch ||
+    hasStreamingMarker !== hasStreamingPatch
+  ) {
+    warn("Found an incomplete dictation transcription patch", patchName);
+    return source;
+  }
+
+  const edits = [];
+
+  if (!hasCapturePatch) {
+    const constraintPattern = new RegExp(
+      `stream:(${IDENT})\\(\\{channelCount:1\\}\\)\\.then\\(`,
+      "g",
+    );
+    const constraintMatches = matches(source, constraintPattern);
+    if (constraintMatches.length !== 1) {
+      warn(
+        `Expected one composer microphone constraint, found ${constraintMatches.length}`,
+        patchName,
+      );
+      return source;
+    }
+    const match = constraintMatches[0];
+    edits.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      replacement: `stream:${match[1]}({${patchedConstraint}}).then(`,
+    });
+  }
+
+  if (!hasRendererPatch) {
+    const fallbacks = resolveFallbackFunction(source);
+    if (fallbacks.length !== 1) {
+      warn(
+        `Expected one multipart transcription fallback, found ${fallbacks.length}`,
+        patchName,
+      );
+      return source;
+    }
+    const fallback = fallbacks[0];
+    edits.push({
+      start: fallback.start,
+      end: fallback.end,
+      replacement: rendererFallbackSource(fallback),
+    });
+  }
+
+  if (!hasStreamingPatch) {
+    const streamingPattern = new RegExp(
+      `cleanupEnabled:!1,streamingEnabled:(${IDENT})(?=[,}])`,
+      "g",
+    );
+    const streamingMatches = matches(source, streamingPattern);
+    if (streamingMatches.length !== 1) {
+      warn(
+        `Expected one composer streaming flag, found ${streamingMatches.length}`,
+        patchName,
+      );
+      return source;
+    }
+    const match = streamingMatches[0];
+    edits.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      replacement: `cleanupEnabled:!1,${patchedStreaming}`,
+    });
+  }
+
+  return applyEdits(source, edits);
+}
+
+function dictationMainHandlerSource({ electronVar }) {
+  return [
+    `"${HANDLER_NAME}":async({audioBase64:__codexAudioBase64,`,
+    "contentType:__codexContentType,origin:__codexOrigin,",
+    "signal:__codexCallerSignal}={})=>{",
+    "if(!this.windowManager?.getPrimaryWindows?.().some(",
+    "__codexWindow=>__codexWindow.webContents===__codexOrigin))",
+    "throw Error(`Dictation transcription is unavailable from this window.`);",
+    "if(typeof __codexAudioBase64!==`string`||",
+    `__codexAudioBase64.length===0||__codexAudioBase64.length>${MAX_BASE64_LENGTH}||`,
+    "__codexAudioBase64.length%4!==0)",
+    "throw Error(`Dictation audio is invalid or too large.`);",
+    "let __codexMime=String(__codexContentType??``).toLowerCase().replace(/\\s+/g,``);",
+    "if(__codexMime!==`audio/webm`&&__codexMime!==`audio/webm;codecs=opus`)",
+    "throw Error(`Dictation audio must be WebM/Opus.`);",
+    "if(this.__codexOpenAITranscriptionActive===!0)",
+    "throw Error(`A dictation transcription is already in progress.`);",
+    "this.__codexOpenAITranscriptionActive=!0;",
+    "let __codexAudio=null,__codexSecret=null,__codexApiKey=``;",
+    "try{",
+    "__codexAudio=Buffer.from(__codexAudioBase64,`base64`);",
+    "if(__codexAudio.length===0||",
+    `__codexAudio.length>${MAX_AUDIO_BYTES}||`,
+    "__codexAudio.toString(`base64`)!==__codexAudioBase64||",
+    "__codexAudio.length<4||__codexAudio[0]!==26||__codexAudio[1]!==69||",
+    "__codexAudio[2]!==223||__codexAudio[3]!==163)",
+    "throw Error(`Dictation audio is invalid or too large.`);",
+    "__codexCallerSignal?.throwIfAborted?.();",
+    "__codexSecret=await new Promise((__codexResolve,__codexReject)=>{",
+    "require(`node:child_process`).execFile(`/usr/bin/secret-tool`,",
+    `[\`lookup\`,\`service\`,\`${SECRET_SERVICE}\`],`,
+    "{encoding:null,timeout:5e3,maxBuffer:4096},",
+    "(__codexError,__codexStdout)=>{",
+    "if(__codexError){__codexReject(Error(`Codex OpenAI transcription key is unavailable.`));return}",
+    "__codexResolve(Buffer.isBuffer(__codexStdout)?__codexStdout:Buffer.from(__codexStdout??``))",
+    "})});",
+    "__codexCallerSignal?.throwIfAborted?.();",
+    "let __codexKeyEnd=__codexSecret.length;",
+    "while(__codexKeyEnd>0&&(__codexSecret[__codexKeyEnd-1]===10||",
+    "__codexSecret[__codexKeyEnd-1]===13))__codexKeyEnd--;",
+    "if(__codexKeyEnd<20)throw Error(`Codex OpenAI transcription key is unavailable.`);",
+    "__codexApiKey=__codexSecret.subarray(0,__codexKeyEnd).toString(`utf8`);",
+    "let __codexForm=new FormData;",
+    "__codexForm.append(`file`,new Blob([__codexAudio],{type:`audio/webm`}),`codex.webm`);",
+    "__codexForm.append(`model`,`gpt-4o-transcribe`);",
+    "__codexForm.append(`language`,`en`);",
+    "let __codexTimeoutSignal=AbortSignal.timeout(12e4),",
+    "__codexRequestSignal=__codexCallerSignal&&typeof AbortSignal.any===`function`?",
+    "AbortSignal.any([__codexCallerSignal,__codexTimeoutSignal]):__codexTimeoutSignal,",
+    `__codexResponse=await ${electronVar}.net.fetch(`,
+    "`https://api.openai.com/v1/audio/transcriptions`,",
+    "{method:`POST`,headers:{Authorization:`Bearer ${__codexApiKey}`},",
+    "body:__codexForm,signal:__codexRequestSignal});",
+    "if(!__codexResponse.ok){",
+    "try{await __codexResponse.body?.cancel()}catch{}",
+    "throw Error(`OpenAI transcription failed (${__codexResponse.status}).`)}",
+    "let __codexPayload;",
+    "try{__codexPayload=await __codexResponse.json()}",
+    "catch{throw Error(`OpenAI transcription returned invalid JSON.`)}",
+    "if(typeof __codexPayload?.text!==`string`)",
+    "throw Error(`OpenAI transcription response did not contain text.`);",
+    `return{text:__codexPayload.text}/*${RENDERER_MARKER}*/`,
+    "}finally{",
+    "this.__codexOpenAITranscriptionActive=!1;",
+    "__codexAudio?.fill(0);__codexSecret?.fill(0);__codexApiKey=``",
+    `}}/*${MAIN_COMPLETION_MARKER}*/`,
+  ].join("");
+}
+
+function applyDictationMainBridgePatch(source) {
+  const patchName = "dictation OpenAI main-process bridge patch";
+  const hasHandler = source.includes(MAIN_HANDLER_MARKER);
+  const hasCompletionMarker = source.includes(MAIN_COMPLETION_MARKER);
+  if (hasHandler && hasCompletionMarker) {
+    return source;
+  }
+  if (hasHandler !== hasCompletionMarker) {
+    warn("Found an incomplete dictation main-process bridge", patchName);
+    return source;
+  }
+
+  const electronVar = requireName(source, "electron");
+  if (electronVar == null) {
+    warn("Could not find the Electron main-process module alias", patchName);
+    return source;
+  }
+
+  const anchor = `"native-desktop-apps":async`;
+  const anchorCount = countLiteral(source, anchor);
+  if (anchorCount !== 1) {
+    warn(
+      `Expected one trusted handler insertion point, found ${anchorCount}`,
+      patchName,
+    );
+    return source;
+  }
+
+  return source.replace(
+    anchor,
+    `${dictationMainHandlerSource({ electronVar })},${anchor}`,
+  );
+}
+
+const descriptors = [
+  {
+    id: "dictation-openai-main-bridge",
+    phase: "main-bundle",
+    order: 20_684,
+    ciPolicy: "optional",
+    apply: applyDictationMainBridgePatch,
+  },
+  {
+    id: "composer-dictation-capture-quality",
+    phase: "webview-asset",
+    order: 20_685,
+    ciPolicy: "optional",
+    pattern: CURRENT_APP_INITIAL_ASSET_PATTERN,
+    missingDescription: "current primary dictation bundle",
+    skipDescription: "dictation capture and OpenAI transcription patch",
+    apply: applyDictationCaptureQualityPatch,
+  },
+];
+
+module.exports = {
+  HANDLER_NAME,
+  MAX_AUDIO_BYTES,
+  SECRET_SERVICE,
+  applyDictationCaptureQualityPatch,
+  applyDictationMainBridgePatch,
+  descriptors,
+  dictationMainHandlerSource,
+};

--- a/linux-features/dictation-capture-quality/test.js
+++ b/linux-features/dictation-capture-quality/test.js
@@ -1,0 +1,613 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const {
+  applyMainBundlePatchDescriptors,
+  applyWebviewAssetPatchDescriptors,
+  normalizePatchDescriptors,
+} = require("../../scripts/patches/engine.js");
+const {
+  enabledLinuxFeaturePackageDependencies,
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const {
+  HANDLER_NAME,
+  MAX_AUDIO_BYTES,
+  SECRET_SERVICE,
+  applyDictationCaptureQualityPatch,
+  applyDictationMainBridgePatch,
+  descriptors,
+} = require("./patch.js");
+
+const dictationSource =
+  "function Gh(e){return btoa(String.fromCharCode(...e))}" +
+  "async function Rrt({blob:e}){return new Uint8Array(await e.arrayBuffer())}" +
+  "async function Lrt(e,t={}){let n=t.contentType??(e.type&&e.type.trim().length>0?e.type:`audio/webm`),r=n.split(/[/;]/)[1]??`webm`,i=zrt(t.filename??`codex.${r}`),a=Brt(),o=Gh(await Rrt({blob:e,boundary:a,filename:i,contentType:n,language:t.language})),s={\"Content-Type\":`multipart/form-data; boundary=${a}`};return(await Yf.getInstance().post(`/transcribe`,o,s)).body.text}" +
+  "function xit(e){let n=Rh(Get);return Sit({...e,cleanupEnabled:!1,streamingEnabled:n})}" +
+  "async function hook(){let I=async e=>{if(noStream)return Lrt(e);try{return await stream.finish()}catch{return Lrt(e)}};" +
+  "let L=async a=>{let text=await I(a);Gf.getInstance().dispatchMessage(`global-dictation-record-history-item`,{text})};" +
+  "let recorder=new MediaRecorder(track);return L(recorder)}" +
+  "function Cit(){return{stream:Knt({channelCount:1}).then(r=>r)}}" +
+  "async function connect(){return post(`/codex/dictation-stream-connect-info`)}";
+
+function syntheticMainBundle() {
+  return [
+    "function launchExternal(){let __codexChild=require(`node:child_process`);",
+    "return __codexChild}",
+    "let electron=require(`electron`);",
+    "class Host{handlers(){return{",
+    "\"get-global-state\":async()=>({value:null}),",
+    "\"native-desktop-apps\":async()=>({apps:[]})",
+    "}}}",
+  ].join("");
+}
+
+function withTempDir(callback) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dictation-capture-quality-"));
+  try {
+    return callback(tempDir);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function withFeatureConfig(enabled, callback) {
+  const previous = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  return withTempDir((tempDir) => {
+    const configPath = path.join(tempDir, "features.json");
+    fs.writeFileSync(configPath, `${JSON.stringify({ enabled })}\n`);
+    process.env.CODEX_LINUX_FEATURES_CONFIG = configPath;
+    try {
+      return callback(path.resolve(__dirname, ".."));
+    } finally {
+      if (previous == null) delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+      else process.env.CODEX_LINUX_FEATURES_CONFIG = previous;
+    }
+  });
+}
+
+function captureWarnings(callback) {
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (...args) => warnings.push(args.join(" "));
+  try {
+    return { value: callback(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+function webmBase64(extraBytes = []) {
+  return Buffer.from([0x1a, 0x45, 0xdf, 0xa3, ...extraBytes]).toString("base64");
+}
+
+function createMainHarness({
+  key = "unit-test-openai-key-material",
+  keyError = null,
+  fetchImpl = null,
+} = {}) {
+  const patched = applyDictationMainBridgePatch(syntheticMainBundle());
+  const execCalls = [];
+  const fetchCalls = [];
+  const childProcess = {
+    execFile(command, args, options, callback) {
+      execCalls.push({ command, args, options });
+      if (keyError != null) {
+        callback(keyError, Buffer.alloc(0), Buffer.from("private keyring detail"));
+        return;
+      }
+      callback(null, Buffer.from(`${key}\n`), Buffer.alloc(0));
+    },
+  };
+  const electron = {
+    net: {
+      async fetch(url, options) {
+        const file = options.body.get("file");
+        const snapshot = {
+          url,
+          authorization: options.headers.Authorization,
+          model: options.body.get("model"),
+          language: options.body.get("language"),
+          filename: file.name,
+          contentType: file.type,
+          fileBytes: Buffer.from(await file.arrayBuffer()),
+          signal: options.signal,
+        };
+        fetchCalls.push(snapshot);
+        if (fetchImpl != null) return fetchImpl(url, options, snapshot);
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return { text: "The morning air felt cool and fresh." };
+          },
+        };
+      },
+    },
+  };
+  const sandbox = {
+    require(name) {
+      if (name === "node:child_process") return childProcess;
+      if (name === "electron") return electron;
+      throw new Error(`unexpected require ${name}`);
+    },
+    AbortSignal,
+    Blob,
+    Buffer,
+    FormData,
+  };
+  vm.runInNewContext(`${patched};this.Host=Host;`, sandbox);
+  const host = new sandbox.Host();
+  const primaryWebContents = { id: 1 };
+  host.windowManager = {
+    getPrimaryWindows() {
+      return [{ webContents: primaryWebContents }];
+    },
+  };
+  const rawHandler = host.handlers()[HANDLER_NAME];
+  return {
+    handler(payload) {
+      return rawHandler({ ...payload, origin: primaryWebContents });
+    },
+    rawHandler,
+    primaryWebContents,
+    execCalls,
+    fetchCalls,
+    patched,
+  };
+}
+
+test("feature stays disabled until selected and loads both descriptors", () => {
+  withFeatureConfig([], (featuresRoot) => {
+    assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot }), []);
+  });
+
+  withFeatureConfig(["dictation-capture-quality"], (featuresRoot) => {
+    const loaded = loadLinuxFeaturePatchDescriptors({ featuresRoot });
+    assert.deepEqual(
+      loaded.map((descriptor) => [
+        descriptor.id,
+        descriptor.phase,
+        descriptor.ciPolicy,
+      ]),
+      [
+        [
+          "feature:dictation-capture-quality:dictation-openai-main-bridge",
+          "main-bundle",
+          "optional",
+        ],
+        [
+          "feature:dictation-capture-quality:composer-dictation-capture-quality",
+          "webview-asset",
+          "optional",
+        ],
+      ],
+    );
+    assert.deepEqual(
+      enabledLinuxFeaturePackageDependencies({
+        featuresRoot,
+        packageFormat: "deb",
+      }),
+      ["libsecret-tools"],
+    );
+    assert.deepEqual(
+      enabledLinuxFeaturePackageDependencies({
+        featuresRoot,
+        packageFormat: "rpm",
+      }),
+      [],
+    );
+    assert.deepEqual(
+      enabledLinuxFeaturePackageDependencies({
+        featuresRoot,
+        packageFormat: "pacman",
+      }),
+      ["libsecret"],
+    );
+  });
+});
+
+test("feature conflicts with conversation mode's microphone processing", () => {
+  assert.throws(
+    () => withFeatureConfig(
+      ["read-aloud", "conversation-mode", "dictation-capture-quality"],
+      (featuresRoot) => loadLinuxFeaturePatchDescriptors({ featuresRoot }),
+    ),
+    /conflicts with 'conversation-mode'/,
+  );
+});
+
+test("descriptors target only the main bundle and current app-initial asset", () => {
+  assert.equal(descriptors[0].phase, "main-bundle");
+  assert.equal(descriptors[1].pattern.test("app-initial-CRKqnyc3.js"), true);
+  assert.equal(descriptors[1].pattern.test("app-initial~app-main~page.js"), false);
+  assert.equal(descriptors[1].pattern.test("global-dictation-page.js"), false);
+});
+
+test("webview patch uses clean capture and forces the trusted batch bridge", () => {
+  const patched = applyDictationCaptureQualityPatch(dictationSource);
+
+  assert.notEqual(patched, dictationSource);
+  assert.match(
+    patched,
+    /channelCount:2,echoCancellation:!1,noiseSuppression:!1,autoGainControl:!1/,
+  );
+  assert.match(
+    patched,
+    new RegExp(`vscode://codex/${HANDLER_NAME}`),
+  );
+  assert.match(patched, /audioBase64:__codexAudioBase64/);
+  assert.match(patched, /cleanupEnabled:!1,streamingEnabled:!1/);
+  assert.match(
+    patched,
+    new RegExp(`e\\.size<=0\\|\\|e\\.size>${MAX_AUDIO_BYTES}`),
+  );
+  assert.doesNotMatch(patched, /post\(`\/transcribe`/);
+  assert.equal(applyDictationCaptureQualityPatch(patched), patched);
+});
+
+test("webview patch rejects an oversized blob before reading it", async () => {
+  const sandbox = { Number, Uint8Array };
+  vm.runInNewContext(
+    `${applyDictationCaptureQualityPatch(dictationSource)};this.fallback=Lrt;`,
+    sandbox,
+  );
+  let read = false;
+
+  await assert.rejects(
+    () => sandbox.fallback({
+      type: "audio/webm",
+      size: MAX_AUDIO_BYTES + 1,
+      async arrayBuffer() {
+        read = true;
+        return new ArrayBuffer(0);
+      },
+    }),
+    /invalid or too large/,
+  );
+  assert.equal(read, false);
+});
+
+test("webview patch fails soft and atomically when anchors drift", () => {
+  for (const [source, expectedWarning] of [
+    [
+      dictationSource.replace("channelCount:1", "sampleRate:48e3"),
+      /Expected one composer microphone constraint/,
+    ],
+    [
+      dictationSource.replace("post(`/transcribe`", "post(`/other`"),
+      /Expected one multipart transcription fallback/,
+    ],
+    [
+      dictationSource.replace("streamingEnabled:n", "streamingEnabled:gate()"),
+      /Expected one composer streaming flag/,
+    ],
+  ]) {
+    const { value, warnings } = captureWarnings(() =>
+      applyDictationCaptureQualityPatch(source),
+    );
+    assert.equal(value, source);
+    assert.match(warnings.join("\n"), expectedWarning);
+    assert.doesNotMatch(value, /codexLinuxOpenAITranscription/);
+  }
+});
+
+test("main bridge patch uses the trusted handler map and is idempotent", () => {
+  const source = syntheticMainBundle();
+  const patched = applyDictationMainBridgePatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, new RegExp(`"${HANDLER_NAME}":async`));
+  assert.match(patched, /\/usr\/bin\/secret-tool/);
+  assert.match(
+    patched,
+    /require\(`node:child_process`\)\.execFile\(`\/usr\/bin\/secret-tool`/,
+  );
+  assert.doesNotMatch(patched, /__codexChild\.execFile/);
+  assert.match(patched, new RegExp(SECRET_SERVICE));
+  assert.match(patched, /https:\/\/api\.openai\.com\/v1\/audio\/transcriptions/);
+  assert.match(patched, /gpt-4o-transcribe/);
+  assert.match(patched, /append\(`language`,`en`\)/);
+  assert.equal(applyDictationMainBridgePatch(patched), patched);
+});
+
+test("main bridge fails soft when its handler insertion point drifts", () => {
+  const source = syntheticMainBundle().replace(
+    "\"native-desktop-apps\":async",
+    "\"desktop-apps\":async",
+  );
+  const { value, warnings } = captureWarnings(() =>
+    applyDictationMainBridgePatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.match(warnings.join("\n"), /Expected one trusted handler insertion point/);
+});
+
+test("main bridge fails soft when it finds a partial prior insertion", () => {
+  const source = syntheticMainBundle().replace(
+    "\"native-desktop-apps\":async",
+    `"${HANDLER_NAME}":async()=>({}),"native-desktop-apps":async`,
+  );
+  const { value, warnings } = captureWarnings(() =>
+    applyDictationMainBridgePatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.match(warnings.join("\n"), /incomplete.*main-process bridge/i);
+});
+
+test("main bridge rejects non-primary callers before keyring or network access", async () => {
+  const { rawHandler, execCalls, fetchCalls } = createMainHarness();
+
+  await assert.rejects(
+    () => rawHandler({
+      audioBase64: webmBase64(),
+      contentType: "audio/webm",
+      origin: { id: 2 },
+    }),
+    /unavailable from this window/,
+  );
+  assert.equal(execCalls.length, 0);
+  assert.equal(fetchCalls.length, 0);
+});
+
+test("main bridge sends exact WebM, model, language, endpoint, and keyring credential", async () => {
+  const key = "unit-test-openai-key-material";
+  const { handler, execCalls, fetchCalls } = createMainHarness({ key });
+  const audio = webmBase64([1, 2, 3, 4]);
+
+  const response = await handler({
+    audioBase64: audio,
+    contentType: "audio/webm;codecs=opus",
+  });
+
+  assert.equal(response.text, "The morning air felt cool and fresh.");
+  assert.equal(execCalls.length, 1);
+  assert.equal(execCalls[0].command, "/usr/bin/secret-tool");
+  assert.deepEqual(Array.from(execCalls[0].args), [
+    "lookup",
+    "service",
+    SECRET_SERVICE,
+  ]);
+  assert.equal(execCalls[0].options.encoding, null);
+  assert.equal(execCalls[0].options.shell, undefined);
+  assert.equal(fetchCalls.length, 1);
+  assert.equal(
+    fetchCalls[0].url,
+    "https://api.openai.com/v1/audio/transcriptions",
+  );
+  assert.equal(fetchCalls[0].authorization, `Bearer ${key}`);
+  assert.equal(fetchCalls[0].model, "gpt-4o-transcribe");
+  assert.equal(fetchCalls[0].language, "en");
+  assert.equal(fetchCalls[0].filename, "codex.webm");
+  assert.equal(fetchCalls[0].contentType, "audio/webm");
+  assert.deepEqual(fetchCalls[0].fileBytes, Buffer.from(audio, "base64"));
+  assert.equal(fetchCalls[0].signal instanceof AbortSignal, true);
+});
+
+test("main bridge rejects invalid, oversized, and non-WebM audio before key or network", async () => {
+  const cases = [
+    { audioBase64: "", contentType: "audio/webm" },
+    { audioBase64: "not-base64", contentType: "audio/webm" },
+    {
+      audioBase64: Buffer.from("plain text").toString("base64"),
+      contentType: "audio/webm",
+    },
+    {
+      audioBase64: webmBase64(),
+      contentType: "audio/wav",
+    },
+    {
+      audioBase64: Buffer.alloc(MAX_AUDIO_BYTES + 1).toString("base64"),
+      contentType: "audio/webm",
+    },
+  ];
+
+  for (const payload of cases) {
+    const { handler, execCalls, fetchCalls } = createMainHarness();
+    await assert.rejects(() => handler(payload), /invalid|WebM\/Opus|too large/i);
+    assert.equal(execCalls.length, 0);
+    assert.equal(fetchCalls.length, 0);
+  }
+});
+
+test("main bridge hides keyring details when the Codex credential is missing", async () => {
+  const { handler, fetchCalls } = createMainHarness({
+    keyError: new Error("secret-tool private backend failure"),
+  });
+
+  await assert.rejects(
+    () => handler({ audioBase64: webmBase64(), contentType: "audio/webm" }),
+    (error) => {
+      assert.match(error.message, /key is unavailable/);
+      assert.doesNotMatch(error.message, /private backend failure/);
+      return true;
+    },
+  );
+  assert.equal(fetchCalls.length, 0);
+});
+
+test("main bridge rejects empty and malformed stored credentials", async () => {
+  for (const key of ["", "too-short"]) {
+    const { handler, fetchCalls } = createMainHarness({ key });
+    await assert.rejects(
+      () => handler({ audioBase64: webmBase64(), contentType: "audio/webm" }),
+      /key is unavailable/,
+    );
+    assert.equal(fetchCalls.length, 0);
+  }
+});
+
+test("main bridge reports API statuses without returning upstream bodies", async () => {
+  for (const status of [401, 429, 500]) {
+    let bodyCancelled = false;
+    const { handler } = createMainHarness({
+      fetchImpl: async () => ({
+        ok: false,
+        status,
+        body: {
+          async cancel() {
+            bodyCancelled = true;
+          },
+        },
+        async json() {
+          return { error: { message: "private upstream detail" } };
+        },
+      }),
+    });
+    await assert.rejects(
+      () => handler({ audioBase64: webmBase64(), contentType: "audio/webm" }),
+      (error) => {
+        assert.match(error.message, new RegExp(`\\(${status}\\)`));
+        assert.doesNotMatch(error.message, /private upstream detail/);
+        return true;
+      },
+    );
+    assert.equal(bodyCancelled, true);
+  }
+});
+
+test("main bridge rejects invalid JSON and missing transcript text", async () => {
+  const invalidJson = createMainHarness({
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        throw new SyntaxError("bad JSON");
+      },
+    }),
+  });
+  await assert.rejects(
+    () => invalidJson.handler({
+      audioBase64: webmBase64(),
+      contentType: "audio/webm",
+    }),
+    /invalid JSON/,
+  );
+
+  const missingText = createMainHarness({
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return {};
+      },
+    }),
+  });
+  await assert.rejects(
+    () => missingText.handler({
+      audioBase64: webmBase64(),
+      contentType: "audio/webm",
+    }),
+    /did not contain text/,
+  );
+});
+
+test("main bridge combines caller cancellation with its request timeout", async () => {
+  const controller = new AbortController();
+  const { handler } = createMainHarness({
+    fetchImpl: async (_url, options) => {
+      controller.abort(new Error("cancelled by caller"));
+      assert.equal(options.signal.aborted, true);
+      throw options.signal.reason;
+    },
+  });
+
+  await assert.rejects(
+    () => handler({
+      audioBase64: webmBase64(),
+      contentType: "audio/webm",
+      signal: controller.signal,
+    }),
+    /cancelled by caller/,
+  );
+});
+
+test("main bridge allows only one paid transcription at a time", async () => {
+  let release;
+  const response = new Promise((resolve) => {
+    release = resolve;
+  });
+  const { handler, execCalls, fetchCalls } = createMainHarness({
+    fetchImpl: async () => response,
+  });
+  const payload = {
+    audioBase64: webmBase64(),
+    contentType: "audio/webm",
+  };
+  const first = handler(payload);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  await assert.rejects(() => handler(payload), /already in progress/);
+  assert.equal(execCalls.length, 1);
+  assert.equal(fetchCalls.length, 1);
+
+  release({
+    ok: true,
+    status: 200,
+    async json() {
+      return { text: "First transcript." };
+    },
+  });
+  assert.equal((await first).text, "First transcript.");
+  assert.equal((await handler(payload)).text, "First transcript.");
+  assert.equal(execCalls.length, 2);
+  assert.equal(fetchCalls.length, 2);
+});
+
+test("enabled descriptors patch both a synthetic main bundle and webview asset", () => {
+  withFeatureConfig(["dictation-capture-quality"], (featuresRoot) => {
+    withTempDir((extractedDir) => {
+      const assetsDir = path.join(extractedDir, "webview", "assets");
+      fs.mkdirSync(assetsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(assetsDir, "app-initial-fixture.js"),
+        dictationSource,
+      );
+
+      const normalized = normalizePatchDescriptors(
+        loadLinuxFeaturePatchDescriptors({ featuresRoot }),
+      );
+      const main = applyMainBundlePatchDescriptors(
+        syntheticMainBundle(),
+        normalized,
+        {},
+        null,
+      ).patchedSource;
+      applyWebviewAssetPatchDescriptors(extractedDir, normalized, {}, null);
+      const webview = fs.readFileSync(
+        path.join(assetsDir, "app-initial-fixture.js"),
+        "utf8",
+      );
+
+      assert.match(main, new RegExp(`"${HANDLER_NAME}":async`));
+      assert.match(webview, new RegExp(`vscode://codex/${HANDLER_NAME}`));
+      assert.match(webview, /codexLinuxDictationCaptureQuality/);
+      assert.match(webview, /codexLinuxDictationBatchOnly/);
+    });
+  });
+});
+
+test("renderer contains no key, OpenAI endpoint, or main-process primitives", () => {
+  const renderer = applyDictationCaptureQualityPatch(dictationSource);
+  const featureText = [
+    fs.readFileSync(path.join(__dirname, "feature.json"), "utf8"),
+    fs.readFileSync(path.join(__dirname, "README.md"), "utf8"),
+    fs.readFileSync(path.join(__dirname, "patch.js"), "utf8"),
+  ].join("\n");
+
+  assert.doesNotMatch(
+    renderer,
+    /Authorization|OPENAI_API_KEY|secret-tool|api\.openai\.com|gpt-4o-transcribe/,
+  );
+  assert.doesNotMatch(featureText, /OPENAI_API_KEY=/);
+  assert.doesNotMatch(featureText, /\/home\/[A-Za-z0-9._-]+/);
+});


### PR DESCRIPTION
## Summary

- add a disabled-by-default `dictation-capture-quality` Linux feature
- request stereo capture with Chromium echo cancellation, noise suppression, and AGC disabled
- route completed WebM/Opus recordings through a main-process bridge to the user's own OpenAI API key using `gpt-4o-transcribe` and `language=en`
- keep the key in Secret Service and out of the renderer, source, environment, and logs
- restrict paid requests to primary Codex windows, allow one request at a time, bound payload size/time, and sanitize upstream errors
- declare the feature's conflict with `conversation-mode` and native `secret-tool` dependencies where package names are portable

## Why

On the affected Linux microphone path, controlled capture comparisons isolated Chromium WebRTC processing as the major accuracy regression. The clean stereo capture produced accurate transcription, while Codex's normal processed path did not. Codex's built-in streaming route also cannot use the user's selected API key, model, and fixed English hint.

This remains opt-in because it changes capture processing, disables the built-in streaming route, sends completed audio to the user-billed OpenAI Audio Transcriptions API, and is intentionally English-only and batch-only.

## Security and support boundaries

The renderer can only pass bounded base64 WebM data through the existing trusted bridge. The main process checks the originating primary window, canonical base64, MIME type, size, and EBML signature before reading the Codex-owned Secret Service credential. It uses a fixed OpenAI endpoint/model/language, never returns upstream bodies, combines caller cancellation with a 120-second timeout, and clears mutable audio/secret buffers best-effort.

Debian and pacman packages declare the portable `secret-tool` provider dependency. RPM, AppImage, and other self-built installs must provide `/usr/bin/secret-tool` and an unlocked Secret Service implementation, as documented.

## Validation

- `node --test linux-features/dictation-capture-quality/test.js` — 20/20 passed
- `node --test linux-features/*/test.js` — 849 passed, 1 intentional skip, 0 failed
- `node --test scripts/patch-linux-window-ui.test.js` — 403/403 passed
- `node --test scripts/lib/linux-features.test.js` — 28/28 passed
- `CODEX_DMG_REFRESH_MODE=pinned make build-app` — accepted with zero blockers or warnings; both feature descriptors applied to Codex 26.721.81911 / Electron 42.3.0
- staged diff and syntax/JSON checks passed; no credential-shaped strings found