### PR TITLE
fix: use launched desktop entry for approval notification icons

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -58,7 +58,34 @@ resolve_script_dir() {
     cd -P "$(dirname "$source")" && pwd
 }
 
+capture_launched_desktop_entry() {
+    unset CODEX_LINUX_LAUNCHED_DESKTOP_ENTRY
+
+    local desktop_file="${GIO_LAUNCHED_DESKTOP_FILE:-}"
+    local launched_pid="${GIO_LAUNCHED_DESKTOP_FILE_PID:-}"
+    local current_pid="${BASHPID:-$$}"
+    local desktop_file_name
+    local desktop_entry
+
+    [ "$launched_pid" = "$current_pid" ] || return 0
+    case "$desktop_file" in
+        /*) ;;
+        *) return 0 ;;
+    esac
+
+    desktop_file_name="${desktop_file##*/}"
+    case "$desktop_file_name" in
+        *.desktop) desktop_entry="${desktop_file_name%.desktop}" ;;
+        *) return 0 ;;
+    esac
+    [ -n "$desktop_entry" ] || return 0
+
+    CODEX_LINUX_LAUNCHED_DESKTOP_ENTRY="$desktop_entry"
+    export CODEX_LINUX_LAUNCHED_DESKTOP_ENTRY
+}
+
 SCRIPT_DIR="$(resolve_script_dir)"
+capture_launched_desktop_entry
 if [ -z "${CODEX_HOME:-}" ]; then
     if [ -n "${HOME:-}" ]; then
         CODEX_HOME="$HOME/.codex"

--- a/notification-actions-linux/src/main.rs
+++ b/notification-actions-linux/src/main.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::Write, path::Path};
+use std::{collections::HashMap, io::Write};
 
 use anyhow::{bail, Context, Result};
 use futures_util::StreamExt;
@@ -207,16 +207,9 @@ fn validate_request(request: &ShowRequest) -> Result<()> {
 }
 
 fn launched_desktop_entry_id() -> Option<String> {
-    let desktop_file = std::env::var_os("GIO_LAUNCHED_DESKTOP_FILE")?;
-    desktop_entry_id(Path::new(&desktop_file))
-}
-
-fn desktop_entry_id(desktop_file: &Path) -> Option<String> {
-    desktop_file
-        .file_name()?
-        .to_str()?
-        .strip_suffix(".desktop")
-        .map(str::to_owned)
+    std::env::var("CODEX_LINUX_LAUNCHED_DESKTOP_ENTRY")
+        .ok()
+        .filter(|desktop_entry| !desktop_entry.is_empty())
 }
 
 fn notification_actions(actions: &[String]) -> Vec<String> {
@@ -275,21 +268,6 @@ mod tests {
         assert_eq!(action_index("action-2", 2), None);
         assert_eq!(action_index("default", 2), None);
         assert_eq!(action_index("action-nope", 2), None);
-    }
-
-    #[test]
-    fn derives_desktop_entry_id_from_desktop_file_path() {
-        assert_eq!(
-            desktop_entry_id(Path::new(
-                "/home/user/.local/share/applications/chatgpt.desktop"
-            )),
-            Some("chatgpt".to_owned())
-        );
-        assert_eq!(
-            desktop_entry_id(Path::new("/usr/share/applications/codex-desktop.desktop")),
-            Some("codex-desktop".to_owned())
-        );
-        assert_eq!(desktop_entry_id(Path::new("/tmp/not-a-desktop-file")), None);
     }
 
     #[test]

--- a/notification-actions-linux/src/main.rs
+++ b/notification-actions-linux/src/main.rs
@@ -1,10 +1,13 @@
-use std::{collections::HashMap, io::Write};
+use std::{collections::HashMap, io::Write, path::Path};
 
 use anyhow::{bail, Context, Result};
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, BufReader};
-use zbus::{zvariant::OwnedValue, Connection, Proxy};
+use zbus::{
+    zvariant::{OwnedValue, Str},
+    Connection, Proxy,
+};
 
 const NOTIFICATIONS_SERVICE: &str = "org.freedesktop.Notifications";
 const NOTIFICATIONS_PATH: &str = "/org/freedesktop/Notifications";
@@ -106,7 +109,13 @@ async fn run() -> Result<()> {
         .await
         .context("failed to subscribe to notification closure")?;
     let action_pairs = notification_actions(&request.actions);
-    let hints: HashMap<String, OwnedValue> = HashMap::new();
+    let mut hints: HashMap<String, OwnedValue> = HashMap::new();
+    if let Some(desktop_entry) = launched_desktop_entry_id() {
+        hints.insert(
+            "desktop-entry".to_owned(),
+            OwnedValue::from(Str::from(desktop_entry)),
+        );
+    }
     let notification_id: u32 = proxy
         .call(
             "Notify",
@@ -197,6 +206,19 @@ fn validate_request(request: &ShowRequest) -> Result<()> {
     Ok(())
 }
 
+fn launched_desktop_entry_id() -> Option<String> {
+    let desktop_file = std::env::var_os("GIO_LAUNCHED_DESKTOP_FILE")?;
+    desktop_entry_id(Path::new(&desktop_file))
+}
+
+fn desktop_entry_id(desktop_file: &Path) -> Option<String> {
+    desktop_file
+        .file_name()?
+        .to_str()?
+        .strip_suffix(".desktop")
+        .map(str::to_owned)
+}
+
 fn notification_actions(actions: &[String]) -> Vec<String> {
     let mut pairs = Vec::with_capacity(2 + actions.len() * 2);
     pairs.push("default".to_owned());
@@ -253,6 +275,21 @@ mod tests {
         assert_eq!(action_index("action-2", 2), None);
         assert_eq!(action_index("default", 2), None);
         assert_eq!(action_index("action-nope", 2), None);
+    }
+
+    #[test]
+    fn derives_desktop_entry_id_from_desktop_file_path() {
+        assert_eq!(
+            desktop_entry_id(Path::new(
+                "/home/user/.local/share/applications/chatgpt.desktop"
+            )),
+            Some("chatgpt".to_owned())
+        );
+        assert_eq!(
+            desktop_entry_id(Path::new("/usr/share/applications/codex-desktop.desktop")),
+            Some("codex-desktop".to_owned())
+        );
+        assert_eq!(desktop_entry_id(Path::new("/tmp/not-a-desktop-file")), None);
     }
 
     #[test]

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4942,6 +4942,30 @@ EOF
     "$BASH_BIN" "$probe" || fail "Expected launcher to preserve all LD_LIBRARY_PATH states"
 }
 
+test_launcher_captures_desktop_entry_for_current_process_only() {
+    info "Checking launcher validates the GIO desktop-entry PID"
+    local probe="$TMP_DIR/launcher-desktop-entry-pid-probe.sh"
+
+    awk '
+        /^capture_launched_desktop_entry\(\) \{/ { capture = 1 }
+        capture { print }
+        capture && /^}/ { exit }
+    ' "$REPO_DIR/launcher/start.sh.template" > "$probe"
+    cat >> "$probe" <<'EOF'
+GIO_LAUNCHED_DESKTOP_FILE=/home/user/.local/share/applications/chatgpt.desktop
+GIO_LAUNCHED_DESKTOP_FILE_PID="$BASHPID"
+capture_launched_desktop_entry
+[ "$CODEX_LINUX_LAUNCHED_DESKTOP_ENTRY" = chatgpt ] || exit 2
+
+GIO_LAUNCHED_DESKTOP_FILE=/usr/share/applications/org.gnome.Terminal.desktop
+GIO_LAUNCHED_DESKTOP_FILE_PID="$((BASHPID + 1))"
+capture_launched_desktop_entry
+[ "${CODEX_LINUX_LAUNCHED_DESKTOP_ENTRY+x}" != x ] || exit 3
+EOF
+
+    "$BASH_BIN" "$probe" || fail "Expected launcher to reject stale GIO desktop-entry metadata"
+}
+
 test_packaged_runtime_keeps_managed_node_out_of_user_service_path() {
     info "Checking packaged runtime exports the user PATH to user services"
     local workspace="$TMP_DIR/packaged-runtime-user-path"
@@ -11134,6 +11158,7 @@ main() {
     test_chrome_native_host_manifest_writer
     test_launcher_managed_node_handles_unset_path
     test_launcher_captures_original_ld_library_path_state
+    test_launcher_captures_desktop_entry_for_current_process_only
     test_packaged_runtime_keeps_managed_node_out_of_user_service_path
     test_launcher_extra_bundled_plugin_cache_rollback
     test_launcher_extra_bundled_plugin_cache_concurrent_destination


### PR DESCRIPTION
## Summary

Fix the missing application icon on Linux approval notifications.

Actionable notifications are sent through the Linux D-Bus notification bridge, which previously omitted the `desktop-entry` hint. The bridge now derives the active desktop entry ID from `GIO_LAUNCHED_DESKTOP_FILE` and includes it in the notification hints, allowing GNOME to resolve the icon configured by the installed desktop entry (including Gear Lever integrations).

_Before_
<img width="400" alt="Screenshot From 2026-08-01 21-20-54 (Edit)" src="https://github.com/user-attachments/assets/70ece196-1fbd-4e4b-b3cb-a1b4d02dc2af" />

_Now_
<img width="400" alt="Screenshot From 2026-08-02 03-40-49 (Edit)" src="https://github.com/user-attachments/assets/71e10734-7bd5-4e7f-b4c7-49ddbf0fc15f" />


No tracked issue is resolved.

## Validation

- `cargo fmt`
- `cargo test -p codex-notification-actions-linux`
- `node --test scripts/patches/impl/main-process/notifications.test.js`
- `git diff --check`
- Full AppImage build
- Manual GNOME/Gear Lever integration test

Not run:

- Repository CI

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.