### PR TITLE
fix: shallow repository watches for current DMG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- The opt-in shallow repository watcher now patches both current app bundles
+  and routes the Linux Parcel working-tree path through the same shallow host,
+  restoring bounded watches on the latest upstream DMG.
 - Open Target Discovery now resolves the selected Linux editor or terminal
   through the current private open-target command path. Command-path drift is
   reported before the feature changes the main bundle, so enabled-feature

--- a/linux-features/shallow-repository-watches/README.md
+++ b/linux-features/shallow-repository-watches/README.md
@@ -10,8 +10,9 @@ many worktrees, generated directories, or namespaced refs can therefore stall
 Electron's main thread simply when its task row is hovered.
 
 The patch changes only Linux recursive requests. Existing non-recursive watches
-and other platforms are untouched. It also reports `recursive: false` through
-the existing coverage result so Codex's focus-recovery path remains available.
+and other platforms are untouched. The current Linux Parcel working-tree path
+is routed through the same shallow host, which reports `recursive: false` so
+Codex's focus-recovery path remains available.
 
 Enable it in `linux-features/features.json` and rebuild:
 

--- a/linux-features/shallow-repository-watches/patch.js
+++ b/linux-features/shallow-repository-watches/patch.js
@@ -4,15 +4,15 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const PATCH_MARKER = "codexLinuxShallowRepositoryWatches";
+const PARCEL_WATCH_MARKER = "codexLinuxShallowParcelWorkingTreeWatch";
 const LOCAL_FILE_WATCH_METHOD =
   /async startFileWatch\((?<options>[A-Za-z_$][\w$]*)\)\{(?=let [^{}]{0,180}?await this\.platformPath\(\),[^{}]{0,180}?\(0,[A-Za-z_$][\w$]*\.watch\)\(this\.getFileSystemPath\(\k<options>\.path\),\{recursive:\k<options>\.recursive\})/gu;
+const PARCEL_WORKING_TREE_WATCH =
+  /process\.platform===`linux`\?[A-Za-z_$][\w$]*\((?<options>[A-Za-z_$][\w$]*),\{ignoredPaths:\[[A-Za-z_$][\w$]*\.posix\.join\(\k<options>\.path,`\.git`\)\]\}\):(?<host>[A-Za-z_$][\w$]*)\.startFileWatch\(\k<options>\)/gu;
 
 function patchWorkerSource(source) {
   const markerCount = source.split(PATCH_MARKER).length - 1;
-  if (markerCount === 1) {
-    return { source, matched: 1, changed: 0, reason: null };
-  }
-  if (markerCount !== 0) {
+  if (markerCount > 1) {
     return {
       source,
       matched: 0,
@@ -21,102 +21,142 @@ function patchWorkerSource(source) {
     };
   }
 
-  LOCAL_FILE_WATCH_METHOD.lastIndex = 0;
-  const matches = [...source.matchAll(LOCAL_FILE_WATCH_METHOD)];
-  if (matches.length !== 1) {
+  let patchedSource = source;
+  let changed = 0;
+  if (markerCount === 0) {
+    LOCAL_FILE_WATCH_METHOD.lastIndex = 0;
+    const matches = [...source.matchAll(LOCAL_FILE_WATCH_METHOD)];
+    if (matches.length !== 1) {
+      return {
+        source,
+        matched: 0,
+        changed: 0,
+        reason: `Found ${matches.length} local startFileWatch implementations`,
+      };
+    }
+
+    const match = matches[0];
+    const optionsName = match.groups.options;
+    const branch =
+      `if(process.platform===\`linux\`&&${optionsName}.recursive){` +
+      `/*${PATCH_MARKER}*/` +
+      `${optionsName}={...${optionsName},recursive:!1}}`;
+    const methodStart = match.index + match[0].length;
+    patchedSource = source.slice(0, methodStart) + branch + source.slice(methodStart);
+    changed = 1;
+  }
+
+  const parcelMarkerCount = patchedSource.split(PARCEL_WATCH_MARKER).length - 1;
+  PARCEL_WORKING_TREE_WATCH.lastIndex = 0;
+  const parcelMatches = [...patchedSource.matchAll(PARCEL_WORKING_TREE_WATCH)];
+  if (
+    parcelMarkerCount > 1 ||
+    parcelMatches.length > 1 ||
+    (parcelMarkerCount > 0 && parcelMatches.length > 0)
+  ) {
     return {
       source,
       matched: 0,
       changed: 0,
-      reason: `Found ${matches.length} local startFileWatch implementations`,
+      reason:
+        `Found ${parcelMatches.length} Parcel working-tree watch branches and ` +
+        `${parcelMarkerCount} markers`,
     };
   }
-
-  const match = matches[0];
-  const optionsName = match.groups.options;
-  const branch =
-    `if(process.platform===\`linux\`&&${optionsName}.recursive){` +
-    `/*${PATCH_MARKER}*/` +
-    `${optionsName}={...${optionsName},recursive:!1}}`;
-  const methodStart = match.index + match[0].length;
+  const finalSource = parcelMatches.length === 0
+    ? patchedSource
+    : patchedSource.replace(
+      PARCEL_WORKING_TREE_WATCH,
+      `/*${PARCEL_WATCH_MARKER}*/$<host>.startFileWatch($<options>)`,
+    );
+  if (parcelMatches.length === 1) changed = 1;
   return {
-    source: source.slice(0, methodStart) + branch + source.slice(methodStart),
+    source: finalSource,
     matched: 1,
-    changed: 1,
+    changed,
     reason: null,
   };
 }
 
-function findLocalFileWatchBundle(extractedDir) {
+function findLocalFileWatchBundles(extractedDir) {
   const buildDir = path.join(extractedDir, ".vite", "build");
   if (!fs.existsSync(buildDir)) {
-    return { target: null, result: null, reason: ".vite/build directory not found" };
+    return { candidates: [], reason: ".vite/build directory not found" };
   }
 
   const bundlePaths = fs.readdirSync(buildDir, { withFileTypes: true })
     .filter((entry) => entry.isFile() && entry.name.endsWith(".js"))
     .map((entry) => path.join(buildDir, entry.name))
     .sort();
-  const patched = [];
-  const raw = [];
+  const candidates = [];
 
   for (const bundlePath of bundlePaths) {
     const source = fs.readFileSync(bundlePath, "utf8");
     const markerCount = source.split(PATCH_MARKER).length - 1;
-    if (markerCount > 0) {
-      patched.push({ bundlePath, result: patchWorkerSource(source) });
-      continue;
-    }
+    const parcelMarkerCount = source.split(PARCEL_WATCH_MARKER).length - 1;
     LOCAL_FILE_WATCH_METHOD.lastIndex = 0;
-    const matches = [...source.matchAll(LOCAL_FILE_WATCH_METHOD)].length;
-    if (matches > 0) raw.push({ bundlePath, matches, source });
-  }
-
-  if (patched.length > 0) {
-    if (patched.length !== 1 || raw.length !== 0) {
-      return {
-        target: null,
-        result: null,
-        reason:
-          `Found shallow-watch markers in ${patched.length} bundles and ` +
-          `${raw.length} unpatched bundles`,
-      };
+    const matchCount = [...source.matchAll(LOCAL_FILE_WATCH_METHOD)].length;
+    PARCEL_WORKING_TREE_WATCH.lastIndex = 0;
+    const parcelMatchCount = [...source.matchAll(PARCEL_WORKING_TREE_WATCH)].length;
+    if (markerCount > 0 || matchCount > 0 || parcelMarkerCount > 0 || parcelMatchCount > 0) {
+      candidates.push({
+        bundlePath,
+        markerCount,
+        matchCount,
+        parcelMarkerCount,
+        parcelMatchCount,
+        source,
+      });
     }
-    return {
-      target: patched[0].bundlePath,
-      result: patched[0].result,
-      reason: patched[0].result.reason,
-    };
   }
 
-  const rawMatchCount = raw.reduce((total, candidate) => total + candidate.matches, 0);
-  if (raw.length !== 1 || rawMatchCount !== 1) {
+  const rawMatchCount = candidates.reduce((total, candidate) => total + candidate.matchCount, 0);
+  const markerCount = candidates.reduce((total, candidate) => total + candidate.markerCount, 0);
+  const parcelContractCount = candidates.reduce(
+    (total, candidate) => total + candidate.parcelMatchCount + candidate.parcelMarkerCount,
+    0,
+  );
+  if (
+    candidates.length !== 2 ||
+    !((rawMatchCount === 2 && markerCount === 0) || (rawMatchCount === 0 && markerCount === 2)) ||
+    parcelContractCount !== 1
+  ) {
     return {
-      target: null,
-      result: null,
+      candidates: [],
       reason:
-        `Found ${rawMatchCount} local startFileWatch implementations across ` +
-        `${bundlePaths.length} build bundles`,
+        `Found ${rawMatchCount} local startFileWatch implementations, ${markerCount} markers, ` +
+        `and ${parcelContractCount} Parcel working-tree branches across ` +
+        `${candidates.length} candidate bundles`,
     };
   }
-  const result = patchWorkerSource(raw[0].source);
-  return { target: raw[0].bundlePath, result, reason: result.reason };
+  return { candidates, reason: null };
 }
 
 function patchWorker(extractedDir) {
-  const discovery = findLocalFileWatchBundle(extractedDir);
-  if (discovery.target == null || discovery.result?.matched !== 1) {
-    const reason = discovery.reason ?? "Local startFileWatch implementation not found";
+  const discovery = findLocalFileWatchBundles(extractedDir);
+  if (discovery.candidates.length !== 2) {
+    const reason = discovery.reason ?? "Local startFileWatch implementations not found";
     console.warn(`WARN: ${reason} - skipping shallow repository-watch feature`);
-    return { matched: discovery.result?.matched ?? 0, changed: 0, reason };
+    return { matched: 0, changed: 0, reason };
   }
-  const result = discovery.result;
-  if (result.changed === 1) fs.writeFileSync(discovery.target, result.source, "utf8");
+  const results = discovery.candidates.map((candidate) => ({
+    bundlePath: candidate.bundlePath,
+    result: patchWorkerSource(candidate.source),
+  }));
+  const failed = results.find(({ result }) => result.matched !== 1);
+  if (failed != null) {
+    const reason = failed.result.reason ?? "Local startFileWatch implementation not patched";
+    console.warn(`WARN: ${reason} - skipping shallow repository-watch feature`);
+    return { matched: 0, changed: 0, reason };
+  }
+  for (const { bundlePath, result } of results) {
+    if (result.changed === 1) fs.writeFileSync(bundlePath, result.source, "utf8");
+  }
   return {
-    matched: result.matched,
-    changed: result.changed,
-    reason: result.reason,
-    target: path.relative(extractedDir, discovery.target),
+    matched: results.length,
+    changed: results.reduce((total, { result }) => total + result.changed, 0),
+    reason: null,
+    targets: results.map(({ bundlePath }) => path.relative(extractedDir, bundlePath)),
   };
 }
 
@@ -128,19 +168,20 @@ const descriptors = [
     ciPolicy: "optional",
     apply: patchWorker,
     status: (result, warnings) => {
-      if (result?.matched !== 1) {
+      if (result?.matched !== 2) {
         return { status: "skipped-optional", reason: result?.reason ?? warnings[0] ?? null };
       }
-      return result.changed === 1 ? "applied" : "already-applied";
+      return result.changed > 0 ? "applied" : "already-applied";
     },
   },
 ];
 
 module.exports = {
   LOCAL_FILE_WATCH_METHOD,
+  PARCEL_WATCH_MARKER,
   PATCH_MARKER,
   descriptors,
-  findLocalFileWatchBundle,
+  findLocalFileWatchBundles,
   patchWorker,
   patchWorkerSource,
 };

--- a/linux-features/shallow-repository-watches/test.js
+++ b/linux-features/shallow-repository-watches/test.js
@@ -12,8 +12,9 @@ const {
 } = require("../../scripts/lib/linux-features.js");
 const {
   PATCH_MARKER,
+  PARCEL_WATCH_MARKER,
   descriptors,
-  findLocalFileWatchBundle,
+  findLocalFileWatchBundles,
   patchWorker,
   patchWorkerSource,
 } = require("./patch.js");
@@ -26,6 +27,14 @@ function localWorkerSource() {
     "i=(0,w.watch)(this.getFileSystemPath(e.path),{recursive:e.recursive},()=>{});",
     "return{coverage:{recursive:e.recursive},path:e.path,closed:t.promise}}",
     "};",
+  ].join("");
+}
+
+function parcelWorkingTreeSource() {
+  return [
+    "function create(t,n){return t.isLocal?process.platform===`linux`?",
+    "Jve(n,{ignoredPaths:[E.posix.join(n.path,`.git`)]}):",
+    "e.startFileWatch(n):t.startFileWatch(n)}",
   ].join("");
 }
 
@@ -131,26 +140,98 @@ test("patch preserves non-recursive Linux watches and recursive watches on other
   assert.deepEqual(darwinSession.coverage, { recursive: true });
 });
 
-test("feature discovers and patches the current hashed build bundle shape", () => {
+test("routes the current Linux Parcel working-tree branch through the shallow host", () => {
+  const first = patchWorkerSource(`${localWorkerSource()}${parcelWorkingTreeSource()}`);
+  assert.equal(first.matched, 1);
+  assert.equal(first.changed, 1);
+  assert.equal(first.source.split(PARCEL_WATCH_MARKER).length - 1, 1);
+  assert.doesNotMatch(first.source, /process\.platform===`linux`\?Jve/);
+  assert.match(
+    first.source,
+    /codexLinuxShallowParcelWorkingTreeWatch\*\/e\.startFileWatch\(n\)/,
+  );
+  assert.deepEqual(
+    patchWorkerSource(first.source),
+    { source: first.source, matched: 1, changed: 0, reason: null },
+  );
+});
+
+test("feature atomically patches both current build bundles", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-shallow-watch-bundle-"));
   try {
     const buildDir = path.join(root, ".vite", "build");
     fs.mkdirSync(buildDir, { recursive: true });
     fs.writeFileSync(path.join(buildDir, "unrelated.js"), "var worker={startFileWatch(){}};");
     fs.writeFileSync(path.join(buildDir, "src-current.js"), localWorkerSource());
+    fs.writeFileSync(
+      path.join(buildDir, "worker.js"),
+      `${localWorkerSource()}${parcelWorkingTreeSource()}`,
+    );
 
-    const discovery = findLocalFileWatchBundle(root);
-    assert.equal(path.basename(discovery.target), "src-current.js");
+    const discovery = findLocalFileWatchBundles(root);
+    assert.deepEqual(
+      discovery.candidates.map(({ bundlePath }) => path.basename(bundlePath)),
+      ["src-current.js", "worker.js"],
+    );
     const first = patchWorker(root);
     assert.deepEqual(first, {
-      matched: 1,
-      changed: 1,
+      matched: 2,
+      changed: 2,
       reason: null,
-      target: path.join(".vite", "build", "src-current.js"),
+      targets: [
+        path.join(".vite", "build", "src-current.js"),
+        path.join(".vite", "build", "worker.js"),
+      ],
     });
     const second = patchWorker(root);
+    assert.equal(second.matched, 2);
     assert.equal(second.changed, 0);
-    assert.equal(fs.readFileSync(discovery.target, "utf8").split(PATCH_MARKER).length - 1, 1);
+    for (const { bundlePath } of discovery.candidates) {
+      assert.equal(fs.readFileSync(bundlePath, "utf8").split(PATCH_MARKER).length - 1, 1);
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("current bundle drift leaves every candidate byte-identical", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-shallow-watch-drift-"));
+  try {
+    const buildDir = path.join(root, ".vite", "build");
+    fs.mkdirSync(buildDir, { recursive: true });
+    const source = localWorkerSource();
+    fs.writeFileSync(path.join(buildDir, "worker.js"), source);
+
+    const result = patchWorker(root);
+    assert.equal(result.matched, 0);
+    assert.equal(result.changed, 0);
+    assert.match(result.reason, /1 local startFileWatch implementation/);
+    assert.equal(fs.readFileSync(path.join(buildDir, "worker.js"), "utf8"), source);
+    assert.equal(descriptors[0].status(result, []).status, "skipped-optional");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("an extra Parcel working-tree branch leaves current bundles byte-identical", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-shallow-watch-parcel-drift-"));
+  try {
+    const buildDir = path.join(root, ".vite", "build");
+    fs.mkdirSync(buildDir, { recursive: true });
+    const sources = new Map([
+      ["src-current.js", localWorkerSource()],
+      ["worker.js", `${localWorkerSource()}${parcelWorkingTreeSource()}`],
+      ["worker-extra.js", parcelWorkingTreeSource()],
+    ]);
+    for (const [name, source] of sources) fs.writeFileSync(path.join(buildDir, name), source);
+
+    const result = patchWorker(root);
+    assert.equal(result.matched, 0);
+    assert.equal(result.changed, 0);
+    assert.match(result.reason, /2 Parcel working-tree branches across 3 candidate bundles/);
+    for (const [name, source] of sources) {
+      assert.equal(fs.readFileSync(path.join(buildDir, name), "utf8"), source);
+    }
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
**IMPORTANT: Please keep only one pull request open at a time. The default maximum is two active pull requests from the same contributor, and even that should be reserved for exceptional circumstances. Maintainers may configure a different per-contributor limit for explicit exceptions. Do not open several pull requests at once; finish or close existing work before submitting more. An automated bot will close pull requests that exceed the effective limit.**

<!-- Complete this template before requesting review or merge. -->

## Summary

Update the opt-in `shallow-repository-watches` feature for the latest upstream DMG.

This change:

- patches both current `LocalExecutionHost.startFileWatch` implementations;
- routes the Linux Parcel working-tree path through the existing shallow host;
- preserves non-recursive Linux watches and behavior on other platforms;
- rejects partial, duplicate, or unknown contracts before writing any bundle;
- keeps the feature opt-in and disabled by default.

## Current problem

The app can become unresponsive after sending a message in a Git worktree. In the observed case, the freeze occurred both when sending the first message in a new thread and when sending another message to that thread. Responsiveness returned when the assistant response completed.
The latest upstream app contains two copies of  `LocalExecutionHost.startFileWatch`, while the existing feature expects exactly one. The worker bundle also contains a Linux-specific Parcel working-tree watcher that bypasses the shallow host.
Consequently, enabling `shallow-repository-watches` no longer bounds every recursive watcher. In the affected workspace, the unpatched runtime created approximately 80,292 inotify watches. Routing all current paths through the shallow host reduced this to 9 watches.

<!-- What changed, why, and which issue it resolves. -->
<!--
Repository labels are assigned by maintainers and authorized collaborators
during triage. Describe the facts and scope; do not self-classify.
-->

## Related

- #1109: introduced the opt-in `shallow-repository-watches` feature for this class of
    recursive watcher problem.
- #1063: introduced the alternative opt-in bounded working-tree watcher strategy.
- #835: reports a similar user-visible freeze caused by stale conversation streaming state.

## Validation

<!-- List the tests and checks you ran. Mention anything not tested or any known risk. -->

- node --test linux-features/shallow-repository-watches/test.js:  8 tests passed
- node --test linux-features/*/test.js - passed
- node --test scripts/patch-linux-window-ui.test.js - 403 tests passed
- Built the latest upstream 26.727.40816 package
 
## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
