### PR TITLE
fix Codex Micro hot-plug discovery

### DIFF
--- a/linux-features/codex-micro/README.md
+++ b/linux-features/codex-micro/README.md
@@ -1,14 +1,30 @@
 # Codex Micro
 
 This opt-in Linux feature enables the Work Louder Codex Micro integration that
-already ships in the upstream Codex desktop app. It does two narrowly scoped
+already ships in the upstream Codex desktop app. It does three narrowly scoped
 things:
 
 1. enables the upstream Codex Micro feature gate locally; and
 2. adds the verified `node-hid@3.3.0` Linux prebuild for the current app's
-   nested Work Louder dependency.
+   nested Work Louder dependency; and
+3. watches Linux `hidraw` topology so a Micro connected after ChatGPT starts is
+   discovered without restarting the app.
 
 The feature is disabled by default.
+
+## Hot-plug discovery
+
+The upstream service uses a native HID topology watcher that is not available
+in the Linux build. Without a replacement, discovery falls back to a 30-second
+scan and a newly connected device can appear to require an app restart.
+
+On Linux, this feature watches `/dev` for `hidraw` additions and removals,
+debounces duplicate events, and asks the existing service to reconcile device
+topology. If the filesystem watcher cannot start or reports an error, a
+two-second unreferenced polling fallback takes over. The service's existing
+settle retries still handle the short delay between device-node creation and
+udev ACL application. Disconnecting or disabling the feature disposes the
+watcher and any fallback timer.
 
 ## Enable
 

--- a/linux-features/codex-micro/patch.js
+++ b/linux-features/codex-micro/patch.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const childProcess = require("node:child_process");
+const fs = require("node:fs");
 const path = require("node:path");
 
 const {
@@ -11,8 +12,16 @@ const {
 const CODEX_MICRO_GATE_ID = "3207467860";
 const CODEX_MICRO_ROUTE = "/settings/codex-micro";
 const CODEX_MICRO_GATE_MARKER = "codexLinuxCodexMicroGateOverride";
+const CODEX_MICRO_HOTPLUG_MARKER = "codexLinuxCodexMicroHotplug";
 const FEATURE_GATE_WARNING = "useFeatureGate hook failed to find a valid StatsigClient";
 const JS_IDENT = "[A-Za-z_$][\\w$]*";
+const CODEX_MICRO_SERVICE_PATTERN =
+  /^codex-micro-service-[A-Za-z0-9_-]+\.js$/;
+const WATCH_TOPOLOGY_FUNCTION = new RegExp(
+  `function (${JS_IDENT})\\((${JS_IDENT})\\)\\{return ` +
+    `(${JS_IDENT})\\(\\)\\.watch\\(\\2\\)\\}`,
+  "g",
+);
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -101,6 +110,161 @@ function applyCodexMicroFeatureGatePatch(source) {
   return source.replace(hook.source, replacement);
 }
 
+function hasCodexMicroServiceContract(source) {
+  return typeof source === "string"
+    && source.includes("hid-topology-watcher.node")
+    && source.includes("hid_topology_watcher.node")
+    && source.includes(".findCodexMicroInterfaces()")
+    && source.includes("scheduleTopologyFallbackScan()");
+}
+
+function codexMicroTopologyWatcher(source) {
+  if (!hasCodexMicroServiceContract(source)) {
+    return null;
+  }
+  WATCH_TOPOLOGY_FUNCTION.lastIndex = 0;
+  const matches = [...source.matchAll(WATCH_TOPOLOGY_FUNCTION)]
+    .filter((match) =>
+      source.includes(`${match[3]}().findCodexMicroInterfaces()`),
+    );
+  if (matches.length !== 1) {
+    return null;
+  }
+  const [match] = matches;
+  return {
+    source: match[0],
+    functionName: match[1],
+    callbackName: match[2],
+    loaderName: match[3],
+  };
+}
+
+function patchCodexMicroHotplugSource(source) {
+  const markerCount = source.split(CODEX_MICRO_HOTPLUG_MARKER).length - 1;
+  if (markerCount === 1) {
+    return { source, matched: 1, changed: 0, reason: null };
+  }
+  if (markerCount !== 0) {
+    return {
+      source,
+      matched: 0,
+      changed: 0,
+      reason: `Found ${markerCount} Codex Micro hot-plug markers`,
+    };
+  }
+
+  const watcher = codexMicroTopologyWatcher(source);
+  if (watcher == null) {
+    return {
+      source,
+      matched: 0,
+      changed: 0,
+      reason: "Current Codex Micro topology watcher contract not found",
+    };
+  }
+
+  const replacement =
+    `function ${watcher.functionName}(${watcher.callbackName}){` +
+    `if(process.platform===\`linux\`){` +
+    `let codexLinuxHotplugTimer=null,codexLinuxDevWatcher=null,` +
+    `codexLinuxPollTimer=null,codexLinuxDisposed=!1,` +
+    `codexLinuxNotify=()=>{if(codexLinuxDisposed)return;` +
+    `codexLinuxHotplugTimer!=null&&` +
+    `clearTimeout(codexLinuxHotplugTimer),codexLinuxHotplugTimer=setTimeout(()=>{` +
+    `codexLinuxHotplugTimer=null,codexLinuxDisposed||` +
+    `${watcher.callbackName}()},100)},codexLinuxStartPolling=()=>{` +
+    `codexLinuxPollTimer==null&&(codexLinuxPollTimer=` +
+    `setInterval(codexLinuxNotify,2e3),codexLinuxPollTimer.unref?.())};` +
+    `try{codexLinuxDevWatcher=require(\`node:fs\`).watch(` +
+    `\`/dev\`,{persistent:!1},(eventType,filename)=>{` +
+    `(filename==null||/^hidraw[0-9]+$/.test(String(filename)))&&` +
+    `codexLinuxNotify()}),codexLinuxDevWatcher.on(\`error\`,()=>{` +
+    `if(codexLinuxDisposed)return;` +
+    `codexLinuxDevWatcher?.close(),codexLinuxDevWatcher=null,` +
+    `codexLinuxStartPolling(),codexLinuxNotify()})}catch{` +
+    `codexLinuxDisposed||(` +
+    `codexLinuxStartPolling(),codexLinuxNotify())}` +
+    `return{dispose(){codexLinuxDisposed=!0,` +
+    `codexLinuxHotplugTimer!=null&&clearTimeout(codexLinuxHotplugTimer),` +
+    `codexLinuxPollTimer!=null&&clearInterval(codexLinuxPollTimer),` +
+    `codexLinuxDevWatcher?.close(),` +
+    `codexLinuxDevWatcher=null}}}` +
+    `return ${watcher.loaderName}().watch(${watcher.callbackName})}` +
+    `/*${CODEX_MICRO_HOTPLUG_MARKER}*/`;
+  return {
+    source: source.replace(watcher.source, replacement),
+    matched: 1,
+    changed: 1,
+    reason: null,
+  };
+}
+
+function applyCodexMicroHotplugPatch(source) {
+  if (typeof source !== "string") {
+    return source;
+  }
+  return patchCodexMicroHotplugSource(source).source;
+}
+
+function findCodexMicroServiceBundle(extractedDir) {
+  const buildDir = path.join(extractedDir, ".vite", "build");
+  if (!fs.existsSync(buildDir)) {
+    return {
+      target: null,
+      result: null,
+      reason: ".vite/build directory not found",
+    };
+  }
+
+  const candidates = fs.readdirSync(buildDir, { withFileTypes: true })
+    .filter((entry) =>
+      entry.isFile() && CODEX_MICRO_SERVICE_PATTERN.test(entry.name),
+    )
+    .map((entry) => path.join(buildDir, entry.name))
+    .sort()
+    .map((bundlePath) => {
+      const source = fs.readFileSync(bundlePath, "utf8");
+      return {
+        bundlePath,
+        result: patchCodexMicroHotplugSource(source),
+      };
+    })
+    .filter(({ result }) => result.matched === 1);
+
+  if (candidates.length !== 1) {
+    return {
+      target: null,
+      result: null,
+      reason:
+        `Found ${candidates.length} current Codex Micro service bundles`,
+    };
+  }
+  return {
+    target: candidates[0].bundlePath,
+    result: candidates[0].result,
+    reason: candidates[0].result.reason,
+  };
+}
+
+function patchCodexMicroService(extractedDir) {
+  const discovery = findCodexMicroServiceBundle(extractedDir);
+  if (discovery.target == null || discovery.result?.matched !== 1) {
+    const reason =
+      discovery.reason ?? "Current Codex Micro service bundle not found";
+    console.warn(`WARN: ${reason} - skipping Linux Codex Micro hot-plug patch`);
+    return { matched: 0, changed: 0, reason };
+  }
+  if (discovery.result.changed === 1) {
+    fs.writeFileSync(discovery.target, discovery.result.source, "utf8");
+  }
+  return {
+    matched: discovery.result.matched,
+    changed: discovery.result.changed,
+    reason: discovery.result.reason,
+    target: path.relative(extractedDir, discovery.target),
+  };
+}
+
 function stageNativeBinding(extractedDir) {
   const helper = path.join(__dirname, "native-binding.js");
   const output = childProcess.execFileSync(process.execPath, [helper, "--stage", extractedDir], {
@@ -114,12 +278,36 @@ function stageNativeBinding(extractedDir) {
 module.exports = {
   CODEX_MICRO_GATE_ID,
   CODEX_MICRO_GATE_MARKER,
+  CODEX_MICRO_HOTPLUG_MARKER,
   CODEX_MICRO_ROUTE,
   applyCodexMicroFeatureGatePatch,
+  applyCodexMicroHotplugPatch,
+  codexMicroTopologyWatcher,
   exportedFeatureGateHook,
+  findCodexMicroServiceBundle,
   hasCodexMicroCallsite,
+  hasCodexMicroServiceContract,
   matchesCodexMicroFeatureGateContract,
+  patchCodexMicroHotplugSource,
+  patchCodexMicroService,
   descriptors: [
+    extractedAppPatch({
+      id: "linux-hid-hotplug",
+      phase: "extracted-app:pre-webview",
+      order: 28_980,
+      ciPolicy: "opt-in",
+      targetSummary: "current Codex Micro main-process service bundle",
+      apply: patchCodexMicroService,
+      status: (result, warnings) => {
+        if (result?.matched !== 1) {
+          return {
+            status: "skipped-optional",
+            reason: result?.reason ?? warnings[0] ?? null,
+          };
+        }
+        return result.changed === 1 ? "applied" : "already-applied";
+      },
+    }),
     webviewAssetPatch({
       id: "webview-feature-gate",
       order: 28_990,

--- a/linux-features/codex-micro/test.js
+++ b/linux-features/codex-micro/test.js
@@ -18,11 +18,15 @@ const {
 const {
   CODEX_MICRO_GATE_ID,
   CODEX_MICRO_GATE_MARKER,
+  CODEX_MICRO_HOTPLUG_MARKER,
   CODEX_MICRO_ROUTE,
   applyCodexMicroFeatureGatePatch,
+  applyCodexMicroHotplugPatch,
   descriptors,
   exportedFeatureGateHook,
+  findCodexMicroServiceBundle,
   matchesCodexMicroFeatureGateContract,
+  patchCodexMicroService,
 } = require("./patch.js");
 const {
   enabledLinuxFeaturePackageDependencies,
@@ -208,6 +212,121 @@ function currentFeatureGateFixture() {
   ].join("");
 }
 
+function currentCodexMicroServiceFixture() {
+  return [
+    "const fs=require(\"node:fs\");",
+    "var nativeName=`hid-topology-watcher.node`,bindingName=`hid_topology_watcher.node`;",
+    "function p(){return require(bindingName)}",
+    "function d(e){return p().watch(e)}",
+    "function f(){return p().findCodexMicroInterfaces()}",
+    "class CodexMicroService{",
+    "start(){try{this.watcher=d(()=>this.handleHidTopologyChanged())}",
+    "catch(error){this.scheduleTopologyFallbackScan()}}",
+    "handleHidTopologyChanged(){this.requestTopologyReconciliation()}",
+    "scheduleTopologyFallbackScan(){this.timer=setTimeout(()=>this.scan(),3e4)}",
+    "}",
+  ].join("");
+}
+
+function evaluatePatchedTopologyWatcher(options = {}) {
+  const source = applyCodexMicroHotplugPatch(currentCodexMicroServiceFixture());
+  const devWatchers = [];
+  const nativeWatchCalls = [];
+  const timeouts = new Map();
+  const intervals = new Map();
+  let nextTimerId = 1;
+
+  const makeTimer = (kind, callback, delay) => {
+    const timer = {
+      id: nextTimerId++,
+      kind,
+      unreferenced: false,
+      unref() {
+        this.unreferenced = true;
+      },
+    };
+    (kind === "timeout" ? timeouts : intervals).set(timer, {
+      callback,
+      delay,
+    });
+    return timer;
+  };
+  const fakeFs = {
+    watch(target, watchOptions, listener) {
+      if (options.watchError != null) {
+        throw options.watchError;
+      }
+      const events = new Map();
+      const watcher = {
+        closeCount: 0,
+        close() {
+          this.closeCount += 1;
+        },
+        on(name, callback) {
+          events.set(name, callback);
+          return this;
+        },
+      };
+      devWatchers.push({ target, watchOptions, listener, events, watcher });
+      return watcher;
+    },
+  };
+  const nativeHandle = { dispose() {} };
+  const nativeBinding = {
+    findCodexMicroInterfaces() {
+      return [];
+    },
+    watch(callback) {
+      nativeWatchCalls.push(callback);
+      return nativeHandle;
+    },
+  };
+  const fakeRequire = (request) => {
+    if (request === "node:fs") {
+      return fakeFs;
+    }
+    if (request === "hid_topology_watcher.node") {
+      return nativeBinding;
+    }
+    throw new Error(`Unexpected fixture require: ${request}`);
+  };
+  const topologyWatcher = new Function(
+    "require",
+    "process",
+    "setTimeout",
+    "clearTimeout",
+    "setInterval",
+    "clearInterval",
+    `${source};return d;`,
+  )(
+    fakeRequire,
+    { platform: options.platform ?? "linux" },
+    (callback, delay) => makeTimer("timeout", callback, delay),
+    (timer) => timeouts.delete(timer),
+    (callback, delay) => makeTimer("interval", callback, delay),
+    (timer) => intervals.delete(timer),
+  );
+
+  return {
+    devWatchers,
+    intervals,
+    nativeHandle,
+    nativeWatchCalls,
+    timeouts,
+    topologyWatcher,
+  };
+}
+
+function runOnlyTimer(timers) {
+  assert.equal(timers.size, 1);
+  const [timer, entry] = timers.entries().next().value;
+  if (timer.kind === "timeout") {
+    timers.delete(timer);
+  }
+  entry.callback();
+  return { timer, delay: entry.delay };
+}
+
 test("Codex Micro locally enables only its current upstream feature gate", () => {
   const source = currentFeatureGateFixture();
   const hook = exportedFeatureGateHook(source);
@@ -231,6 +350,123 @@ test("Codex Micro locally enables only its current upstream feature gate", () =>
   );
   assert.equal(applyCodexMicroFeatureGatePatch(patched), patched);
   assert.equal(matchesCodexMicroFeatureGateContract(patched), true);
+});
+
+test("Codex Micro service patch adds disposable Linux hidraw hot-plug discovery", () => {
+  const source = currentCodexMicroServiceFixture();
+  const patched = applyCodexMicroHotplugPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, new RegExp(CODEX_MICRO_HOTPLUG_MARKER));
+  assert.match(patched, /process\.platform===`linux`/);
+  assert.match(patched, /require\(`node:fs`\)\.watch\(`\/dev`/);
+  assert.match(patched, /\^hidraw/);
+  assert.match(patched, /dispose\(\)/);
+  assert.match(patched, /setInterval\(codexLinuxNotify,2e3\)/);
+  assert.match(patched, /clearInterval\(codexLinuxPollTimer\)/);
+  assert.match(patched, /if\(codexLinuxDisposed\)return/);
+  assert.match(patched, /return p\(\)\.watch\(e\)/);
+  assert.doesNotMatch(patched, /function d\(e\)\{[^}]*let e=/);
+  assert.doesNotThrow(() => new Function(patched));
+  assert.equal(applyCodexMicroHotplugPatch(patched), patched);
+});
+
+test("Codex Micro Linux hot-plug watcher filters, debounces, and disposes", () => {
+  const runtime = evaluatePatchedTopologyWatcher();
+  let notifications = 0;
+  const handle = runtime.topologyWatcher(() => {
+    notifications += 1;
+  });
+
+  assert.equal(runtime.nativeWatchCalls.length, 0);
+  assert.equal(runtime.devWatchers.length, 1);
+  const devWatcher = runtime.devWatchers[0];
+  assert.equal(devWatcher.target, "/dev");
+  assert.deepEqual(devWatcher.watchOptions, { persistent: false });
+
+  devWatcher.listener("rename", "event0");
+  assert.equal(runtime.timeouts.size, 0);
+  devWatcher.listener("rename", "hidraw7");
+  assert.equal(runOnlyTimer(runtime.timeouts).delay, 100);
+  assert.equal(notifications, 1);
+
+  devWatcher.listener("change", null);
+  assert.equal(runtime.timeouts.size, 1);
+  handle.dispose();
+  assert.equal(runtime.timeouts.size, 0);
+  assert.equal(runtime.intervals.size, 0);
+  assert.equal(devWatcher.watcher.closeCount, 1);
+
+  devWatcher.events.get("error")(new Error("late watcher error"));
+  assert.equal(runtime.intervals.size, 0);
+  assert.equal(notifications, 1);
+});
+
+test("Codex Micro Linux hot-plug watcher polls only after watch failure", () => {
+  const runtime = evaluatePatchedTopologyWatcher({
+    watchError: new Error("watch unavailable"),
+  });
+  let notifications = 0;
+  const handle = runtime.topologyWatcher(() => {
+    notifications += 1;
+  });
+
+  assert.equal(runtime.devWatchers.length, 0);
+  assert.equal(runtime.intervals.size, 1);
+  const [interval] = runtime.intervals.keys();
+  assert.equal(interval.unreferenced, true);
+  assert.equal(runOnlyTimer(runtime.timeouts).delay, 100);
+  assert.equal(notifications, 1);
+
+  assert.equal(runOnlyTimer(runtime.intervals).delay, 2_000);
+  assert.equal(runOnlyTimer(runtime.timeouts).delay, 100);
+  assert.equal(notifications, 2);
+
+  handle.dispose();
+  assert.equal(runtime.intervals.size, 0);
+  assert.equal(runtime.timeouts.size, 0);
+});
+
+test("Codex Micro keeps the native topology watcher outside Linux", () => {
+  const runtime = evaluatePatchedTopologyWatcher({ platform: "darwin" });
+  const callback = () => {};
+
+  assert.equal(runtime.topologyWatcher(callback), runtime.nativeHandle);
+  assert.deepEqual(runtime.nativeWatchCalls, [callback]);
+  assert.equal(runtime.devWatchers.length, 0);
+  assert.equal(runtime.intervals.size, 0);
+  assert.equal(runtime.timeouts.size, 0);
+});
+
+test("Codex Micro service patch rejects unrelated topology watchers", () => {
+  const unrelated =
+    "function watchTopology(callback){return loadWatcher().watch(callback)}";
+  assert.equal(applyCodexMicroHotplugPatch(unrelated), unrelated);
+  const ambiguous =
+    currentCodexMicroServiceFixture() + currentCodexMicroServiceFixture();
+  assert.equal(applyCodexMicroHotplugPatch(ambiguous), ambiguous);
+});
+
+test("Codex Micro service discovery patches exactly one current bundle", (t) => {
+  const root = tempDirectory(t, "codex-micro-hotplug-");
+  const buildDir = path.join(root, ".vite", "build");
+  const servicePath = path.join(buildDir, "codex-micro-service-fixture.js");
+  writeFile(servicePath, currentCodexMicroServiceFixture());
+  writeFile(path.join(buildDir, "unrelated.js"), "const unrelated=true;");
+
+  const discovery = findCodexMicroServiceBundle(root);
+  assert.equal(discovery.target, servicePath);
+  assert.equal(discovery.result.matched, 1);
+  assert.equal(discovery.result.changed, 1);
+
+  const result = patchCodexMicroService(root);
+  assert.equal(result.changed, 1);
+  assert.equal(result.target, ".vite/build/codex-micro-service-fixture.js");
+  assert.match(fs.readFileSync(servicePath, "utf8"), new RegExp(CODEX_MICRO_HOTPLUG_MARKER));
+
+  const repeated = patchCodexMicroService(root);
+  assert.equal(repeated.changed, 0);
+  assert.equal(repeated.matched, 1);
 });
 
 test("generic Statsig hook bundles are not accepted as Codex Micro assets", () => {


### PR DESCRIPTION
## Summary

Fix Linux Codex Micro discovery when the controller is connected after the
desktop app has already started.

The current Linux package does not include the native HID topology watcher used
by the upstream service, so the service falls back to a slow periodic scan. This
change extends the existing opt-in `codex-micro` feature with a narrowly scoped
Linux replacement:

- watch `/dev` for `hidraw` additions and removals, with a 100 ms debounce;
- retain the upstream native watcher unchanged on non-Linux platforms;
- start an unreferenced two-second polling fallback only if the filesystem
  watcher cannot start or later reports an error;
- dispose the watcher, debounce timer, and fallback timer with the service;
- fail soft and idempotently when the current service-bundle contract is absent
  or has already been patched.

The feature remains disabled by default. No generated application output is
changed.

## Validation

- Official GitHub Actions retry
  [30533926887](https://github.com/ilysenko/codex-desktop-linux/actions/runs/30533926887)
  passed all five jobs:
  - Rust and Smoke Tests
  - Build Debian Package
  - Build RPM Package
  - Build Pacman Package
  - Nix Package Builds
- Official upstream-DMG build
  [30533926896](https://github.com/ilysenko/codex-desktop-linux/actions/runs/30533926896)
  passed against the current image.
- Fork GitHub Actions run
  [30532647148](https://github.com/RoeeJ/codex-desktop-linux/actions/runs/30532647148)
  passed all five jobs:
  - Rust and Smoke Tests
  - Build Debian Package
  - Build RPM Package
  - Build Pacman Package
  - Nix Package Builds
- `node --test linux-features/codex-micro/test.js` — 32/32 passed.
- `node --test scripts/lib/linux-features.test.js` — 28/28 passed.
- `cargo fmt --check`, Clippy with warnings denied, workspace checks, and
  workspace tests passed.
- `bash tests/scripts_smoke.sh` passed.
- Shell/Node syntax checks and `git diff --check` passed.
- A clean side-by-side build from commit
  `008a86db782979ff8ca0d2ab805abce402db26c8` against current upstream DMG
  26.721.81911 was accepted with all three Codex Micro descriptors applied.
- Live duckyPad Pro hardware validation passed twice: the same running Electron
  process released the controller on disconnect and reopened it after reconnect
  under a newly enumerated `hidraw` path, without restarting the app.

The first official core run had one transient failure in the unrelated,
unchanged updater test
`trusted_standalone_installer_path_ignores_inherited_user_tools`. Current
`main`, the fork CI run, local workspace tests, and the fresh official run all
passed that test, so no unrelated updater change was added to this PR.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
