### PR TITLE
Fix upstream DMG drift

### DIFF
--- a/linux-features/codex-micro/patch.js
+++ b/linux-features/codex-micro/patch.js
@@ -16,7 +16,7 @@ const CODEX_MICRO_HOTPLUG_MARKER = "codexLinuxCodexMicroHotplug";
 const FEATURE_GATE_WARNING = "useFeatureGate hook failed to find a valid StatsigClient";
 const JS_IDENT = "[A-Za-z_$][\\w$]*";
 const CODEX_MICRO_SERVICE_PATTERN =
-  /^codex-micro-service-[A-Za-z0-9_-]+\.js$/;
+  /^service-[A-Za-z0-9_-]+\.js$/;
 const WATCH_TOPOLOGY_FUNCTION = new RegExp(
   `function (${JS_IDENT})\\((${JS_IDENT})\\)\\{return ` +
     `(${JS_IDENT})\\(\\)\\.watch\\(\\2\\)\\}`,

--- a/linux-features/codex-micro/test.js
+++ b/linux-features/codex-micro/test.js
@@ -450,7 +450,7 @@ test("Codex Micro service patch rejects unrelated topology watchers", () => {
 test("Codex Micro service discovery patches exactly one current bundle", (t) => {
   const root = tempDirectory(t, "codex-micro-hotplug-");
   const buildDir = path.join(root, ".vite", "build");
-  const servicePath = path.join(buildDir, "codex-micro-service-fixture.js");
+  const servicePath = path.join(buildDir, "service-current.js");
   writeFile(servicePath, currentCodexMicroServiceFixture());
   writeFile(path.join(buildDir, "unrelated.js"), "const unrelated=true;");
 
@@ -461,7 +461,7 @@ test("Codex Micro service discovery patches exactly one current bundle", (t) => 
 
   const result = patchCodexMicroService(root);
   assert.equal(result.changed, 1);
-  assert.equal(result.target, ".vite/build/codex-micro-service-fixture.js");
+  assert.equal(result.target, ".vite/build/service-current.js");
   assert.match(fs.readFileSync(servicePath, "utf8"), new RegExp(CODEX_MICRO_HOTPLUG_MARKER));
 
   const repeated = patchCodexMicroService(root);

--- a/linux-features/directory-only-working-tree-watch/patch.js
+++ b/linux-features/directory-only-working-tree-watch/patch.js
@@ -2186,75 +2186,74 @@ function patchWorkerSource(source, settings) {
   return { source: helper + withBranch, matched: 1, changed: 1, reason: null };
 }
 
-function findLocalFileWatchBundle(extractedDir, settings) {
+function findLocalFileWatchBundles(extractedDir, settings) {
   const buildDir = path.join(extractedDir, ".vite", "build");
   if (!fs.existsSync(buildDir)) {
-    return { target: null, result: null, reason: ".vite/build directory not found" };
+    return { targets: [], reason: ".vite/build directory not found" };
   }
 
   const bundlePaths = fs.readdirSync(buildDir, { withFileTypes: true })
     .filter((entry) => entry.isFile() && entry.name.endsWith(".js"))
     .map((entry) => path.join(buildDir, entry.name))
     .sort();
-  const alreadyPatched = [];
-  const rawMatches = [];
-  let rawMatchCount = 0;
+  const targets = [];
 
   for (const bundlePath of bundlePaths) {
     const source = fs.readFileSync(bundlePath, "utf8");
     const helperCount = source.split(`function ${HELPER_NAME}(`).length - 1;
     const branchCount = source.split(`return ${HELPER_NAME}(this,`).length - 1;
     if (helperCount > 0 || branchCount > 0) {
-      alreadyPatched.push({ bundlePath, source, result: patchWorkerSource(source, settings) });
+      targets.push({ bundlePath, result: patchWorkerSource(source, settings) });
       continue;
     }
     LOCAL_FILE_WATCH_METHOD.lastIndex = 0;
     const matches = [...source.matchAll(LOCAL_FILE_WATCH_METHOD)].length;
-    if (matches > 0) rawMatches.push({ bundlePath, source, matches });
-    rawMatchCount += matches;
-  }
-
-  if (alreadyPatched.length > 0) {
-    if (alreadyPatched.length !== 1 || rawMatchCount !== 0) {
-      return {
-        target: null,
-        result: null,
-        reason:
-          `Found directory-watch patch markers in ${alreadyPatched.length} bundles ` +
-          `and ${rawMatchCount} unpatched local startFileWatch implementations`,
-      };
+    if (matches > 0) {
+      targets.push({ bundlePath, result: patchWorkerSource(source, settings) });
     }
-    const target = alreadyPatched[0];
-    return { target: target.bundlePath, result: target.result, reason: target.result.reason };
   }
 
-  if (rawMatchCount !== 1 || rawMatches.length !== 1) {
+  const targetNames = targets.map(({ bundlePath }) => path.basename(bundlePath));
+  const hasWorker = targetNames.filter((name) => name === "worker.js").length === 1;
+  const srcCount = targetNames.filter((name) =>
+    /^src-[A-Za-z0-9_-]+\.js$/u.test(name),
+  ).length;
+  if (
+    targets.length !== 2 ||
+    !hasWorker ||
+    srcCount !== 1 ||
+    targets.some(({ result }) => result.matched !== 1)
+  ) {
     return {
-      target: null,
-      result: null,
-      reason: `Found ${rawMatchCount} local startFileWatch implementations across ${bundlePaths.length} build bundles`,
+      targets: [],
+      reason:
+        `Found ${targets.length} current local startFileWatch bundles ` +
+        `(${targetNames.join(", ") || "none"}) across ${bundlePaths.length} build bundles`,
     };
   }
 
-  const target = rawMatches[0];
-  const result = patchWorkerSource(target.source, settings);
-  return { target: target.bundlePath, result, reason: result.reason };
+  return { targets, reason: null };
 }
 
 function patchWorker(extractedDir, context = {}) {
-  const discovery = findLocalFileWatchBundle(extractedDir, normalizedSettings(context));
-  if (discovery.target == null || discovery.result?.matched !== 1) {
-    const reason = discovery.reason ?? "Local startFileWatch implementation not found";
+  const discovery = findLocalFileWatchBundles(extractedDir, normalizedSettings(context));
+  if (discovery.targets.length !== 2) {
+    const reason = discovery.reason ?? "Current local startFileWatch bundles not found";
     console.warn(`WARN: ${reason} - skipping directory-only working-tree watch feature`);
-    return { matched: discovery.result?.matched ?? 0, changed: 0, reason };
+    return { matched: 0, changed: 0, reason };
   }
-  const result = discovery.result;
-  if (result.changed === 1) fs.writeFileSync(discovery.target, result.source, "utf8");
+
+  for (const { bundlePath, result } of discovery.targets) {
+    if (result.changed === 1) {
+      fs.writeFileSync(bundlePath, result.source, "utf8");
+    }
+  }
+  const changed = discovery.targets.reduce((count, { result }) => count + result.changed, 0);
   return {
-    matched: result.matched,
-    changed: result.changed,
-    reason: result.reason,
-    target: path.relative(extractedDir, discovery.target),
+    matched: discovery.targets.length,
+    changed,
+    reason: null,
+    targets: discovery.targets.map(({ bundlePath }) => path.relative(extractedDir, bundlePath)),
   };
 }
 
@@ -2266,10 +2265,10 @@ const descriptors = [
     ciPolicy: "optional",
     apply: patchWorker,
     status: (result, warnings) => {
-      if (result?.matched !== 1) {
+      if (result?.matched !== 2) {
         return { status: "skipped-optional", reason: result?.reason ?? warnings[0] ?? null };
       }
-      return result.changed === 1 ? "applied" : "already-applied";
+      return result.changed > 0 ? "applied" : "already-applied";
     },
   },
 ];
@@ -2281,7 +2280,7 @@ module.exports = {
   LOCAL_FILE_WATCH_METHOD,
   codexLinuxStartDirectoryOnlyWorkingTreeWatch,
   descriptors,
-  findLocalFileWatchBundle,
+  findLocalFileWatchBundles,
   normalizedSettings,
   patchWorker,
   patchWorkerSource,

--- a/linux-features/directory-only-working-tree-watch/test.js
+++ b/linux-features/directory-only-working-tree-watch/test.js
@@ -175,37 +175,42 @@ test("feature patch reports drift instead of patching an ambiguous worker", () =
   assert.equal(descriptors[0].status(result, []).status, "skipped-optional");
 });
 
-test("feature discovers the local host in the current hashed build bundle", async () => {
+test("feature patches the current local host copies in src and worker bundles", async () => {
   await withTempTree((root) => {
     const buildDir = path.join(root, ".vite", "build");
     const workerPath = path.join(buildDir, "worker.js");
     const localHostPath = path.join(buildDir, "src-current.js");
     fs.mkdirSync(buildDir, { recursive: true });
-    fs.writeFileSync(workerPath, "var gitWorker={startFileWatch(){}};");
+    fs.writeFileSync(workerPath, localWorkerSource());
     fs.writeFileSync(localHostPath, localWorkerSource());
 
     const first = patchWorker(root);
-    assert.equal(first.matched, 1);
-    assert.equal(first.changed, 1);
-    assert.equal(first.target, path.join(".vite", "build", "src-current.js"));
-    assert.equal(fs.readFileSync(workerPath, "utf8"), "var gitWorker={startFileWatch(){}};");
-    const patched = fs.readFileSync(localHostPath, "utf8");
-    assert.match(patched, /function codexLinuxStartDirectoryOnlyWorkingTreeWatch\(/);
-    assert.doesNotThrow(() => new Function(patched));
+    assert.equal(first.matched, 2);
+    assert.equal(first.changed, 2);
+    assert.deepEqual(first.targets, [
+      path.join(".vite", "build", "src-current.js"),
+      path.join(".vite", "build", "worker.js"),
+    ]);
+    for (const bundlePath of [localHostPath, workerPath]) {
+      const patched = fs.readFileSync(bundlePath, "utf8");
+      assert.match(patched, /function codexLinuxStartDirectoryOnlyWorkingTreeWatch\(/);
+      assert.doesNotThrow(() => new Function(patched));
+    }
 
     const second = patchWorker(root);
-    assert.equal(second.matched, 1);
+    assert.equal(second.matched, 2);
     assert.equal(second.changed, 0);
-    assert.equal(second.target, path.join(".vite", "build", "src-current.js"));
+    assert.deepEqual(second.targets, first.targets);
   });
 });
 
-test("feature rejects multiple local host implementations across build bundles", async () => {
+test("feature rejects local host copies outside the current src and worker pair", async () => {
   await withTempTree((root) => {
     const buildDir = path.join(root, ".vite", "build");
     fs.mkdirSync(buildDir, { recursive: true });
     fs.writeFileSync(path.join(buildDir, "src-first.js"), localWorkerSource());
     fs.writeFileSync(path.join(buildDir, "src-second.js"), localWorkerSource());
+    fs.writeFileSync(path.join(buildDir, "worker.js"), localWorkerSource());
 
     const originalWarn = console.warn;
     console.warn = () => {};
@@ -217,7 +222,7 @@ test("feature rejects multiple local host implementations across build bundles",
     }
     assert.equal(result.matched, 0);
     assert.equal(result.changed, 0);
-    assert.match(result.reason, /Found 2 local startFileWatch implementations across 2 build bundles/);
+    assert.match(result.reason, /Found 3 current local startFileWatch bundles/);
   });
 });
 

--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -331,7 +331,7 @@ function applyTerminalDiscoveryPatch(currentSource, deps) {
   const platformsIndex = patchedSource.indexOf("platforms:{", patchedTerminalIndex);
   const platformsBlock =
     platformsIndex === -1 ? null : findBalancedBlock(patchedSource, patchedSource.indexOf("{", platformsIndex));
-  if (platformsBlock == null || platformsBlock.text.includes("linux:{")) {
+  if (platformsBlock == null) {
     warn("Could not apply terminal open-target patch");
     return currentSource;
   }
@@ -349,10 +349,8 @@ function applyIdeDiscoveryPatch(currentSource, deps) {
   const { fsVar, pathVar } = deps;
   const editorFactoryIndex = currentSource.search(/function\s+[A-Za-z_$][\w$]*\(\{id:[A-Za-z_$][\w$]*,label:[A-Za-z_$][\w$]*,icon:[A-Za-z_$][\w$]*,darwinDetect:/u);
   const jetBrainsFactoryIndex = currentSource.search(/function\s+[A-Za-z_$][\w$]*\(\{id:[A-Za-z_$][\w$]*,label:[A-Za-z_$][\w$]*,icon:[A-Za-z_$][\w$]*,toolboxTarget:/u);
-  const hasEditorFactory = editorFactoryIndex !== -1;
-  const hasJetBrainsFactory = jetBrainsFactoryIndex !== -1;
   const hasZedTarget = currentSource.includes("id:`zed`");
-  if (!hasEditorFactory && !hasJetBrainsFactory && !hasZedTarget) {
+  if (editorFactoryIndex === -1 && jetBrainsFactoryIndex === -1 && !hasZedTarget) {
     warn("Could not find IDE open-target factories");
     return currentSource;
   }
@@ -375,11 +373,6 @@ function applyIdeDiscoveryPatch(currentSource, deps) {
     deps,
   );
 
-  const ideCoreHelpers = patchedSource.includes("function codexLinuxIdeCommand(")
-    ? ""
-    : `function codexLinuxIdeCommand(e){let t={cursor:[\`cursor\`],vscode:[\`code\`,\`codium\`],vscodeInsiders:[\`code-insiders\`],windsurf:[\`windsurf\`],antigravity:[\`antigravity\`],zed:[\`zed\`,\`zeditor\`,\`zedit\`,\`zed-cli\`],intellij:[\`idea\`],webstorm:[\`webstorm\`],pycharm:[\`pycharm\`],goland:[\`goland\`],clion:[\`clion\`],rustrover:[\`rustrover\`],rider:[\`rider\`],phpstorm:[\`phpstorm\`],androidStudio:[\`studio\`,\`studio.sh\`]}[e]??[];for(let e of t){let t=codexLinuxFindExecutable(e);if(t)return t}return null}` +
-      `function codexLinuxIdePlatform(e,t,n,r,i){let a=codexLinuxIdeCommand(e);return a?{label:t,icon:n,kind:\`editor\`,hidden:r,detect:()=>a,args:i,supportsSsh:!0}:void 0}` +
-      `function codexLinuxJetBrainsIdePlatform(e,t,n,r){let i=codexLinuxIdeCommand(e);return i?{label:t,icon:n,kind:\`editor\`,detect:()=>i,args:r}:void 0}`;
   const dynamicDiscoveryHelpers = patchedSource.includes("function codexLinuxDiscoveredIdeTargets(")
     ? ""
     : `function codexLinuxSplitDesktopExec(e){let t=[],n=\`\`,r=null,i=!1;for(let a=0;a<e.length;a++){let o=e[a];if(i){n+=o,i=!1;continue}if(o===\`\\\\\`){r&&(n+=o);i=!0;continue}if(r){o===r?r=null:n+=o;continue}if(o===\`"\`||o===\`'\`){r=o;continue}if(/\\s/u.test(o)){n&&(t.push(n),n=\`\`);continue}n+=o}return n&&t.push(n),t}` +
@@ -418,7 +411,7 @@ function applyIdeDiscoveryPatch(currentSource, deps) {
     `function codexLinuxUniqueDesktopIdeId(e,t){let n=codexLinuxDesktopIdeId(e),r=n,i=2;for(;t.has(r);)r=\`\${n}-\${i++}\`;return t.add(r),r}` +
     `function codexLinuxDiscoveredIdeTargets(){if(process.platform!==\`linux\`)return[];let e=[],t=new Set,n=new Set,r=new Set;for(let a of codexLinuxDesktopDirs())for(let o of codexLinuxDesktopEntryFiles(a)){let a=codexLinuxParseDesktopEntry(o),s=a?.Id?.toLowerCase();if(!a)continue;if((a.Hidden||\`\`).trim().toLowerCase()===\`true\`){s&&r.add(s);continue}if(s&&r.has(s)||!codexLinuxLooksLikeIde(a))continue;if(a.TryExec&&!codexLinuxDesktopTryExecAvailable(a.TryExec))continue;let i=codexLinuxResolveDesktopExec(a.Exec);if(!i||codexLinuxKnownIdeDesktopDuplicate(i))continue;let c=\`\${a.Name}|${"${i.command}"}|${"${i.args.join(` `)}"}\`.toLowerCase();if(t.has(c))continue;t.add(c);let l=a.Name.trim(),u=codexLinuxDesktopIdeIcon(a,i),d=codexLinuxUniqueDesktopIdeId(a,n),f=codexLinuxDesktopIconPath(a);e.push({id:d,platforms:{linux:{label:l,icon:u,iconPath:f?()=>f:void 0,kind:\`editor\`,detect:()=>i.command,args:e=>codexLinuxDesktopArgs(i.args,e),open:async({command:e,path:t})=>{await codexLinuxLaunchDesktopEntry(o,t,e,i.args)}}}})}return e}`;
 
-  const helpers = ideCoreHelpers + dynamicDiscoveryHelpers;
+  const helpers = dynamicDiscoveryHelpers;
   if (helpers.length > 0) {
     const helperInsertionIndex = patchedSource.includes("function codexLinuxFindExecutable(")
       ? patchedSource.indexOf("function codexLinuxFindExecutable(")
@@ -426,32 +419,6 @@ function applyIdeDiscoveryPatch(currentSource, deps) {
     const helperEnd = patchedSource.indexOf("async function codexLinuxOpenFileManager(", helperInsertionIndex);
     const ideHelperInsertionIndex = helperEnd === -1 ? helperInsertionIndex : helperEnd;
     patchedSource = patchedSource.slice(0, ideHelperInsertionIndex) + helpers + patchedSource.slice(ideHelperInsertionIndex);
-  }
-
-  patchedSource = patchedSource.replace(
-    /(function\s+[A-Za-z_$][\w$]*\(\{id:([A-Za-z_$][\w$]*),label:([A-Za-z_$][\w$]*),icon:([A-Za-z_$][\w$]*),darwinDetect:[^)]*?hidden:([A-Za-z_$][\w$]*)\}\)\{return\{id:\2,platforms:\{[^]*?win32:[^]*?args:([A-Za-z_$][\w$]*),supportsSsh:!0\}:void 0)(\}\}\})/u,
-    "$1,linux:codexLinuxIdePlatform($2,$3,$4,$5,$6)$7",
-  );
-
-  patchedSource = patchedSource.replace(
-    /(function\s+[A-Za-z_$][\w$]*\(\{id:([A-Za-z_$][\w$]*),label:([A-Za-z_$][\w$]*),icon:([A-Za-z_$][\w$]*),toolboxTarget:[^)]*?\}\)\{return\{id:\2,platforms:\{[^]*?args:([A-Za-z_$][\w$]*)\}:void 0)(\}\}\})/u,
-    "$1,linux:codexLinuxJetBrainsIdePlatform($2,$3,$4,$5)$6",
-  );
-
-  const patchedZedIndex = patchedSource.indexOf("id:`zed`");
-  if (patchedZedIndex !== -1) {
-    const zedPlatformsIndex = patchedSource.indexOf("platforms:{", patchedZedIndex);
-    const zedPlatformsBlock = findBalancedBlock(patchedSource, patchedSource.indexOf("{", zedPlatformsIndex));
-    if (zedPlatformsBlock != null && !zedPlatformsBlock.text.includes("linux:{")) {
-      const argsVar = zedPlatformsBlock.text.match(/win32:\{[^}]*args:([A-Za-z_$][\w$]*)/u)?.[1];
-      if (argsVar != null) {
-        const linuxZed = `,linux:{label:\`Zed\`,icon:\`apps/zed.png\`,kind:\`editor\`,detect:()=>codexLinuxIdeCommand(\`zed\`),args:${argsVar}}`;
-        patchedSource =
-          patchedSource.slice(0, zedPlatformsBlock.end - 1) +
-          linuxZed +
-          patchedSource.slice(zedPlatformsBlock.end - 1);
-      }
-    }
   }
 
   if (!patchedSource.includes("...codexLinuxDiscoveredIdeTargets()")) {
@@ -473,16 +440,6 @@ function applyIdeDiscoveryPatch(currentSource, deps) {
     } else {
       warn("Could not append dynamic IDE desktop discovery");
     }
-  }
-
-  if (hasEditorFactory && !patchedSource.includes("linux:codexLinuxIdePlatform(")) {
-    warn("Could not apply generic IDE factory patch");
-  }
-  if (hasJetBrainsFactory && !patchedSource.includes("linux:codexLinuxJetBrainsIdePlatform(")) {
-    warn("Could not apply JetBrains IDE factory patch");
-  }
-  if (hasZedTarget && !patchedSource.includes("linux:{label:`Zed`")) {
-    warn("Could not apply Zed IDE target patch");
   }
 
   return patchedSource;

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -37,7 +37,7 @@ const fileManagerBundle =
 const terminalOpenTargetBundle =
   "var uh={id:`terminal`,platforms:{darwin:{label:`Terminal`,icon:`apps/terminal.png`,kind:`terminal`,detect:()=>`open`,args:e=>[`-a`,`Terminal`,e]},win32:{label:`Terminal`,icon:`apps/microsoft-terminal.png`,kind:`terminal`,detect:vh,iconPath:()=>null,args:yh,open:({command:e,path:t})=>bh(e,yh(t))}}};function vh(){return `wt.exe`}function yh(e){return[`-d`,e]}async function bh(){}";
 const ideOpenTargetsBundle =
-  "function ih({id:e,label:t,icon:n,darwinDetect:r,win32Detect:i,darwinEnv:a,darwinArgs:o,hidden:s}){return{id:e,platforms:{darwin:r?{label:t,icon:n,kind:`editor`,hidden:s,detect:r,env:a,args:o??ah,supportsSsh:!0}:void 0,win32:i?{label:t,icon:n,kind:`editor`,hidden:s,detect:i,args:ah,supportsSsh:!0}:void 0}}}var ah=(e,t)=>t?[`${e}:${t.line}:${t.column}`]:[e];var Og=ih({id:`vscode`,label:`VS Code`,icon:`apps/vscode.png`,darwinDetect:()=>`open`,win32Detect:()=>`Code.exe`});var jh=ih({id:`cursor`,label:`Cursor`,icon:`apps/cursor.png`,darwinDetect:()=>`open`,win32Detect:()=>`Cursor.exe`});function sg({id:e,label:t,icon:n,toolboxTarget:r,macExecutable:i,windowsPathCommands:a,windowsInstallDirPrefixes:o,windowsInstallExecutables:s}){return{id:e,platforms:{darwin:{label:t,icon:n,kind:`editor`,detect:()=>`open`,args:mg},win32:a&&o&&s?{label:t,icon:n,kind:`editor`,detect:()=>`idea.exe`,args:mg}:void 0}}}function mg(e,t){return t?[`--line`,t.line.toString(),`--column`,t.column.toString(),e]:[e]}var $h=sg({id:`intellij`,label:`IntelliJ IDEA`,icon:`apps/intellij.png`,toolboxTarget:`intellij`,macExecutable:`idea`,windowsPathCommands:[`idea`],windowsInstallDirPrefixes:[`idea`],windowsInstallExecutables:[`idea`]});var Wg={id:`zed`,platforms:{darwin:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:Gg,args:hg},win32:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:Kg,args:hg}}};function Gg(){}function Kg(){}function hg(e,t){return t?[`${e}:${t.line}:${t.column}`]:[e]}var Xg=[Og,jh,Wg,$h];";
+  "function ih({id:e,label:t,icon:n,darwinDetect:r,win32Detect:i,linuxDetect:a,darwinEnv:o,darwinArgs:s,hidden:l}){return{id:e,platforms:{darwin:r?{label:t,icon:n,kind:`editor`,hidden:l,detect:r,env:o,args:s??ah,supportsSsh:!0}:void 0,win32:i?{label:t,icon:n,kind:`editor`,hidden:l,detect:i,args:ah,supportsSsh:!0}:void 0,linux:a?{label:t,icon:n,kind:`editor`,hidden:l,detect:a,args:ah,supportsSsh:!0}:void 0}}}var ah=(e,t)=>t?[`${e}:${t.line}:${t.column}`]:[e];var Og=ih({id:`vscode`,label:`VS Code`,icon:`apps/vscode.png`,darwinDetect:()=>`open`,win32Detect:()=>`Code.exe`,linuxDetect:()=>codexLinuxFindExecutable(`code`)});var jh=ih({id:`cursor`,label:`Cursor`,icon:`apps/cursor.png`,darwinDetect:()=>`open`,win32Detect:()=>`Cursor.exe`,linuxDetect:()=>codexLinuxFindExecutable(`cursor`)});function sg({id:e,label:t,icon:n,toolboxTarget:r,macExecutable:i,windowsPathCommands:a,windowsInstallDirPrefixes:o,windowsInstallExecutables:s}){return{id:e,platforms:{darwin:{label:t,icon:n,kind:`editor`,detect:()=>`open`,args:mg},win32:a&&o&&s?{label:t,icon:n,kind:`editor`,detect:()=>`idea.exe`,args:mg}:void 0}}}function mg(e,t){return t?[`--line`,t.line.toString(),`--column`,t.column.toString(),e]:[e]}var $h=sg({id:`intellij`,label:`IntelliJ IDEA`,icon:`apps/intellij.png`,toolboxTarget:`intellij`,macExecutable:`idea`,windowsPathCommands:[`idea`],windowsInstallDirPrefixes:[`idea`],windowsInstallExecutables:[`idea`]});var Wg={id:`zed`,platforms:{darwin:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:Gg,args:hg},win32:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:Kg,args:hg},linux:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:()=>codexLinuxFindExecutable(`zed`),args:hg}}};function Gg(){}function Kg(){}function hg(e,t){return t?[`${e}:${t.line}:${t.column}`]:[e]}var Xg=[Og,jh,Wg,$h];";
 const openTargetsBundle = `${mainBundlePrefix}${fileManagerBundle}${terminalOpenTargetBundle}${ideOpenTargetsBundle}`;
 const collidingPathAliasBundle =
   "let n=require(`electron`),o=require(`node:path`),c=require(`node:fs`),u=require(`node:child_process`);" +
@@ -194,13 +194,11 @@ function withLinuxFeatureRootEnv(root, fn) {
   }
 }
 
-test("open-target discovery directly adds file manager, terminal, and IDE support", () => {
+test("open-target discovery upgrades file manager and terminal support and adds dynamic IDEs", () => {
   const patched = applyPatchTwice(applyMainBundlePatch, openTargetsBundle);
 
   assert.match(patched, /codexLinuxOpenFileManager\(e\)/);
   assert.match(patched, /linux:\{label:`Terminal`/);
-  assert.match(patched, /linux:codexLinuxIdePlatform\(/);
-  assert.match(patched, /linux:codexLinuxJetBrainsIdePlatform\(/);
   assert.match(patched, /\.\.\.codexLinuxDiscoveredIdeTargets\(\)/);
 });
 
@@ -1560,7 +1558,7 @@ test("open-target discovery reports current command lookup drift as an enabled f
   });
 });
 
-test("open-target discovery does not add a second built-in Zed target", () => {
+test("open-target discovery leaves the upstream built-in Zed target unchanged", () => {
   const zedAlreadyLinux = openTargetsBundle.replace(
     "win32:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:Kg,args:hg}}",
     "win32:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:Kg,args:hg},linux:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:Gg,args:hg}}",
@@ -1568,4 +1566,5 @@ test("open-target discovery does not add a second built-in Zed target", () => {
   const patched = applyPatchTwice(applyMainBundlePatch, zedAlreadyLinux);
 
   assert.equal((patched.match(/linux:\{label:`Zed`/g) || []).length, 1);
+  assert.doesNotMatch(patched, /codexLinuxIdeCommand/);
 });

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -21,15 +21,12 @@ const REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE =
 const REMOTE_CONTROL_SETTINGS_UX_MARKER = "codexLinuxRemoteControlSettingsTabs";
 const REMOTE_CONTROL_SETTINGS_TABS_HELPER =
   "function codexLinuxRemoteControlSettingsTabs(e){return e}";
-const REMOTE_CONTROL_SETTINGS_TABS_OLD_HELPER =
-  "function codexLinuxRemoteControlSettingsTabs(e){return typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`)?e.filter(e=>e.key!==`access-other-devices`):e}";
 const REMOTE_CONTROL_SSH_INSTALL_ACTION_MARKER = "codexLinuxRemoteControlSshInstallActions";
 const REMOTE_CONTROL_SSH_INSTALL_RELEASE_MARKER = "codexLinuxRemoteControlSshInstallRelease";
 const REMOTE_CONNECTIONS_REFRESH_MARKER = "codexLinuxRemoteConnectionsRefreshNow";
 const REMOTE_MOBILE_CHROME_BRIDGE_MARKER = "codexLinuxRemoteMobileBrowserBackends";
 const REMOTE_CONTROL_LOAD_GATE_MARKER = "codexLinuxRemoteControlLoadGateEnabled";
 const REMOTE_CONTROL_FEATURE_SYNC_MARKER = "codexLinuxRemoteControlFeatureSyncEnabled";
-const REMOTE_CONTROL_FEATURE_SYNC_HOST_SCOPE_MARKER = "codexLinuxRemoteControlFeatureSyncHostScoped";
 const REMOTE_CONTROL_LOAD_GATE_NEEDLE =
   /function ([A-Za-z_$][\w$]*)\(\)\{return ([A-Za-z_$][\w$]*)\(`1042620455`\)\}/u;
 const REMOTE_MOBILE_THREAD_RUNTIME_MARKER = "codexLinuxRemoteMobileThreadRuntimeStatus";
@@ -369,85 +366,50 @@ function applyLinuxRemoteControlFeatureSyncPatch(source) {
   if (!source.includes("set-experimental-feature-enablement-for-host")) {
     return source;
   }
-
-  // The current per-host feature enablement helper copies the supported
-  // defaults, then adds remote_plugin without remote_control. Current app
-  // servers use remote_plugin for remote marketplace data, so Linux adds only
-  // remote_control while preserving the upstream remote_plugin assignment.
-  let patched = source;
-  let changed = false;
-  const enablementRegex =
-    /(for\(let ([A-Za-z_$][\w$]*) of [A-Za-z_$][\w$]*\)\{let ([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\[\2\];\3!=null&&\(([A-Za-z_$][\w$]*)\[\2\]=\3\)\})return \4\[([A-Za-z_$][\w$]*)\]=([A-Za-z_$][\w$]*),\4\}/u;
-  if (!patched.includes(REMOTE_CONTROL_FEATURE_SYNC_MARKER)) {
-    const match = patched.match(enablementRegex);
-    if (match != null) {
-      const [, loopBlock, , , enablementVar, remotePluginVar, remotePluginValue] = match;
-      const replacement =
-        `${loopBlock}return typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)` +
-        `?(${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(arguments[2],arguments[3])&&(${enablementVar}.remote_control=!0),${enablementVar}[${remotePluginVar}]=${remotePluginValue},${enablementVar})` +
-        `:(${enablementVar}[${remotePluginVar}]=${remotePluginValue},${enablementVar})}` +
-        `function ${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(e,t){return e==null||t==null||e===t}`;
-      patched = patched.replace(enablementRegex, replacement);
-      changed = true;
-    }
-  }
-
-  const scoped = applyLinuxRemoteControlFeatureSyncHostScopePatch(patched);
-  if (scoped !== patched) {
-    patched = scoped;
-    changed = true;
-  }
-
-  if (changed || patched.includes(REMOTE_CONTROL_FEATURE_SYNC_MARKER)) {
-    return patched;
-  }
-
-  console.warn("WARN: Could not find app-server feature sync list - skipping Linux remote-control feature sync patch");
-  return source;
-}
-
-function applyLinuxRemoteControlFeatureSyncHostScopePatch(source) {
-  if (source.includes(REMOTE_CONTROL_FEATURE_SYNC_HOST_SCOPE_MARKER)) {
+  if (source.includes(`function ${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(`)) {
     return source;
   }
 
-  const builderCallRegex =
-    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*|![01])\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.get\(([A-Za-z_$][\w$]*)\),/u;
-  const builderCallMatch = source.match(builderCallRegex);
-  if (builderCallMatch == null) {
-    return source;
-  }
-
-  const [
-    ,
-    enablementVar,
-    builderFn,
-    featureConfigVar,
-    remotePluginValueVar,
-    localHostVar,
-  ] = builderCallMatch;
   const id = "[A-Za-z_$][\\w$]*";
+  const syncSetupRegex = new RegExp(
+    `let (${id})=(${id})\\((${id}),(${id}),(${id})\\),` +
+      `(${id})=(${id})\\.get\\((${id})\\),(${id})=new Set\\(`,
+    "u",
+  );
+  const setupMatch = source.match(syncSetupRegex);
+  const enablementVar = setupMatch?.[1];
+  const localHostVar = setupMatch?.[6];
+  const activeHostsVar = setupMatch?.[9];
+  if (enablementVar == null || localHostVar == null || activeHostsVar == null) {
+    console.warn("WARN: Could not find app-server feature sync setup - skipping Linux remote-control feature sync patch");
+    return source;
+  }
+
   const flatMapRegex = new RegExp(
-    `\\(0,(${id})\\.(${id})\\)\\((${id})\\.get\\((${id})\\),${enablementVar}\\)\\?\\[\\]:` +
-      `\\(\\3\\.set\\(\\4,${enablementVar}\\),\\[(${id})\\(\\x60set-experimental-feature-enablement-for-host\\x60,` +
-      `\\{hostId:\\4,enablement:${enablementVar}\\}\\)`,
+    `Array\\.from\\(${activeHostsVar}\\)\\.flatMap\\((${id})=>` +
+      `\\(0,(${id})\\.default\\)\\((${id})\\.get\\(\\1\\),${enablementVar}\\)\\?\\[\\]:` +
+      `\\(\\3\\.set\\(\\1,${enablementVar}\\),\\[(${id})\\(\\x60set-experimental-feature-enablement-for-host\\x60,` +
+      `\\{hostId:\\1,enablement:${enablementVar}\\}\\)`,
     "u",
   );
   const match = source.match(flatMapRegex);
   if (match == null) {
+    console.warn("WARN: Could not find app-server feature sync list - skipping Linux remote-control feature sync patch");
     return source;
   }
 
-  const [needle, compareNamespaceVar, compareFnVar, cacheMapVar, hostVar, requestFnVar] = match;
-  const helperName = "codexLinuxRemoteControlFeatureSyncForHost";
+  const [needle, hostVar, compareNamespaceVar, cacheMapVar, requestFnVar] = match;
   const scopedEnablement =
-    `${helperName}(${builderFn},${featureConfigVar},${remotePluginValueVar},${hostVar},${localHostVar})`;
+    `${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(${enablementVar},${localHostVar},${hostVar})`;
   const replacement =
-    `(0,${compareNamespaceVar}.${compareFnVar})(${cacheMapVar}.get(${hostVar}),${scopedEnablement})?[]:` +
+    `Array.from(${activeHostsVar}).flatMap(${hostVar}=>(0,${compareNamespaceVar}.default)` +
+    `(${cacheMapVar}.get(${hostVar}),${scopedEnablement})?[]:` +
     `(${cacheMapVar}.set(${hostVar},${scopedEnablement}),[${requestFnVar}(\`set-experimental-feature-enablement-for-host\`,` +
-    `{hostId:${hostVar},enablement:${scopedEnablement}})/*${REMOTE_CONTROL_FEATURE_SYNC_HOST_SCOPE_MARKER}*/`;
+    `{hostId:${hostVar},enablement:${scopedEnablement}})`;
   const helper =
-    `function ${helperName}(e,t,n,r,i){return e(t,n,r,i)}`;
+    `function ${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(e,t,n){return ` +
+    `typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)&&t===n` +
+    `?{...e,remote_control:!0}:e}`;
 
   return `${source.replace(needle, replacement)}\n${helper}`;
 }
@@ -528,28 +490,17 @@ function applyLinuxRemoteControlSshInstallActionPatch(source) {
   }
 
   const actionGateRegex =
-    /let ([A-Za-z_$][\w$]*)=([^;]+?)&&\(([A-Za-z_$][\w$]*)\?\.code===`remote-codex-not-found`\|\|\3\?\.code===`update-required`\);([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)==null\|\|\1\?null:([A-Za-z_$][\w$]*)\(\{action:\5\.action,/u;
+    /let ([A-Za-z_$][\w$]*)=\([^;]{1,160}\)&&\(([A-Za-z_$][\w$]*)\?\.code===`remote-codex-not-found`\|\|\2\?\.code===`update-required`\)(?=,[A-Za-z_$][\w$]*;)/u;
   const match = source.match(actionGateRegex);
-  if (match != null) {
-    const [, gateVar, , , renderedActionVar, connectionActionVar, renderActionFn] = match;
-    return source.replace(
-      actionGateRegex,
-      `let ${gateVar}=/*${REMOTE_CONTROL_SSH_INSTALL_ACTION_MARKER}*/!1;${renderedActionVar}=${connectionActionVar}==null?null:${renderActionFn}({action:${connectionActionVar}.action,`,
-    );
-  }
-
-  const currentActionGateRegex =
-    /let ([A-Za-z_$][\w$]*)=([^;,]+?)&&\(([A-Za-z_$][\w$]*)\?\.code===`remote-codex-not-found`\|\|\3\?\.code===`update-required`\),([\s\S]*?)([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)==null\|\|\1\?null:([A-Za-z_$][\w$]*)\(\{action:\6\.action,/u;
-  const currentMatch = source.match(currentActionGateRegex);
-  if (currentMatch == null) {
+  if (match == null) {
     console.warn("WARN: Could not find remote-control SSH install action gate - skipping Linux install action patch");
     return source;
   }
 
-  const [, gateVar, , , betweenGateAndAction, renderedActionVar, connectionActionVar, renderActionFn] = currentMatch;
+  const [, gateVar] = match;
   return source.replace(
-    currentActionGateRegex,
-    `let ${gateVar}=/*${REMOTE_CONTROL_SSH_INSTALL_ACTION_MARKER}*/!1,${betweenGateAndAction}${renderedActionVar}=${connectionActionVar}==null?null:${renderActionFn}({action:${connectionActionVar}.action,`,
+    actionGateRegex,
+    `let ${gateVar}=/*${REMOTE_CONTROL_SSH_INSTALL_ACTION_MARKER}*/!1`,
   );
 }
 
@@ -561,120 +512,41 @@ function applyLinuxRemoteControlSshInstallReleasePatch(source) {
     return source;
   }
 
-  const actionBuilderRegex =
-    /function ([A-Za-z_$][\w$]*)\(\{action:([A-Za-z_$][\w$]*),disabled:([A-Za-z_$][\w$]*),hostId:([A-Za-z_$][\w$]*),installCodexPending:([A-Za-z_$][\w$]*),onAuthenticate:([A-Za-z_$][\w$]*),onInstallCodex:([A-Za-z_$][\w$]*)(?:,onRestart:([A-Za-z_$][\w$]*))?\}\)\{if\(\2==null\)return null;switch\(\2\.kind\)\{case`install-codex`:return\{disabled:\3,label:\2\.label,loading:\5,loadingLabel:\2\.loadingLabel,renderInElectronOnly:!0,tooltipText:\2\.tooltipText,onClick:\(\)=>\7\(\4\)\}/u;
-  const actionCallRegex =
-    /let ([A-Za-z_$][\w$]*)=([^;]+?)&&\(([A-Za-z_$][\w$]*)\?\.code===`remote-codex-not-found`\|\|\3\?\.code===`update-required`\);([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)==null\|\|\1\?null:([A-Za-z_$][\w$]*)\(\{action:\5\.action,disabled:([A-Za-z_$][\w$]*),hostId:([A-Za-z_$][\w$]*)\.hostId,installCodexPending:([A-Za-z_$][\w$]*),(?:onRestart:([A-Za-z_$][\w$]*),)?onAuthenticate:([A-Za-z_$][\w$]*),onInstallCodex:([A-Za-z_$][\w$]*)\}\)/u;
-  const mutationRegex =
-    /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.mutate\(\{hostId:\2\},\{onSuccess:\(\{state:([A-Za-z_$][\w$]*),error:([A-Za-z_$][\w$]*)\}\)=>\{([A-Za-z_$][\w$]*)\(\2,\4,\5\)\}\}\)\}/u;
-  const localVersionRegex =
-    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.c\)\((\d+)\),\{connection:([A-Za-z_$][\w$]*),disabled:([A-Za-z_$][\w$]*),installCodexPending:([A-Za-z_$][\w$]*),([\s\S]*?)onAuthenticate:([A-Za-z_$][\w$]*),([\s\S]*?)onInstallCodex:([A-Za-z_$][\w$]*),([\s\S]*?)\}=\2,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\),\{appServerVersion:([A-Za-z_$][\w$]*),error:([A-Za-z_$][\w$]*),installedCodexVersion:([A-Za-z_$][\w$]*),state:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\6\.hostId\),([A-Za-z_$][\w$]*)=\6\.displayName/u;
-  const currentActionCallRegex =
-    /let ([A-Za-z_$][\w$]*)=([^;,]+?)&&\(([A-Za-z_$][\w$]*)\?\.code===`remote-codex-not-found`\|\|\3\?\.code===`update-required`\),([\s\S]*?)([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)==null\|\|\1\?null:([A-Za-z_$][\w$]*)\(\{action:\6\.action,disabled:([A-Za-z_$][\w$]*),hostId:([A-Za-z_$][\w$]*)\.hostId,installCodexPending:([A-Za-z_$][\w$]*),(?:onRestart:([A-Za-z_$][\w$]*),)?onAuthenticate:([A-Za-z_$][\w$]*),onInstallCodex:([A-Za-z_$][\w$]*)\}\)/u;
-  const currentLocalVersionRegex =
-    /\{appServerVersion:([A-Za-z_$][\w$]*),error:([A-Za-z_$][\w$]*),installedCodexVersion:([A-Za-z_$][\w$]*),state:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\.hostId\),([A-Za-z_$][\w$]*)=\6\.displayName/u;
-
-  const actionBuilderMatch = source.match(actionBuilderRegex);
-  const actionCallMatch = source.match(actionCallRegex);
-  const mutationMatch = source.match(mutationRegex);
-  const localVersionMatch = source.match(localVersionRegex);
+  const id = "[A-Za-z_$][\\w$]*";
+  const currentActionBuilderRegex = new RegExp(
+    `function (${id})\\(\\{action:(${id}),disabled:(${id}),hostId:(${id}),` +
+      `installCodexPending:(${id}),onAuthenticate:(${id}),onInstallCodex:(${id}),` +
+      `onReconnect:(${id}),onRestart:(${id})\\}\\)\\{if\\(\\2==null\\)return null;` +
+      `switch\\(\\2\\.kind\\)\\{case\\x60install-codex\\x60:return\\{disabled:\\3,label:\\2\\.label,` +
+      `loading:\\5,loadingLabel:\\2\\.loadingLabel,renderInElectronOnly:!0,` +
+      `tooltipText:\\2\\.tooltipText,onClick:\\(\\)=>\\7\\(\\4\\)\\}`,
+    "u",
+  );
+  const currentActionCallRegex = new RegExp(
+    `(${id})\\(\\{action:(${id})\\.action,disabled:(${id}),hostId:(${id})\\.hostId,` +
+      `installCodexPending:(${id}),onReconnect:(${id}),onRestart:(${id}),` +
+      `onAuthenticate:(${id}),onInstallCodex:(${id})\\}\\)`,
+    "u",
+  );
+  const currentLocalVersionRegex = new RegExp(
+    `\\{appServerVersion:(${id}),error:(${id}),installedCodexVersion:(${id}),state:(${id})\\}` +
+      `=(${id})\\((${id})\\.hostId\\),(${id})=\\6\\.displayName`,
+    "u",
+  );
+  const currentMutationRegex = new RegExp(
+    `(${id})=(${id})=>\\{(${id})\\.mutate\\(\\{hostId:\\2\\},` +
+      `\\{onSuccess:\\(\\{state:(${id}),error:(${id})\\}\\)=>\\{(${id})\\(\\2,\\4,\\5\\)\\}\\}\\)\\}`,
+    "u",
+  );
+  const currentActionBuilderMatch = source.match(currentActionBuilderRegex);
   const currentActionCallMatch = source.match(currentActionCallRegex);
   const currentLocalVersionMatch = source.match(currentLocalVersionRegex);
+  const currentMutationMatch = source.match(currentMutationRegex);
   if (
-    actionBuilderMatch != null &&
-    mutationMatch != null &&
-    currentActionCallMatch != null &&
-    currentLocalVersionMatch != null
-  ) {
-    const [
-      ,
-      builderFn,
-      builderActionVar,
-      builderDisabledVar,
-      builderHostVar,
-      builderPendingVar,
-      builderAuthVar,
-      builderInstallVar,
-      builderRestartVar,
-    ] = actionBuilderMatch;
-    const builderRestartPart = builderRestartVar == null ? "" : `,onRestart:${builderRestartVar}`;
-    const actionBuilderReplacement =
-      `function ${builderFn}({action:${builderActionVar},disabled:${builderDisabledVar},hostId:${builderHostVar},installCodexPending:${builderPendingVar},` +
-      `installCodexRelease:codexLinuxRemoteControlSshInstallReleaseTarget,onAuthenticate:${builderAuthVar},onInstallCodex:${builderInstallVar}${builderRestartPart}}){` +
-      `if(${builderActionVar}==null)return null;switch(${builderActionVar}.kind){case\`install-codex\`:return{disabled:${builderDisabledVar},label:${builderActionVar}.label,loading:${builderPendingVar},` +
-      `loadingLabel:${builderActionVar}.loadingLabel,renderInElectronOnly:!0,tooltipText:${builderActionVar}.tooltipText,onClick:()=>${builderInstallVar}(${builderHostVar},codexLinuxRemoteControlSshInstallReleaseTarget)}`;
-
-    const [
-      ,
-      gateVar,
-      gateExpression,
-      errorVar,
-      betweenGateAndAction,
-      renderedActionVar,
-      connectionActionVar,
-      renderActionFn,
-      disabledVar,
-      connectionVar,
-      pendingVar,
-      restartVar,
-      authenticateVar,
-      installVar,
-    ] = currentActionCallMatch;
-    const restartPart = restartVar == null ? "" : `onRestart:${restartVar},`;
-    const actionCallReplacement =
-      `let ${gateVar}=${gateExpression}&&(${errorVar}?.code===\`remote-codex-not-found\`||${errorVar}?.code===\`update-required\`),` +
-      `${betweenGateAndAction}${renderedActionVar}=${connectionActionVar}==null||${gateVar}?null:${renderActionFn}({action:${connectionActionVar}.action,disabled:${disabledVar},hostId:${connectionVar}.hostId,` +
-      `installCodexPending:${pendingVar},installCodexRelease:${REMOTE_CONTROL_SSH_INSTALL_RELEASE_MARKER}(${errorVar}),${restartPart}onAuthenticate:${authenticateVar},onInstallCodex:${installVar}})`;
-
-    const [
-      ,
-      currentAppServerVersionVar,
-      currentErrorVar,
-      currentInstalledVersionVar,
-      currentStateVar,
-      currentConnectionStateFn,
-      currentConnectionVar,
-      currentDisplayNameVar,
-    ] = currentLocalVersionMatch;
-    const currentLocalVersionReplacement =
-      `{appServerVersion:${currentAppServerVersionVar},error:${currentErrorVar},installedCodexVersion:${currentInstalledVersionVar},state:${currentStateVar}}=${currentConnectionStateFn}(${currentConnectionVar}.hostId),` +
-      `{appServerVersion:codexLinuxRemoteControlSshInstallLocalVersion}=${currentConnectionStateFn}(\`local\`);` +
-      `codexLinuxRemoteControlSshInstallDefaultRelease=codexLinuxRemoteControlValidRelease(codexLinuxRemoteControlSshInstallLocalVersion)??codexLinuxRemoteControlSshInstallDefaultRelease;` +
-      `let ${currentDisplayNameVar}=${currentConnectionVar}.displayName`;
-
-    const [
-      ,
-      mutationHandlerVar,
-      mutationHostVar,
-      mutationVar,
-      mutationStateVar,
-      mutationErrorVar,
-      syncStateFn,
-    ] = mutationMatch;
-    const mutationReplacement =
-      `${mutationHandlerVar}=(${mutationHostVar},codexLinuxRemoteControlSshInstallTargetRelease)=>{` +
-      `let codexLinuxRemoteControlSshInstallRequest={hostId:${mutationHostVar}},` +
-      `codexLinuxRemoteControlSshInstallResolvedRelease=codexLinuxRemoteControlSshInstallTargetRelease??codexLinuxRemoteControlSshInstallDefaultRelease;` +
-      `codexLinuxRemoteControlSshInstallResolvedRelease!=null&&(codexLinuxRemoteControlSshInstallRequest.release=codexLinuxRemoteControlSshInstallResolvedRelease),` +
-      `${mutationVar}.mutate(codexLinuxRemoteControlSshInstallRequest,{onSuccess:({state:${mutationStateVar},error:${mutationErrorVar}})=>{${syncStateFn}(${mutationHostVar},${mutationStateVar},${mutationErrorVar})}})}`;
-
-    const helper = [
-      "let codexLinuxRemoteControlSshInstallDefaultRelease=null;",
-      "function codexLinuxRemoteControlValidRelease(e){return typeof e==`string`&&e.trim().length>0?e.trim():null}",
-      `function ${REMOTE_CONTROL_SSH_INSTALL_RELEASE_MARKER}(e){return e?.code===\`update-required\`?codexLinuxRemoteControlValidRelease(e.minRequiredVersion):null}`,
-    ].join("");
-
-    return helper + source
-      .replace(currentLocalVersionRegex, currentLocalVersionReplacement)
-      .replace(actionBuilderRegex, actionBuilderReplacement)
-      .replace(currentActionCallRegex, actionCallReplacement)
-      .replace(mutationRegex, mutationReplacement);
-  }
-  if (
-    actionBuilderMatch == null ||
-    actionCallMatch == null ||
-    mutationMatch == null ||
-    localVersionMatch == null
+    currentActionBuilderMatch == null ||
+    currentActionCallMatch == null ||
+    currentLocalVersionMatch == null ||
+    currentMutationMatch == null
   ) {
     console.warn("WARN: Could not find remote-control SSH install release needles - skipping Linux install release patch");
     return source;
@@ -682,76 +554,63 @@ function applyLinuxRemoteControlSshInstallReleasePatch(source) {
 
   const [
     ,
-    rowComponentFn,
-    rowPropsVar,
-    rowCacheVar,
-    rowCompilerVar,
-    rowCacheSize,
-    rowConnectionVar,
-    rowDisabledVar,
-    rowInstallPendingVar,
-    rowBetweenPendingAndAuth,
-    rowAuthenticateVar,
-    rowBetweenAuthAndInstall,
-    rowInstallVar,
-    rowTrailingProps,
-    rowFormatVar,
-    rowFormatFn,
-    rowAppServerVersionVar,
-    rowErrorVar,
-    rowInstalledVersionVar,
-    rowStateVar,
-    rowConnectionStateFn,
-    rowDisplayNameVar,
-  ] = localVersionMatch;
-  const localVersionReplacement =
-    `function ${rowComponentFn}(${rowPropsVar}){let ${rowCacheVar}=(0,${rowCompilerVar}.c)(${rowCacheSize}),` +
-    `{connection:${rowConnectionVar},disabled:${rowDisabledVar},installCodexPending:${rowInstallPendingVar},` +
-    `${rowBetweenPendingAndAuth}onAuthenticate:${rowAuthenticateVar},${rowBetweenAuthAndInstall}` +
-    `onInstallCodex:${rowInstallVar},${rowTrailingProps}}=${rowPropsVar},${rowFormatVar}=${rowFormatFn}(),` +
-    `{appServerVersion:${rowAppServerVersionVar},error:${rowErrorVar},installedCodexVersion:${rowInstalledVersionVar},state:${rowStateVar}}=${rowConnectionStateFn}(${rowConnectionVar}.hostId),` +
-    `{appServerVersion:codexLinuxRemoteControlSshInstallLocalVersion}=${rowConnectionStateFn}(\`local\`);` +
-    `codexLinuxRemoteControlSshInstallDefaultRelease=codexLinuxRemoteControlValidRelease(codexLinuxRemoteControlSshInstallLocalVersion)??codexLinuxRemoteControlSshInstallDefaultRelease;` +
-    `let ${rowDisplayNameVar}=${rowConnectionVar}.displayName`;
-
-  const [
-    ,
     builderFn,
-    builderActionVar,
-    builderDisabledVar,
-    builderHostVar,
-    builderPendingVar,
-    builderAuthVar,
-    builderInstallVar,
-    builderRestartVar,
-  ] = actionBuilderMatch;
-  const builderRestartPart = builderRestartVar == null ? "" : `,onRestart:${builderRestartVar}`;
-  const actionBuilderReplacement =
-    `function ${builderFn}({action:${builderActionVar},disabled:${builderDisabledVar},hostId:${builderHostVar},installCodexPending:${builderPendingVar},` +
-    `installCodexRelease:codexLinuxRemoteControlSshInstallReleaseTarget,onAuthenticate:${builderAuthVar},onInstallCodex:${builderInstallVar}${builderRestartPart}}){` +
-    `if(${builderActionVar}==null)return null;switch(${builderActionVar}.kind){case\`install-codex\`:return{disabled:${builderDisabledVar},label:${builderActionVar}.label,loading:${builderPendingVar},` +
-    `loadingLabel:${builderActionVar}.loadingLabel,renderInElectronOnly:!0,tooltipText:${builderActionVar}.tooltipText,onClick:()=>${builderInstallVar}(${builderHostVar},codexLinuxRemoteControlSshInstallReleaseTarget)}`;
-
-  const [
-    ,
-    gateVar,
-    loadGateVar,
-    errorVar,
-    renderedActionVar,
-    connectionActionVar,
-    renderActionFn,
+    actionVar,
     disabledVar,
-    connectionVar,
+    hostVar,
     pendingVar,
-    restartVar,
     authenticateVar,
     installVar,
-  ] = actionCallMatch;
-  const restartPart = restartVar == null ? "" : `onRestart:${restartVar},`;
+    reconnectVar,
+    restartVar,
+  ] = currentActionBuilderMatch;
+  const actionBuilderReplacement =
+    `function ${builderFn}({action:${actionVar},disabled:${disabledVar},hostId:${hostVar},` +
+    `installCodexPending:${pendingVar},installCodexRelease:codexLinuxRemoteControlSshInstallReleaseTarget,` +
+    `onAuthenticate:${authenticateVar},onInstallCodex:${installVar},onReconnect:${reconnectVar},onRestart:${restartVar}}){` +
+    `if(${actionVar}==null)return null;switch(${actionVar}.kind){case\`install-codex\`:return{` +
+    `disabled:${disabledVar},label:${actionVar}.label,loading:${pendingVar},loadingLabel:${actionVar}.loadingLabel,` +
+    `renderInElectronOnly:!0,tooltipText:${actionVar}.tooltipText,` +
+    `onClick:()=>${installVar}(${hostVar},codexLinuxRemoteControlSshInstallReleaseTarget)}`;
+
+  const [
+    ,
+    actionFn,
+    connectionActionVar,
+    callDisabledVar,
+    connectionVar,
+    callPendingVar,
+    callReconnectVar,
+    callRestartVar,
+    callAuthenticateVar,
+    callInstallVar,
+  ] = currentActionCallMatch;
   const actionCallReplacement =
-    `let ${gateVar}=${loadGateVar}&&(${errorVar}?.code===\`remote-codex-not-found\`||${errorVar}?.code===\`update-required\`);` +
-    `${renderedActionVar}=${connectionActionVar}==null||${gateVar}?null:${renderActionFn}({action:${connectionActionVar}.action,disabled:${disabledVar},hostId:${connectionVar}.hostId,` +
-    `installCodexPending:${pendingVar},installCodexRelease:${REMOTE_CONTROL_SSH_INSTALL_RELEASE_MARKER}(${errorVar}),${restartPart}onAuthenticate:${authenticateVar},onInstallCodex:${installVar}})`;
+    `${actionFn}({action:${connectionActionVar}.action,disabled:${callDisabledVar},` +
+    `hostId:${connectionVar}.hostId,installCodexPending:${callPendingVar},` +
+    `installCodexRelease:${REMOTE_CONTROL_SSH_INSTALL_RELEASE_MARKER}(codexLinuxRemoteControlSshInstallError),` +
+    `onReconnect:${callReconnectVar},onRestart:${callRestartVar},` +
+    `onAuthenticate:${callAuthenticateVar},onInstallCodex:${callInstallVar}})`;
+
+  const [
+    ,
+    appServerVersionVar,
+    errorVar,
+    installedVersionVar,
+    stateVar,
+    connectionStateFn,
+    localConnectionVar,
+    displayNameVar,
+  ] = currentLocalVersionMatch;
+  const localVersionReplacement =
+    `{appServerVersion:${appServerVersionVar},error:${errorVar},` +
+    `installedCodexVersion:${installedVersionVar},state:${stateVar}}=` +
+    `${connectionStateFn}(${localConnectionVar}.hostId),` +
+    `{appServerVersion:codexLinuxRemoteControlSshInstallLocalVersion}=${connectionStateFn}(\`local\`),` +
+    `codexLinuxRemoteControlSshInstallError=${errorVar},` +
+    `${displayNameVar}=(codexLinuxRemoteControlSshInstallDefaultRelease=` +
+    `codexLinuxRemoteControlValidRelease(codexLinuxRemoteControlSshInstallLocalVersion)??` +
+    `codexLinuxRemoteControlSshInstallDefaultRelease,${localConnectionVar}.displayName)`;
 
   const [
     ,
@@ -761,34 +620,33 @@ function applyLinuxRemoteControlSshInstallReleasePatch(source) {
     mutationStateVar,
     mutationErrorVar,
     syncStateFn,
-  ] = mutationMatch;
+  ] = currentMutationMatch;
   const mutationReplacement =
     `${mutationHandlerVar}=(${mutationHostVar},codexLinuxRemoteControlSshInstallTargetRelease)=>{` +
     `let codexLinuxRemoteControlSshInstallRequest={hostId:${mutationHostVar}},` +
-    `codexLinuxRemoteControlSshInstallResolvedRelease=codexLinuxRemoteControlSshInstallTargetRelease??codexLinuxRemoteControlSshInstallDefaultRelease;` +
-    `codexLinuxRemoteControlSshInstallResolvedRelease!=null&&(codexLinuxRemoteControlSshInstallRequest.release=codexLinuxRemoteControlSshInstallResolvedRelease),` +
-    `${mutationVar}.mutate(codexLinuxRemoteControlSshInstallRequest,{onSuccess:({state:${mutationStateVar},error:${mutationErrorVar}})=>{${syncStateFn}(${mutationHostVar},${mutationStateVar},${mutationErrorVar})}})}`;
+    `codexLinuxRemoteControlSshInstallResolvedRelease=` +
+    `codexLinuxRemoteControlSshInstallTargetRelease??codexLinuxRemoteControlSshInstallDefaultRelease;` +
+    `codexLinuxRemoteControlSshInstallResolvedRelease!=null&&` +
+    `(codexLinuxRemoteControlSshInstallRequest.release=codexLinuxRemoteControlSshInstallResolvedRelease),` +
+    `${mutationVar}.mutate(codexLinuxRemoteControlSshInstallRequest,{onSuccess:({state:${mutationStateVar},` +
+    `error:${mutationErrorVar}})=>{${syncStateFn}(${mutationHostVar},${mutationStateVar},${mutationErrorVar})}})}`;
 
   const helper = [
-    "let codexLinuxRemoteControlSshInstallDefaultRelease=null;",
+    "let codexLinuxRemoteControlSshInstallDefaultRelease=null,codexLinuxRemoteControlSshInstallError=null;",
     "function codexLinuxRemoteControlValidRelease(e){return typeof e==`string`&&e.trim().length>0?e.trim():null}",
     `function ${REMOTE_CONTROL_SSH_INSTALL_RELEASE_MARKER}(e){return e?.code===\`update-required\`?codexLinuxRemoteControlValidRelease(e.minRequiredVersion):null}`,
   ].join("");
 
   return helper + source
-    .replace(localVersionRegex, localVersionReplacement)
-    .replace(actionBuilderRegex, actionBuilderReplacement)
-    .replace(actionCallRegex, actionCallReplacement)
-    .replace(mutationRegex, mutationReplacement);
+    .replace(currentLocalVersionRegex, localVersionReplacement)
+    .replace(currentActionBuilderRegex, actionBuilderReplacement)
+    .replace(currentActionCallRegex, actionCallReplacement)
+    .replace(currentMutationRegex, mutationReplacement);
 }
 
 function applyLinuxRemoteControlSettingsUxPatch(source) {
   let patched = applyLinuxRemoteControlSshInstallReleasePatch(replaceLinuxRemoteControlCopy(source).patched);
   patched = applyLinuxRemoteControlSshInstallActionPatch(patched);
-
-  if (patched.includes(REMOTE_CONTROL_SETTINGS_TABS_OLD_HELPER)) {
-    patched = patched.replace(REMOTE_CONTROL_SETTINGS_TABS_OLD_HELPER, REMOTE_CONTROL_SETTINGS_TABS_HELPER);
-  }
 
   if (!patched.includes(REMOTE_CONTROL_SETTINGS_UX_MARKER)) {
     const helperNeedle = /function ([A-Za-z_$][\w$]*)\(e,t\)\{return e\.displayName\.localeCompare\(t\.displayName\)\}/u;

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -216,18 +216,9 @@ function syntheticRemoteConnectionVisibilityBundle() {
 
 function syntheticAppMainFeatureSyncBundle() {
   return [
-    "var GF=[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_suggest`],vI=`remote_plugin`;",
-    "function KF(){let e=(0,Z.c)(6),t=K(G),[n]=ts(`statsig_default_enable_features`),r=Lc(),i=Io(),a,o;",
-    "return e[0]!==r?(a=()=>{let r=qF(n,!0);qn(`set-experimental-feature-enablement-for-host`,{hostId:t,enablement:r}).catch(n=>{q.error(`Failed to sync experimental feature enablement`,{sensitive:{error:n}})})},o=[r],e[0]=r,e[1]=a,e[2]=o):(a=e[1],o=e[2]),null}",
-    "function qF(e,t){let n={};for(let r of GF){let i=e[r];i!=null&&(n[r]=i)}return n[vI]=t,n}",
-  ].join("");
-}
-
-function syntheticCurrentAppMainFeatureSyncBundle() {
-  return [
-    "var gI=[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_suggest`],vI=`remote_plugin`,Ir=`local-host`,Vt=`hosts`,Ro=`features-query`,G={error(){}};",
-    "function yI(){let e=new Map,o=()=>{if(ln(`set-default-feature-overrides`,{overrides:features??null}),features==null)return;let i=bI(features,!0),o=store.get(Ir),s=new Set(store.get(Vt).filter(e=>e===o||xn(store,e).state===`connected`));for(let t of e.keys())s.has(t)||e.delete(t);let c=store.get(Vt).filter(e=>s.has(e)).flatMap(t=>(0,dv.default)(e.get(t),i)?[]:(e.set(t,i),[ln(`set-experimental-feature-enablement-for-host`,{hostId:t,enablement:i}).catch(n=>{e.delete(t),G.error(`Failed to sync experimental feature enablement`,{safe:{hostId:t},sensitive:{error:n}})})]));c.length!==0&&Promise.all(c).then(()=>{query.invalidateQueries({queryKey:Ro})})};return o()}",
-    "function bI(e,t){let n={};for(let t of gI){let r=e[t];r!=null&&(n[t]=r)}return n[vI]=t,n}",
+    "var gI=[`apps_mcp_path_override`,`auth_elicitation`,`tool_suggest`],vI=`remote_plugin`,Ir=`local-host`,Vt=`hosts`,Ro=`features-query`,remotePlugin=!0,mcp=!0,G={error(){}};",
+    "function yI(){let e=new Map,o=()=>{if(ln(`set-default-feature-overrides`,{overrides:features??null}),features==null)return;let i=bI(features,remotePlugin,mcp),a=store.get(Ir),s=new Set(store.get(Vt).filter(e=>e===a||xn(store,e).state===`connected`));for(let t of e.keys())s.has(t)||e.delete(t);let c=Array.from(s).flatMap(t=>(0,dv.default)(e.get(t),i)?[]:(e.set(t,i),[ln(`set-experimental-feature-enablement-for-host`,{hostId:t,enablement:i}).catch(n=>{e.delete(t),G.error(`Failed to sync experimental feature enablement`,{safe:{hostId:t},sensitive:{error:n}})})]));c.length!==0&&Promise.all(c).then(()=>{query.invalidateQueries({queryKey:Ro})})};return o()}",
+    "function bI(e,t,n){let r={memories:!1};for(let t of gI){let n=e[t];n!=null&&(r[t]=n)}return r.mcp_2026_07_28=n,r[vI]=t,r}",
   ].join("");
 }
 
@@ -271,7 +262,6 @@ function syntheticSettingsBundle() {
     "tabs:[{key:`control-this-mac`,name:o===`windows`?(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.controlThisMac.windows`,defaultMessage:`Control this PC`,description:`Tab label for settings that let other devices control this Windows device`}):(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.controlThisMac`,defaultMessage:`Control this Mac`,description:`Tab label for settings that let other devices control this computer`})},{key:`access-other-devices`,name:(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.accessOtherDevices`,defaultMessage:`Control other devices`,description:`Tab label for settings that let this computer control other devices`})},{key:`ssh`,name:(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.ssh`,defaultMessage:`SSH`,description:`Tab label for SSH remote connections`})}],selectedKey:je,variant:`underline`,onSelect:se}",
     "tabs:[{key:`access-other-devices`,name:(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.accessOtherDevices`,defaultMessage:`Control other devices`,description:`Tab label for settings that let this computer control other devices`})},{key:`ssh`,name:(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.ssh`,defaultMessage:`SSH`,description:`Tab label for SSH remote connections`})}],selectedKey:je,variant:`underline`,onSelect:se}",
     "const a=`Control this Mac from your phone or other device`,b=`Add device to control this Mac remotely`,c=`Devices that can control this Mac`,d=`Keep Mac awake`,e=`Allow this Mac to be discovered and controlled`,f=`Control other devices from this Mac`,g=`Authorize this Mac to control other devices signed in to your ChatGPT account`,h=`Devices you can control from this Mac`;",
-    "let xe=!Pe&&(Te?.code===`remote-codex-not-found`||Te?.code===`update-required`);Ce=Ae==null||xe?null:Re({action:Ae.action,connection:Ee});",
     "function nr(e,t){return e.displayName.localeCompare(t.displayName)}",
     "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}",
   ].join("");
@@ -279,9 +269,9 @@ function syntheticSettingsBundle() {
 
 function syntheticSshInstallSettingsBundle() {
   return [
-    "function pn({action:e,disabled:t,hostId:n,installCodexPending:r,onAuthenticate:i,onInstallCodex:a}){if(e==null)return null;switch(e.kind){case`install-codex`:return{disabled:t,label:e.label,loading:r,loadingLabel:e.loadingLabel,renderInElectronOnly:!0,tooltipText:e.tooltipText,onClick:()=>a(n)};case`login`:return{label:e.label,onClick:()=>i(n)};case`settings`:return null}}",
+    "function pn({action:e,disabled:t,hostId:n,installCodexPending:r,onAuthenticate:i,onInstallCodex:a,onReconnect:o,onRestart:s}){if(e==null)return null;switch(e.kind){case`install-codex`:return{disabled:t,label:e.label,loading:r,loadingLabel:e.loadingLabel,renderInElectronOnly:!0,tooltipText:e.tooltipText,onClick:()=>a(n)};case`login`:return{label:e.label,onClick:()=>i(n)};case`restart`:return{label:e.label,onClick:s};case`reconnect`:return{label:e.label,onClick:o};case`settings`:return null}}",
     "let et=R(`install-remote-codex`),vt=(e,t,n)=>{globalThis.__states.push({hostId:e,state:t,error:n})},bt=e=>{et.mutate({hostId:e},{onSuccess:({state:t,error:n})=>{vt(e,t,n)}})};",
-    "function un(e){let t=(0,$.c)(86),{connection:n,disabled:r,installCodexPending:i,onAuthenticate:a,onEdit:o,onInstallCodex:s,onLogoutConnection:c,onRemove:l,onShowDetails:u,onToggleConnection:d}=e,f=ee(),{appServerVersion:p,error:m,installedCodexVersion:h,state:g}=De(n.hostId),_=n.displayName,v;let T=w,E=oe(`2153867414`),D,O,k,A,j,M;if(t[8]!==p||t[9]!==n.hostId||t[10]!==r||t[11]!==m||t[12]!==i||t[13]!==h||t[14]!==f||t[15]!==a||t[16]!==s||t[17]!==E||t[18]!==g){k=fn({appServerVersion:p,installedCodexVersion:h,state:g}),D=g===`connected`||m?.code===`login-required`||m?.code===`update-required`||m?.code===`restart-required`;let{statusError:e,isRestartAvailableNotice:o,statusState:c}=dn({error:m,restartAvailableNotice:k,state:g});A=e,O=o,j=c==null?null:Ne(f,{canLogin:!0,error:A,state:c,surface:`connections-row`});let l=!E&&(A?.code===`remote-codex-not-found`||A?.code===`update-required`);M=j==null||l?null:pn({action:j.action,disabled:r,hostId:n.hostId,installCodexPending:i,onAuthenticate:a,onInstallCodex:s}),t[8]=p,t[9]=n.hostId,t[10]=r,t[11]=m,t[12]=i,t[13]=h,t[14]=f,t[15]=a,t[16]=s,t[17]=E,t[18]=g,t[19]=D,t[20]=O,t[21]=k,t[22]=A,t[23]=j,t[24]=M}else D=t[19],O=t[20],k=t[21],A=t[22],j=t[23],M=t[24];return M}",
+    "function un(e){let{connection:n,disabled:r,installCodexPending:i,onAuthenticate:a,onInstallCodex:s,onReconnect:c,onRestart:l}=e,{appServerVersion:p,error:m,installedCodexVersion:h,state:g}=De(n.hostId),_=n.displayName,j=Ne(),E=!1;let D=(n.kind||!E)&&(m?.code===`remote-codex-not-found`||m?.code===`update-required`),M;return M=j==null||D?null:pn({action:j.action,disabled:r,hostId:n.hostId,installCodexPending:i,onReconnect:c,onRestart:l,onAuthenticate:a,onInstallCodex:s}),M}",
     "function nr(e,t){return e.displayName.localeCompare(t.displayName)}",
   ].join("");
 }
@@ -1453,17 +1443,18 @@ test("Linux remote-control feature sync forces remote_control and preserves remo
   const patched = applyLinuxRemoteControlFeatureSyncPatch(source);
 
   assert.notEqual(patched, source);
-  assert.match(patched, /\.remote_control=!0/);
-  assert.match(patched, /n\[vI\]=t/);
+  assert.match(patched, /r\[vI\]=t/);
   assert.match(patched, /codexLinuxRemoteControlFeatureSyncEnabled/);
-  assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)\?\(/);
-  assert.match(patched, /\?\(codexLinuxRemoteControlFeatureSyncEnabled\(arguments\[2\],arguments\[3\]\)&&\(n\.remote_control=!0\),n\[vI\]=t,n\)/);
-  assert.match(patched, /:\(n\[vI\]=t,n\)\}/);
+  assert.match(patched, /codexLinuxRemoteControlFeatureSyncEnabled\(i,a,t\)/);
+  assert.match(
+    patched,
+    /navigator\.userAgent\.includes\(`Linux`\)&&t===n\?\{\.\.\.e,remote_control:!0\}:e/,
+  );
   assert.equal(applyLinuxRemoteControlFeatureSyncPatch(patched), patched);
 });
 
 test("Linux remote-control feature sync does not advertise SSH hosts to mobile", async () => {
-  const source = syntheticCurrentAppMainFeatureSyncBundle();
+  const source = syntheticAppMainFeatureSyncBundle();
   const patched = applyLinuxRemoteControlFeatureSyncPatch(source);
 
   assert.notEqual(patched, source);
@@ -1564,7 +1555,7 @@ test("Linux mobile setup dialog copy does not refer to Mac-only setup", () => {
 });
 
 test("Linux remote-control settings UX patch keeps outbound tab visible and removes Mac copy", () => {
-  const source = syntheticSettingsBundle();
+  const source = syntheticSettingsBundle() + syntheticSshInstallSettingsBundle();
   const patched = applyLinuxRemoteControlSettingsUxPatch(source);
 
   assert.notEqual(patched, source);
@@ -1573,7 +1564,6 @@ test("Linux remote-control settings UX patch keeps outbound tab visible and remo
   assert.match(patched, /function codexLinuxRemoteControlSettingsTabs\(e\)\{return e\}/);
   assert.doesNotMatch(patched, /e\.filter\(e=>e\.key!==`access-other-devices`\)/);
   assert.match(patched, /key:`access-other-devices`/);
-  assert.match(patched, /Ce=Ae==null\?null:Re\(\{action:Ae\.action/);
   assert.match(patched, /Control this Linux desktop/);
   assert.match(patched, /Control this Linux desktop from your phone or other device/);
   assert.match(patched, /Add device to control this Linux desktop remotely/);
@@ -3652,7 +3642,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         assert.match(patchedAppServerLaunchFile, /codexLinuxRemoteMobileAppServerArgs/);
         assert.match(patchedAppServerLaunchFile, /`--remote-control`/);
         assert.match(patchedRemoteConnectionVisibilityFile, /codexLinuxRemoteControlLoadGateEnabled/);
-        assert.match(patchedAppMainFile, /\.remote_control=!0/);
+        assert.match(patchedAppMainFile, /\{\.\.\.e,remote_control:!0\}/);
         assert.match(patchedVisibilityFile, /navigator\.userAgent\.includes\(`Linux`\)/);
         assert.match(patchedRemoteConnectionsSettingsFile, /codexLinuxRemoteControlSettingsTabs/);
         assert.match(patchedRemoteConnectionsSettingsFile, /codexLinuxRemoteControlResetMobileSetupAfterRevoke/);

--- a/linux-features/ui-tweaks/patches/sidebar-project-name.js
+++ b/linux-features/ui-tweaks/patches/sidebar-project-name.js
@@ -2,14 +2,14 @@
 
 const DEFAULT_PROJECT_NAME_STYLE = "font-weight: 700 !important;";
 const PROJECTS_SIDEBAR_ASSET_PATTERN = /^app-initial-[^.]+\.js$/;
-const PROJECT_NAME_SELECTOR = ".group\\/folder-row .text-fade-truncate.pr-1";
+const PROJECT_NAME_SELECTOR = ".group\\/folder-row .text-fade-truncate.pe-1";
 const STYLE_ID = "codex-linux-ui-tweaks-sidebar-project-name-style";
 const RUNTIME_MARKER = "codexLinuxUiTweaksSidebarProjectNameStyleRuntime";
 const UNSAFE_PROJECT_NAME_STYLE_PATTERN = /[{}@<>]|\r|\n|\/\*|\*\/|\burl\s*\(/i;
 
 const SIDEBAR_PROJECT_NAME_MARKERS = [
   "group/folder-row",
-  "className:`text-fade-truncate pr-1`",
+  "className:`text-fade-truncate pe-1`",
 ];
 
 function warn(message) {

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -45,7 +45,7 @@ const {
 function projectBundleFixture() {
   return [
     "function row(){let j=Pn(`group/folder-row group relative flex h-[var(--height-token-row)] text-sm text-token-foreground`);",
-    "let V=(0,Iy.jsx)(`span`,{className:`text-fade-truncate pr-1`,children:p});return [j,V]}",
+    "let V=(0,Iy.jsx)(`span`,{className:`text-fade-truncate pe-1`,children:p});return [j,V]}",
   ].join("");
 }
 


### PR DESCRIPTION
<!-- upstream-dmg-sha256:fb93a239c811c7639cf45a90ff36c262fa0290640140cd12da3fdc60b62255ae -->

## Summary
- repair Linux compatibility drift for the current upstream DMG
- remove obsolete compatibility paths replaced by the current DMG shape

## Validation
- exact current-DMG acceptance recorded by watchdog v2
- GitHub CI must pass, including Nix Package Builds
