### PR TITLE
ci: build Linux packages and portable tarball

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,0 +1,281 @@
+name: Build Linux Artifacts
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-linux-artifacts-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CI_PACKAGE_VERSION: 2026.04.28.000000+ci${{ github.run_number }}
+  UPSTREAM_DMG_URL: https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg
+  UPSTREAM_DMG_PATH: /tmp/codex-upstream-ci/Codex.dmg
+  DMG_CACHE_SCHEMA_VERSION: v1
+
+jobs:
+  build:
+    name: Build deb, rpm, and tar.gz
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Install build tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y \
+            curl \
+            g++ \
+            make \
+            p7zip-full \
+            python3 \
+            rpm \
+            tar \
+            unzip
+          SEVENZIP_SYSTEM_INSTALL=1 \
+          NODEJS_MAJOR=24 \
+            bash scripts/install-deps.sh
+          command -v 7zz || command -v 7z
+
+      - name: Install Rust toolchain
+        run: |
+          set -euo pipefail
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustc --version
+          cargo --version
+
+      - name: Capture upstream DMG metadata
+        id: upstream-metadata
+        run: |
+          set -euo pipefail
+
+          headers_file="$(mktemp)"
+          trap 'rm -f "$headers_file"' EXIT
+          curl -fsSLI "$UPSTREAM_DMG_URL" > "$headers_file"
+
+          last_modified="$(awk 'tolower($0) ~ /^last-modified:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); print; exit}' "$headers_file")"
+          etag="$(awk 'tolower($0) ~ /^etag:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); gsub(/"/,""); print; exit}' "$headers_file")"
+          content_length="$(awk 'tolower($0) ~ /^content-length:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); print; exit}' "$headers_file")"
+          last_modified="${last_modified:-unknown}"
+          etag="${etag:-no-etag}"
+          content_length="${content_length:-unknown}"
+          cache_segment="$(printf '%s|%s|%s\n' "$last_modified" "$etag" "$content_length" | sha256sum | cut -d' ' -f1)"
+
+          {
+            echo "last_modified=$last_modified"
+            echo "etag=$etag"
+            echo "content_length=$content_length"
+            echo "cache_segment=$cache_segment"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached upstream DMG
+        id: dmg-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/codex-upstream-ci/Codex.dmg
+          key: upstream-dmg-${{ env.DMG_CACHE_SCHEMA_VERSION }}-${{ steps.upstream-metadata.outputs.cache_segment }}
+
+      - name: Download upstream DMG
+        if: steps.dmg-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "$UPSTREAM_DMG_PATH")"
+          curl -fL --retry 3 --retry-delay 2 -o "$UPSTREAM_DMG_PATH" "$UPSTREAM_DMG_URL"
+
+      - name: Write upstream DMG metadata
+        run: |
+          set -euo pipefail
+          test -s "$UPSTREAM_DMG_PATH"
+          dmg_sha256="$(sha256sum "$UPSTREAM_DMG_PATH" | cut -d' ' -f1)"
+          dmg_size_bytes="$(stat -c '%s' "$UPSTREAM_DMG_PATH")"
+          tested_at_utc="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+          cat > upstream-dmg-metadata.json <<JSON
+          {
+            "url": "$UPSTREAM_DMG_URL",
+            "path": "$UPSTREAM_DMG_PATH",
+            "last_modified": "${{ steps.upstream-metadata.outputs.last_modified }}",
+            "etag": "${{ steps.upstream-metadata.outputs.etag }}",
+            "content_length": "${{ steps.upstream-metadata.outputs.content_length }}",
+            "sha256": "$dmg_sha256",
+            "size_bytes": $dmg_size_bytes,
+            "tested_at_utc": "$tested_at_utc",
+            "cache_schema_version": "$DMG_CACHE_SCHEMA_VERSION"
+          }
+          JSON
+
+      - name: Build Linux app from upstream DMG
+        env:
+          CODEX_ACCEPTANCE_DECISION_JSON: ${{ github.workspace }}/upstream-dmg-decision.json
+          CODEX_ACCEPTANCE_OVERRIDE: '0'
+          CODEX_ACCEPTANCE_SOURCE: github-actions
+          CODEX_DMG_REFRESH_MODE: pinned
+          CODEX_UPSTREAM_DMG_METADATA_JSON: ${{ github.workspace }}/upstream-dmg-metadata.json
+          REBUILD_REPORT_DIR: ${{ github.workspace }}/upstream-acceptance
+        run: make build-app DMG="$UPSTREAM_DMG_PATH"
+
+      - name: Build updater binary
+        run: cargo build --release -p codex-update-manager
+
+      - name: Build Debian package
+        run: |
+          set -euo pipefail
+          PACKAGE_VERSION="$CI_PACKAGE_VERSION" \
+          UPDATER_BINARY_SOURCE="$GITHUB_WORKSPACE/target/release/codex-update-manager" \
+            ./scripts/build-deb.sh
+
+      - name: Build RPM package in Fedora
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -e CI_PACKAGE_VERSION="$CI_PACKAGE_VERSION" \
+            -v "$GITHUB_WORKSPACE:/work" \
+            -w /work \
+            docker.io/library/fedora:42@sha256:99e203b80b1c3d8f7e161ec10a68fd02b081ef83a3963553e513c82846b97814 \
+            bash -lc '
+              set -euo pipefail
+              dnf install -y --setopt=install_weak_deps=False \
+                gcc-c++ make python3 rpm-build 7zip curl unzip tar
+              command -v 7z
+              PACKAGE_VERSION="$CI_PACKAGE_VERSION" \
+              UPDATER_BINARY_SOURCE=/work/target/release/codex-update-manager \
+                ./scripts/build-rpm.sh
+            '
+
+      - name: Build portable tarball
+        run: PACKAGE_VERSION="$CI_PACKAGE_VERSION" ./scripts/build-tarball.sh
+
+      - name: Generate checksums and verify artifact layout
+        run: |
+          set -euo pipefail
+          mapfile -t artifacts < <(find dist -maxdepth 1 -type f \( -name '*.deb' -o -name '*.rpm' -o -name '*.tar.gz' \) -print | sort)
+          test "${#artifacts[@]}" -eq 3
+          printf '%s\n' "${artifacts[@]}" | xargs -r sha256sum > SHA256SUMS
+          grep -q 'codex-desktop_.*\.deb$' SHA256SUMS
+          grep -q 'codex-desktop-.*\.rpm$' SHA256SUMS
+          grep -q 'codex-desktop-.*\.tar\.gz$' SHA256SUMS
+          {
+            echo "## Linux artifacts"
+            echo
+            printf -- '- `%s`\n' "${artifacts[@]}"
+            echo "- Portable baseline: Ubuntu 22.04 (glibc compatibility)."
+            echo "- RPM builder: Fedora 42 container."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: codex-desktop-linux-${{ github.sha }}
+          path: |
+            dist/*.deb
+            dist/*.rpm
+            dist/*.tar.gz
+            SHA256SUMS
+            upstream-dmg-metadata.json
+            upstream-dmg-decision.json
+            upstream-acceptance/**/*.json
+          if-no-files-found: error
+          retention-days: 30
+
+  distro-smoke:
+    name: Smoke ${{ matrix.distro }}
+    needs: build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: Ubuntu 22.04
+            image: docker.io/library/ubuntu:22.04@sha256:962f6cadeae0ea6284001009daa4cc9a8c37e75d1f5191cf0eb83fe565b63dd7
+            format: deb
+          - distro: Ubuntu 24.04
+            image: docker.io/library/ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
+            format: deb
+          - distro: Debian 12
+            image: docker.io/library/debian:12@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc
+            format: deb
+          - distro: Fedora 42
+            image: docker.io/library/fedora:42@sha256:99e203b80b1c3d8f7e161ec10a68fd02b081ef83a3963553e513c82846b97814
+            format: rpm
+          - distro: openSUSE Tumbleweed
+            image: registry.opensuse.org/opensuse/tumbleweed:latest@sha256:dfd8ff24e536ef4d4b6a24951aae454840d6c3d51fd771d1d08a584e48b18567
+            format: rpm
+          - distro: Arch Linux
+            image: docker.io/library/archlinux:base-devel@sha256:fdff15f24df062598faebf380430955a9bd2109736e179ebb354f1208f725774
+            format: tarball
+
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: codex-desktop-linux-${{ github.sha }}
+          path: .
+
+      - name: Install package or extract tarball
+        env:
+          DISTRO_FORMAT: ${{ matrix.format }}
+          DISTRO_IMAGE: ${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -e DISTRO_FORMAT="$DISTRO_FORMAT" \
+            -v "$GITHUB_WORKSPACE:/work:ro" \
+            -w /work \
+            "$DISTRO_IMAGE" \
+            bash -s <<'SCRIPT'
+          set -euo pipefail
+          case "$DISTRO_FORMAT" in
+            deb)
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update -qq
+              apt-get install -y --no-install-recommends ca-certificates
+              apt-get install -y ./dist/*.deb
+              test -x /opt/codex-desktop/start.sh
+              command -v 7z
+              ;;
+            rpm)
+              if command -v dnf >/dev/null 2>&1; then
+                dnf install -y ca-certificates
+                dnf install -y ./dist/*.rpm
+              else
+                zypper --non-interactive --no-gpg-checks refresh
+                zypper --non-interactive --no-gpg-checks install -y ./dist/*.rpm
+              fi
+              test -x /opt/codex-desktop/start.sh
+              command -v 7z
+              ;;
+            tarball)
+              archive="$(find dist -maxdepth 1 -name '*.tar.gz' -print -quit)"
+              test -n "$archive"
+              tar -tzf "$archive" | grep -q '/start.sh$'
+              extract_dir="$(mktemp -d)"
+              tar -xzf "$archive" -C "$extract_dir"
+              launcher="$(find "$extract_dir" -type f -name start.sh -print -quit)"
+              test -x "$launcher"
+              bash -n "$launcher"
+              ;;
+            *)
+              echo "Unknown package format: $DISTRO_FORMAT" >&2
+              exit 2
+              ;;
+          esac
+          SCRIPT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           bash -n scripts/build-rpm.sh
           bash -n scripts/build-pacman.sh
           bash -n scripts/build-appimage.sh
+          bash -n scripts/build-tarball.sh
           bash -n scripts/ci/update-nix-hashes.sh
           bash -n scripts/ci/validate-nix-pins.sh
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ if [ -z "$$format" ]; then \
 fi; \
 printf '%s\n' "$$format"
 
-.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream inspect-upstream-intel inspect-upstream-intel-devcontainer build-app build-app-fresh setup-native bootstrap-native install-native update-native rebuild-next run-app build-dev-app run-dev-app deb rpm pacman appimage package install service-enable service-status clean-dist clean-state
+.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream inspect-upstream-intel inspect-upstream-intel-devcontainer build-app build-app-fresh setup-native bootstrap-native install-native update-native rebuild-next run-app build-dev-app run-dev-app deb rpm pacman appimage tarball package install service-enable service-status clean-dist clean-state
 
 help:
 	@printf '\nChatGPT Desktop for Linux Make Targets\n\n'
@@ -93,6 +93,7 @@ help:
 	@printf '  %-18s %s\n' "make rpm" "Build the RPM package into dist/ (Fedora/openSUSE)"
 	@printf '  %-18s %s\n' "make pacman" "Build the pacman package into dist/ (Arch)"
 	@printf '  %-18s %s\n' "make appimage" "Build the AppImage into dist/ (local self-build)"
+	@printf '  %-18s %s\n' "make tarball" "Build a portable .tar.gz archive into dist/"
 	@printf '  %-18s %s\n' "make package" "Build native package (auto-detects deb, rpm, or pacman)"
 	@printf '  %-18s %s\n' "make install" "Install the latest generated native package"
 	@printf '  %-18s %s\n' "make service-enable" "Enable and start codex-update-manager.service for the current user"
@@ -109,7 +110,7 @@ help:
 	@printf '  %-18s %s\n' "REBUILD_REPORT_DIR=..." "Override inspect/rebuild report output directory"
 	@printf '  %-18s %s\n' "DEV_APP_ID=..." "Override side-by-side test app id/bin (default: codex-cua-lab)"
 	@printf '  %-18s %s\n' "DEV_APP_NAME=..." "Override side-by-side test app display name"
-	@printf '  %-18s %s\n' "PACKAGE_VERSION=..." "Override the package version for make deb / make rpm / make pacman / make appimage"
+	@printf '  %-18s %s\n' "PACKAGE_VERSION=..." "Override the package version for make deb / make rpm / make pacman / make appimage / make tarball"
 	@printf '  %-18s %s\n' "PACKAGE_WITH_UPDATER=0" "Build packages without codex-update-manager or the updater service"
 	@printf '  %-18s %s\n' "CODEX_CLI_BUNDLE_SOURCE=..." "Embed an installed Codex CLI package in a local AppImage"
 	@printf '  %-18s %s\n' "MAX_BUILD_THREADS=8" "Set supported build jobs/compression threads (default: 0, tool/user defaults)"
@@ -145,6 +146,7 @@ help:
 	@printf '  %s\n' "MAX_BUILD_THREADS=8 make rpm"
 	@printf '  %s\n' "make pacman PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
 	@printf '  %s\n' "make appimage PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
+	@printf '  %s\n' "make tarball PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
 	@printf '  %s\n' "make install"
 	@printf '  %s\n\n' "make service-enable"
 
@@ -288,6 +290,10 @@ pacman: maybe-build-updater
 appimage:
 	@echo "[make] Building AppImage"
 	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" CODEX_CLI_BUNDLE_SOURCE="$(CODEX_CLI_BUNDLE_SOURCE)" ./scripts/build-appimage.sh
+
+tarball:
+	@echo "[make] Building portable tarball"
+	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-tarball.sh
 
 package: maybe-build-updater
 	@echo "[make] Building native package (auto-detecting distro)"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/ilysenko/codex-desktop-linux/actions/workflows/ci.yml"><img src="https://github.com/ilysenko/codex-desktop-linux/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/ilysenko/codex-desktop-linux/actions/workflows/build-artifacts.yml"><img src="https://github.com/ilysenko/codex-desktop-linux/actions/workflows/build-artifacts.yml/badge.svg" alt="Build Linux Artifacts"></a>
   <a href="https://github.com/ilysenko/codex-desktop-linux/actions/workflows/upstream-build-app.yml"><img src="https://github.com/ilysenko/codex-desktop-linux/actions/workflows/upstream-build-app.yml/badge.svg" alt="Upstream Build App"></a>
   <a href="https://discord.gg/skCB3DXqgw"><img src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white" alt="Join the Discord community"></a>
 </p>
@@ -11,9 +12,10 @@ The official ChatGPT app is available for macOS and Windows; this repository
 covers Linux by converting the upstream macOS `Codex.dmg` into a runnable Linux
 Electron app.
 
-The project builds native `.deb`, `.rpm`, and `.pkg.tar.zst` packages, supports
-local AppImage self-builds and Nix, and can install a local update manager that
-rebuilds future Linux packages from newer upstream DMGs.
+The project builds native `.deb`, `.rpm`, and `.pkg.tar.zst` packages, publishes
+a portable `.tar.gz` archive through GitHub Actions, supports local AppImage
+self-builds and Nix, and can install a local update manager that rebuilds future
+Linux packages from newer upstream DMGs.
 
 <p align="center">
   <a href="#how-to-install">Install</a> ·
@@ -51,7 +53,7 @@ cd codex-desktop-linux
 | openSUSE | `make bootstrap-native` | Builds and installs an `.rpm` |
 | Arch, Manjaro, EndeavourOS | `make bootstrap-native` | Builds and installs a pacman package |
 | NixOS / Nix | `nix run github:ilysenko/codex-desktop-linux` | See [Nix docs](docs/nix.md) |
-| Atomic desktops / other distros | `make build-app && make appimage` | Local self-build; no bundled updater |
+| Atomic desktops / other distros | Download the Actions `.tar.gz` artifact | Portable archive; no package-manager integration |
 
 Recommended native install:
 
@@ -335,6 +337,7 @@ make deb
 make rpm
 make pacman
 make appimage
+make tarball
 ```
 
 The package scripts only repackage the already-generated `codex-app/`. They do

--- a/docs/agents/repository-map.md
+++ b/docs/agents/repository-map.md
@@ -175,6 +175,8 @@ extension point to core rather than moving the feature itself into core.
   Builds `.pkg.tar.zst` from `codex-app/`.
 - `scripts/build-appimage.sh`
   Builds an AppImage using `packaging/appimage/`.
+- `scripts/build-tarball.sh`
+  Builds a portable `.tar.gz` archive from `codex-app/`.
 - `packaging/linux/`
   Debian control files, RPM spec, pacman `PKGBUILD.template`/install hooks,
   desktop entry, icon policy, Polkit policy, packaged runtime helper, shared

--- a/docs/agents/validation-playbook.md
+++ b/docs/agents/validation-playbook.md
@@ -14,6 +14,7 @@ bash -n scripts/build-deb.sh
 bash -n scripts/build-rpm.sh
 bash -n scripts/build-pacman.sh
 bash -n scripts/build-appimage.sh
+bash -n scripts/build-tarball.sh
 ```
 
 For launcher behavior changes, rebuild or inspect the generated launcher:
@@ -107,6 +108,7 @@ bundles, desktop files, permissions, or runtime helpers are touched:
 ./scripts/build-rpm.sh
 ./scripts/build-pacman.sh
 ./scripts/build-appimage.sh
+./scripts/build-tarball.sh
 ```
 
 Use a package version override when a deterministic package name helps review:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,7 +114,7 @@ Run the subset that matches your change. For installer, packaging, patcher, or
 updater changes:
 
 ```bash
-bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh scripts/install-deps.sh
+bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh scripts/build-tarball.sh scripts/install-deps.sh
 node --check scripts/patch-linux-window-ui.js
 node --test scripts/patch-linux-window-ui.test.js
 node --test linux-features/*/test.js

--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -35,12 +35,15 @@ sudo dnf install python3 7zip curl unzip tar rpm-build make gcc-c++ @development
 sudo dnf install python3 p7zip p7zip-plugins curl unzip tar rpm-build make gcc-c++
 sudo dnf groupinstall 'Development Tools'
 
-# openSUSE
-sudo zypper install python3 p7zip-full curl unzip tar
+# openSUSE Tumbleweed
+sudo zypper install python3 7zip curl unzip tar
 sudo zypper install -t pattern devel_basis
 
+# Older openSUSE Leap releases may provide p7zip-full instead of 7zip:
+sudo zypper install python3 p7zip-full curl unzip tar
+
 # Arch / Manjaro
-sudo pacman -S --needed python p7zip curl unzip tar zstd base-devel
+sudo pacman -S --needed python 7zip curl unzip tar zstd base-devel
 
 # Rust toolchain
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -155,7 +158,12 @@ After `make build-app` or `make build-app-fresh`, build a package from
 | RPM | `make rpm` | `dist/codex-desktop-*.x86_64.rpm` | `sudo dnf install dist/codex-desktop-*.rpm` or `sudo zypper install dist/codex-desktop-*.rpm` |
 | Arch | `make pacman` | `dist/codex-desktop-*.pkg.tar.zst` | `sudo pacman -U dist/codex-desktop-*.pkg.tar.zst` |
 | AppImage | `make appimage` | `dist/codex-desktop-*.AppImage` | Run directly |
+| Portable archive | `make tarball` | `dist/codex-desktop-*-linux-*.tar.gz` | Extract and run `start.sh` |
 | Auto-detect | `make package && make install` | matches host distro | handled by `make install` |
+
+The portable archive is built on Ubuntu 22.04 as a glibc compatibility baseline.
+It avoids a package-manager dependency, but the target system still needs the
+runtime libraries required by Electron and the generated app.
 
 Override package version:
 
@@ -173,6 +181,13 @@ make build-app
 make appimage
 ./dist/codex-desktop-*.AppImage
 ```
+
+The `Build Linux Artifacts` workflow also creates a portable `.tar.gz` archive
+for every pull request, `main` push, version tag, and manual dispatch. It uses
+Ubuntu 22.04 as the glibc baseline, builds RPM inside Fedora 42, and runs
+package smoke checks on Ubuntu, Debian, Fedora, openSUSE, and Arch containers.
+Download the workflow artifact together with `SHA256SUMS` when a native
+package manager is unavailable.
 
 The AppImage flow does not include `codex-update-manager`, the systemd user
 service, polkit policy, or the native-package update builder.

--- a/packaging/linux/PKGBUILD.template
+++ b/packaging/linux/PKGBUILD.template
@@ -8,7 +8,7 @@ url="https://github.com/ilysenko/codex-desktop-linux"
 license=('MIT')
 depends=(
     'python'
-    'p7zip'
+    '7zip'
     'polkit'
     'curl'
     'unzip'

--- a/packaging/linux/control
+++ b/packaging/linux/control
@@ -4,7 +4,7 @@ Section: utils
 Priority: optional
 Architecture: __ARCH__
 Maintainer: ChatGPT Desktop for Linux Maintainers
-Depends: build-essential, curl, dpkg, p7zip-full, pkexec | policykit-1, polkitd | policykit-1, python3, unzip, xdg-utils, libasound2t64 | libasound2, libatk-bridge2.0-0, libatk1.0-0, libc6, libcairo2, libcups2t64 | libcups2, libdbus-1-3, libdrm2, libgbm1, libglib2.0-0t64 | libglib2.0-0, libgtk-3-0t64 | libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libstdc++6, libx11-6, libx11-xcb1, libxcb-dri3-0, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2, __LINUX_FEATURE_DEPENDENCIES__
+Depends: build-essential, curl, dpkg, 7zip | p7zip-full, pkexec | policykit-1, polkitd | policykit-1, python3, unzip, xdg-utils, libasound2t64 | libasound2, libatk-bridge2.0-0, libatk1.0-0, libc6, libcairo2, libcups2t64 | libcups2, libdbus-1-3, libdrm2, libgbm1, libglib2.0-0t64 | libglib2.0-0, libgtk-3-0t64 | libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libstdc++6, libx11-6, libx11-xcb1, libxcb-dri3-0, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2, __LINUX_FEATURE_DEPENDENCIES__
 Recommends: zenity, kdialog
 Description: ChatGPT Desktop for Linux
  Community-built Linux package for ChatGPT Desktop generated from the macOS DMG.

--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=scripts/lib/package-common.sh
+. "$REPO_DIR/scripts/lib/package-common.sh"
+
+APP_DIR="${APP_DIR_OVERRIDE:-$REPO_DIR/codex-app}"
+DIST_DIR="${DIST_DIR_OVERRIDE:-$REPO_DIR/dist}"
+PACKAGE_NAME="${PACKAGE_NAME:-codex-desktop}"
+PACKAGE_VERSION="${PACKAGE_VERSION:-$(date -u +%Y.%m.%d.%H%M%S)}"
+
+map_arch() {
+    case "$(uname -m)" in
+        x86_64) echo "x86_64" ;;
+        aarch64|arm64) echo "aarch64" ;;
+        armv7l|armhf) echo "armhf" ;;
+        *) error "Unsupported tarball architecture: $(uname -m)" ;;
+    esac
+}
+
+validate_package_version() {
+    case "$PACKAGE_VERSION" in
+        ""|*[!A-Za-z0-9._+-]*)
+            error "PACKAGE_VERSION contains unsupported characters: $PACKAGE_VERSION"
+            ;;
+    esac
+}
+
+main() {
+    ensure_app_layout
+    validate_package_version
+
+    local arch archive_root output_file staging_dir source_date_epoch
+    arch="$(map_arch)"
+    archive_root="$PACKAGE_NAME-$PACKAGE_VERSION-linux-$arch"
+    output_file="$DIST_DIR/$archive_root.tar.gz"
+    staging_dir="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '$staging_dir'" EXIT
+
+    mkdir -p "$staging_dir/$archive_root"
+    cp -aT "$APP_DIR" "$staging_dir/$archive_root"
+
+    source_date_epoch="${SOURCE_DATE_EPOCH:-}"
+    if [ -z "$source_date_epoch" ]; then
+        source_date_epoch="$(date -u +%s)"
+    fi
+    case "$source_date_epoch" in
+        ''|*[!0-9]*) error "SOURCE_DATE_EPOCH must be a Unix timestamp" ;;
+    esac
+
+    mkdir -p "$DIST_DIR"
+    rm -f "$output_file"
+    info "Building portable tarball: $output_file"
+    tar \
+        --sort=name \
+        --mtime="@$source_date_epoch" \
+        --owner=0 \
+        --group=0 \
+        --numeric-owner \
+        -czf "$output_file" \
+        -C "$staging_dir" \
+        "$archive_root"
+    chmod 0644 "$output_file"
+    info "Built tarball: $output_file"
+}
+
+main "$@"

--- a/scripts/ci/build-artifacts-workflow.test.js
+++ b/scripts/ci/build-artifacts-workflow.test.js
@@ -1,0 +1,45 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const repoRoot = path.resolve(__dirname, "../..");
+const workflowPath = path.join(
+  repoRoot,
+  ".github",
+  "workflows",
+  "build-artifacts.yml",
+);
+
+const escapeRegExp = (value) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+test("artifact workflow covers triggers, packages, and distro smoke", () => {
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+
+  assert.match(workflow, /^  pull_request:\s*$/m);
+  assert.match(workflow, /^      - main\s*$/m);
+  assert.match(workflow, /^      - 'v\*'\s*$/m);
+  assert.match(workflow, /^  workflow_dispatch:\s*$/m);
+  assert.match(workflow, /runs-on: ubuntu-22\.04/);
+  assert.match(workflow, /\.\/scripts\/build-deb\.sh/);
+  assert.match(workflow, /\.\/scripts\/build-rpm\.sh/);
+  assert.match(workflow, /\.\/scripts\/build-tarball\.sh/);
+  assert.match(workflow, /dist\/\*\.deb/);
+  assert.match(workflow, /dist\/\*\.rpm/);
+  assert.match(workflow, /dist\/\*\.tar\.gz/);
+  assert.match(workflow, /uses:\s+actions\/upload-artifact@/);
+  assert.match(workflow, /uses:\s+actions\/download-artifact@/);
+  assert.match(workflow, /path: \./);
+
+  for (const distro of [
+    "Ubuntu 22.04",
+    "Ubuntu 24.04",
+    "Debian 12",
+    "Fedora 42",
+    "openSUSE Tumbleweed",
+    "Arch Linux",
+  ]) {
+    assert.match(workflow, new RegExp(`distro: ${escapeRegExp(distro)}`));
+  }
+});

--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -236,6 +236,7 @@ run_core_job() {
     bash -n scripts/build-rpm.sh
     bash -n scripts/build-pacman.sh
     bash -n scripts/build-appimage.sh
+    bash -n scripts/build-tarball.sh
     bash -n scripts/ci-local.sh
     bash -n scripts/ci/*.sh
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -281,15 +281,22 @@ install_pacman() {
 
     sudo pacman -S --needed --noconfirm \
         "${node_packages[@]}" python \
-        p7zip curl unzip zstd \
+        7zip curl unzip zstd \
         base-devel
 }
 
 install_zypper() {
     info "Detected openSUSE (zypper)"
+    local seven_zip_package
+    if zypper --non-interactive info 7zip >/dev/null 2>&1; then
+        seven_zip_package="7zip"
+    else
+        seven_zip_package="p7zip-full"
+        warn "7zip is unavailable; falling back to p7zip-full"
+    fi
     sudo zypper --non-interactive install \
         nodejs-default npm-default python3 \
-        p7zip-full curl unzip
+        "$seven_zip_package" curl unzip
     sudo zypper --non-interactive install -t pattern devel_basis
 }
 
@@ -456,8 +463,8 @@ case "$DISTRO" in
   sudo dnf install python3 7zip curl unzip rpm-build make gcc-c++ @development-tools             # Fedora 41+ (dnf5)
   sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip rpm-build make gcc-c++      # Fedora <41 (dnf)
     && sudo dnf groupinstall 'Development Tools'
-  sudo pacman -S nodejs npm python p7zip curl unzip zstd base-devel                 # Arch
-  sudo zypper install nodejs-default npm-default python3 p7zip-full curl unzip      # openSUSE
+  sudo pacman -S nodejs npm python 7zip curl unzip zstd base-devel                 # Arch
+  sudo zypper install nodejs-default npm-default python3 7zip curl unzip            # openSUSE Tumbleweed; use p7zip-full on older Leap
     && sudo zypper install -t pattern devel_basis"
         ;;
 esac

--- a/scripts/lib/install-helpers.sh
+++ b/scripts/lib/install-helpers.sh
@@ -23,8 +23,8 @@ Or install manually:
   sudo dnf install python3 7zip curl unzip rpm-build make gcc-c++ @development-tools             # Fedora 41+ (dnf5)
   sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip rpm-build make gcc-c++      # Fedora <41 (dnf)
     && sudo dnf groupinstall 'Development Tools'
-  sudo pacman -S python p7zip curl unzip zstd base-devel                            # Arch
-  sudo zypper install python3 p7zip-full curl unzip                                 # openSUSE
+  sudo pacman -S python 7zip curl unzip zstd base-devel                             # Arch
+  sudo zypper install python3 7zip curl unzip                                       # openSUSE Tumbleweed; use p7zip-full on older Leap
     && sudo zypper install -t pattern devel_basis
 EOF
 }


### PR DESCRIPTION
## Summary

- Add GitHub Actions automation for pull requests, main pushes, version tags, and manual runs.
- Build and upload .deb, .rpm, and portable .tar.gz artifacts with SHA256SUMS.
- Add distro smoke checks for Ubuntu 22.04/24.04, Debian 12, Fedora 42, openSUSE Tumbleweed, and Arch Linux.
- Add a reproducible make tarball build path and document the artifact workflow.
- Improve 7-Zip dependency compatibility for Fedora, Arch, openSUSE, and Debian package metadata.

## Source-of-truth files

- .github/workflows/build-artifacts.yml
- scripts/build-tarball.sh
- scripts/ci/build-artifacts-workflow.test.js
- scripts/install-deps.sh and scripts/lib/install-helpers.sh
- Packaging templates and build documentation

## Validation

- git diff --check passed before commit.
- Per repository instructions, local compiling and tests were not run.
- GitHub Actions is configured to perform the actual app build, updater build, package builds, shell/Node checks, artifact layout checks, and distro smoke tests.

## Notes

- RPM is built inside a pinned Fedora 42 container.
- The portable archive uses Ubuntu 22.04 as the glibc baseline.
- Existing unrelated local changes to AGENTS.md and .hceignore are not part of this PR.