### PR TITLE
fix: prevent lingering app icon after quit

### DIFF
--- a/docs/windowless-warm-start-fix-report.md
+++ b/docs/windowless-warm-start-fix-report.md
@@ -68,10 +68,11 @@ On Linux, both branches now pass a cleanup factory to one bounded helper:
 
 1. `Promise.resolve().then(factory)` contains synchronous disposer and drain
    setup exceptions.
-2. `Promise.race()` limits the drain to three seconds.
+2. `Promise.race()` limits the complete drain and context-disposal sequence to
+   three seconds.
 3. Rejected `Promise.allSettled()` results and deadline expiry are logged.
-4. Context disposal remains bounded by the upstream five-second limit and
-   cannot suppress shared-disposable cleanup.
+4. Context disposal runs inside the same three-second deadline, so the upstream
+   timeout cannot extend the lifetime of an already windowless process.
 5. Shared-disposable failure is logged and cannot suppress `app.exit(0)`.
 
 `app.exit(0)` is deliberate. The patched path has already run the available
@@ -106,7 +107,7 @@ Automated regression coverage exercises:
 - both current upstream drain branches;
 - synchronous lifecycle-disposer and drain-setup failures;
 - asynchronous drain rejection and deadline expiry;
-- context-disposal and shared-disposable failures;
+- context-disposal stalls and failures, plus shared-disposable failures;
 - Linux forced exit and unchanged non-Linux graceful quit;
 - late drain settlement after the deadline;
 - exact idempotence and scoped postcondition detection;

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2778,11 +2778,21 @@ test("Linux will-quit reaches app.exit after the drain deadline", async () => {
 
 test("Linux will-quit bounds context disposal inside the quit deadline", async () => {
   const stalledContextDispose = new Promise(() => {});
+  let contextDisposeCalls = 0;
+  let disposablesCalls = 0;
   const state = await runPatchedLinuxWillQuit({
-    contextDispose: () => stalledContextDispose,
+    contextDispose() {
+      contextDisposeCalls += 1;
+      return stalledContextDispose;
+    },
+    disposablesDispose() {
+      disposablesCalls += 1;
+    },
     timeoutMs: 5,
   });
 
+  assert.equal(contextDisposeCalls, 1);
+  assert.equal(disposablesCalls, 1);
   assert.equal(state.exitCalls, 1);
   assert.deepEqual(state.exitCodes, [0]);
   assert.equal(state.quitCalls, 0);

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -3053,11 +3053,11 @@ test("does not accept damaged Linux quit cleanup factory bodies", () => {
   const sources = [
     patched.replace(
       "codexLinuxRunQuitCleanup(()=>{c.dispose(),u.dispose();return Promise.allSettled([p(),m()])})",
-      "codexLinuxRunQuitCleanup(()=>Promise.resolve())",
+      "codexLinuxRunQuitCleanup(()=>{return Promise.resolve()})",
     ),
     patched.replace(
       "codexLinuxRunQuitCleanup(()=>{c.dispose(),u.dispose();return Promise.allSettled([d.flush(),f.flush(),p(),m()])})",
-      "codexLinuxRunQuitCleanup(()=>Promise.resolve())",
+      "codexLinuxRunQuitCleanup(()=>{return Promise.resolve()})",
     ),
   ];
   const descriptor = corePatchDescriptors().find(

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2801,6 +2801,56 @@ test("Linux will-quit bounds context disposal inside the quit deadline", async (
   ]);
 });
 
+test("Linux reduced will-quit branch shares the complete cleanup deadline", async () => {
+  const stalledContextDispose = new Promise(() => {});
+  let contextDisposeCalls = 0;
+  let disposablesCalls = 0;
+  let globalStateFlushCalls = 0;
+  let settingsFlushCalls = 0;
+  let stopCodexMicroCalls = 0;
+  let flushTracingCalls = 0;
+  const state = await runPatchedLinuxWillQuit({
+    contextDispose() {
+      contextDisposeCalls += 1;
+      return stalledContextDispose;
+    },
+    disposablesDispose() {
+      disposablesCalls += 1;
+    },
+    flushTracing() {
+      flushTracingCalls += 1;
+      return Promise.resolve();
+    },
+    globalStateFlush() {
+      globalStateFlushCalls += 1;
+      return Promise.resolve();
+    },
+    settingsFlush() {
+      settingsFlushCalls += 1;
+      return Promise.resolve();
+    },
+    shouldSkipDrain: true,
+    stopCodexMicro() {
+      stopCodexMicroCalls += 1;
+      return Promise.resolve();
+    },
+    timeoutMs: 5,
+  });
+
+  assert.equal(contextDisposeCalls, 1);
+  assert.equal(disposablesCalls, 1);
+  assert.equal(globalStateFlushCalls, 0);
+  assert.equal(settingsFlushCalls, 0);
+  assert.equal(stopCodexMicroCalls, 1);
+  assert.equal(flushTracingCalls, 1);
+  assert.equal(state.exitCalls, 1);
+  assert.deepEqual(state.exitCodes, [0]);
+  assert.equal(state.quitCalls, 0);
+  assert.deepEqual(state.warnings, [
+    "WARN: Linux quit cleanup failed Error: Linux quit cleanup timed out",
+  ]);
+});
+
 test("Linux will-quit logs rejected asynchronous drain work before exit", async () => {
   const state = await runPatchedLinuxWillQuit({
     globalStateFlush: () => Promise.reject(new Error("global-state flush rejected")),
@@ -2971,6 +3021,29 @@ test("recognizes the bounded Linux quit cleanup as already applied", () => {
   assert.equal(result.patchedSource, source);
   assert.deepEqual(warnings, []);
   assert.equal(report.patches[0]?.status, "already-applied");
+});
+
+test("does not accept a partial Linux quit cleanup call-site patch", () => {
+  const source = applyLinuxWillQuitDrainTimeoutPatch(
+    willQuitDrainBundleFixture(),
+  ).replace(
+    "codexLinuxRunQuitCleanup(()=>{c.dispose(),u.dispose();",
+    "codexLinuxRunQuitDrain(()=>{c.dispose(),u.dispose();",
+  );
+  const descriptor = corePatchDescriptors().find(
+    (candidate) => candidate.id === "linux-explicit-quit-drain-timeout",
+  );
+  const report = createPatchReport();
+  const { value: result, warnings } = captureWarns(() =>
+    applyMainBundlePatchDescriptors(source, [descriptor], {}, report),
+  );
+
+  assert.equal(result.patchedSource, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not uniquely match current will-quit drain sequence — skipping Linux explicit quit drain timeout patch",
+  ]);
+  assert.equal(report.patches[0]?.status, "failed-required");
+  assert.equal(report.patches[0]?.reason, warnings[0]);
 });
 
 test("a non-exiting Linux finalizer is not accepted as already applied", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -3046,6 +3046,39 @@ test("does not accept a partial Linux quit cleanup call-site patch", () => {
   assert.equal(report.patches[0]?.reason, warnings[0]);
 });
 
+test("does not accept damaged Linux quit cleanup factory bodies", () => {
+  const patched = applyLinuxWillQuitDrainTimeoutPatch(
+    willQuitDrainBundleFixture(),
+  );
+  const sources = [
+    patched.replace(
+      "codexLinuxRunQuitCleanup(()=>{c.dispose(),u.dispose();return Promise.allSettled([p(),m()])})",
+      "codexLinuxRunQuitCleanup(()=>Promise.resolve())",
+    ),
+    patched.replace(
+      "codexLinuxRunQuitCleanup(()=>{c.dispose(),u.dispose();return Promise.allSettled([d.flush(),f.flush(),p(),m()])})",
+      "codexLinuxRunQuitCleanup(()=>Promise.resolve())",
+    ),
+  ];
+  const descriptor = corePatchDescriptors().find(
+    (candidate) => candidate.id === "linux-explicit-quit-drain-timeout",
+  );
+
+  for (const source of sources) {
+    const report = createPatchReport();
+    const { value: result, warnings } = captureWarns(() =>
+      applyMainBundlePatchDescriptors(source, [descriptor], {}, report),
+    );
+
+    assert.equal(result.patchedSource, source);
+    assert.deepEqual(warnings, [
+      "WARN: Could not uniquely match current will-quit drain sequence — skipping Linux explicit quit drain timeout patch",
+    ]);
+    assert.equal(report.patches[0]?.status, "failed-required");
+    assert.equal(report.patches[0]?.reason, warnings[0]);
+  }
+});
+
 test("a non-exiting Linux finalizer is not accepted as already applied", () => {
   const previousBrokenPatch = applyLinuxWillQuitDrainTimeoutPatch(
     willQuitDrainBundleFixture(),

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2709,7 +2709,7 @@ test("adds a bounded will-quit drain fallback on Linux", () => {
   assert.doesNotMatch(patched, /codexLinuxQuitFinalized/);
   assert.match(
     patched,
-    /Promise\.resolve\(\)\.then\(\(\)=>U5\(h,N5\)\)\.catch\(e=>\{try\{console\.warn\(`WARN: Linux quit context cleanup failed`,e\)\}catch\{\}\}\)/,
+    /\.then\(\(\)=>Promise\.resolve\(\)\.then\(\(\)=>U5\(h,N5\)\)\.catch\(e=>\{try\{console\.warn\(`WARN: Linux quit context cleanup failed`,e\)\}catch\{\}\}\)\)/,
   );
   assert.match(
     patched,
@@ -2717,14 +2717,14 @@ test("adds a bounded will-quit drain fallback on Linux", () => {
   );
   assert.match(
     patched,
-    /Promise\.race\(\[Promise\.resolve\(\)\.then\(e\)\.then\(codexLinuxLogQuitDrainResults\),new Promise\(\(_,e\)=>setTimeout\(\(\)=>e\(Error\(`Linux quit drain timed out`\)\),typeof codexLinuxExplicitQuitDrainTimeoutMs===`number`\?codexLinuxExplicitQuitDrainTimeoutMs:3e3\)\)\]\)\.catch\(e=>\{try\{console\.warn\(`WARN: Linux quit drain cleanup failed`,e\)\}catch\{\}\}\)\.then\(codexLinuxFinalizeQuit\)/,
+    /Promise\.race\(\[Promise\.resolve\(\)\.then\(e\)[^;]+new Promise\(\(_,e\)=>setTimeout\(\(\)=>e\(Error\(`Linux quit cleanup timed out`\)\),typeof codexLinuxExplicitQuitDrainTimeoutMs===`number`\?codexLinuxExplicitQuitDrainTimeoutMs:3e3\)\)\]\)\.catch\(e=>\{try\{console\.warn\(`WARN: Linux quit cleanup failed`,e\)\}catch\{\}\}\)\.then\(codexLinuxFinalizeQuit\)/,
   );
   assert.match(
     patched,
-    /codexLinuxRunQuitDrain=e=>\{if\(process\.platform===`linux`\)\{/,
+    /codexLinuxRunQuitCleanup=e=>\{if\(process\.platform===`linux`\)\{/,
   );
   assert.equal(
-    (patched.match(/codexLinuxRunQuitDrain\(\(\)=>\{/g) ?? []).length,
+    (patched.match(/codexLinuxRunQuitCleanup\(\(\)=>\{/g) ?? []).length,
     2,
   );
   assert.equal(
@@ -2768,12 +2768,27 @@ test("Linux will-quit reaches app.exit after the drain deadline", async () => {
   assert.deepEqual(state.exitCodes, [0]);
   assert.equal(state.quitCalls, 0);
   assert.deepEqual(state.warnings, [
-    "WARN: Linux quit drain cleanup failed Error: Linux quit drain timed out",
+    "WARN: Linux quit cleanup failed Error: Linux quit cleanup timed out",
   ]);
   resolveGlobalState();
   await new Promise((resolve) => setTimeout(resolve, 10));
   assert.equal(state.exitCalls, 1);
   assert.equal(state.quitCalls, 0);
+});
+
+test("Linux will-quit bounds context disposal inside the quit deadline", async () => {
+  const stalledContextDispose = new Promise(() => {});
+  const state = await runPatchedLinuxWillQuit({
+    contextDispose: () => stalledContextDispose,
+    timeoutMs: 5,
+  });
+
+  assert.equal(state.exitCalls, 1);
+  assert.deepEqual(state.exitCodes, [0]);
+  assert.equal(state.quitCalls, 0);
+  assert.deepEqual(state.warnings, [
+    "WARN: Linux quit cleanup failed Error: Linux quit cleanup timed out",
+  ]);
 });
 
 test("Linux will-quit logs rejected asynchronous drain work before exit", async () => {
@@ -2929,6 +2944,23 @@ test("missing, renamed, or ambiguous will-quit targets fail the required lifecyc
     assert.equal(report.patches[0]?.status, "failed-required");
     assert.equal(report.patches[0]?.reason, warnings[0]);
   }
+});
+
+test("recognizes the bounded Linux quit cleanup as already applied", () => {
+  const source = applyLinuxWillQuitDrainTimeoutPatch(
+    willQuitDrainBundleFixture(),
+  );
+  const descriptor = corePatchDescriptors().find(
+    (candidate) => candidate.id === "linux-explicit-quit-drain-timeout",
+  );
+  const report = createPatchReport();
+  const { value: result, warnings } = captureWarns(() =>
+    applyMainBundlePatchDescriptors(source, [descriptor], {}, report),
+  );
+
+  assert.equal(result.patchedSource, source);
+  assert.deepEqual(warnings, []);
+  assert.equal(report.patches[0]?.status, "already-applied");
 });
 
 test("a non-exiting Linux finalizer is not accepted as already applied", () => {

--- a/scripts/patches/impl/main-process/quit-lifecycle.js
+++ b/scripts/patches/impl/main-process/quit-lifecycle.js
@@ -117,15 +117,16 @@ function applyLinuxWillQuitDrainTimeoutPatch(currentSource) {
   const appliedMarkers = [
     "codexLinuxLogQuitDrainResults=e=>{",
     "codexLinuxFinalizeQuit=()=>{",
-    "codexLinuxRunQuitDrain=e=>{if(process.platform===`linux`){Promise.race([Promise.resolve().then(e)",
-    "Linux quit drain timed out",
+    "codexLinuxRunQuitCleanup=e=>{if(process.platform===`linux`){Promise.race([Promise.resolve().then(e)",
+    "Linux quit cleanup timed out",
     "WARN: Linux quit drain cleanup failed",
     "WARN: Linux quit context cleanup failed",
+    "WARN: Linux quit cleanup failed",
     "WARN: Linux quit disposables cleanup failed",
   ];
   const appliedFinalizerStart = currentSource.indexOf(appliedMarkers[0]);
   const appliedFinalizerEnd = currentSource.indexOf(
-    ",codexLinuxRunQuitDrain=",
+    ",codexLinuxRunQuitCleanup=",
     appliedFinalizerStart,
   );
   const hasAppliedFinalizerPostcondition =
@@ -151,18 +152,18 @@ function applyLinuxWillQuitDrainTimeoutPatch(currentSource) {
   const { outer, finalizer, reduced, full } = candidate.shape;
   const originalFinalizer = `${outer.upstreamFinalize}=()=>{${outer.finalizer}}`;
   const linuxFinalizer =
-    `codexLinuxLogQuitDrainResults=e=>{for(let t of e)if(t.status===\`rejected\`)try{console.warn(\`WARN: Linux quit drain cleanup failed\`,t.reason)}catch{};return e},codexLinuxFinalizeQuit=()=>{Promise.resolve().then(()=>${finalizer.contextDispose}(${finalizer.contextArg},${finalizer.contextTimeout})).catch(e=>{try{console.warn(\`WARN: Linux quit context cleanup failed\`,e)}catch{}}).then(()=>{try{${finalizer.disposables}.dispose()}catch(e){try{console.warn(\`WARN: Linux quit disposables cleanup failed\`,e)}catch{}}finally{${finalizer.electron}.app.exit(0)}})},codexLinuxRunQuitDrain=e=>{if(${linuxQuitDrainGuard}){Promise.race([Promise.resolve().then(e).then(codexLinuxLogQuitDrainResults),new Promise((_,e)=>setTimeout(()=>e(Error(\`Linux quit drain timed out\`)),typeof codexLinuxExplicitQuitDrainTimeoutMs===\`number\`?codexLinuxExplicitQuitDrainTimeoutMs:3e3))]).catch(e=>{try{console.warn(\`WARN: Linux quit drain cleanup failed\`,e)}catch{}}).then(codexLinuxFinalizeQuit);return}e().then(${outer.upstreamFinalize})}`;
+    `codexLinuxLogQuitDrainResults=e=>{for(let t of e)if(t.status===\`rejected\`)try{console.warn(\`WARN: Linux quit drain cleanup failed\`,t.reason)}catch{};return e},codexLinuxFinalizeQuit=()=>{try{${finalizer.disposables}.dispose()}catch(e){try{console.warn(\`WARN: Linux quit disposables cleanup failed\`,e)}catch{}}finally{${finalizer.electron}.app.exit(0)}},codexLinuxRunQuitCleanup=e=>{if(${linuxQuitDrainGuard}){Promise.race([Promise.resolve().then(e).then(codexLinuxLogQuitDrainResults).catch(e=>{try{console.warn(\`WARN: Linux quit drain cleanup failed\`,e)}catch{}}).then(()=>Promise.resolve().then(()=>${finalizer.contextDispose}(${finalizer.contextArg},${finalizer.contextTimeout})).catch(e=>{try{console.warn(\`WARN: Linux quit context cleanup failed\`,e)}catch{}})),new Promise((_,e)=>setTimeout(()=>e(Error(\`Linux quit cleanup timed out\`)),typeof codexLinuxExplicitQuitDrainTimeoutMs===\`number\`?codexLinuxExplicitQuitDrainTimeoutMs:3e3))]).catch(e=>{try{console.warn(\`WARN: Linux quit cleanup failed\`,e)}catch{}}).then(codexLinuxFinalizeQuit);return}e().then(${outer.upstreamFinalize})}`;
   let patchedBody = candidate.body.replace(
     `let ${originalFinalizer};`,
     `let ${originalFinalizer},${linuxFinalizer};`,
   );
   patchedBody = patchedBody.replace(
     `${reduced.hotkey}.dispose(),${reduced.dictation}.dispose(),Promise.allSettled([${reduced.stop}(),${reduced.trace}()]).then(${outer.upstreamFinalize})`,
-    `codexLinuxRunQuitDrain(()=>{${reduced.hotkey}.dispose(),${reduced.dictation}.dispose();return Promise.allSettled([${reduced.stop}(),${reduced.trace}()])})`,
+    `codexLinuxRunQuitCleanup(()=>{${reduced.hotkey}.dispose(),${reduced.dictation}.dispose();return Promise.allSettled([${reduced.stop}(),${reduced.trace}()])})`,
   );
   patchedBody = patchedBody.replace(
     `${full.hotkey}.dispose(),${full.dictation}.dispose(),Promise.allSettled([${full.globalState}.flush(),${full.settings}.flush(),${full.stop}(),${full.trace}()]).then(${outer.upstreamFinalize})`,
-    `codexLinuxRunQuitDrain(()=>{${full.hotkey}.dispose(),${full.dictation}.dispose();return Promise.allSettled([${full.globalState}.flush(),${full.settings}.flush(),${full.stop}(),${full.trace}()])})`,
+    `codexLinuxRunQuitCleanup(()=>{${full.hotkey}.dispose(),${full.dictation}.dispose();return Promise.allSettled([${full.globalState}.flush(),${full.settings}.flush(),${full.stop}(),${full.trace}()])})`,
   );
 
   return `${currentSource.slice(0, candidate.openBrace + 1)}${patchedBody}${currentSource.slice(candidate.closeBrace)}`;

--- a/scripts/patches/impl/main-process/quit-lifecycle.js
+++ b/scripts/patches/impl/main-process/quit-lifecycle.js
@@ -152,14 +152,36 @@ function hasAppliedWillQuitCleanupPostcondition(currentSource, appliedFinalizerS
     return false;
   }
 
+  const identifier = "[A-Za-z_$][\\w$]*";
   const cleanupCall = /codexLinuxRunQuitCleanup\(\(\)=>\{/g;
-  const reducedCalls =
-    handlerBody
-      .slice(reducedBranchStart, reducedBranchEnd)
-      .match(cleanupCall)?.length ?? 0;
-  const fullCalls =
-    handlerBody.slice(reducedBranchEnd + 8).match(cleanupCall)?.length ?? 0;
-  return reducedCalls === 1 && fullCalls === 1;
+  const reducedBody = handlerBody.slice(
+    reducedBranchStart,
+    reducedBranchEnd,
+  );
+  const fullBody = handlerBody.slice(reducedBranchEnd + 8);
+  if (
+    (reducedBody.match(cleanupCall) ?? []).length !== 1 ||
+    (fullBody.match(cleanupCall) ?? []).length !== 1
+  ) {
+    return false;
+  }
+
+  const reducedMatch = reducedBody.match(new RegExp(
+    `codexLinuxRunQuitCleanup\\(\\(\\)=>\\{(?<hotkey>${identifier})\\.dispose\\(\\),(?<dictation>${identifier})\\.dispose\\(\\);return Promise\\.allSettled\\(\\[(?<stop>${identifier})\\(\\),(?<trace>${identifier})\\(\\)\\]\\)\\}\\)`,
+  ));
+  const fullMatch = fullBody.match(new RegExp(
+    `codexLinuxRunQuitCleanup\\(\\(\\)=>\\{(?<hotkey>${identifier})\\.dispose\\(\\),(?<dictation>${identifier})\\.dispose\\(\\);return Promise\\.allSettled\\(\\[(?<globalState>${identifier})\\.flush\\(\\),(?<settings>${identifier})\\.flush\\(\\),(?<stop>${identifier})\\(\\),(?<trace>${identifier})\\(\\)\\]\\)\\}\\)`,
+  ));
+  if (reducedMatch?.groups == null || fullMatch?.groups == null) {
+    return false;
+  }
+
+  return (
+    reducedMatch.groups.hotkey === fullMatch.groups.hotkey &&
+    reducedMatch.groups.dictation === fullMatch.groups.dictation &&
+    reducedMatch.groups.stop === fullMatch.groups.stop &&
+    reducedMatch.groups.trace === fullMatch.groups.trace
+  );
 }
 
 function applyLinuxWillQuitDrainTimeoutPatch(currentSource) {

--- a/scripts/patches/impl/main-process/quit-lifecycle.js
+++ b/scripts/patches/impl/main-process/quit-lifecycle.js
@@ -112,6 +112,40 @@ function currentWillQuitDrainCandidates(currentSource) {
   return candidates;
 }
 
+function hasAppliedWillQuitCleanupPostcondition(currentSource, appliedFinalizerStart) {
+  const listenerNeedle = ".app.on(`will-quit`,";
+  const listenerIndex = currentSource.lastIndexOf(
+    listenerNeedle,
+    appliedFinalizerStart,
+  );
+  if (listenerIndex === -1) {
+    return false;
+  }
+
+  const handlerStart = listenerIndex + listenerNeedle.length;
+  const handlerMatch = currentSource
+    .slice(handlerStart, handlerStart + 100)
+    .match(/^[A-Za-z_$][\w$]*=>\{/);
+  if (handlerMatch == null) {
+    return false;
+  }
+
+  const openBrace = handlerStart + handlerMatch[0].length - 1;
+  const closeBrace = findMatchingBrace(currentSource, openBrace);
+  if (
+    closeBrace === -1 ||
+    appliedFinalizerStart <= openBrace ||
+    appliedFinalizerStart >= closeBrace
+  ) {
+    return false;
+  }
+
+  const handlerBody = currentSource.slice(openBrace + 1, closeBrace);
+  return (
+    handlerBody.match(/codexLinuxRunQuitCleanup\(\(\)=>\{/g) ?? []
+  ).length === 2;
+}
+
 function applyLinuxWillQuitDrainTimeoutPatch(currentSource) {
   const linuxQuitDrainGuard = "process.platform===`linux`";
   const appliedMarkers = [
@@ -134,6 +168,10 @@ function applyLinuxWillQuitDrainTimeoutPatch(currentSource) {
     appliedFinalizerEnd > appliedFinalizerStart &&
     /finally\{[A-Za-z_$][\w$]*\.app\.exit\(0\)\}/.test(
       currentSource.slice(appliedFinalizerStart, appliedFinalizerEnd),
+    ) &&
+    hasAppliedWillQuitCleanupPostcondition(
+      currentSource,
+      appliedFinalizerStart,
     );
   if (
     appliedMarkers.every((marker) => currentSource.includes(marker)) &&

--- a/scripts/patches/impl/main-process/quit-lifecycle.js
+++ b/scripts/patches/impl/main-process/quit-lifecycle.js
@@ -141,9 +141,25 @@ function hasAppliedWillQuitCleanupPostcondition(currentSource, appliedFinalizerS
   }
 
   const handlerBody = currentSource.slice(openBrace + 1, closeBrace);
-  return (
-    handlerBody.match(/codexLinuxRunQuitCleanup\(\(\)=>\{/g) ?? []
-  ).length === 2;
+  const reducedBranchStart = handlerBody.indexOf(
+    ".shouldSkipDrainBeforeQuit()){",
+  );
+  const reducedBranchEnd = handlerBody.indexOf(
+    ";return}",
+    reducedBranchStart,
+  );
+  if (reducedBranchStart === -1 || reducedBranchEnd === -1) {
+    return false;
+  }
+
+  const cleanupCall = /codexLinuxRunQuitCleanup\(\(\)=>\{/g;
+  const reducedCalls =
+    handlerBody
+      .slice(reducedBranchStart, reducedBranchEnd)
+      .match(cleanupCall)?.length ?? 0;
+  const fullCalls =
+    handlerBody.slice(reducedBranchEnd + 8).match(cleanupCall)?.length ?? 0;
+  return reducedCalls === 1 && fullCalls === 1;
 }
 
 function applyLinuxWillQuitDrainTimeoutPatch(currentSource) {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -9200,13 +9200,15 @@ JS
     assert_not_contains "$extracted/.vite/build/main-test.js" 'codexLinuxQuitFinalized'
     assert_contains "$extracted/.vite/build/main-test.js" 'WARN: Linux quit drain cleanup failed'
     assert_contains "$extracted/.vite/build/main-test.js" 'WARN: Linux quit context cleanup failed'
+    assert_contains "$extracted/.vite/build/main-test.js" 'WARN: Linux quit cleanup failed'
     assert_contains "$extracted/.vite/build/main-test.js" 'WARN: Linux quit disposables cleanup failed'
     assert_contains "$extracted/.vite/build/main-test.js" 'finally{l.app.exit(0)}'
     assert_not_contains "$extracted/.vite/build/main-test.js" 'finally{l.app.quit()}'
-    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxRunQuitDrain(()=>{' '2'
-    assert_contains "$extracted/.vite/build/main-test.js" 'Promise.resolve().then(e).then(codexLinuxLogQuitDrainResults),new Promise'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxRunQuitCleanup(()=>{' '2'
+    assert_contains "$extracted/.vite/build/main-test.js" 'Promise.resolve().then(e).then(codexLinuxLogQuitDrainResults).catch'
+    assert_contains "$extracted/.vite/build/main-test.js" '.then(()=>Promise.resolve().then(()=>U5(h,N5)).catch'
     assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxExplicitQuitDrainTimeoutMs'
-    assert_contains "$extracted/.vite/build/main-test.js" 'setTimeout(()=>e(Error(`Linux quit drain timed out`)),typeof codexLinuxExplicitQuitDrainTimeoutMs'
+    assert_contains "$extracted/.vite/build/main-test.js" 'setTimeout(()=>e(Error(`Linux quit cleanup timed out`)),typeof codexLinuxExplicitQuitDrainTimeoutMs'
     assert_not_contains "$extracted/.vite/build/main-test.js" '\`number\`'
     assert_not_contains "$output_log" 'WARN: Could not find tray quit menu handler'
     assert_not_contains "$output_log" 'WARN: Could not find quit-app IPC handler'
@@ -9312,7 +9314,7 @@ NODE
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt()' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxLogQuitDrainResults=e=>{' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxFinalizeQuit=()=>{' '1'
-    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxRunQuitDrain(()=>{' '2'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxRunQuitCleanup(()=>{' '2'
 }
 
 test_keybinds_settings_tab_patch_smoke() {


### PR DESCRIPTION
## Summary
- keep Linux drain and context disposal inside one three-second quit deadline
- always run shared disposal and `app.exit(0)` after the bounded cleanup
- validate both reduced/full patched call sites and reject partial or structurally damaged required patches
- cover stalled context disposal, both runtime drain branches, and patch idempotence regressions

## Tests/checks run
- `node --test scripts/patch-linux-window-ui.test.js` (410/410)
- focused `test_linux_explicit_quit_patch_smoke`
- `node --check scripts/patches/impl/main-process/quit-lifecycle.js`
- `bash -n tests/scripts_smoke.sh`
- `git diff --check`

## Notes / risks
- The full smoke suite was started and completed cross-format package fixtures, but a local autofs wait blocked an unrelated launcher TMPDIR fixture; GitHub CI remains the full-suite gate.