### PR TITLE
Keep current feature composition idempotent on second pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Repeated current-DMG patch passes now keep composed native and frameless
+  titlebars, external-open handling, Record & Replay, and Browser Use runtime
+  resolution byte-identical. Complete markers no longer depend on
+  function-local minified aliases, while partial markers remain fail-soft and
+  leave drifted assets untouched.
 - Remote mobile control now patches the current 26.721 dual-gate enablement
   bridge instead of reporting it as already applied. Startup auto-connects the
   environment owned by this Desktop without overwriting saved choices for

--- a/linux-features/frameless-titlebar/test.js
+++ b/linux-features/frameless-titlebar/test.js
@@ -14,6 +14,9 @@ const {
   applyLinuxNativeTitlebarPatch,
 } = require("../../scripts/patches/impl/main-process/window.js");
 const {
+  applyLinuxWindowControlsSafeAreaPatch,
+} = require("../../scripts/patches/impl/webview/index.js");
+const {
   applyFramelessTitlebarBranchPatch,
   applyFramelessTitlebarMainPatch,
   applyFramelessTitlebarOverlaySyncPatch,
@@ -273,6 +276,40 @@ test("frameless-titlebar retains standard end padding after the core safe-area p
     ),
     "jsx(slot,{codexLinuxUseWindowControlsSafeArea:!1,side:`end`})",
   );
+});
+
+test("frameless-titlebar composes idempotently with the core safe-area patch", () => {
+  const source = [
+    "var eV=Object.freeze({default:Object.freeze({left:0,right:0}),applicationMenu:Object.freeze({left:0,right:0})});",
+    "function ol({isHeaderEdgeScroll:e,isApplicationMenuBarEnabled:t}){return jsx(sl,{entries:h,fitWidth:r,slotWidth:u,side:`end`})}",
+    "function sl({entries:e,fitWidth:t,side:n,slotWidth:r}){let i=e.some(({align:e})=>e===`end`),o=a({\"pe-2\":n===`start`&&i||n===`end`});return jsx(o)}",
+    "let newer=i.includes(`win`)||r.includes(`windows`)||i.includes(`linux`)?t??eV.applicationMenu:eV.default;",
+  ].join("");
+  const corePatched = applyLinuxWindowControlsSafeAreaPatch(source);
+  const composed = applyFramelessTitlebarWebviewPatch(corePatched);
+
+  assert.equal(applyLinuxWindowControlsSafeAreaPatch(composed), composed);
+  assert.equal(applyFramelessTitlebarWebviewPatch(composed), composed);
+  assert.deepEqual(
+    captureWarnings(() => applyLinuxWindowControlsSafeAreaPatch(composed)),
+    [],
+  );
+});
+
+test("core safe-area patch preserves incomplete frameless composition", () => {
+  const source = [
+    "var eV=Object.freeze({default:Object.freeze({left:0,right:0}),applicationMenu:Object.freeze({left:0,right:0})});",
+    "function ol({isHeaderEdgeScroll:e,isApplicationMenuBarEnabled:t}){return jsx(sl,{entries:h,fitWidth:r,slotWidth:u,codexLinuxUseWindowControlsSafeArea:!1,side:`end`})}",
+    "function sl({entries:e,fitWidth:t,side:n,slotWidth:r}){let i=e.some(({align:e})=>e===`end`),o=a({\"pe-2\":n===`start`&&i||n===`end`});return jsx(o)}",
+  ].join("");
+
+  const warnings = captureWarnings(() => {
+    assert.equal(applyLinuxWindowControlsSafeAreaPatch(source), source);
+  });
+
+  assert.deepEqual(warnings, [
+    "WARN: Could not validate frameless Linux window-controls safe-area composition — leaving asset unchanged",
+  ]);
 });
 
 test("frameless-titlebar reports each current webview sub-contract drift", () => {

--- a/linux-features/frameless-titlebar/test.js
+++ b/linux-features/frameless-titlebar/test.js
@@ -11,6 +11,9 @@ const {
   loadLinuxFeaturePatchDescriptors,
 } = require("../../scripts/lib/linux-features.js");
 const {
+  applyLinuxNativeTitlebarPatch,
+} = require("../../scripts/patches/impl/main-process/window.js");
+const {
   applyFramelessTitlebarBranchPatch,
   applyFramelessTitlebarMainPatch,
   applyFramelessTitlebarOverlaySyncPatch,
@@ -41,6 +44,17 @@ function copyFeatureTo(featuresRoot) {
   for (const name of ["feature.json", "README.md", "patch.js"]) {
     fs.copyFileSync(path.join(__dirname, name), path.join(featureDir, name));
   }
+}
+
+function nativeTitlebarCompositionFixture() {
+  return [
+    "function A2(e){return e===`avatarOverlay`}",
+    "function I2({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return n&&!A2(t)&&(e===`darwin`||e===`win32`)?{backgroundColor:r?a2:o2,backgroundMaterial:e===`win32`?`none`:null}:e===`linux`&&!A2(t)?{backgroundColor:r?a2:o2,backgroundMaterial:null}:{backgroundColor:i2,backgroundMaterial:null}}",
+    "function j9(e=1){return{color:i2,symbolColor:c.nativeTheme.shouldUseDarkColors?v2:_2,height:Math.round(g2*e)}}",
+    "case`quickChat`:case`primary`:return n===`darwin`?{titleBarStyle:`hiddenInset`,trafficLightPosition:A9(r),...e===`quickChat`?{hasShadow:!0,resizable:!0,transparent:!0}:{},...t?{}:{vibrancy:`menu`}}:n===`win32`||n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:j9(r),...e===`quickChat`?{resizable:!0}:{}}:{titleBarStyle:`default`,...e===`quickChat`?{resizable:!0}:{}};",
+    "setWindowZoom(e,t){let n=c.BrowserWindow.fromWebContents(e),r=n&&this.windowAppearances.get(n.id);n==null||r!==`primary`&&r!==`quickChat`||(process.platform===`darwin`?n.setWindowButtonPosition(A9(t)):(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(n.id,t),n.setTitleBarOverlay(j9(t))))}",
+    "installApplicationMenuTitleBarOverlaySync(e,t){if(process.platform!==`win32`&&process.platform!==`linux`||t!==`primary`&&t!==`quickChat`)return;let n=()=>{e.isDestroyed()||e.setTitleBarOverlay(j9(this.windowZooms.get(e.id)))};return c.nativeTheme.on(`updated`,n),n(),()=>{c.nativeTheme.off(`updated`,n)}}",
+  ].join("");
 }
 
 test("frameless-titlebar stays disabled until listed in features.json", () => {
@@ -160,6 +174,52 @@ test("frameless-titlebar composes with the current native-titlebar patch shape",
     /n===`linux`\?\{titleBarStyle:`hidden`,\.\.\.e===`quickChat`\?\{resizable:!0\}:\{\}\}/,
   );
   assert.doesNotMatch(patched, /titleBarOverlay:n===`linux`/);
+});
+
+test("native-titlebar remains complete after frameless-titlebar composition", () => {
+  const corePatched = applyLinuxNativeTitlebarPatch(
+    nativeTitlebarCompositionFixture(),
+  );
+  const composed = applyFramelessTitlebarMainPatch(corePatched);
+  let rerun;
+  const warnings = captureWarnings(() => {
+    rerun = applyLinuxNativeTitlebarPatch(composed);
+  });
+
+  assert.equal(rerun, composed);
+  assert.deepEqual(warnings, []);
+});
+
+test("native-titlebar rejects partial frameless compositions byte-identically", () => {
+  const corePatched = applyLinuxNativeTitlebarPatch(
+    nativeTitlebarCompositionFixture(),
+  );
+  const composed = applyFramelessTitlebarMainPatch(corePatched);
+  const variants = [
+    composed.replace(
+      "function codexLinuxTitleBarOverlay",
+      "function codexLinuxTitleBarOverlayMissing",
+    ),
+    composed.replace(
+      "process.platform===`win32`&&(this.windowZooms.set",
+      "(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set",
+    ),
+    composed.replace(
+      "if(process.platform!==`win32`||t!==`primary`",
+      "if(process.platform!==`win32`&&process.platform!==`linux`||t!==`primary`",
+    ),
+  ];
+
+  for (const source of variants) {
+    let rerun;
+    const warnings = captureWarnings(() => {
+      rerun = applyLinuxNativeTitlebarPatch(source);
+    });
+    assert.equal(rerun, source);
+    assert.deepEqual(warnings, [
+      "WARN: Could not find primary BrowserWindow titlebar snippet — skipping Linux native titlebar patch",
+    ]);
+  }
 });
 
 test("frameless-titlebar reports current main-process drift", () => {

--- a/linux-features/record-and-replay/patch.js
+++ b/linux-features/record-and-replay/patch.js
@@ -1,9 +1,12 @@
 "use strict";
 
-const { requireName } = require("../../scripts/patches/lib/minified-js.js");
-
 const RECORD_REPLAY_PLUGIN_NAME = "record-and-replay";
 const HUD_RUNTIME_VERSION = 5;
+const RECORD_REPLAY_MODULE_EXPRESSIONS = Object.freeze({
+  childProcessVar: 'require("node:child_process")',
+  fsVar: 'require("node:fs")',
+  pathVar: 'require("node:path")',
+});
 
 function warn(message, patchName) {
   console.warn(`WARN: ${message} - skipping ${patchName}`);
@@ -198,15 +201,8 @@ function recordReplayChronicleTrayPatchedPattern() {
 }
 
 function hasCompleteRecordReplayMainBridgePatch(source) {
-  const childProcessVar = requireName(source, "node:child_process");
-  const fsVar = requireName(source, "node:fs");
-  const pathVar = requireName(source, "node:path");
-  if (childProcessVar == null || fsVar == null || pathVar == null) {
-    return false;
-  }
-
-  const helperPayload = recordReplayHelperSource({ childProcessVar, fsVar, pathVar });
-  const bridgePayload = recordReplayBridgeSource({ childProcessVar, fsVar, pathVar });
+  const helperPayload = recordReplayHelperSource(RECORD_REPLAY_MODULE_EXPRESSIONS);
+  const bridgePayload = recordReplayBridgeSource(RECORD_REPLAY_MODULE_EXPRESSIONS);
   const bridgeInsertion = `${bridgePayload},"get-global-state":async({key:`;
   return countOccurrences(source, helperPayload) === 1
     && countOccurrences(source, bridgePayload) === 1
@@ -260,23 +256,15 @@ function applyRecordReplayMainBridgePatch(currentSource) {
   }
 
   let patchedSource = currentSource;
-  const childProcessVar = requireName(currentSource, "node:child_process");
-  const fsVar = requireName(currentSource, "node:fs");
-  const pathVar = requireName(currentSource, "node:path");
-  if (childProcessVar == null || fsVar == null || pathVar == null) {
-    warn("Could not find Node module aliases", patchName);
-    return currentSource;
-  }
-
   const handlerNeedle = `"get-global-state":async({key:`;
   if (!currentSource.includes(handlerNeedle)) {
     warn("Could not find global-state bridge insertion point", patchName);
     return currentSource;
   }
 
-  patchedSource = `${recordReplayHelperSource({ childProcessVar, fsVar, pathVar })}\n${patchedSource.replace(
+  patchedSource = `${recordReplayHelperSource(RECORD_REPLAY_MODULE_EXPRESSIONS)}\n${patchedSource.replace(
     handlerNeedle,
-    `${recordReplayBridgeSource({ childProcessVar, fsVar, pathVar })},${handlerNeedle}`,
+    `${recordReplayBridgeSource(RECORD_REPLAY_MODULE_EXPRESSIONS)},${handlerNeedle}`,
   )}`;
   return applyRecordReplayChronicleTrayPatch(patchedSource);
 }

--- a/linux-features/record-and-replay/test.js
+++ b/linux-features/record-and-replay/test.js
@@ -16,6 +16,9 @@ const {
   stageEnabledLinuxFeatureInstall,
 } = require("../../scripts/lib/linux-features.js");
 const {
+  applyLinuxExternalOpenEnvPatch,
+} = require("../../scripts/patches/impl/main-process/browser.js");
+const {
   applyRecordReplayDictationTranscriptPatch,
   applyRecordReplayGlobalDictationTranscriptPatch,
   applyRecordReplayHudPatch,
@@ -202,7 +205,10 @@ test("record-and-replay bridge patch is idempotent and uses execFile", () => {
   assert.match(patched, /"linux-record-replay-import-skill":async/);
   assert.match(patched, /\.execFile\(n,e,\{encoding:"utf8",timeout:t,maxBuffer:16777216\}/);
   assert.match(patched, /codexLinuxRecordReplayWriteTempJson/);
-  assert.match(patched, /finally\{try\{fs\.unlinkSync\(c\)\}catch\{\}\}/);
+  assert.match(
+    patched,
+    /finally\{try\{require\("node:fs"\)\.unlinkSync\(c\)\}catch\{\}\}/,
+  );
   assert.match(patched, /"browser-trace"/);
   assert.match(patched, /"--trace-file"/);
   assert.doesNotMatch(patched, /exec\(/);
@@ -214,6 +220,27 @@ test("record-and-replay bridge patch is idempotent and uses execFile", () => {
   assert.doesNotMatch(patched, /"--mode"/);
 });
 
+test("record-and-replay bridge remains complete after external-open composition", () => {
+  const source = [
+    '"use strict";let electron=require("electron");',
+    'const cp=require("node:child_process"),fs=require("node:fs"),path=require("node:path");',
+    "var tray={getChronicleSidecarControlState:()=>tt().skysight?$9:Se.appServerConnectionRegistry.getMaybeConnection(`local`)?.getChronicleSidecarControlState()??$9,toggleChronicleSidecar:async()=>{if(tt().skysight)return $9;let e=Se.appServerConnectionRegistry.getMaybeConnection(V);return e==null?$9:e.getChronicleSidecarControlState().running?e.pauseChronicleSidecar():e.resumeChronicleSidecar()}};",
+    'var bridge={"get-global-state":async({key:e})=>null};',
+  ].join("");
+  const recordPatched = applyRecordReplayMainBridgePatch(source);
+  const composed = applyLinuxExternalOpenEnvPatch(recordPatched);
+  const { value, warnings } = captureWarns(() =>
+    applyRecordReplayMainBridgePatch(composed),
+  );
+
+  assert.equal(value, composed);
+  assert.deepEqual(warnings, []);
+  assert.match(
+    composed,
+    /require\("node:child_process"\)\.execFile\(/,
+  );
+});
+
 test("record-and-replay rejects incomplete current bridge variants byte-identically", () => {
   const source = [
     'const cp=require("node:child_process"),fs=require("node:fs"),path=require("node:path");',
@@ -221,16 +248,13 @@ test("record-and-replay rejects incomplete current bridge variants byte-identica
     'var bridge={"get-global-state":async({key:e})=>null};',
   ].join("");
   const patched = applyRecordReplayMainBridgePatch(source);
-  const bridgePayload = recordReplayBridgeSource({
-    childProcessVar: "cp",
-    fsVar: "fs",
-    pathVar: "path",
-  });
-  const helperPayload = recordReplayHelperSource({
-    childProcessVar: "cp",
-    fsVar: "fs",
-    pathVar: "path",
-  });
+  const moduleExpressions = {
+    childProcessVar: 'require("node:child_process")',
+    fsVar: 'require("node:fs")',
+    pathVar: 'require("node:path")',
+  };
+  const bridgePayload = recordReplayBridgeSource(moduleExpressions);
+  const helperPayload = recordReplayHelperSource(moduleExpressions);
   const trayStart = patched.indexOf("var tray=");
   const trayEnd = patched.indexOf(";var bridge=", trayStart);
   const trayStatement = patched.slice(trayStart, trayEnd + 1);

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -14,6 +14,9 @@ const vm = require("node:vm");
 const {
   applyPetOverlayPatch,
 } = require("../linux-features/pet-overlay/patch.js");
+const {
+  patchWrapperUpdateSettingsAssets,
+} = require("../linux-features/codex-wrapper-updater/patch.js");
 
 // Pin the feature config so a developer's local gitignored features.json
 // cannot change which patch descriptors these core tests exercise.
@@ -5753,6 +5756,84 @@ test("patches physical-key fallback through native Keyboard Shortcuts asset scan
     const secondResult = patchKeybindsSettingsAssets(extractedDir);
     assert.equal(secondResult.matched, true);
     assert.equal(secondResult.changed, 0);
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
+});
+
+test("preserves wrapper updater extensions across Linux settings patch passes", () => {
+  const { extractedDir, assetsDir } = createModernNativeKeyboardShortcutsSettingsFixture();
+  try {
+    const firstCoreResult = patchKeybindsSettingsAssets(extractedDir);
+    assert.equal(firstCoreResult.matched, true);
+
+    const settingsPath = path.join(assetsDir, linuxDesktopSettingsAsset);
+    const generatedSource = fs.readFileSync(settingsPath, "utf8");
+    assert.match(
+      generatedSource,
+      /var codexLinuxDesktopSettingsVersion=1,KEYS=\{/,
+    );
+
+    const firstFeatureResult = patchWrapperUpdateSettingsAssets(extractedDir);
+    assert.deepEqual(firstFeatureResult, { matched: true, changed: 1 });
+    const composedSource = fs.readFileSync(settingsPath, "utf8");
+    assert.match(composedSource, /wrapperUpdates:"codex-linux-wrapper-updates-enabled"/);
+    assert.match(composedSource, /featurePickerOnUpdate:"codex-linux-feature-picker-on-update"/);
+
+    const secondCoreResult = patchKeybindsSettingsAssets(extractedDir);
+    assert.equal(secondCoreResult.matched, true);
+    assert.equal(secondCoreResult.changed, 0);
+    assert.equal(fs.readFileSync(settingsPath, "utf8"), composedSource);
+
+    const secondFeatureResult = patchWrapperUpdateSettingsAssets(extractedDir);
+    assert.deepEqual(secondFeatureResult, { matched: true, changed: 0 });
+    assert.equal(fs.readFileSync(settingsPath, "utf8"), composedSource);
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
+});
+
+test("rejects incomplete generated Linux settings markers without writing assets", () => {
+  const { extractedDir, assetsDir } = createModernNativeKeyboardShortcutsSettingsFixture();
+  try {
+    assert.equal(patchKeybindsSettingsAssets(extractedDir).matched, true);
+    const settingsPath = path.join(assetsDir, linuxDesktopSettingsAsset);
+    fs.writeFileSync(
+      settingsPath,
+      fs.readFileSync(settingsPath, "utf8").replace(
+        "codexLinuxDesktopSettingsVersion=1",
+        "codexLinuxDesktopSettingsVersion=2",
+      ),
+      "utf8",
+    );
+    const assetsBefore = new Map(
+      fs.readdirSync(assetsDir).map((name) => [
+        name,
+        fs.readFileSync(path.join(assetsDir, name), "utf8"),
+      ]),
+    );
+
+    const { value: result, warnings } = captureWarns(() =>
+      patchKeybindsSettingsAssets(extractedDir),
+    );
+
+    assert.equal(result.matched, false);
+    assert.equal(result.changed, 0);
+    assert.match(result.reason, /generated Linux desktop settings marker is stale or incomplete/);
+    assert.ok(
+      warnings.some((warning) =>
+        warning.includes("generated Linux desktop settings marker is stale or incomplete"),
+      ),
+    );
+    assert.deepEqual(
+      new Map(
+        fs.readdirSync(assetsDir).map((name) => [
+          name,
+          fs.readFileSync(path.join(assetsDir, name), "utf8"),
+        ]),
+      ),
+      assetsBefore,
+    );
   } finally {
     fs.rmSync(extractedDir, { recursive: true, force: true });
   }

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -10230,6 +10230,77 @@ test("patchMainBundleSource stays idempotent after wrapping the Electron require
   assert.match(patched, /updatePersistentTrayMenu\(\)\{process\.platform===`linux`/);
 });
 
+test("current main-process feature composition stays byte-identical on a second descriptor pass", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-main-feature-composition-"));
+  try {
+    const featuresConfigPath = path.join(tempRoot, "features.json");
+    fs.writeFileSync(
+      featuresConfigPath,
+      JSON.stringify({ enabled: ["record-and-replay", "frameless-titlebar"] }),
+    );
+    const descriptorIds = new Set([
+      "linux-native-titlebar",
+      "feature:record-and-replay:linux-record-replay-main-bridge",
+      "linux-external-open-env",
+      "feature:frameless-titlebar:main-process",
+    ]);
+    const descriptors = normalizePatchDescriptors([
+      ...corePatchDescriptors(),
+      ...featurePatchDescriptors({ featuresConfigPath }),
+    ].filter((descriptor) => descriptorIds.has(descriptor.id)));
+    assert.deepEqual(
+      descriptors.map((descriptor) => descriptor.id),
+      [
+        "linux-native-titlebar",
+        "feature:record-and-replay:linux-record-replay-main-bridge",
+        "linux-external-open-env",
+        "feature:frameless-titlebar:main-process",
+      ],
+    );
+
+    const source = [
+      "\"use strict\";let c=require(`electron`);",
+      "function A9(e){return e===`avatarOverlay`}",
+      "function I9({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return n&&!A9(t)&&(e===`darwin`||e===`win32`)?{backgroundColor:r?L9:K9,backgroundMaterial:e===`win32`?`none`:null}:e===`linux`&&!A9(t)?{backgroundColor:r?L9:K9,backgroundMaterial:null}:{backgroundColor:W9,backgroundMaterial:null}}",
+      "function j9(e=1){return{color:W9,symbolColor:c.nativeTheme.shouldUseDarkColors?i9:r9,height:Math.round(g9*e)}}",
+      "case`quickChat`:case`primary`:return n===`darwin`?{titleBarStyle:`hiddenInset`,trafficLightPosition:A9(r),...e===`quickChat`?{hasShadow:!0,resizable:!0,transparent:!0}:{},...t?{}:{vibrancy:`menu`}}:n===`win32`||n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:j9(r),...e===`quickChat`?{resizable:!0}:{}}:{titleBarStyle:`default`,...e===`quickChat`?{resizable:!0}:{}};",
+      "setWindowZoom(e,t){let n=c.BrowserWindow.fromWebContents(e),r=n&&this.windowAppearances.get(n.id);n==null||r!==`primary`&&r!==`quickChat`||(process.platform===`darwin`?n.setWindowButtonPosition(A9(t)):(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(n.id,t),n.setTitleBarOverlay(j9(t))))}",
+      "installApplicationMenuTitleBarOverlaySync(e,t){if(process.platform!==`win32`&&process.platform!==`linux`||t!==`primary`&&t!==`quickChat`)return;let n=()=>{e.isDestroyed()||e.setTitleBarOverlay(j9(this.windowZooms.get(e.id)))};return c.nativeTheme.on(`updated`,n),n(),()=>{c.nativeTheme.off(`updated`,n)}}",
+      "var tray={getChronicleSidecarControlState:()=>tt().skysight?$9:Se.appServerConnectionRegistry.getMaybeConnection(`local`)?.getChronicleSidecarControlState()??$9,toggleChronicleSidecar:async()=>{if(tt().skysight)return $9;let e=Se.appServerConnectionRegistry.getMaybeConnection(V);return e==null?$9:e.getChronicleSidecarControlState().running?e.pauseChronicleSidecar():e.resumeChronicleSidecar()}};",
+      "var bridge={\"get-global-state\":async({key:e})=>null};",
+      "async function openExternal(url,options){return c.shell.openExternal(url,options)}",
+    ].join("");
+    const context = { iconAsset: null };
+    const firstReport = createPatchReport();
+    const first = captureWarns(() =>
+      applyMainBundlePatchDescriptors(source, descriptors, context, firstReport),
+    );
+
+    assert.notEqual(first.value.patchedSource, source);
+    assert.deepEqual(first.warnings, []);
+    assert.deepEqual(first.value.warnings, []);
+    assert.deepEqual(
+      firstReport.patches.map(({ name, status }) => ({ name, status })),
+      descriptors.map(({ id }) => ({ name: id, status: "applied" })),
+    );
+
+    const secondReport = createPatchReport();
+    const second = captureWarns(() =>
+      applyMainBundlePatchDescriptors(first.value.patchedSource, descriptors, context, secondReport),
+    );
+
+    assert.equal(second.value.patchedSource, first.value.patchedSource);
+    assert.deepEqual(second.warnings, []);
+    assert.deepEqual(second.value.warnings, []);
+    assert.deepEqual(
+      secondReport.patches.map(({ name, status }) => ({ name, status })),
+      descriptors.map(({ id }) => ({ name: id, status: "already-applied" })),
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("adds a fallback source for renderer git-origins requests without weakening other git operations", () => {
   const source =
     "handleVSCodeRequest(n,r,i,a,o){try{let s=r,c=this.handlers[s];if(typeof c!=`function`)throw Error(`${r} not implemented in the current Electron process. Restart Codex to load the latest Electron handlers.`);let l=()=>c({...a,origin:n,windowHostId:i});if(o==null){if(e.qt(r))throw Error(`Missing git operation source for ${r}`);return l()}return t.Kt({source:o,requestKind:r},l)}catch(e){throw e}}";

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -10021,7 +10021,7 @@ test("warns when Linux external-open helper exists without wrapped Electron requ
 
   assert.equal(value, source);
   assert.deepEqual(warnings, [
-    "WARN: Could not find Electron require initializer — skipping Linux external open environment patch",
+    "WARN: Found incomplete Linux external open environment patch — skipping",
   ]);
 });
 

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1525,31 +1525,6 @@ function currentBundledPluginCopyBundleFixture() {
   );
 }
 
-function chromeNativeHostRuntimeBundleFixture() {
-  return [
-    "let r=require(`node:path`),o=require(`node:fs`);",
-    "function Mc({resourcesPath:e,executableName:t}){if(!e)return null;let n=(0,r.join)(e,t);try{return(0,o.statSync)(n).isFile()?n:null}catch{return null}}",
-    "function Pc(e){return Mc({resourcesPath:e,executableName:process.platform===`win32`?`node_repl.exe`:`node_repl`})}",
-    "function Fc(e){return Mc({resourcesPath:e,executableName:process.platform===`win32`?`node.exe`:`node`})}",
-    "function Ic(e){return Mc({resourcesPath:e,executableName:process.platform===`win32`?`codex.exe`:`codex`})}",
-    "function Qp(e){let t=Ic(e.resourcesPath)??$p(e.devRuntimeRepoRoot,[`extension`,`bin`,process.platform===`win32`?`codex.exe`:`codex`]),n=Fc(e.resourcesPath)??$p(e.devRuntimeRepoRoot,[`electron`,`bin`,process.platform===`win32`?`node.exe`:`node`]),r=Pc(e.resourcesPath)??$p(e.devRuntimeRepoRoot,[`electron`,`bin`,process.platform===`win32`?`node_repl.exe`:`node_repl`]),i=[t==null?`codex`:null,n==null?`node`:null,r==null?`node_repl`:null].filter(e=>e!=null);if(i.length>0)throw Error(`Missing bundled Electron runtime required to sync Chrome native host resources for ${e.nativeHostName}: ${i.join(`, `)} (resourcesPath: ${e.resourcesPath}).`);if(t==null||n==null||r==null)throw Error(`Missing bundled Electron runtime required to sync Chrome native host resources for ${e.nativeHostName}.`);return{codexCliPath:t,nodePath:n,nodeReplPath:r}}",
-    "function $p(e,t){if(e==null)return null;let n=(0,r.join)(e,...t);try{return(0,o.statSync)(n).isFile()?n:null}catch{return null}}",
-  ].join("");
-}
-
-function currentChromeNativeHostRuntimeBundleFixture() {
-  return [
-    "let r=require(`node:path`),o=require(`node:fs`);",
-    "function Mc({resourcesPath:e,executableName:t}){if(!e)return null;let n=(0,r.join)(e,t);try{return(0,o.statSync)(n).isFile()?n:null}catch{return null}}",
-    "function Oj(e){return Mc({resourcesPath:e,executableName:process.platform===`win32`?`node_repl.exe`:`node_repl`})}",
-    "function kj(e){return Mc({resourcesPath:e,executableName:process.platform===`win32`?`node.exe`:`node`})}",
-    "function Nj(e){return Mc({resourcesPath:e,executableName:process.platform===`win32`?`codex.exe`:`codex`})}",
-    "function QL(e){let t=Nj(e.resourcesPath)??$L(e.devRuntimeRepoRoot,[`extension`,`bin`,process.platform===`win32`?`codex.exe`:`codex`]),n=kj(e.resourcesPath),r=Oj(e.resourcesPath),i=[t==null?`codex`:null,n==null?`node`:null,r==null?`node_repl`:null].filter(e=>e!=null);if(i.length>0)throw Error(`Missing bundled Electron runtime required to sync Chrome native host resources for ${e.nativeHostName}: ${i.join(`, `)} (resourcesPath: ${e.resourcesPath}).`);if(t==null||n==null||r==null)throw Error(`Missing bundled Electron runtime required to sync Chrome native host resources for ${e.nativeHostName}.`);return{codexCliPath:t,nodePath:n,nodeModuleDirs:Aj(e.resourcesPath),nodeReplPath:r}}",
-    "function $L(e,t){if(e==null)return null;let n=(0,r.join)(e,...t);try{return(0,o.statSync)(n).isFile()?n:null}catch{return null}}",
-    "function Aj(e){return []}",
-  ].join("");
-}
-
 function currentBrowserUseTrustedHashesRuntimeBuilderFixture() {
   return "\"use strict\";let l=require(`node:fs`),s=require(`node:path`),u=require(`node:crypto`);function build({codexHome:t,nodePath:i,nodeReplPath:a,trustedBrowserClientSha256s:h=[],shouldUseWslPaths:f}){return h}";
 }
@@ -1564,34 +1539,6 @@ function electron42BrowserUseRuntimeResolverBundleFixture() {
     "function Kn(e){return e===`linux`?`/primary/node`:null}",
     "function Hn({env:e=process.env,isPackaged:n=!0,platform:r=process.platform,repoRoot:i=process.cwd(),resolveCodexPath:a=t.Wn,resolveNodePath:o=t.Gn,resolveNodeReplPath:s=t.Kn,resolvePrimaryRuntimeNodePath:c=Kn,resourcesPath:l}){let u=l??tt({env:e,resourcesPath:process.resourcesPath}),d=c(r),f=Gn({platform:r,rawValue:e.CODEX_CLI_PATH,resolveWindowsAppsPath:a})??Wn({devRelativePathSegments:[`extension`,`bin`,`codex`],isPackaged:n,platform:r,repoRoot:i,resolveBundledPath:a,resourcesPath:u}),p=Wn({devRelativePathSegments:null,isPackaged:n,platform:r,repoRoot:i,resolveBundledPath:o,resourcesPath:u}),m=Gn({platform:r,rawValue:e.CODEX_BROWSER_USE_NODE_PATH,resolveWindowsAppsPath:o})??(p.path==null&&d!=null?{path:d,source:`primary-runtime`}:p),h=Gn({platform:r,rawValue:e.CODEX_NODE_REPL_PATH,resolveWindowsAppsPath:s})??Wn({devRelativePathSegments:null,isPackaged:n,platform:r,repoRoot:i,resolveBundledPath:s,resourcesPath:u});return{codexCliPath:f.path,codexCliPathSource:f.source,nodeModuleDirs:t.Vn(u),nodePath:m.path,nodePathSource:m.source,nodeReplPath:h.path,nodeReplPathSource:h.source,platform:r}}",
     "function Wn(e){return{path:null,source:`missing`}}function Gn({rawValue:e}){return e==null?null:{path:e,source:`env-override`}}",
-  ].join("");
-}
-
-function currentChromePluginAppServerRuntimeBundleFixture() {
-  return [
-    "let r=require(`node:path`),o=require(`node:fs`);",
-    "async function XB(e){let t=ZB(e),n=NM(e.resourcesPath),r=MM(e.resourcesPath),i=[t==null?`codex`:null,n==null?`node`:null,r==null?`node_repl`:null].filter(e=>e!=null);if(i.length>0)throw Error(`Missing bundled Electron runtime required to sync Chrome native host resources for ${e.nativeHostName}: ${i.join(`, `)} (resourcesPath: ${e.resourcesPath}).`);if(t==null||n==null||r==null)throw Error(`Missing bundled Electron runtime required to sync Chrome native host resources for ${e.nativeHostName}.`);return{codexCliPath:await fz({codexCliPath:t,codexHome:e.codexHome,nativeHostName:e.nativeHostName}),nodePath:n,nodeModuleDirs:PM(e.resourcesPath),nodeReplPath:r}}",
-    "function ZB(e){return LM(e.resourcesPath)??QB(e.devRuntimeRepoRoot,[`extension`,`bin`,process.platform===`win32`?`codex.exe`:`codex`])}function NM(e){return null}function MM(e){return null}function PM(e){return []}function QB(e,t){return null}function LM(e){return null}async function fz({codexCliPath:e}){return e}",
-  ].join("");
-}
-
-function currentChromePluginCodexAppServerRuntimeBundleFixture() {
-  return [
-    "let r=require(`node:path`),o=require(`node:fs`);",
-    "async function VH(e){let t=_U(e);if(t==null)throw Error(`Missing bundled Electron Codex runtime required to sync Chrome plugin app server for ${e.nativeHostName} (resourcesPath: ${e.resourcesPath??`<none>`}).`);return AV({codexCliPath:t,codexHome:e.codexHome,nativeHostName:e.nativeHostName})}",
-    "function _U(e){return tM(e.resourcesPath)??vU(e.devRuntimeRepoRoot,[`extension`,`bin`,process.platform===`win32`?`codex.exe`:`codex`])}function vU(e,t){return null}function tM(e){return null}async function AV({codexCliPath:e}){return{codexCliPath:e}}",
-  ].join("");
-}
-
-function currentChromePluginIsolatedAppServerRuntimeBundleFixture() {
-  const runtime = currentChromePluginCodexAppServerRuntimeBundleFixture().replace(
-    "async function AV({codexCliPath:e}){return{codexCliPath:e}}",
-    "async function AV(e){let t=e.nativeHostName===nU,n=e.codexCliPath,r=process.env.ISSUE805_ISOLATED_CLI;o.copyFileSync(n,r);o.chmodSync(r,448);return r}",
-  );
-  return [
-    "async function decoy(e){let t=e.nativeHostName===nU;return `decoy`}",
-    "var tU=`.plugin-appserver`,nU=`com.openai.codexextension`;",
-    runtime,
   ].join("");
 }
 
@@ -7744,105 +7691,16 @@ test("fails closed when bundled plugin reconcile insertion order drifts", () => 
   assert.match(warnings[0], /insertion order drifted/);
 });
 
-test("uses Linux managed runtime paths for Chrome native host sync", () => {
-  const patched = applyPatchTwice(
-    applyLinuxChromeNativeHostRuntimePatch,
-    chromeNativeHostRuntimeBundleFixture(),
-  );
-  const files = new Set([
-    "/opt/codex/resources/node-runtime/bin/node",
-    "/opt/codex/resources/node_repl",
-    "/home/josh/.local/bin/codex",
-  ]);
-
-  const result = vm.runInNewContext(
-    `${patched};Qp({resourcesPath:"/opt/codex/resources",devRuntimeRepoRoot:null,nativeHostName:"com.openai.codexextension"});`,
-    {
-      require(moduleName) {
-        if (moduleName === "node:path") {
-          return path;
-        }
-        if (moduleName === "node:fs") {
-          return {
-            statSync(filePath) {
-              if (!files.has(filePath)) {
-                throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
-              }
-              return { isFile: () => true };
-            },
-          };
-        }
-        return require(moduleName);
-      },
-      process: {
-        platform: "linux",
-        env: {
-          CODEX_CLI_PATH: "/home/josh/.local/bin/codex",
-        },
-      },
-    },
-  );
-
-  assert.deepEqual(JSON.parse(JSON.stringify(result)), {
-    codexCliPath: "/home/josh/.local/bin/codex",
-    nodePath: "/opt/codex/resources/node-runtime/bin/node",
-    nodeReplPath: "/opt/codex/resources/node_repl",
-  });
-});
-
-test("uses Linux managed runtime paths for current Chrome native host sync shape", () => {
-  const patched = applyPatchTwice(
-    applyLinuxChromeNativeHostRuntimePatch,
-    currentChromeNativeHostRuntimeBundleFixture(),
-  );
-  const files = new Set([
-    "/opt/codex/resources/node-runtime/bin/node",
-    "/opt/codex/resources/node_repl",
-    "/home/josh/.local/bin/codex",
-  ]);
-
-  const result = vm.runInNewContext(
-    `${patched};QL({resourcesPath:"/opt/codex/resources",devRuntimeRepoRoot:null,nativeHostName:"com.openai.codexextension"});`,
-    {
-      require(moduleName) {
-        if (moduleName === "node:path") {
-          return path;
-        }
-        if (moduleName === "node:fs") {
-          return {
-            statSync(filePath) {
-              if (!files.has(filePath)) {
-                throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
-              }
-              return { isFile: () => true };
-            },
-          };
-        }
-        return require(moduleName);
-      },
-      process: {
-        platform: "linux",
-        env: {
-          CODEX_CLI_PATH: "/home/josh/.local/bin/codex",
-        },
-      },
-    },
-  );
-
-  assert.deepEqual(JSON.parse(JSON.stringify(result)), {
-    codexCliPath: "/home/josh/.local/bin/codex",
-    nodeModuleDirs: [],
-    nodePath: "/opt/codex/resources/node-runtime/bin/node",
-    nodeReplPath: "/opt/codex/resources/node_repl",
-  });
-});
-
 test("uses Linux managed runtime paths for Electron 42 Browser Use runtime resolver", () => {
-  const patched = applyPatchTwice(
-    applyLinuxChromeNativeHostRuntimePatch,
+  const first = applyLinuxChromeNativeHostRuntimePatch(
     electron42BrowserUseRuntimeResolverBundleFixture(),
   );
+  const { value: patched, warnings } = captureWarns(() =>
+    applyLinuxChromeNativeHostRuntimePatch(first),
+  );
 
+  assert.equal(patched, first);
+  assert.deepEqual(warnings, []);
   assert.match(
     patched,
     /codexLinuxChromeNativeHostRuntimeEntry\(codexLinuxChromeNativeHostRuntimePath\(`codex`\),`linux-path`\)\?\?Wn/,
@@ -7855,29 +7713,14 @@ test("uses Linux managed runtime paths for Electron 42 Browser Use runtime resol
     patched,
     /codexLinuxChromeNativeHostRuntimeFile\(u,\[\[r===`win32`\?`node_repl\.exe`:`node_repl`\]\]\)/,
   );
-});
 
-test("uses Linux managed runtime paths for current Chrome plugin app-server sync", () => {
-  const patched = applyPatchTwice(
-    applyLinuxChromeNativeHostRuntimePatch,
-    currentChromePluginAppServerRuntimeBundleFixture(),
-  );
-
-  assert.match(patched, /ZB\(e\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(`CODEX_CLI_PATH`\)\?\?codexLinuxChromeNativeHostRuntimePath\(`codex`\)/);
-  assert.match(patched, /NM\(e\.resourcesPath\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(`CODEX_BROWSER_USE_NODE_PATH`\)/);
-  assert.match(patched, /codexLinuxChromeNativeHostRuntimeFile\(e\.resourcesPath,\[\[`node-runtime`,`bin`,process\.platform===`win32`\?`node\.exe`:`node`\]\]\)/);
-  assert.match(patched, /MM\(e\.resourcesPath\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(`CODEX_NODE_REPL_PATH`\)/);
-});
-
-test("uses Linux Codex CLI path for Chrome plugin app-server sync", async () => {
-  const patched = applyPatchTwice(
-    applyLinuxChromeNativeHostRuntimePatch,
-    currentChromePluginCodexAppServerRuntimeBundleFixture(),
-  );
-  const files = new Set(["/home/josh/.local/bin/codex"]);
-
-  const result = await vm.runInNewContext(
-    `${patched};VH({resourcesPath:"/opt/codex/resources",devRuntimeRepoRoot:null,nativeHostName:"com.openai.codexextension"});`,
+  const files = new Set([
+    "/opt/codex/resources/node-runtime/bin/node",
+    "/opt/codex/resources/node_repl",
+    "/home/josh/.local/bin/codex",
+  ]);
+  const result = vm.runInNewContext(
+    `${patched};Hn({env:{CODEX_CLI_PATH:"/home/josh/.local/bin/codex",PATH:""},isPackaged:true,platform:"linux",repoRoot:null,resolveCodexPath:()=>null,resolveNodePath:()=>null,resolveNodeReplPath:()=>null,resolvePrimaryRuntimeNodePath:()=>null,resourcesPath:"/opt/codex/resources"});`,
     {
       require(moduleName) {
         if (moduleName === "node:path") {
@@ -7896,113 +7739,47 @@ test("uses Linux Codex CLI path for Chrome plugin app-server sync", async () => 
         return require(moduleName);
       },
       process: {
+        cwd: () => "/tmp",
+        env: {},
         platform: "linux",
-        env: {
-          CODEX_CLI_PATH: "/home/josh/.local/bin/codex",
-          PATH: "",
-        },
+        resourcesPath: "/opt/codex/resources",
       },
+      t: { Vn: () => [] },
     },
   );
 
   assert.deepEqual(JSON.parse(JSON.stringify(result)), {
     codexCliPath: "/home/josh/.local/bin/codex",
+    codexCliPathSource: "env-override",
+    nodeModuleDirs: [],
+    nodePath: "/opt/codex/resources/node-runtime/bin/node",
+    nodePathSource: "linux-node-runtime",
+    nodeReplPath: "/opt/codex/resources/node_repl",
+    nodeReplPathSource: "linux-node-repl-runtime",
+    platform: "linux",
   });
 });
 
-test("keeps the original Linux CLI path when Chrome plugin app-server sync would isolate it", async () => {
-  const patched = applyPatchTwice(
-    applyLinuxChromeNativeHostRuntimePatch,
-    currentChromePluginIsolatedAppServerRuntimeBundleFixture(),
+test("rejects partial Electron 42 Browser Use runtime markers byte-identically", () => {
+  const patched = applyLinuxChromeNativeHostRuntimePatch(
+    electron42BrowserUseRuntimeResolverBundleFixture(),
   );
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-chrome-esm-cli-"));
-  try {
-    const packageDir = path.join(root, "CLI installs");
-    const cliPath = path.join(packageDir, "codex");
-    const isolatedPath = path.join(root, "isolated", "codex");
-    fs.mkdirSync(path.dirname(isolatedPath), { recursive: true });
-    fs.mkdirSync(packageDir, { recursive: true });
-    fs.writeFileSync(path.join(packageDir, "package.json"), '{"type":"module"}\n');
-    fs.writeFileSync(path.join(packageDir, "dependency.js"), 'export const version = "esm-ok";\n');
-    fs.writeFileSync(
-      cliPath,
-      '#!/usr/bin/env node\nimport { version } from "./dependency.js";\nconsole.log(version);\n',
-    );
-    fs.chmodSync(cliPath, 0o700);
+  const variants = [
+    patched.replace("`linux-path`", "`linux-path-corrupt`"),
+    patched.replace("`linux-node-runtime`", "`linux-node-runtime-corrupt`"),
+    patched.replace("`linux-node-repl-runtime`", "`linux-node-repl-runtime-corrupt`"),
+  ];
 
-    const result = await vm.runInNewContext(
-      `${patched};VH({resourcesPath:"/opt/codex/resources",devRuntimeRepoRoot:null,nativeHostName:"com.openai.codexextension"});`,
-      {
-        require,
-        process: {
-          platform: "linux",
-          env: {
-            CODEX_CLI_PATH: cliPath,
-            ISSUE805_ISOLATED_CLI: isolatedPath,
-            PATH: "",
-          },
-        },
-      },
+  for (const source of variants) {
+    assert.notEqual(source, patched);
+    const { value, warnings } = captureWarns(() =>
+      applyLinuxChromeNativeHostRuntimePatch(source),
     );
-
-    assert.equal(result, cliPath);
-    assert.equal(fs.existsSync(isolatedPath), false);
-    assert.match(patched, /async function decoy\(e\)\{let t=e\.nativeHostName===nU;return `decoy`\}/);
-    const execution = spawnSync(result, [], { encoding: "utf8" });
-    assert.equal(execution.status, 0, execution.stderr);
-    assert.equal(execution.stdout.trim(), "esm-ok");
-  } finally {
-    fs.rmSync(root, { recursive: true, force: true });
+    assert.equal(value, source);
+    assert.deepEqual(warnings, [
+      "WARN: Found incomplete Chrome native host runtime patch — skipping Linux runtime path patch",
+    ]);
   }
-});
-
-test("preserves Chrome plugin app-server isolation outside Linux", async () => {
-  const patched = applyPatchTwice(
-    applyLinuxChromeNativeHostRuntimePatch,
-    currentChromePluginIsolatedAppServerRuntimeBundleFixture(),
-  );
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-chrome-non-linux-cli-"));
-  try {
-    const sourcePath = path.join(root, "source-codex");
-    const isolatedPath = path.join(root, "isolated-codex");
-    fs.writeFileSync(sourcePath, "source");
-
-    const result = await vm.runInNewContext(
-      `${patched};AV({codexCliPath:${JSON.stringify(sourcePath)},nativeHostName:"com.openai.codexextension"});`,
-      {
-        require,
-        process: {
-          platform: "darwin",
-          env: { ISSUE805_ISOLATED_CLI: isolatedPath },
-        },
-      },
-    );
-
-    assert.equal(result, isolatedPath);
-    assert.equal(fs.readFileSync(isolatedPath, "utf8"), "source");
-  } finally {
-    fs.rmSync(root, { recursive: true, force: true });
-  }
-});
-
-test("patches multiple Chrome runtime resolvers in one Electron 42 bundle", () => {
-  const patched = applyPatchTwice(
-    applyLinuxChromeNativeHostRuntimePatch,
-    [
-      electron42BrowserUseRuntimeResolverBundleFixture(),
-      currentChromePluginCodexAppServerRuntimeBundleFixture(),
-      currentChromePluginAppServerRuntimeBundleFixture(),
-    ].join(""),
-  );
-
-  assert.match(
-    patched,
-    /codexLinuxChromeNativeHostRuntimeEntry\(codexLinuxChromeNativeHostRuntimePath\(`codex`\),`linux-path`\)\?\?Wn/,
-  );
-  assert.match(patched, /_U\(e\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(`CODEX_CLI_PATH`\)\?\?codexLinuxChromeNativeHostRuntimePath\(`codex`\)/);
-  assert.match(patched, /ZB\(e\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(`CODEX_CLI_PATH`\)\?\?codexLinuxChromeNativeHostRuntimePath\(`codex`\)/);
-  assert.match(patched, /NM\(e\.resourcesPath\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(`CODEX_BROWSER_USE_NODE_PATH`\)/);
-  assert.equal((patched.match(/function codexLinuxChromeNativeHostRuntimeFile/g) || []).length, 1);
 });
 
 test("reports drifted Chrome native host runtime resolver as optional drift", () => {
@@ -8012,10 +7789,10 @@ test("reports drifted Chrome native host runtime resolver as optional drift", ()
     fs.mkdirSync(buildDir, { recursive: true });
     fs.writeFileSync(
       path.join(buildDir, "main.js"),
-      [
-        "let r=require(`node:path`),o=require(`node:fs`);",
-        "function Qp(e){throw Error(`Missing bundled Electron runtime required to sync Chrome native host resources for ${e.nativeHostName}.`)}",
-      ].join(""),
+      electron42BrowserUseRuntimeResolverBundleFixture().replace(
+        "resourcesPath:l}){let u=l??",
+        "resourcesPath:l}){const u=l??",
+      ),
     );
 
     const report = createPatchReport();

--- a/scripts/patches/impl/chrome-plugin.js
+++ b/scripts/patches/impl/chrome-plugin.js
@@ -5,11 +5,40 @@ const path = require("node:path");
 
 const {
   findMatchingBrace,
-  requireName,
 } = require("../lib/minified-js.js");
 const {
   readDirectoryNames,
 } = require("../lib/assets.js");
+
+const LINUX_CHROME_NATIVE_HOST_RUNTIME_HELPER =
+  "function codexLinuxChromeNativeHostRuntimeFile(e,t){if(process.platform!==`linux`||e==null)return null;for(let n of t){let t=(0,require(`node:path`).join)(e,...n);try{if((0,require(`node:fs`).statSync)(t).isFile())return t}catch{}}return null}" +
+  "function codexLinuxChromeNativeHostRuntimeEnv(e){if(process.platform!==`linux`)return null;let t=process.env[e];if(t==null||t.length===0)return null;try{return(0,require(`node:fs`).statSync)(t).isFile()?t:null}catch{return null}}" +
+  "function codexLinuxChromeNativeHostRuntimePath(e){if(process.platform!==`linux`)return null;for(let t of(process.env.PATH??``).split(`:`)){if(t.length===0)continue;let n=(0,require(`node:path`).join)(t,e);try{if((0,require(`node:fs`).statSync)(n).isFile())return n}catch{}}return null}" +
+  "function codexLinuxChromeNativeHostRuntimeEntry(e,t){return e==null?null:{path:e,source:t}}";
+
+const LINUX_CHROME_NATIVE_HOST_RUNTIME_MARKERS = [
+  "codexLinuxChromeNativeHostRuntimeEntry(codexLinuxChromeNativeHostRuntimePath(`codex`),`linux-path`)",
+  "`linux-node-runtime`",
+  "`linux-node-repl-runtime`",
+];
+
+function markerCount(source, marker) {
+  return source.split(marker).length - 1;
+}
+
+function hasCompleteLinuxChromeNativeHostRuntimePatch(source) {
+  return markerCount(source, LINUX_CHROME_NATIVE_HOST_RUNTIME_HELPER) === 1 &&
+    LINUX_CHROME_NATIVE_HOST_RUNTIME_MARKERS.every((marker) =>
+      markerCount(source, marker) === 1
+    );
+}
+
+function hasAnyLinuxChromeNativeHostRuntimeMarker(source) {
+  return source.includes("codexLinuxChromeNativeHostRuntime") ||
+    LINUX_CHROME_NATIVE_HOST_RUNTIME_MARKERS.some((marker) =>
+      source.includes(marker)
+    );
+}
 
 function applyLinuxChromePluginAutoInstallPatch(currentSource) {
   const gateRegex =
@@ -59,198 +88,39 @@ function applyLinuxChromePluginAutoInstallPatch(currentSource) {
 }
 
 function applyLinuxChromeNativeHostRuntimePatch(currentSource) {
-  if (
-    currentSource.includes("codexLinuxChromePluginAppServerSourcePath") &&
-    currentSource.includes("codexLinuxChromeNativeHostRuntimeFile")
-  ) {
+  if (hasCompleteLinuxChromeNativeHostRuntimePatch(currentSource)) {
     return currentSource;
   }
-
-  let helper = "";
-  if (!currentSource.includes("codexLinuxChromeNativeHostRuntimeFile")) {
-    const fsVar = requireName(currentSource, "node:fs");
-    const pathVar = requireName(currentSource, "node:path");
-    if (fsVar == null || pathVar == null) {
-      console.warn(
-        "WARN: Could not find fs/path aliases — skipping Linux Chrome native host runtime patch",
-      );
-      return currentSource;
-    }
-
-    helper =
-      `function codexLinuxChromeNativeHostRuntimeFile(e,t){if(process.platform!==\`linux\`||e==null)return null;for(let n of t){let t=(0,${pathVar}.join)(e,...n);try{if((0,${fsVar}.statSync)(t).isFile())return t}catch{}}return null}function codexLinuxChromeNativeHostRuntimeEnv(e){if(process.platform!==\`linux\`)return null;let t=process.env[e];if(t==null||t.length===0)return null;try{return(0,${fsVar}.statSync)(t).isFile()?t:null}catch{return null}}function codexLinuxChromeNativeHostRuntimePath(e){if(process.platform!==\`linux\`)return null;for(let t of(process.env.PATH??\`\`).split(\`:\`)){if(t.length===0)continue;let n=(0,${pathVar}.join)(t,e);try{if((0,${fsVar}.statSync)(n).isFile())return n}catch{}}return null}function codexLinuxChromeNativeHostRuntimeEntry(e,t){return e==null?null:{path:e,source:t}}`;
-  }
-
-  let patchedSource = currentSource;
-  let changed = false;
-  const takePatch = (nextSource) => {
-    if (nextSource == null || nextSource === patchedSource) {
-      return false;
-    }
-    patchedSource = nextSource;
-    helper = "";
-    changed = true;
-    return true;
-  };
-
-  const sourcePathPatched = applyLinuxChromePluginAppServerSourcePathPatch(patchedSource);
-  if (sourcePathPatched !== patchedSource) {
-    patchedSource = sourcePathPatched;
-    changed = true;
-  }
-  takePatch(applyModernChromeNativeHostRuntimePatch(patchedSource, helper));
-  takePatch(applyChromePluginCodexAppServerRuntimePatch(patchedSource, helper));
-  takePatch(applyChromePluginAppServerRuntimePatch(patchedSource, helper));
-  if (changed) {
-    return patchedSource;
-  }
-
-  const missingRuntimeMessage =
-    "Missing bundled Electron runtime required to sync Chrome native host resources";
-  if (
-    !currentSource.includes(missingRuntimeMessage) &&
-    !currentSource.includes("Missing bundled Electron Codex runtime required to sync Chrome plugin app server")
-  ) {
+  if (hasAnyLinuxChromeNativeHostRuntimeMarker(currentSource)) {
     console.warn(
-      "WARN: Could not find Chrome native host runtime resolver — skipping Linux runtime path patch",
+      "WARN: Found incomplete Chrome native host runtime patch — skipping Linux runtime path patch",
     );
     return currentSource;
   }
 
-  const appServerRuntimePatch = applyChromePluginAppServerRuntimePatch(
+  const patched = applyModernChromeNativeHostRuntimePatch(
     currentSource,
-    helper,
+    LINUX_CHROME_NATIVE_HOST_RUNTIME_HELPER,
   );
-  if (appServerRuntimePatch != null) {
-    return appServerRuntimePatch;
+  if (patched != null) {
+    return patched;
   }
 
-  const runtimeResolverRegex =
-    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\.resourcesPath\)\?\?([A-Za-z_$][\w$]*)\(\2\.devRuntimeRepoRoot,\[`extension`,`bin`,process\.platform===`win32`\?`codex\.exe`:`codex`\]\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\.resourcesPath\)\?\?\5\(\2\.devRuntimeRepoRoot,\[`electron`,`bin`,process\.platform===`win32`\?`node\.exe`:`node`\]\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\.resourcesPath\)\?\?\5\(\2\.devRuntimeRepoRoot,\[`electron`,`bin`,process\.platform===`win32`\?`node_repl\.exe`:`node_repl`\]\),/;
-  const match = currentSource.match(runtimeResolverRegex);
-  if (match != null) {
-    const [
-      originalPrefix,
-      resolverName,
-      configVar,
-      codexVar,
-      codexResourceFn,
-      devRuntimeFn,
-      nodeVar,
-      nodeResourceFn,
-      nodeReplVar,
-      nodeReplResourceFn,
-    ] = match;
-    const replacement =
-      `${helper}function ${resolverName}(${configVar}){let ${codexVar}=${codexResourceFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_CLI_PATH\`)??codexLinuxChromeNativeHostRuntimePath(\`codex\`)??${devRuntimeFn}(${configVar}.devRuntimeRepoRoot,[\`extension\`,\`bin\`,process.platform===\`win32\`?\`codex.exe\`:\`codex\`]),${nodeVar}=${nodeResourceFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_BROWSER_USE_NODE_PATH\`)??codexLinuxChromeNativeHostRuntimeEnv(\`NODE_REPL_NODE_PATH\`)??codexLinuxChromeNativeHostRuntimeFile(${configVar}.resourcesPath,[[\`node-runtime\`,\`bin\`,process.platform===\`win32\`?\`node.exe\`:\`node\`]])??${devRuntimeFn}(${configVar}.devRuntimeRepoRoot,[\`electron\`,\`bin\`,process.platform===\`win32\`?\`node.exe\`:\`node\`]),${nodeReplVar}=${nodeReplResourceFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_NODE_REPL_PATH\`)??codexLinuxChromeNativeHostRuntimeFile(${configVar}.resourcesPath,[[process.platform===\`win32\`?\`node_repl.exe\`:\`node_repl\`]])??${devRuntimeFn}(${configVar}.devRuntimeRepoRoot,[\`electron\`,\`bin\`,process.platform===\`win32\`?\`node_repl.exe\`:\`node_repl\`]),`;
-
-    return currentSource.replace(originalPrefix, replacement);
-  }
-
-  const currentRuntimeResolverRegex =
-    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\.resourcesPath\)\?\?([A-Za-z_$][\w$]*)\(\2\.devRuntimeRepoRoot,\[`extension`,`bin`,process\.platform===`win32`\?`codex\.exe`:`codex`\]\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\.resourcesPath\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\.resourcesPath\),/;
-  const currentMatch = currentSource.match(currentRuntimeResolverRegex);
-  if (currentMatch == null) {
+  if (
+    currentSource.includes("CODEX_BROWSER_USE_NODE_PATH") &&
+    currentSource.includes("nodeReplPathSource") &&
+    currentSource.includes("resolvePrimaryRuntimeNodePath")
+  ) {
     console.warn(
       "WARN: Could not identify Chrome native host runtime resolver shape — skipping Linux runtime path patch",
     );
     return currentSource;
   }
 
-  const [
-    originalPrefix,
-    resolverName,
-    configVar,
-    codexVar,
-    codexResourceFn,
-    devRuntimeFn,
-    nodeVar,
-    nodeResourceFn,
-    nodeReplVar,
-    nodeReplResourceFn,
-  ] = currentMatch;
-  const replacement =
-    `${helper}function ${resolverName}(${configVar}){let ${codexVar}=${codexResourceFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_CLI_PATH\`)??codexLinuxChromeNativeHostRuntimePath(\`codex\`)??${devRuntimeFn}(${configVar}.devRuntimeRepoRoot,[\`extension\`,\`bin\`,process.platform===\`win32\`?\`codex.exe\`:\`codex\`]),${nodeVar}=${nodeResourceFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_BROWSER_USE_NODE_PATH\`)??codexLinuxChromeNativeHostRuntimeEnv(\`NODE_REPL_NODE_PATH\`)??codexLinuxChromeNativeHostRuntimeFile(${configVar}.resourcesPath,[[\`node-runtime\`,\`bin\`,process.platform===\`win32\`?\`node.exe\`:\`node\`]])??${devRuntimeFn}(${configVar}.devRuntimeRepoRoot,[\`electron\`,\`bin\`,process.platform===\`win32\`?\`node.exe\`:\`node\`]),${nodeReplVar}=${nodeReplResourceFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_NODE_REPL_PATH\`)??codexLinuxChromeNativeHostRuntimeFile(${configVar}.resourcesPath,[[process.platform===\`win32\`?\`node_repl.exe\`:\`node_repl\`]])??${devRuntimeFn}(${configVar}.devRuntimeRepoRoot,[\`electron\`,\`bin\`,process.platform===\`win32\`?\`node_repl.exe\`:\`node_repl\`]),`;
-
-  return currentSource.replace(originalPrefix, replacement);
-}
-
-function applyLinuxChromePluginAppServerSourcePathPatch(currentSource) {
-  const marker = "codexLinuxChromePluginAppServerSourcePath";
-  const isolationRoot = currentSource.indexOf(".plugin-appserver");
-  if (currentSource.includes(marker) || isolationRoot === -1) {
-    return currentSource;
-  }
-
-  const isolationSource = currentSource.slice(isolationRoot, isolationRoot + 12_000);
-  const syncFunctionRegex =
-    /async function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{(?=let [A-Za-z_$][\w$]*=\2\.nativeHostName===)/;
-  const match = isolationSource.match(syncFunctionRegex);
-  if (match == null) {
-    console.warn(
-      "WARN: Could not find Chrome plugin app-server isolation function — Linux CLI path may not be relocatable",
-    );
-    return currentSource;
-  }
-
-  const [functionStart, , configVar] = match;
-  const helper = `function ${marker}(e){return e.codexCliPath}`;
-  const functionIndex = isolationRoot + match.index;
-  return currentSource.slice(0, functionIndex) +
-    `${helper}${functionStart}if(process.platform===\`linux\`)return ${marker}(${configVar});` +
-    currentSource.slice(functionIndex + functionStart.length);
-}
-
-function applyChromePluginCodexAppServerRuntimePatch(currentSource, helper) {
-  if (!currentSource.includes("Missing bundled Electron Codex runtime required to sync Chrome plugin app server")) {
-    return null;
-  }
-
-  const appServerCodexRuntimeRegex =
-    /async function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\);if\(\3==null\)throw Error\(`Missing bundled Electron Codex runtime required to sync Chrome plugin app server for \$\{\2\.nativeHostName\} \(resourcesPath: \$\{\2\.resourcesPath\?\?`<none>`\}\)\.`\);return ([A-Za-z_$][\w$]*)\(\{codexCliPath:\3,codexHome:\2\.codexHome,nativeHostName:\2\.nativeHostName\}\)\}/;
-  const match = currentSource.match(appServerCodexRuntimeRegex);
-  if (match == null) {
-    return null;
-  }
-
-  const [
-    original,
-    resolverFn,
-    configVar,
-    codexVar,
-    bundledCodexResolverFn,
-    syncFn,
-  ] = match;
-  const replacement =
-    `${helper}async function ${resolverFn}(${configVar}){let ${codexVar}=${bundledCodexResolverFn}(${configVar})??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_CLI_PATH\`)??codexLinuxChromeNativeHostRuntimePath(\`codex\`);if(${codexVar}==null)throw Error(\`Missing bundled Electron Codex runtime required to sync Chrome plugin app server for \${${configVar}.nativeHostName} (resourcesPath: \${${configVar}.resourcesPath??\`<none>\`}).\`);return ${syncFn}({codexCliPath:${codexVar},codexHome:${configVar}.codexHome,nativeHostName:${configVar}.nativeHostName})}`;
-  return currentSource.replace(original, replacement);
-}
-
-function applyChromePluginAppServerRuntimePatch(currentSource, helper) {
-  if (!currentSource.includes("nativeHostName") || !currentSource.includes("nodeModuleDirs")) {
-    return null;
-  }
-
-  const appServerRuntimeRegex =
-    /async function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\.resourcesPath\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\.resourcesPath\),/;
-  const match = currentSource.match(appServerRuntimeRegex);
-  if (match == null) {
-    return null;
-  }
-  const [
-    originalPrefix,
-    resolverFn,
-    configVar,
-    codexVar,
-    codexResolverFn,
-    nodeVar,
-    nodeResolverFn,
-    nodeReplVar,
-    nodeReplResolverFn,
-  ] = match;
-  const replacement =
-    `${helper}async function ${resolverFn}(${configVar}){let ${codexVar}=${codexResolverFn}(${configVar})??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_CLI_PATH\`)??codexLinuxChromeNativeHostRuntimePath(\`codex\`),${nodeVar}=${nodeResolverFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_BROWSER_USE_NODE_PATH\`)??codexLinuxChromeNativeHostRuntimeEnv(\`NODE_REPL_NODE_PATH\`)??codexLinuxChromeNativeHostRuntimeFile(${configVar}.resourcesPath,[[\`node-runtime\`,\`bin\`,process.platform===\`win32\`?\`node.exe\`:\`node\`]]),${nodeReplVar}=${nodeReplResolverFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_NODE_REPL_PATH\`)??codexLinuxChromeNativeHostRuntimeFile(${configVar}.resourcesPath,[[process.platform===\`win32\`?\`node_repl.exe\`:\`node_repl\`]]),`;
-  return currentSource.replace(originalPrefix, replacement);
+  console.warn(
+    "WARN: Could not find Chrome native host runtime resolver — skipping Linux runtime path patch",
+  );
+  return currentSource;
 }
 
 function applyModernChromeNativeHostRuntimePatch(currentSource, helper) {
@@ -301,25 +171,35 @@ function applyModernChromeNativeHostRuntimePatch(currentSource, helper) {
     (_match, prefix, resolverFn) =>
       `${prefix}codexLinuxChromeNativeHostRuntimeEntry(codexLinuxChromeNativeHostRuntimePath(\`codex\`),\`linux-path\`)??${resolverFn}({devRelativePathSegments:[\`extension\`,\`bin\`,\`codex\`]`,
   );
+  if (patchedResolver === resolverSource) {
+    return null;
+  }
+  const codexPatchedResolver = patchedResolver;
   patchedResolver = patchedResolver.replace(
     nodePathRegex,
     (_match, prefix, fallbackExpressionStart) =>
       `${prefix}codexLinuxChromeNativeHostRuntimeEntry(codexLinuxChromeNativeHostRuntimeFile(${resourcesVar},[[\`node-runtime\`,\`bin\`,${platformVar}===\`win32\`?\`node.exe\`:\`node\`]]),\`linux-node-runtime\`)??${fallbackExpressionStart}`,
   );
+  if (patchedResolver === codexPatchedResolver) {
+    return null;
+  }
+  const nodePatchedResolver = patchedResolver;
   patchedResolver = patchedResolver.replace(
     nodeReplPathRegex,
     (_match, prefix, resolverFn) =>
       `${prefix}codexLinuxChromeNativeHostRuntimeEntry(codexLinuxChromeNativeHostRuntimeFile(${resourcesVar},[[${platformVar}===\`win32\`?\`node_repl.exe\`:\`node_repl\`]]),\`linux-node-repl-runtime\`)??${resolverFn}({devRelativePathSegments:null`,
   );
-
-  if (patchedResolver === resolverSource) {
+  if (patchedResolver === nodePatchedResolver) {
     return null;
   }
 
-  return currentSource.slice(0, functionStart) +
+  const patchedSource = currentSource.slice(0, functionStart) +
     helper +
     patchedResolver +
     currentSource.slice(functionEnd + 1);
+  return hasCompleteLinuxChromeNativeHostRuntimePatch(patchedSource)
+    ? patchedSource
+    : null;
 }
 
 function patchLinuxChromeNativeHostRuntimeAssets(extractedDir) {
@@ -336,8 +216,7 @@ function patchLinuxChromeNativeHostRuntimeAssets(extractedDir) {
     const filePath = path.join(buildDir, fileName);
     const source = fs.readFileSync(filePath, "utf8");
     if (
-      !source.includes("Missing bundled Electron runtime required to sync Chrome native host resources") &&
-      !source.includes("codexLinuxChromeNativeHostRuntimeFile") &&
+      !source.includes("codexLinuxChromeNativeHostRuntime") &&
       !(
         source.includes("CODEX_BROWSER_USE_NODE_PATH") &&
         source.includes("nodeReplPathSource") &&

--- a/scripts/patches/impl/keybinds-settings.js
+++ b/scripts/patches/impl/keybinds-settings.js
@@ -22,6 +22,9 @@ const linuxDesktopSettingsAsset = "linux-desktop-settings-linux.js";
 const linuxKeybindOverridesKey = "codex-linux-keybind-overrides";
 const linuxReactRuntimeExport = "codexLinuxReact";
 const linuxJsxRuntimeExport = "codexLinuxJsx";
+const linuxDesktopSettingsSourceVersion = 1;
+const linuxDesktopSettingsSourceMarker =
+  `var codexLinuxDesktopSettingsVersion=${linuxDesktopSettingsSourceVersion},KEYS={`;
 
 function versionedAssetSpecifier(assetName, source) {
   const digest = crypto.createHash("sha256").update(source).digest("hex").slice(0, 12);
@@ -501,7 +504,10 @@ function resolveLinuxDesktopSettingsAsset(extractedDir) {
     includeHotkeySettings: false,
   });
 
-  const source = buildLinuxDesktopSettingsSource(dependencies);
+  const source = buildLinuxDesktopSettingsSource(dependencies).replace(
+    "var KEYS={",
+    linuxDesktopSettingsSourceMarker,
+  );
   return {
     filePath: path.join(webviewAssetsDir, linuxDesktopSettingsAsset),
     source,
@@ -803,6 +809,27 @@ function applyCollectedAssetPatchWrites(patches) {
   return changed;
 }
 
+function selectLinuxDesktopSettingsSource(previousSource, generatedSource) {
+  if (
+    previousSource == null ||
+    !previousSource.includes("codexLinuxDesktopSettingsVersion")
+  ) {
+    return generatedSource;
+  }
+
+  const markerCount =
+    previousSource.split(linuxDesktopSettingsSourceMarker).length - 1;
+  const markerPrefixCount =
+    previousSource.split("codexLinuxDesktopSettingsVersion=").length - 1;
+  if (markerCount === 1 && markerPrefixCount === 1) {
+    return previousSource;
+  }
+
+  throw new Error(
+    "Required Keybinds settings patch failed: generated Linux desktop settings marker is stale or incomplete",
+  );
+}
+
 function patchKeybindsSettingsAssets(extractedDir) {
   try {
     if (!hasNativeKeyboardShortcutsSettings(extractedDir)) {
@@ -814,6 +841,10 @@ function patchKeybindsSettingsAssets(extractedDir) {
     const previousSettingsSource = settingsAssetExists
       ? fs.readFileSync(settingsAsset.filePath, "utf8")
       : null;
+    const nextSettingsSource = selectLinuxDesktopSettingsSource(
+      previousSettingsSource,
+      settingsAsset.source,
+    );
     // Treat generated updates as patches so a route bundle can receive both
     // the runtime exports and the Linux route insertion without one write
     // overwriting the other.
@@ -852,8 +883,8 @@ function patchKeybindsSettingsAssets(extractedDir) {
       ),
     ];
 
-    fs.writeFileSync(settingsAsset.filePath, settingsAsset.source, "utf8");
-    let changed = previousSettingsSource !== settingsAsset.source ? 1 : 0;
+    fs.writeFileSync(settingsAsset.filePath, nextSettingsSource, "utf8");
+    let changed = previousSettingsSource !== nextSettingsSource ? 1 : 0;
     changed += applyCollectedAssetPatchWrites(patches);
     return {
       matched: true,

--- a/scripts/patches/impl/main-process/browser.js
+++ b/scripts/patches/impl/main-process/browser.js
@@ -496,10 +496,29 @@ function buildLinuxExternalOpenHelpers() {
 }
 
 function applyLinuxExternalOpenEnvPatch(currentSource) {
-  const hasHelper = currentSource.includes("function codexLinuxPatchExternalOpen(");
-  const hasPatchedElectronRequire = /codexLinuxPatchExternalOpen\(require\(([`'"])electron\1\)\)/.test(
-    currentSource,
-  );
+  const helperPayload = buildLinuxExternalOpenHelpers();
+  const helperCount = currentSource.split(helperPayload).length - 1;
+  const patchedElectronRequireCount = [
+    ...currentSource.matchAll(
+      /codexLinuxPatchExternalOpen\(require\(([`'"])electron\1\)\)/g,
+    ),
+  ].length;
+  const hasAnyPatchArtifact =
+    currentSource.includes("codexLinuxExternalOpenEnv")
+    || currentSource.includes("codexLinuxLaunchExternalUrl")
+    || currentSource.includes("codexLinuxOpenExternalWithFallback")
+    || currentSource.includes("codexLinuxPatchExternalOpen")
+    || patchedElectronRequireCount > 0;
+  if (hasAnyPatchArtifact) {
+    if (helperCount === 1 && patchedElectronRequireCount > 0) {
+      return currentSource;
+    }
+    console.warn(
+      "WARN: Found incomplete Linux external open environment patch — skipping",
+    );
+    return currentSource;
+  }
+
   let patchedAnyElectronRequire = false;
   const patchedSource = currentSource.replace(
     /([A-Za-z_$][\w$]*=)require\(([`'"])electron\2\)/g,
@@ -510,16 +529,10 @@ function applyLinuxExternalOpenEnvPatch(currentSource) {
   );
 
   if (!patchedAnyElectronRequire) {
-    if (!(hasHelper && hasPatchedElectronRequire)) {
-      console.warn(
-        "WARN: Could not find Electron require initializer — skipping Linux external open environment patch",
-      );
-    }
+    console.warn(
+      "WARN: Could not find Electron require initializer — skipping Linux external open environment patch",
+    );
     return currentSource;
-  }
-
-  if (hasHelper) {
-    return patchedSource;
   }
 
   const strictDirective = '"use strict";';
@@ -528,7 +541,7 @@ function applyLinuxExternalOpenEnvPatch(currentSource) {
     : 0;
   return (
     patchedSource.slice(0, helperInsertionIndex) +
-    buildLinuxExternalOpenHelpers() +
+    helperPayload +
     patchedSource.slice(helperInsertionIndex)
   );
 }

--- a/scripts/patches/impl/main-process/browser.test.js
+++ b/scripts/patches/impl/main-process/browser.test.js
@@ -108,6 +108,50 @@ test("Linux external open env patch is idempotent", () => {
   assert.equal(second, first, "second application should not change the source");
 });
 
+test("Linux external open env patch ignores feature-owned Electron requires after its complete marker", () => {
+  const source = '"use strict";let e=require("electron");';
+  const patched = applyLinuxExternalOpenEnvPatch(source);
+  const composed =
+    `${patched}function featureRuntime(){let featureElectron=require(\`electron\`);return featureElectron.app}`;
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => warnings.push(message);
+  try {
+    assert.equal(applyLinuxExternalOpenEnvPatch(composed), composed);
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.deepEqual(warnings, []);
+  assert.match(composed, /featureElectron=require\(`electron`\)/);
+});
+
+test("Linux external open env patch rejects partial marker states byte-identically", () => {
+  const complete = applyLinuxExternalOpenEnvPatch(
+    '"use strict";let e=require("electron");',
+  );
+  const variants = [
+    '"use strict";function codexLinuxPatchExternalOpen(e){return e}let featureElectron=require(`electron`);',
+    '"use strict";let e=codexLinuxPatchExternalOpen(require(`electron`));',
+    complete.replace("return __codexEnv}", "return process.env}"),
+    complete + complete,
+  ];
+
+  for (const source of variants) {
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (message) => warnings.push(message);
+    try {
+      assert.equal(applyLinuxExternalOpenEnvPatch(source), source);
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert.deepEqual(warnings, [
+      "WARN: Found incomplete Linux external open environment patch — skipping",
+    ]);
+  }
+});
+
 test("Linux external open env patch warns when no electron require found", () => {
   const source = '"use strict";const fs=require("node:fs");';
   const warnings = [];

--- a/scripts/patches/impl/main-process/window.js
+++ b/scripts/patches/impl/main-process/window.js
@@ -161,6 +161,45 @@ function findMinifiedMethod(source, signatureRegex) {
   };
 }
 
+function hasLinuxTitlebarWithoutOverlayComposition(
+  source,
+  helperFunctionRegex,
+) {
+  if (!helperFunctionRegex.test(source)) {
+    return false;
+  }
+
+  const primaryTitlebarRegex =
+    /case`quickChat`:case`primary`:return [^;]{0,2000}?([A-Za-z_$][\w$]*)===`win32`\?\{titleBarStyle:`hidden`,titleBarOverlay:([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\),\.\.\.([A-Za-z_$][\w$]*)===`quickChat`\?\{resizable:!0\}:\{\}\}:\1===`linux`\?\{titleBarStyle:`hidden`,\.\.\.\4===`quickChat`\?\{resizable:!0\}:\{\}\}:/;
+  if (!primaryTitlebarRegex.test(source)) {
+    return false;
+  }
+
+  const zoomMethod = findMinifiedMethod(
+    source,
+    /setWindowZoom\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{/,
+  );
+  const zoomRegex =
+    /process\.platform===`win32`&&\(this\.windowZooms\.set\(([A-Za-z_$][\w$]*)\.id,([A-Za-z_$][\w$]*)\),\1\.setTitleBarOverlay\(([A-Za-z_$][\w$]*)\(\2\)\)\)/;
+  if (zoomMethod != null && !zoomRegex.test(zoomMethod.text)) {
+    return false;
+  }
+
+  const overlaySyncMethod = findMinifiedMethod(
+    source,
+    /installApplicationMenuTitleBarOverlaySync\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{/,
+  );
+  const overlaySyncRegex =
+    /installApplicationMenuTitleBarOverlaySync\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{if\(process\.platform!==`win32`\|\|\2!==`primary`&&\2!==`quickChat`\)return;let ([A-Za-z_$][\w$]*)=\(\)=>\{\1\.isDestroyed\(\)\|\|\1\.setTitleBarOverlay\(([A-Za-z_$][\w$]*)\(this\.windowZooms\.get\(\1\.id\)\)\)\}/;
+  if (overlaySyncMethod != null && !overlaySyncRegex.test(overlaySyncMethod.text)) {
+    return false;
+  }
+
+  return !source.includes(
+    `setTitleBarOverlay(process.platform===\`linux\`?${LINUX_TITLEBAR_OVERLAY_HELPER}(`,
+  );
+}
+
 function applyLinuxNativeTitlebarPatch(currentSource) {
   const helperFunctionRegex = new RegExp(
     'function ' +
@@ -177,6 +216,14 @@ function applyLinuxNativeTitlebarPatch(currentSource) {
   const primaryTitlebarMatch = currentSource.match(primaryTitlebarRegex);
   const patchedPrimaryTitlebarMatch = currentSource.match(patchedPrimaryTitlebarRegex);
   if (primaryTitlebarMatch == null && patchedPrimaryTitlebarMatch == null) {
+    if (
+      hasLinuxTitlebarWithoutOverlayComposition(
+        currentSource,
+        helperFunctionRegex,
+      )
+    ) {
+      return currentSource;
+    }
     console.warn("WARN: Could not find primary BrowserWindow titlebar snippet — skipping Linux native titlebar patch");
     return currentSource;
   }

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -184,9 +184,56 @@ function applyLinuxHeaderSlotSafeAreaPatch(currentSource) {
     .replace(slotSource, patchedSlotSource);
 }
 
+function matchesFramelessWindowControlsSafeAreaComposition(currentSource) {
+  const prop = LINUX_WINDOW_CONTROLS_SAFE_AREA_PROP;
+  const overrideMatches = currentSource.match(
+    new RegExp(`${prop}:!1,side:\`end\``, "gu"),
+  ) ?? [];
+  if (overrideMatches.length === 0) {
+    return null;
+  }
+
+  const insetMatches = [
+    ...currentSource.matchAll(
+      /applicationMenu:Object\.freeze\(\{left:0,right:(\d+)\}\)/gu,
+    ),
+  ];
+  const slotSignatureMatches = currentSource.match(
+    new RegExp(
+      `function [A-Za-z_$][\\w$]*\\(\\{entries:[A-Za-z_$][\\w$]*,fitWidth:[A-Za-z_$][\\w$]*,side:[A-Za-z_$][\\w$]*,slotWidth:[A-Za-z_$][\\w$]*,${prop}\\}\\)`,
+      "gu",
+    ),
+  ) ?? [];
+  const paddingMatches = currentSource.match(
+    new RegExp(
+      `"pe-2":([A-Za-z_$][\\w$]*)===\`start\`&&[A-Za-z_$][\\w$]*\\|\\|\\1===\`end\`&&!${prop},"pe-\\(--spacing-token-safe-header-right\\)":\\1===\`end\`&&${prop}`,
+      "gu",
+    ),
+  ) ?? [];
+
+  return (
+    overrideMatches.length === 1 &&
+    insetMatches.length > 0 &&
+    insetMatches.every((match) => match[1] === "0") &&
+    slotSignatureMatches.length === 1 &&
+    paddingMatches.length === 1
+  );
+}
+
 function applyLinuxWindowControlsSafeAreaPatch(currentSource) {
   const currentInset = `applicationMenu:Object.freeze({left:0,right:${LINUX_WINDOW_CONTROLS_SAFE_AREA_RIGHT}})`;
   const defaultInset = "applicationMenu:Object.freeze({left:0,right:0})";
+  const framelessComposition =
+    matchesFramelessWindowControlsSafeAreaComposition(currentSource);
+  if (framelessComposition === true) {
+    return currentSource;
+  }
+  if (framelessComposition === false) {
+    console.warn(
+      "WARN: Could not validate frameless Linux window-controls safe-area composition — leaving asset unchanged",
+    );
+    return currentSource;
+  }
 
   let patchedSource = currentSource;
   if (patchedSource.includes(defaultInset)) {


### PR DESCRIPTION
## Summary

- make the current-DMG core and enabled Linux feature patches recognize complete composed markers on a second descriptor pass
- fail closed on incomplete/partial composition without modifying the asset
- preserve codex-wrapper-updater settings extensions when the core settings generator runs again
- add composition regressions across external-open, native titlebar, frameless titlebar, Chrome runtime, Record & Replay, and generated settings paths

## Root cause

Independent descriptors could each be idempotent alone while a later descriptor saw an earlier descriptor's injected helper or marker as an upstream shape. That made a full second pass modify the generated asset or overwrite a feature-owned settings extension.

## Current upstream and candidate

- Base: origin/main@042adb7b23b1f47ca8d6a09da0b1abc5e00ff4a7
- ChatGPT Desktop: 26.721.81911
- Electron: 42.3.0
- DMG SHA-256: 7b3722e4f5864202b1dd69e6e6062f2f8c4388d215091503c73e1957b4cbf97a
- Isolated ten-feature candidate verdict: accepted_with_warnings
- The only candidate warning is the existing optional linux-bundled-plugin-copy-permissions drift.

## Validation

- TMPDIR=/tmp node --test scripts/patch-linux-window-ui.test.js
- TMPDIR=/tmp node --test linux-features/*/test.js
- bash tests/scripts_smoke.sh
- syntax checks for every changed JavaScript source file
- full second pass over the already extracted accepted candidate with the preserved ten-feature configuration:
  - 135/135 descriptors covered (83 core, 52 feature)
  - 134 already-applied, 0 applied
  - the only skipped-optional is linux-bundled-plugin-copy-permissions
  - complete extracted-tree SHA-256 manifest unchanged before/after
  - source app.asar SHA-256 unchanged before/after

## Scope and overlap

This PR changes source patch implementations and tests only; it does not modify a generated app, package payload, updater state, or the daily driver.

PR #1180 also touches adjacent main-process titlebar code for a separate context-menu fix. This draft is intentionally based on the same current main and should be rebased after #1180 if that PR lands first.