### PR TITLE
fix: restore AppImage window after remount

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -319,6 +319,7 @@ Launches the $CODEX_LINUX_APP_DISPLAY_NAME app.
 Options:
   -h, --help                  Show this help message and exit
   --new-instance              Start a separate app instance on the first free port in the multi-launch range
+  --show                      Show or focus the main window
   --new-chat                  Open the main window on a new chat
   --quick-chat                Open a projectless quick chat
   --prompt-chat               Show the compact prompt for a new chat
@@ -2275,7 +2276,7 @@ find_running_app_pid() {
 
     if [ -f "$APP_PID_FILE" ]; then
         pid="$(cat "$APP_PID_FILE" 2>/dev/null || true)"
-        if pid_matches_executable "$pid" "$SCRIPT_DIR/electron"; then
+        if pid_matches_running_app "$pid"; then
             echo "$pid"
             return 0
         fi
@@ -2320,15 +2321,52 @@ pid_matches_app_identity() {
     [[ "$cmdline" == *"--app-id=$CODEX_LINUX_APP_ID"* ]]
 }
 
+pid_matches_appimage_install() {
+    local pid="$1"
+    local actual
+    local resident_appimage
+
+    [ -n "${APPIMAGE:-}" ] || return 1
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    [ -d "/proc/$pid" ] || return 1
+    actual="$(pid_cmdline_arg0_path "$pid")"
+    case "${actual##*/}" in
+        electron|electron\ *) ;;
+        *) return 1 ;;
+    esac
+    pid_is_current_user "$pid" || return 1
+    ! pid_is_electron_helper "$pid" || return 1
+    resident_appimage="$(pid_environ_value "$pid" APPIMAGE 2>/dev/null || true)"
+    [ -n "$resident_appimage" ] && [ "$resident_appimage" = "$APPIMAGE" ]
+}
+
+pid_matches_app_install() {
+    local pid="$1"
+
+    pid_matches_executable "$pid" "$SCRIPT_DIR/electron" || pid_matches_appimage_install "$pid"
+}
+
+pid_matches_running_app() {
+    local pid="$1"
+
+    if pid_matches_executable "$pid" "$SCRIPT_DIR/electron"; then
+        return 0
+    fi
+
+    pid_matches_appimage_install "$pid" || return 1
+    pid_matches_app_identity "$pid" || return 1
+    pid_in_same_launch_instance "$pid"
+}
+
 pid_is_foreign_codex_electron() {
     local pid="$1"
     local actual
 
     [[ "$pid" =~ ^[0-9]+$ ]] || return 1
     [ -d "/proc/$pid" ] || return 1
+    ! pid_matches_app_install "$pid" || return 1
     actual="$(pid_cmdline_arg0_path "$pid")"
     [ -n "$actual" ] || return 1
-    ! pid_arg0_matches_path "$actual" "$SCRIPT_DIR/electron" || return 1
     case "${actual##*/}" in
         electron|electron\ *) ;;
         *) return 1 ;;
@@ -2346,7 +2384,7 @@ discover_running_app_pid() {
         [ -r "$proc_cmdline" ] || continue
         pid="${proc_cmdline#/proc/}"
         pid="${pid%/cmdline}"
-        if pid_matches_executable "$pid" "$SCRIPT_DIR/electron" && pid_in_same_launch_instance "$pid"; then
+        if pid_matches_running_app "$pid" && pid_in_same_launch_instance "$pid"; then
             echo "$pid"
             return 0
         fi
@@ -2431,7 +2469,7 @@ set_detected_running_app() {
 }
 
 running_app_is_active() {
-    [ -n "${RUNNING_APP_PID:-}" ] && pid_matches_executable "$RUNNING_APP_PID" "$SCRIPT_DIR/electron"
+    [ -n "${RUNNING_APP_PID:-}" ] && pid_matches_running_app "$RUNNING_APP_PID"
 }
 
 using_second_instance_handoff() {
@@ -2450,9 +2488,12 @@ detect_warm_start() {
         return 0
     fi
 
-    if runtime_recovery_scan_needed && pid="$(discover_running_app_pid)"; then
-        set_detected_running_app "$pid"
-        return 0
+    if runtime_recovery_scan_needed; then
+        if pid="$(discover_running_app_pid)"; then
+            set_detected_running_app "$pid"
+            return 0
+        fi
+        detect_cross_install_conflict
     fi
 
     if ! linux_setting_enabled "codex-linux-warm-start-enabled" 1; then
@@ -2478,13 +2519,14 @@ terminate_stale_electron_with_pidfd() {
     local pid="$1"
     local expected_start_time
 
-    pid_matches_executable "$pid" "$SCRIPT_DIR/electron" || return 1
+    pid_matches_running_app "$pid" || return 1
     expected_start_time="$(pid_start_time "$pid")" || return 1
 
     python3 - \
         "$pid" \
         "$expected_start_time" \
         "$SCRIPT_DIR/electron" \
+        "${APPIMAGE:-}" \
         "$CODEX_LINUX_APP_ID" \
         "$CODEX_LINUX_INSTANCE_ID" \
         "$MULTI_LAUNCH_ACTIVE" <<'PY'
@@ -2496,9 +2538,10 @@ import sys
 pid = int(sys.argv[1])
 expected_start_time = sys.argv[2]
 expected_executable = sys.argv[3]
-expected_app_id = sys.argv[4]
-expected_instance_id = sys.argv[5]
-expected_multi_launch = sys.argv[6] == "1"
+expected_appimage = sys.argv[4]
+expected_app_id = sys.argv[5]
+expected_instance_id = sys.argv[6]
+expected_multi_launch = sys.argv[7] == "1"
 
 if not hasattr(os, "pidfd_open") or not hasattr(signal, "pidfd_send_signal"):
     print("pidfd APIs are unavailable; refusing to terminate the stale Electron process", file=sys.stderr)
@@ -2532,11 +2575,19 @@ for entry in environ_entries:
     key, value = entry.split(b"=", 1)
     environ[os.fsdecode(key)] = os.fsdecode(value)
 
+actual_executable = os.fsdecode(cmdline[0]) if cmdline else ""
+install_matches = actual_executable == expected_executable
+if not install_matches and expected_appimage:
+    install_matches = (
+        os.path.basename(actual_executable) == "electron"
+        and environ.get("APPIMAGE") == expected_appimage
+    )
+
 identity_matches = (
     actual_start_time == expected_start_time
     and actual_uid == os.geteuid()
     and bool(cmdline)
-    and os.fsdecode(cmdline[0]) == expected_executable
+    and install_matches
     and not any(part.startswith(b"--type=") for part in cmdline[1:])
     and expected_app_id in {
         environ.get("CODEX_LINUX_APP_ID"),
@@ -2641,6 +2692,7 @@ recover_unhealthy_running_app() {
 
 send_warm_start_launch_action() {
     [ "$WARM_START" -eq 1 ] || return 1
+    running_app_is_active || return 1
     [ -S "$LAUNCH_ACTION_SOCKET" ] || return 1
 
     python3 - "$LAUNCH_ACTION_SOCKET" "$@" <<'PY'
@@ -3064,7 +3116,7 @@ clear_stale_pid_file() {
 
     local pid=""
     pid="$(cat "$APP_PID_FILE" 2>/dev/null || true)"
-    if [ -z "$pid" ] || ! pid_matches_executable "$pid" "$SCRIPT_DIR/electron"; then
+    if [ -z "$pid" ] || ! pid_matches_running_app "$pid"; then
         rm -f "$APP_PID_FILE"
     fi
 }
@@ -4337,7 +4389,7 @@ launch_electron() {
         exec "$SCRIPT_DIR/electron" "${ELECTRON_LAUNCH_ARGS[@]}" "${ELECTRON_ARGS[@]}"
     ) &
     ELECTRON_PID=$!
-    if [ -n "${RUNNING_APP_PID:-}" ] && pid_matches_executable "$RUNNING_APP_PID" "$SCRIPT_DIR/electron"; then
+    if [ -n "${RUNNING_APP_PID:-}" ] && pid_matches_running_app "$RUNNING_APP_PID"; then
         echo "Preserving ChatGPT Desktop pid=$RUNNING_APP_PID liveness marker for second-instance handoff"
     else
         echo "$ELECTRON_PID" > "$APP_PID_FILE"

--- a/packaging/appimage/codex-desktop.desktop
+++ b/packaging/appimage/codex-desktop.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=__PACKAGE_DISPLAY_NAME__
 Comment=__PACKAGE_COMMENT__
-Exec=AppRun %u
+Exec=AppRun --show %u
 Icon=__PACKAGE_NAME__
 Terminal=false
 Type=Application

--- a/tests/launcher_warm_start_recovery.sh
+++ b/tests/launcher_warm_start_recovery.sh
@@ -5,6 +5,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 APP_DIR="$TMP_DIR/app"
+REMOUNT_APP_DIR="$TMP_DIR/remounted-app"
+SECOND_APP_DIR="$APP_DIR"
+APPIMAGE_PATH="$TMP_DIR/codex-desktop.AppImage"
+APPIMAGE_RECOVERY="${CODEX_TEST_APPIMAGE_REMOUNT:-0}"
 HOME_DIR="$TMP_DIR/home"
 RUNTIME_DIR="$TMP_DIR/runtime"
 STATE_DIR="$HOME_DIR/.local/state/codex-desktop"
@@ -15,6 +19,10 @@ APP_LOG="$HOME_DIR/.cache/codex-desktop/launcher.log"
 LAUNCHER_PID=""
 SOCKET_PID=""
 HOOK_PID=""
+
+if [ "$APPIMAGE_RECOVERY" = "1" ]; then
+    SECOND_APP_DIR="$REMOUNT_APP_DIR"
+fi
 
 cleanup() {
     local pid
@@ -30,9 +38,11 @@ cleanup() {
         pid="${cmdline#/proc/}"
         pid="${pid%/cmdline}"
         IFS= read -r -d '' arg0 < "$cmdline" 2>/dev/null || true
-        if [ "${arg0:-}" = "$APP_DIR/electron" ]; then
-            kill "$pid" 2>/dev/null || true
-        fi
+        case "${arg0:-}" in
+            "$APP_DIR/electron"|"$REMOUNT_APP_DIR/electron")
+                kill "$pid" 2>/dev/null || true
+                ;;
+        esac
         arg0=""
     done
     rm -rf "$TMP_DIR"
@@ -165,6 +175,11 @@ HOOK
     chmod +x "$APP_DIR/.codex-linux/prelaunch.d/blocking-test-hook"
 fi
 
+if [ "$APPIMAGE_RECOVERY" = "1" ]; then
+    cp -a "$APP_DIR" "$REMOUNT_APP_DIR"
+    touch "$APPIMAGE_PATH"
+fi
+
 python3 - "$SOCKET_PATH" <<'PY' &
 import os
 import socket
@@ -200,8 +215,14 @@ COMMON_ENV=(
 if [ "${CODEX_TEST_DISABLE_PIDFD:-0}" = "1" ]; then
     COMMON_ENV+=("PYTHONPATH=$TMP_DIR/python-site")
 fi
+FIRST_APPIMAGE_ENV=()
+SECOND_APPIMAGE_ENV=()
+if [ "$APPIMAGE_RECOVERY" = "1" ]; then
+    FIRST_APPIMAGE_ENV=("APPIMAGE=$APPIMAGE_PATH" "APPDIR=$APP_DIR")
+    SECOND_APPIMAGE_ENV=("APPIMAGE=$APPIMAGE_PATH" "APPDIR=$SECOND_APP_DIR")
+fi
 
-"${COMMON_ENV[@]}" "$APP_DIR/start.sh" > "$FIRST_LOG" 2>&1 &
+"${COMMON_ENV[@]}" "${FIRST_APPIMAGE_ENV[@]}" "$APP_DIR/start.sh" > "$FIRST_LOG" 2>&1 &
 LAUNCHER_PID=$!
 
 if [ "${CODEX_TEST_KILL_DURING_PRELAUNCH:-0}" = "1" ]; then
@@ -213,7 +234,7 @@ if [ "${CODEX_TEST_KILL_DURING_PRELAUNCH:-0}" = "1" ]; then
     rm -f "$APP_DIR/.codex-linux/prelaunch.d/blocking-test-hook"
 
     SECONDS=0
-    "${COMMON_ENV[@]}" "$APP_DIR/start.sh" > "$SECOND_LOG" 2>&1 &
+    "${COMMON_ENV[@]}" "${SECOND_APPIMAGE_ENV[@]}" "$SECOND_APP_DIR/start.sh" > "$SECOND_LOG" 2>&1 &
     LAUNCHER_PID=$!
     replacement_is_ready() {
         pid_file_is_live && webview_is_ready
@@ -256,7 +277,7 @@ wait_for "webview parent-death cleanup" webview_is_down
 kill -0 "$FIRST_ELECTRON_PID" 2>/dev/null \
     || fail "Electron should survive the launcher SIGKILL"
 
-"${COMMON_ENV[@]}" "$APP_DIR/start.sh" > "$SECOND_LOG" 2>&1 &
+"${COMMON_ENV[@]}" "${SECOND_APPIMAGE_ENV[@]}" "$SECOND_APP_DIR/start.sh" > "$SECOND_LOG" 2>&1 &
 LAUNCHER_PID=$!
 
 new_electron_is_ready() {
@@ -278,4 +299,8 @@ kill "$SECOND_ELECTRON_PID"
 wait "$LAUNCHER_PID"
 LAUNCHER_PID=""
 
-printf '%s\n' "launcher recovery test passed (warm-start disabled=${CODEX_TEST_DISABLE_WARM_START:-0})"
+if [ "$APPIMAGE_RECOVERY" = "1" ]; then
+    printf '%s\n' "launcher AppImage remount recovery test passed"
+else
+    printf '%s\n' "launcher recovery test passed (warm-start disabled=${CODEX_TEST_DISABLE_WARM_START:-0})"
+fi

--- a/tests/launcher_window_reopen_behavior.sh
+++ b/tests/launcher_window_reopen_behavior.sh
@@ -53,6 +53,9 @@ fi
 
 TMP_DIR="$(mktemp -d)"
 APP_DIR="$TMP_DIR/app"
+REMOUNT_APP_DIR="$TMP_DIR/remounted-app"
+FOREIGN_APP_DIR="$TMP_DIR/foreign-app"
+SECOND_APP_DIR="$APP_DIR"
 HOME_DIR="$TMP_DIR/home"
 RUNTIME_DIR="$TMP_DIR/runtime"
 STATE_DIR="$HOME_DIR/.local/state/codex-desktop"
@@ -60,16 +63,29 @@ SOCKET_PATH="$RUNTIME_DIR/codex-desktop/launch-action.sock"
 HANDOFF_RESULT="$TMP_DIR/handoff.json"
 FIRST_LOG="$TMP_DIR/first-launch.log"
 SECOND_LOG="$TMP_DIR/second-launch.log"
+FOREIGN_LOG="$TMP_DIR/foreign-launch.log"
 APP_LOG="$HOME_DIR/.cache/codex-desktop/launcher.log"
+FOREIGN_CACHE_DIR="$TMP_DIR/foreign-cache"
+FOREIGN_APP_LOG="$FOREIGN_CACHE_DIR/codex-desktop/launcher.log"
+APPIMAGE_PATH="$TMP_DIR/codex-desktop.AppImage"
+FOREIGN_APPIMAGE_PATH="$TMP_DIR/other-codex-desktop.AppImage"
+APPIMAGE_REOPEN="${CODEX_TEST_APPIMAGE_REMOUNT:-0}"
+SECOND_LAUNCH_ARG="--new-chat"
 LAUNCHER_PID=""
 SECOND_LAUNCHER_PID=""
 SOCKET_PID=""
 DECOY_PID=""
 FIRST_ELECTRON_PID=""
+FIRST_WEBVIEW_PID=""
 FINAL_ELECTRON_PID=""
 HANDOFF_STATUS="not-attempted"
 TIMEOUT_STATUS="false"
 ERROR_STATUS="false"
+
+if [ "$APPIMAGE_REOPEN" = "1" ]; then
+    SECOND_APP_DIR="$REMOUNT_APP_DIR"
+    SECOND_LAUNCH_ARG="--show"
+fi
 
 count_test_main_processes() {
     local count=0
@@ -81,9 +97,11 @@ count_test_main_processes() {
         pid="${cmdline#/proc/}"
         pid="${pid%/cmdline}"
         IFS= read -r -d '' arg0 < "$cmdline" 2>/dev/null || true
-        if [ "${arg0:-}" = "$APP_DIR/electron" ]; then
-            count=$((count + 1))
-        fi
+        case "${arg0:-}" in
+            "$APP_DIR/electron"|"$REMOUNT_APP_DIR/electron"|"$FOREIGN_APP_DIR/electron")
+                count=$((count + 1))
+                ;;
+        esac
         arg0=""
     done
     printf '%s\n' "$count"
@@ -180,21 +198,27 @@ cleanup() {
     set +e
     webview_pid="$(cat "$STATE_DIR/webview.pid" 2>/dev/null || true)"
     stop_owned_process_bounded "$LAUNCHER_PID" argv "$APP_DIR/start.sh" || cleanup_failed=1
-    stop_owned_process_bounded "$SECOND_LAUNCHER_PID" argv "$APP_DIR/start.sh" || cleanup_failed=1
+    stop_owned_process_bounded "$SECOND_LAUNCHER_PID" argv "$SECOND_APP_DIR/start.sh" || cleanup_failed=1
     stop_owned_process_bounded "$SOCKET_PID" argv "$SOCKET_PATH" || cleanup_failed=1
-    stop_owned_process_bounded "$webview_pid" argv "$APP_DIR/.codex-linux/webview-server.py" || cleanup_failed=1
+    for pid in "$FIRST_WEBVIEW_PID" "$webview_pid"; do
+        stop_owned_process_bounded "$pid" argv "$APP_DIR/.codex-linux/webview-server.py" || cleanup_failed=1
+        stop_owned_process_bounded "$pid" argv "$REMOUNT_APP_DIR/.codex-linux/webview-server.py" || cleanup_failed=1
+        stop_owned_process_bounded "$pid" argv "$FOREIGN_APP_DIR/.codex-linux/webview-server.py" || cleanup_failed=1
+    done
     stop_owned_process_bounded "$DECOY_PID" arg0 "$TMP_DIR/decoy-electron" || cleanup_failed=1
     for cmdline in /proc/[0-9]*/cmdline; do
         [ -r "$cmdline" ] || continue
         pid="${cmdline#/proc/}"
         pid="${pid%/cmdline}"
         IFS= read -r -d '' arg0 < "$cmdline" 2>/dev/null || true
-        if [ "${arg0:-}" = "$APP_DIR/electron" ]; then
-            IFS= read -r -d '' revalidated_arg0 < "$cmdline" 2>/dev/null || true
-            if [ "${revalidated_arg0:-}" = "$APP_DIR/electron" ]; then
-                stop_owned_process_bounded "$pid" arg0 "$APP_DIR/electron" || cleanup_failed=1
-            fi
-        fi
+        case "${arg0:-}" in
+            "$APP_DIR/electron"|"$REMOUNT_APP_DIR/electron"|"$FOREIGN_APP_DIR/electron")
+                IFS= read -r -d '' revalidated_arg0 < "$cmdline" 2>/dev/null || true
+                if [ "${revalidated_arg0:-}" = "$arg0" ]; then
+                    stop_owned_process_bounded "$pid" arg0 "$arg0" || cleanup_failed=1
+                fi
+                ;;
+        esac
         arg0=""
         revalidated_arg0=""
     done
@@ -357,6 +381,12 @@ cp "$APP_DIR/electron" "$TMP_DIR/decoy-electron"
 "$TMP_DIR/decoy-electron" --app-id=codex-desktop &
 DECOY_PID=$!
 
+if [ "$APPIMAGE_REOPEN" = "1" ]; then
+    cp -a "$APP_DIR" "$REMOUNT_APP_DIR"
+    cp -a "$APP_DIR" "$FOREIGN_APP_DIR"
+    touch "$APPIMAGE_PATH" "$FOREIGN_APPIMAGE_PATH"
+fi
+
 COMMON_ENV=(
     env -i
     "PATH=$PATH"
@@ -365,12 +395,21 @@ COMMON_ENV=(
     "CODEX_CLI_PATH=$(command -v true)"
     "CODEX_WEBVIEW_PORT=$PORT"
 )
+FIRST_APPIMAGE_ENV=()
+SECOND_APPIMAGE_ENV=()
+if [ "$APPIMAGE_REOPEN" = "1" ]; then
+    FIRST_APPIMAGE_ENV=("APPIMAGE=$APPIMAGE_PATH" "APPDIR=$APP_DIR")
+    SECOND_APPIMAGE_ENV=("APPIMAGE=$APPIMAGE_PATH" "APPDIR=$SECOND_APP_DIR")
+fi
 
-"${COMMON_ENV[@]}" "$APP_DIR/start.sh" > "$FIRST_LOG" 2>&1 &
+"${COMMON_ENV[@]}" "${FIRST_APPIMAGE_ENV[@]}" "$APP_DIR/start.sh" > "$FIRST_LOG" 2>&1 &
 LAUNCHER_PID=$!
 wait_for "first Electron marker" pid_file_is_live
 wait_for "first launcher lock release" launcher_lock_is_available
 FIRST_ELECTRON_PID="$(read_live_app_pid)"
+FIRST_WEBVIEW_PID="$(cat "$STATE_DIR/webview.pid" 2>/dev/null || true)"
+[[ "$FIRST_WEBVIEW_PID" =~ ^[0-9]+$ ]] && kill -0 "$FIRST_WEBVIEW_PID" 2>/dev/null \
+    || fail "first packaged webview server is not live"
 
 python3 - "$SOCKET_PATH" "$HANDOFF_RESULT" <<'PY' &
 import json
@@ -401,8 +440,36 @@ PY
 SOCKET_PID=$!
 wait_for "controlled handoff socket" test -S "$SOCKET_PATH"
 
+if [ "$APPIMAGE_REOPEN" = "1" ]; then
+    set +e
+    timeout 8s "${COMMON_ENV[@]}" \
+        "APPIMAGE=$FOREIGN_APPIMAGE_PATH" \
+        "APPDIR=$FOREIGN_APP_DIR" \
+        "XDG_CACHE_HOME=$FOREIGN_CACHE_DIR" \
+        "$FOREIGN_APP_DIR/start.sh" --show > "$FOREIGN_LOG" 2>&1
+    rc=$?
+    set -e
+    [ "$rc" -ne 0 ] && [ "$rc" -ne 124 ] \
+        || fail "different AppImage launcher was not rejected safely (status $rc)"
+    [ ! -e "$HANDOFF_RESULT" ] \
+        || fail "different AppImage reached the resident launch-action socket"
+    kill -0 "$FIRST_ELECTRON_PID" 2>/dev/null \
+        || fail "different AppImage stopped the healthy resident Electron"
+    kill -0 "$FIRST_WEBVIEW_PID" 2>/dev/null \
+        || fail "different AppImage stopped the resident webview server"
+    [ "$(cat "$STATE_DIR/app.pid" 2>/dev/null || true)" = "$FIRST_ELECTRON_PID" ] \
+        || fail "different AppImage changed the resident app marker"
+    [ "$(cat "$STATE_DIR/webview.pid" 2>/dev/null || true)" = "$FIRST_WEBVIEW_PID" ] \
+        || fail "different AppImage changed the resident webview marker"
+    [ -S "$SOCKET_PATH" ] && kill -0 "$SOCKET_PID" 2>/dev/null \
+        || fail "different AppImage removed the resident launch-action socket"
+    grep -Fq "Foreign ChatGPT Desktop process:" "$FOREIGN_APP_LOG" \
+        || fail "different AppImage rejection did not report the cross-install conflict"
+fi
+
 if [ "${CODEX_TEST_FORCE_RESIDENT_REPLACEMENT:-0}" = "1" ]; then
-    "${COMMON_ENV[@]}" "$APP_DIR/start.sh" --new-chat > "$SECOND_LOG" 2>&1 &
+    "${COMMON_ENV[@]}" "${SECOND_APPIMAGE_ENV[@]}" \
+        "$SECOND_APP_DIR/start.sh" "$SECOND_LAUNCH_ARG" > "$SECOND_LOG" 2>&1 &
     SECOND_LAUNCHER_PID=$!
     if [ "${CODEX_TEST_MUTATION_CONTROL_ONLY:-0}" = "1" ]; then
         set +e
@@ -430,7 +497,8 @@ if [ "${CODEX_TEST_FORCE_RESIDENT_REPLACEMENT:-0}" = "1" ]; then
 fi
 
 set +e
-timeout 8s "${COMMON_ENV[@]}" "$APP_DIR/start.sh" --new-chat > "$SECOND_LOG" 2>&1
+timeout 8s "${COMMON_ENV[@]}" "${SECOND_APPIMAGE_ENV[@]}" \
+    "$SECOND_APP_DIR/start.sh" "$SECOND_LAUNCH_ARG" > "$SECOND_LOG" 2>&1
 rc=$?
 set -e
 if [ "$rc" -ne 0 ]; then
@@ -452,13 +520,13 @@ kill -0 "$FIRST_ELECTRON_PID" 2>/dev/null \
     || fail "runtime marker no longer identifies the healthy resident"
 [ "$HANDOFF_STATUS" = "acknowledged" ] \
     || fail "controlled resident did not acknowledge the reopen handoff"
-python3 - "$HANDOFF_RESULT" <<'PY' \
-    || fail "reopen handoff did not preserve the --new-chat argument"
+python3 - "$HANDOFF_RESULT" "$SECOND_LAUNCH_ARG" <<'PY' \
+    || fail "reopen handoff did not preserve the $SECOND_LAUNCH_ARG argument"
 import json
 import sys
 
 with open(sys.argv[1], encoding="utf-8") as result:
-    assert json.load(result)["argv"] == ["--new-chat"]
+    assert json.load(result)["argv"] == [sys.argv[2]]
 PY
 [ "$(count_test_main_processes)" -eq 1 ] \
     || fail "reopen handoff left more than one controlled Electron process"
@@ -471,5 +539,10 @@ if grep -Eqi 'notify-send|zenity|could not safely|failed to' "$SECOND_LOG" "$APP
     fail "reopen handoff emitted a user-visible error"
 fi
 
-record_result "preserved"
-printf '%s\n' "launcher window-reopen behavior test passed"
+if [ "$APPIMAGE_REOPEN" = "1" ]; then
+    record_result "appimage-remount-preserved"
+    printf '%s\n' "launcher AppImage remount window-reopen behavior test passed"
+else
+    record_result "preserved"
+    printf '%s\n' "launcher window-reopen behavior test passed"
+fi

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1538,7 +1538,7 @@ SCRIPT
     assert_file_not_exists "$capture_dir/AppDir/usr/lib/systemd/user/codex-update-manager.service"
     assert_file_not_exists "$capture_dir/AppDir/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
     assert_file_not_exists "$capture_dir/AppDir/opt/codex-desktop/update-builder"
-    assert_contains "$capture_dir/AppDir/codex-desktop.desktop" "Exec=AppRun %u"
+    assert_contains "$capture_dir/AppDir/codex-desktop.desktop" "Exec=AppRun --show %u"
     assert_contains "$capture_dir/AppDir/codex-desktop.desktop" "Icon=codex-desktop"
     assert_contains "$capture_dir/AppDir/codex-desktop.desktop" "Keywords=codex;openai;ai;coding;"
     assert_contains "$capture_dir/AppDir/codex-desktop.desktop" "X-AppImage-Version=2026.03.24.120000+appimage"
@@ -1594,7 +1594,7 @@ SCRIPT
     assert_contains "$capture_dir/AppDir/AppRun" "resources/codex-cli/bin/codex"
     assert_contains "$capture_dir/AppDir/AppRun" "export CODEX_CLI_PATH"
 
-    printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "${CODEX_CLI_PATH:-}"' > "$capture_dir/AppDir/opt/codex-desktop/start.sh"
+    printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "${CODEX_CLI_PATH:-}" "$@"' > "$capture_dir/AppDir/opt/codex-desktop/start.sh"
     chmod 0755 "$capture_dir/AppDir/opt/codex-desktop/start.sh"
     local app_run_output
     local app_run_path
@@ -1603,6 +1603,8 @@ SCRIPT
     [ "$app_run_output" = "$bundled_cli" ] || fail "Expected AppRun to select bundled Codex CLI: $app_run_output"
     app_run_output="$(env -i PATH="$app_run_path" HOME="$workspace/home" APPDIR="$capture_dir/AppDir" CODEX_CLI_PATH=/custom/codex "$BASH_BIN" "$capture_dir/AppDir/AppRun")"
     [ "$app_run_output" = "/custom/codex" ] || fail "Expected explicit CODEX_CLI_PATH to override bundled CLI: $app_run_output"
+    app_run_output="$(env -i PATH="$app_run_path" HOME="$workspace/home" APPDIR="$capture_dir/AppDir" "$BASH_BIN" "$capture_dir/AppDir/AppRun" --show)"
+    [ "$app_run_output" = "$bundled_cli"$'\n''--show' ] || fail "Expected AppRun to preserve the desktop --show action: $app_run_output"
     [ "$("$BASH_BIN" "$bundled_cli" --version)" = "v22.22.2" ] || fail "Expected bundled CLI wrapper to use the managed Node runtime"
 
     rm -rf "$platform_source" "$capture_dir"
@@ -5466,6 +5468,7 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/launcher/start.sh.template" "codex-browser-sidebar"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "codex-linux-warm-start-enabled"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "--new-instance"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "--show"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_MULTI_LAUNCH"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_MULTI_LAUNCH_PORT_RANGE"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "choose_multi_launch_port"
@@ -5518,6 +5521,10 @@ adopt_body = source.split("adopt_existing_webview_server() {", 1)[1].split("star
 ensure_body = source.split("start_webview_server() {", 1)[1].split("wait_for_webview_server", 1)[0]
 reconcile_body = source.split("reconcile_runtime_state() {", 1)[1].split("set_electron_defaults() {", 1)[0]
 match_executable_body = source.split("pid_matches_executable() {", 1)[1].split("find_running_app_pid() {", 1)[0]
+match_appimage_body = source.split("pid_matches_appimage_install() {", 1)[1].split("pid_matches_app_install() {", 1)[0]
+match_install_body = source.split("pid_matches_app_install() {", 1)[1].split("pid_matches_running_app() {", 1)[0]
+match_running_body = source.split("pid_matches_running_app() {", 1)[1].split("pid_is_foreign_codex_electron() {", 1)[0]
+find_running_body = source.split("find_running_app_pid() {", 1)[1].split("pid_in_same_launch_instance() {", 1)[0]
 arg0_path_body = source.split("pid_cmdline_arg0_path() {", 1)[1].split("pid_arg0_matches_path() {", 1)[0]
 arg0_match_body = source.split("pid_arg0_matches_path() {", 1)[1].split("pid_environ_lines() {", 1)[0]
 foreign_body = source.split("pid_is_foreign_codex_electron() {", 1)[1].split("discover_running_app_pid() {", 1)[0]
@@ -5570,6 +5577,8 @@ if 'send_warm_start_launch_action "${LAUNCHER_ARGS[@]}"' not in source:
     raise SystemExit("warm-start handoff must not receive launcher-only multi-launch flags")
 if "client.shutdown(socket.SHUT_WR)" not in send_body or "response = client.recv(32)" not in send_body:
     raise SystemExit("warm-start IPC client must read the Electron socket acknowledgement")
+if "running_app_is_active || return 1" not in send_body:
+    raise SystemExit("warm-start IPC must revalidate the shared resident identity before socket handoff")
 if 'launch_electron "${LAUNCHER_ARGS[@]}"' not in source:
     raise SystemExit("Electron launch must receive sanitized launcher args")
 if 'FEATURE_LAUNCHER_HOOK_DIR="$SCRIPT_DIR/.codex-linux/launcher.d"' not in source:
@@ -5582,8 +5591,10 @@ if 'Adopted concurrently-started verified webview server' not in source:
     raise SystemExit("launcher must tolerate a concurrent verified webview server winning the bind race")
 if 'set_detected_running_app "$pid"' not in detect_body:
     raise SystemExit("detect_warm_start must record a pid-file running app even when warm start is disabled")
-if 'runtime_recovery_scan_needed && pid="$(discover_running_app_pid)"' not in detect_body:
+if 'if runtime_recovery_scan_needed; then' not in detect_body or 'pid="$(discover_running_app_pid)"' not in detect_body:
     raise SystemExit("detect_warm_start must limit the running-app scan to recovery cases")
+if detect_body.index('pid="$(discover_running_app_pid)"') > detect_body.index("detect_cross_install_conflict"):
+    raise SystemExit("detect_warm_start must reject a foreign install only after same-install recovery discovery")
 if '[ -S "$LAUNCH_ACTION_SOCKET" ]' in detect_body:
     raise SystemExit("detect_warm_start must not gate the running-app scan on launch socket existence; hidden instances can lose the socket")
 if not re.search(r'if ! linux_setting_enabled "codex-linux-warm-start-enabled" 1; then.*?return 0', source, re.S):
@@ -5600,7 +5611,7 @@ if "terminate_stale_electron_with_pidfd" not in warm_recovery_body:
     raise SystemExit("warm-start recovery must terminate only an identity-verified stale Electron")
 if "os.pidfd_open" not in terminate_body or "signal.pidfd_send_signal" not in terminate_body:
     raise SystemExit("stale Electron termination must bind signals to a pidfd")
-for identity_guard in ("expected_start_time", "expected_executable", "expected_app_id", "expected_instance_id"):
+for identity_guard in ("expected_start_time", "expected_executable", "expected_appimage", "expected_app_id", "expected_instance_id"):
     if identity_guard not in terminate_body:
         raise SystemExit(f"pidfd termination is missing identity guard: {identity_guard}")
 if 'running_app_is_active || return 0' not in warm_recovery_body or '[ "$WARM_START" -eq 1 ]' in warm_recovery_body:
@@ -5611,7 +5622,7 @@ if not re.search(r'trap cleanup_launcher EXIT.*?recover_unhealthy_running_app.*?
     raise SystemExit("launcher must recover an unhealthy packaged origin before warm-start IPC")
 if launch_body.count("unset ELECTRON_RUN_AS_NODE") != 2:
     raise SystemExit("launch_electron must clear ELECTRON_RUN_AS_NODE before both Electron launch paths")
-if 'pid_matches_executable "$RUNNING_APP_PID" "$SCRIPT_DIR/electron"' not in launch_body:
+if 'pid_matches_running_app "$RUNNING_APP_PID"' not in launch_body:
     raise SystemExit("launch_electron must not overwrite APP_PID_FILE for second-instance handoff")
 if 'echo "$ELECTRON_PID" > "$APP_PID_FILE"' not in launch_body:
     raise SystemExit("launch_electron must still write APP_PID_FILE for normal cold launches")
@@ -5629,6 +5640,20 @@ if "command -v timeout" in source or re.search(r'(^|[ \t])timeout[ \t]+"?\\$', s
     raise SystemExit("launcher hot path must not require external timeout")
 if match_executable_body.index('actual="$(pid_cmdline_arg0_path "$pid")"') > match_executable_body.index('pid_is_current_user "$pid"'):
     raise SystemExit("launcher process discovery must check cmdline arg0 before reading /proc status for UID")
+if 'pid_matches_executable "$pid" "$SCRIPT_DIR/electron" || pid_matches_appimage_install "$pid"' not in match_install_body:
+    raise SystemExit("resident install matching must keep exact executable identity before the AppImage fallback")
+if 'pid_environ_value "$pid" APPIMAGE' not in match_appimage_body or '[ "$resident_appimage" = "$APPIMAGE" ]' not in match_appimage_body:
+    raise SystemExit("resident install matching must use the stable AppImage path across transient remounts")
+native_fast_path = 'if pid_matches_executable "$pid" "$SCRIPT_DIR/electron"; then\n        return 0\n    fi'
+if native_fast_path not in match_running_body or match_running_body.index(native_fast_path) > match_running_body.index("pid_matches_appimage_install"):
+    raise SystemExit("native resident matching must return before AppImage and additional environment reads")
+for identity_guard in ("pid_matches_app_identity", "pid_in_same_launch_instance"):
+    if identity_guard not in match_running_body:
+        raise SystemExit(f"resident matching is missing shared identity guard: {identity_guard}")
+if "pid_matches_running_app" not in find_running_body:
+    raise SystemExit("app.pid discovery must use the shared resident identity contract")
+if '! pid_matches_app_install "$pid"' not in foreign_body:
+    raise SystemExit("cross-install detection must exclude AppImage remounts from foreign residents")
 if 'basename "$actual"' in foreign_body:
     raise SystemExit("foreign Electron detection must not fork basename for every /proc candidate")
 if 'readlink "/proc/$pid/cwd"' in summary_body:
@@ -5797,8 +5822,8 @@ if 'clear_stale_pid_file' not in reconcile_body:
 if 'if [ -z "$webview_pid" ] || { ! pid_is_webview_server "$webview_pid" && ! pid_is_stale_webview_server "$webview_pid"; }; then' not in reconcile_body:
     raise SystemExit("reconcile_runtime_state must clear stale launcher webview ownership markers without touching valid orphaned servers")
 discover_body = source.split("discover_running_app_pid() {", 1)[1].split("running_app_is_active() {", 1)[0]
-if 'pid_in_same_launch_instance "$pid"' not in discover_body:
-    raise SystemExit("discover_running_app_pid must filter by launch instance so default and side-by-side apps never adopt each other")
+if 'pid_matches_running_app "$pid"' not in discover_body or 'pid_in_same_launch_instance "$pid"' not in discover_body:
+    raise SystemExit("discover_running_app_pid must use the shared resident identity contract")
 instance_match_body = source.split("pid_in_same_launch_instance() {", 1)[1].split("discover_running_app_pid() {", 1)[0]
 if 'CODEX_LINUX_INSTANCE_ID=$CODEX_LINUX_INSTANCE_ID' not in instance_match_body or 'CODEX_LINUX_MULTI_LAUNCH=1' not in instance_match_body:
     raise SystemExit("pid_in_same_launch_instance must match instance identity from the process environment")
@@ -9478,6 +9503,11 @@ function makeWindow(id) {
     },
     focus() {
       state.windowCalls.push(`${id}:focus`);
+      if (state.focusError) {
+        const error = state.focusError;
+        state.focusError = null;
+        throw error;
+      }
     },
   };
 }
@@ -9518,6 +9548,7 @@ function resetCalls() {
   state.ensureHostWindowCalls = [];
   state.createFreshLocalWindowCalls = [];
   state.focusCalls = [];
+  state.focusError = null;
   state.windowCalls = [];
   state.errors = [];
   state.ieCalls = 0;
@@ -9704,6 +9735,14 @@ async function boot(settings = {}, env = { CODEX_DESKTOP_LAUNCH_ACTION_SOCKET: "
 
   resetCalls();
   state.primaryWindow = state.primary;
+  state.focusError = new Error("focus rejected");
+  await runSecondInstance(["codex-desktop", "--new-chat"]);
+  assert(state.errors.length === 1 && state.errors[0].meta.kind === "linux-launch-action-failed", "a rejected launch action should be reported");
+  assert(state.ieCalls === 1, "a rejected launch action should run the previous focus fallback");
+  assert(state.focusCalls.length === 2 && state.focusCalls.every((id) => id === "primary"), "fallback should retry focus after a rejected launch action");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
   await runSecondInstance(["codex-desktop", "--quick-chat"]);
   assert(state.queueArgs.length === 0, "--quick-chat without a deeplink should not be consumed by deeplink routing");
   assert(state.createFreshLocalWindowCalls.length === 0, "--quick-chat should reuse the warm primary window");
@@ -9749,6 +9788,21 @@ async function boot(settings = {}, env = { CODEX_DESKTOP_LAUNCH_ACTION_SOCKET: "
   socket = await runSocketArgs(["codex-desktop"]);
   assert(socket.outputs[0] === "ok\n", "warm-start socket should acknowledge fallback focus args");
   assert(state.ieCalls === 1, "warm-start socket should use the focus fallback for args without launch flags");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  socket = await runSocketArgs(["--show"]);
+  assert(socket.outputs[0] === "ok\n", "warm-start socket should acknowledge the AppImage show action");
+  assert(state.ieCalls === 1, "AppImage --show should reuse the existing focus fallback");
+  assert(state.focusCalls.length === 1 && state.focusCalls[0] === "primary", "AppImage --show should focus the warm primary window");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  const firstShow = runSocketArgs(["--show"]);
+  const secondShow = runSocketArgs(["--show"]);
+  const [firstShowSocket, secondShowSocket] = await Promise.all([firstShow, secondShow]);
+  assert(firstShowSocket.outputs[0] === "ok\n" && secondShowSocket.outputs[0] === "ok\n", "overlapping AppImage activations should both be acknowledged");
+  assert(state.ieCalls === 2 && state.focusCalls.length === 2, "overlapping AppImage activations should both reach the idempotent focus fallback");
 
   resetCalls();
   state.primaryWindow = state.primary;
@@ -9805,6 +9859,12 @@ async function boot(settings = {}, env = { CODEX_DESKTOP_LAUNCH_ACTION_SOCKET: "
   assert(state.createFreshLocalWindowCalls.length === 0, "initial --new-chat should reuse a warm primary window");
   assert(state.navigateCalls.length === 1 && state.navigateCalls[0].path === "/", "initial --new-chat should navigate an existing window to /");
   assert(state.focusCalls.length === 1 && state.focusCalls[0] === "primary", "initial --new-chat should focus the main window");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  await runInitialArgs(["codex-desktop", "--show"]);
+  assert(state.ieCalls === 1, "initial AppImage --show should reuse the existing focus fallback");
+  assert(state.focusCalls.length === 1 && state.focusCalls[0] === "primary", "initial AppImage --show should focus the main window");
 
   await boot({ promptChatEnabled: false });
   resetCalls();
@@ -10801,6 +10861,7 @@ EOF
 test_launcher_warm_start_recovery() {
     info "Checking warm-start recovery after launcher SIGKILL"
     bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
+    CODEX_TEST_APPIMAGE_REMOUNT=1 bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
     CODEX_TEST_DISABLE_WARM_START=1 bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
     CODEX_TEST_KILL_DURING_PRELAUNCH=1 bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
     CODEX_TEST_DISABLE_PIDFD=1 CODEX_TEST_NORMAL_LOCK_ONLY=1 \
@@ -10811,6 +10872,7 @@ test_launcher_warm_start_recovery() {
 
 test_launcher_window_reopen_behavior() {
     local nominal_log="$TMP_DIR/launcher-window-reopen-nominal.log"
+    local appimage_remount_log="$TMP_DIR/launcher-window-reopen-appimage-remount.log"
     local mutation_log="$TMP_DIR/launcher-window-reopen-mutation.log"
     local mutation_control_log="$TMP_DIR/launcher-window-reopen-mutation-control.log"
     local no_pidfd_log="$TMP_DIR/launcher-window-reopen-no-pidfd.log"
@@ -10843,6 +10905,22 @@ test_launcher_window_reopen_behavior() {
         fail "Window-reopen behavior harness nominal run failed (status $status)"
     fi
     cat "$nominal_log"
+
+    set +e
+    CODEX_TEST_APPIMAGE_REMOUNT=1 \
+        bash "$REPO_DIR/tests/launcher_window_reopen_behavior.sh" \
+        > "$appimage_remount_log" 2>&1
+    status=$?
+    set -e
+    if [ "$status" -ne 0 ] \
+        || ! grep -Fxq \
+            'launcher AppImage remount window-reopen behavior test passed' \
+            "$appimage_remount_log" \
+        || ! grep -Fq '"outcome":"appimage-remount-preserved"' "$appimage_remount_log"; then
+        cat "$appimage_remount_log" >&2
+        fail "Window-reopen behavior harness AppImage remount run failed (status $status)"
+    fi
+    cat "$appimage_remount_log"
 
     set +e
     CODEX_TEST_FORCE_RESIDENT_REPLACEMENT=1 \


### PR DESCRIPTION
Fixes #1171

## Summary

- Recognize the same running AppImage after APPDIR remounts by using the stable APPIMAGE path only when the executable path differs.
- Share that resident identity across discovery, liveness checks, IPC handoff, recovery, and pidfd revalidation while rejecting a different AppImage install before state mutation.
- Send desktop activations through AppRun --show and retain the existing recovery ordering and focus fallback.

## Validation

- bash -n launcher/start.sh.template tests/launcher_warm_start_recovery.sh tests/launcher_window_reopen_behavior.sh tests/scripts_smoke.sh
- git diff --check
- bash tests/scripts_smoke.sh
- GitHub CI: all 6 required checks passed

Not run: make package. The AppImage builder and production AppRun argument flow are covered by smoke fixtures, and all CI package builds passed.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed CONTRIBUTING.md, kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest CODEX.DMG and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.