### PR TITLE
HEROX-1202: Fix remote mobile Desktop app-server patch

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -46,9 +46,9 @@ const REMOTE_CONTROL_STATUS_WAIT_MARKER = "codexLinuxRemoteControlStatusWaitMs";
 const REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER = "codexLinuxRemoteControlResetMobileSetupAfterRevoke";
 const REMOTE_CONTROL_VISIBILITY_MARKER = "codexLinuxRemoteControlVisibilityEnabled";
 const REMOTE_CONTROL_COPY_MARKER = "codexLinuxRemoteControlCopy";
-const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileAppServerArgs";
-const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE =
-  "[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`]";
+const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileLocalAppServerArgs";
+const REMOTE_MOBILE_APP_SERVER_BASE_ARGS_NEEDLE = "[`-c`,`features.code_mode_host=true`]";
+const REMOTE_MOBILE_APP_SERVER_LAUNCH_TAIL = "`app-server`,`--analytics-default-enabled`]}";
 const REMOTE_CONTROL_APP_INITIAL_ASSET_PATTERN = /^app-initial-[^.]+\.js$/u;
 const REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS = [
   ["defaultMessage:`Mac`", "defaultMessage:`Linux`"],
@@ -213,15 +213,41 @@ function applyLinuxRemoteMobileAppServerRemoteControlPatch(source) {
   if (source.includes(REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER)) {
     return source;
   }
-  if (!source.includes(REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE)) {
+  const baseArgsMatches = [
+    ...source.matchAll(
+      new RegExp(`([A-Za-z_$][\\w$]*)=${escapeRegExp(REMOTE_MOBILE_APP_SERVER_BASE_ARGS_NEEDLE)}`, "gu"),
+    ),
+  ];
+  if (baseArgsMatches.length !== 1) {
+    return source;
+  }
+
+  const baseArgsVariable = baseArgsMatches[0][1];
+  const launchFunctionMatches = [
+    ...source.matchAll(
+      new RegExp(
+        `function ([A-Za-z_$][\\w$]*)\\(\\)\\{return\\[\\.\\.\\.${escapeRegExp(baseArgsVariable)},`,
+        "gu",
+      ),
+    ),
+  ];
+  if (launchFunctionMatches.length !== 1) {
+    return source;
+  }
+
+  const launchFunctionIndex = launchFunctionMatches[0].index;
+  const nextFunctionIndex = source.indexOf("}function", launchFunctionIndex);
+  const launchTailIndex = source.indexOf(REMOTE_MOBILE_APP_SERVER_LAUNCH_TAIL, launchFunctionIndex);
+  if (launchTailIndex < 0 || (nextFunctionIndex >= 0 && launchTailIndex >= nextFunctionIndex)) {
     return source;
   }
 
   const helper =
-    "function codexLinuxRemoteMobileAppServerArgs(){return process.platform===`linux`?[`-c`,`features.code_mode_host=true`,`app-server`,`--remote-control`,`--analytics-default-enabled`]:[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`]}";
-  const replaced = source
-    .split(REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE)
-    .join("codexLinuxRemoteMobileAppServerArgs()");
+    "function codexLinuxRemoteMobileLocalAppServerArgs(){return process.platform===`linux`?[`--remote-control`]:[]}";
+  const replacementTail = "`app-server`,...codexLinuxRemoteMobileLocalAppServerArgs(),`--analytics-default-enabled`]}";
+  const replaced = `${source.slice(0, launchTailIndex)}${replacementTail}${source.slice(
+    launchTailIndex + REMOTE_MOBILE_APP_SERVER_LAUNCH_TAIL.length,
+  )}`;
   // Insert after a leading "use strict" so prepending the helper does not
   // demote the directive to a plain expression and de-strict the bundle.
   const insertAt = replaced.startsWith('"use strict";')
@@ -251,22 +277,26 @@ function applyLinuxRemoteMobileAppServerRemoteControlExtractedAppPatch(extracted
     const filePath = path.join(buildDir, candidate);
     const source = fs.readFileSync(filePath, "utf8");
     if (
-      !source.includes(REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE) &&
+      !source.includes(REMOTE_MOBILE_APP_SERVER_BASE_ARGS_NEEDLE) &&
       !source.includes(REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER)
     ) {
       continue;
     }
-    matched += 1;
     const patched = applyLinuxRemoteMobileAppServerRemoteControlPatch(source);
     if (patched !== source) {
+      matched += 1;
       fs.writeFileSync(filePath, patched, "utf8");
       changed += 1;
+    } else if (source.includes(REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER)) {
+      matched += 1;
     }
   }
 
   if (matched === 0) {
-    const reason = "no default app-server launch args found";
-    console.warn("WARN: Could not find default app-server launch args - skipping remote mobile app-server remote-control patch");
+    const reason = "no local Desktop app-server base args found";
+    console.warn(
+      "WARN: Could not find local Desktop app-server base args - skipping remote mobile app-server remote-control patch",
+    );
     return { matched, changed, reason };
   }
   return { matched, changed };

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -49,6 +49,10 @@ const REMOTE_CONTROL_COPY_MARKER = "codexLinuxRemoteControlCopy";
 const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileLocalAppServerArgs";
 const REMOTE_MOBILE_APP_SERVER_BASE_ARGS_NEEDLE = "[`-c`,`features.code_mode_host=true`]";
 const REMOTE_MOBILE_APP_SERVER_LAUNCH_TAIL = "`app-server`,`--analytics-default-enabled`]}";
+const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_HELPER =
+  "function codexLinuxRemoteMobileLocalAppServerArgs(){return process.platform===`linux`?[`--remote-control`]:[]}";
+const REMOTE_MOBILE_APP_SERVER_PATCHED_LAUNCH_TAIL =
+  "`app-server`,...codexLinuxRemoteMobileLocalAppServerArgs(),`--analytics-default-enabled`]}";
 const REMOTE_CONTROL_APP_INITIAL_ASSET_PATTERN = /^app-initial-[^.]+\.js$/u;
 const REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS = [
   ["defaultMessage:`Mac`", "defaultMessage:`Linux`"],
@@ -211,6 +215,11 @@ function applyLinuxRemoteControlClientRevocationRecoveryPatch(source) {
 
 function applyLinuxRemoteMobileAppServerRemoteControlPatch(source) {
   if (source.includes(REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER)) {
+    if (!hasLinuxRemoteMobileLocalAppServerRemoteControlPatch(source)) {
+      console.warn(
+        "WARN: Found an incomplete local Desktop app-server remote-control patch - refusing to accept partial state",
+      );
+    }
     return source;
   }
   const baseArgsMatches = [
@@ -242,10 +251,7 @@ function applyLinuxRemoteMobileAppServerRemoteControlPatch(source) {
     return source;
   }
 
-  const helper =
-    "function codexLinuxRemoteMobileLocalAppServerArgs(){return process.platform===`linux`?[`--remote-control`]:[]}";
-  const replacementTail = "`app-server`,...codexLinuxRemoteMobileLocalAppServerArgs(),`--analytics-default-enabled`]}";
-  const replaced = `${source.slice(0, launchTailIndex)}${replacementTail}${source.slice(
+  const replaced = `${source.slice(0, launchTailIndex)}${REMOTE_MOBILE_APP_SERVER_PATCHED_LAUNCH_TAIL}${source.slice(
     launchTailIndex + REMOTE_MOBILE_APP_SERVER_LAUNCH_TAIL.length,
   )}`;
   // Insert after a leading "use strict" so prepending the helper does not
@@ -255,7 +261,14 @@ function applyLinuxRemoteMobileAppServerRemoteControlPatch(source) {
     : replaced.startsWith("'use strict';")
       ? "'use strict';".length
       : 0;
-  return `${replaced.slice(0, insertAt)}${helper}${replaced.slice(insertAt)}`;
+  return `${replaced.slice(0, insertAt)}${REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_HELPER}${replaced.slice(insertAt)}`;
+}
+
+function hasLinuxRemoteMobileLocalAppServerRemoteControlPatch(source) {
+  return (
+    source.includes(REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_HELPER) &&
+    source.includes(REMOTE_MOBILE_APP_SERVER_PATCHED_LAUNCH_TAIL)
+  );
 }
 
 function applyLinuxRemoteMobileAppServerRemoteControlExtractedAppPatch(extractedDir) {
@@ -287,7 +300,7 @@ function applyLinuxRemoteMobileAppServerRemoteControlExtractedAppPatch(extracted
       matched += 1;
       fs.writeFileSync(filePath, patched, "utf8");
       changed += 1;
-    } else if (source.includes(REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER)) {
+    } else if (hasLinuxRemoteMobileLocalAppServerRemoteControlPatch(source)) {
       matched += 1;
     }
   }
@@ -1493,6 +1506,8 @@ module.exports = [
 module.exports.applyLinuxRemoteControlDeviceKeyPatch = applyLinuxRemoteControlDeviceKeyPatch;
 module.exports.applyLinuxRemoteMobileAppServerRemoteControlPatch =
   applyLinuxRemoteMobileAppServerRemoteControlPatch;
+module.exports.hasLinuxRemoteMobileLocalAppServerRemoteControlPatch =
+  hasLinuxRemoteMobileLocalAppServerRemoteControlPatch;
 module.exports.applyLinuxRemoteMobileChromeBridgePatch = applyLinuxRemoteMobileChromeBridgePatch;
 module.exports.applyLinuxRemoteMobileCompletedItemRecoveryPatch =
   applyLinuxRemoteMobileCompletedItemRecoveryPatch;

--- a/linux-features/remote-mobile-control/stage.sh
+++ b/linux-features/remote-mobile-control/stage.sh
@@ -14,7 +14,7 @@ printf '%s\n' "remote-mobile-control" > "$feature_marker"
 install -m 0755 "$SCRIPT_DIR/linux-features/remote-mobile-control/cold-start-hook.sh" "$cold_start_hook"
 
 if [ -d "$WORK_DIR/app-extracted/.vite/build" ] &&
-    grep -R -q "codexLinuxRemoteMobileAppServerArgs" "$WORK_DIR/app-extracted/.vite/build" 2>/dev/null; then
+    grep -R -q "codexLinuxRemoteMobileLocalAppServerArgs" "$WORK_DIR/app-extracted/.vite/build" 2>/dev/null; then
     rm -f "$desktop_remote_control_marker"
     printf '%s\n' "version=1" "owner=desktop" > "$desktop_remote_control_marker"
 else

--- a/linux-features/remote-mobile-control/stage.sh
+++ b/linux-features/remote-mobile-control/stage.sh
@@ -14,7 +14,24 @@ printf '%s\n' "remote-mobile-control" > "$feature_marker"
 install -m 0755 "$SCRIPT_DIR/linux-features/remote-mobile-control/cold-start-hook.sh" "$cold_start_hook"
 
 if [ -d "$WORK_DIR/app-extracted/.vite/build" ] &&
-    grep -R -q "codexLinuxRemoteMobileLocalAppServerArgs" "$WORK_DIR/app-extracted/.vite/build" 2>/dev/null; then
+    node - "$WORK_DIR/app-extracted/.vite/build" "$patch_module" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [buildDir, patchModulePath] = process.argv.slice(2);
+const { hasLinuxRemoteMobileLocalAppServerRemoteControlPatch } = require(patchModulePath);
+
+if (typeof hasLinuxRemoteMobileLocalAppServerRemoteControlPatch !== "function") {
+  process.exit(1);
+}
+
+const found = fs.readdirSync(buildDir).some((name) => {
+  if (!/\.m?js$/u.test(name)) return false;
+  return hasLinuxRemoteMobileLocalAppServerRemoteControlPatch(fs.readFileSync(path.join(buildDir, name), "utf8"));
+});
+process.exit(found ? 0 : 1);
+NODE
+then
     rm -f "$desktop_remote_control_marker"
     printf '%s\n' "version=1" "owner=desktop" > "$desktop_remote_control_marker"
 else

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -32,6 +32,7 @@ const {
   applyLinuxRemoteControlEnablementBridgePatch,
   applyLinuxRemoteMobileActiveStatusPatch,
   applyLinuxRemoteMobileAppServerRemoteControlPatch,
+  hasLinuxRemoteMobileLocalAppServerRemoteControlPatch,
   applyLinuxRemoteMobileChromeBridgePatch,
   applyLinuxRemoteMobileCompletedItemRecoveryPatch,
   applyLinuxRemoteMobileConversationHydrationPatch,
@@ -563,7 +564,10 @@ test("remote mobile stage hook is idempotent and stages its markers and executab
     };
 
     fs.mkdirSync(buildDir, { recursive: true });
-    fs.writeFileSync(path.join(buildDir, "main.js"), "globalThis.codexLinuxRemoteMobileLocalAppServerArgs=true;");
+    fs.writeFileSync(
+      path.join(buildDir, "main.js"),
+      applyLinuxRemoteMobileAppServerRemoteControlPatch(syntheticCurrentLocalAppServerLaunchBundle()),
+    );
 
     const first = runStageHook(env);
     const second = runStageHook(env);
@@ -611,6 +615,33 @@ test("remote mobile stage hook removes a stale ownership marker when only the le
   }
 });
 
+test("remote mobile stage hook rejects an incomplete local Desktop patch marker", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-stage-"));
+  try {
+    const installDir = path.join(tempRoot, "package", "opt", "codex-desktop");
+    const workDir = path.join(tempRoot, "work");
+    const buildDir = path.join(workDir, "app-extracted", ".vite", "build");
+    const marker = path.join(installDir, ".codex-linux", "desktop-app-server-remote-control-enabled");
+
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, "src.js"), "globalThis.codexLinuxRemoteMobileLocalAppServerArgs=true;");
+
+    const result = runStageHook({
+      ARCH: "x64",
+      CODEX_UPSTREAM_APP_DIR: path.join(tempRoot, "upstream-app"),
+      INSTALL_DIR: installDir,
+      SCRIPT_DIR: REPO_ROOT,
+      WORK_DIR: workDir,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.existsSync(marker), false);
+    assert.match(result.stderr, /Desktop app-server remote-control marker not found/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("remote mobile stage hook replaces an ownership marker symlink without following it", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-stage-"));
   try {
@@ -622,7 +653,10 @@ test("remote mobile stage hook replaces an ownership marker symlink without foll
 
     fs.mkdirSync(buildDir, { recursive: true });
     fs.mkdirSync(path.dirname(marker), { recursive: true });
-    fs.writeFileSync(path.join(buildDir, "main.js"), "globalThis.codexLinuxRemoteMobileLocalAppServerArgs=true;");
+    fs.writeFileSync(
+      path.join(buildDir, "main.js"),
+      applyLinuxRemoteMobileAppServerRemoteControlPatch(syntheticCurrentLocalAppServerLaunchBundle()),
+    );
     fs.writeFileSync(target, "preserved\n");
     fs.symlinkSync(target, marker);
 
@@ -1245,6 +1279,14 @@ test("Linux remote mobile app-server launch enables remote control on the Deskto
     /return\[\.\.\.Iz,\.\.\.Lz\.flatMap\(.+`app-server`,\.\.\.codexLinuxRemoteMobileLocalAppServerArgs\(\),`--analytics-default-enabled`\]\}/,
   );
   assert.equal(applyLinuxRemoteMobileAppServerRemoteControlPatch(patched), patched);
+  assert.equal(hasLinuxRemoteMobileLocalAppServerRemoteControlPatch(patched), true);
+});
+
+test("Linux remote mobile app-server launch rejects an incomplete local patch marker", () => {
+  const source = "globalThis.codexLinuxRemoteMobileLocalAppServerArgs=true;";
+
+  assert.equal(applyLinuxRemoteMobileAppServerRemoteControlPatch(source), source);
+  assert.equal(hasLinuxRemoteMobileLocalAppServerRemoteControlPatch(source), false);
 });
 
 test("Linux remote mobile app-server launch does not treat the legacy WSL path as the Desktop transport", () => {
@@ -1271,6 +1313,29 @@ test("Linux remote mobile extracted-app patch modifies only the local Desktop tr
     assert.deepEqual(result, { matched: 1, changed: 1 });
     assert.equal(fs.readFileSync(wslFile, "utf8"), syntheticLegacyWslAppServerLaunchBundle());
     assert.match(fs.readFileSync(localFile, "utf8"), /codexLinuxRemoteMobileLocalAppServerArgs/);
+  } finally {
+    fs.rmSync(tempApp, { recursive: true, force: true });
+  }
+});
+
+test("Linux remote mobile extracted-app patch rejects WSL-only and partial local matches", () => {
+  const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-partial-transport-"));
+  try {
+    const buildDir = path.join(tempApp, ".vite", "build");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, "main-test.js"), syntheticLegacyWslAppServerLaunchBundle());
+    fs.writeFileSync(path.join(buildDir, "src-test.js"), "globalThis.codexLinuxRemoteMobileLocalAppServerArgs=true;");
+
+    const descriptor = remoteMobilePatchDescriptors.find(
+      ({ id }) => id === "linux-remote-mobile-app-server-remote-control",
+    );
+    const result = descriptor.apply(tempApp);
+
+    assert.deepEqual(result, {
+      matched: 0,
+      changed: 0,
+      reason: "no local Desktop app-server base args found",
+    });
   } finally {
     fs.rmSync(tempApp, { recursive: true, force: true });
   }

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -285,8 +285,15 @@ function syntheticSettingsRefreshBundle() {
   ].join("");
 }
 
-function syntheticAppServerLaunchBundle() {
+function syntheticLegacyWslAppServerLaunchBundle() {
   return "var Uz=`Codex Desktop`,Wz=[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`],Gz={appServerVersion:`current`};";
+}
+
+function syntheticCurrentLocalAppServerLaunchBundle() {
+  return [
+    "var Fz=`Codex Desktop`,Iz=[`-c`,`features.code_mode_host=true`],Lz=[{configKey:`chatgpt_base_url`,envVar:`CODEX_APP_SERVER_CHATGPT_BASE_URL`},{configKey:`openai_base_url`,envVar:`CODEX_APP_SERVER_OPENAI_BASE_URL`}];",
+    "function uB(){return[...Iz,...Lz.flatMap(({configKey:e,envVar:t})=>{let n=process.env[t]?.trim();return n==null||n===``?[]:[`-c`,`${e}=${JSON.stringify(n)}`]}),`app-server`,`--analytics-default-enabled`]}",
+  ].join("");
 }
 
 function syntheticCurrentSettingsBundle() {
@@ -556,7 +563,7 @@ test("remote mobile stage hook is idempotent and stages its markers and executab
     };
 
     fs.mkdirSync(buildDir, { recursive: true });
-    fs.writeFileSync(path.join(buildDir, "main.js"), "globalThis.codexLinuxRemoteMobileAppServerArgs=true;");
+    fs.writeFileSync(path.join(buildDir, "main.js"), "globalThis.codexLinuxRemoteMobileLocalAppServerArgs=true;");
 
     const first = runStageHook(env);
     const second = runStageHook(env);
@@ -575,7 +582,7 @@ test("remote mobile stage hook is idempotent and stages its markers and executab
   }
 });
 
-test("remote mobile stage hook removes a stale ownership marker when the patch marker is missing", () => {
+test("remote mobile stage hook removes a stale ownership marker when only the legacy WSL patch marker exists", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-stage-"));
   try {
     const installDir = path.join(tempRoot, "package", "opt", "codex-desktop");
@@ -585,7 +592,7 @@ test("remote mobile stage hook removes a stale ownership marker when the patch m
 
     fs.mkdirSync(buildDir, { recursive: true });
     fs.mkdirSync(path.dirname(marker), { recursive: true });
-    fs.writeFileSync(path.join(buildDir, "main.js"), "globalThis.someOtherPatch=true;");
+    fs.writeFileSync(path.join(buildDir, "main.js"), "globalThis.codexLinuxRemoteMobileAppServerArgs=true;");
     fs.writeFileSync(marker, "stale\n");
 
     const result = runStageHook({
@@ -615,7 +622,7 @@ test("remote mobile stage hook replaces an ownership marker symlink without foll
 
     fs.mkdirSync(buildDir, { recursive: true });
     fs.mkdirSync(path.dirname(marker), { recursive: true });
-    fs.writeFileSync(path.join(buildDir, "main.js"), "globalThis.codexLinuxRemoteMobileAppServerArgs=true;");
+    fs.writeFileSync(path.join(buildDir, "main.js"), "globalThis.codexLinuxRemoteMobileLocalAppServerArgs=true;");
     fs.writeFileSync(target, "preserved\n");
     fs.symlinkSync(target, marker);
 
@@ -1224,29 +1231,57 @@ test("Linux remote-control client recovery handles bare missing key material err
 });
 
 test("Linux remote mobile app-server launch enables remote control on the Desktop app-server", () => {
-  const source = syntheticAppServerLaunchBundle();
+  const source = syntheticCurrentLocalAppServerLaunchBundle();
   const patched = applyLinuxRemoteMobileAppServerRemoteControlPatch(source);
 
   assert.notEqual(patched, source);
-  assert.match(patched, /codexLinuxRemoteMobileAppServerArgs/);
+  assert.match(patched, /codexLinuxRemoteMobileLocalAppServerArgs/);
   assert.match(
     patched,
-    /process\.platform===`linux`\?\[`-c`,`features\.code_mode_host=true`,`app-server`,`--remote-control`,`--analytics-default-enabled`\]:\[`-c`,`features\.code_mode_host=true`,`app-server`,`--analytics-default-enabled`\]/,
+    /process\.platform===`linux`\?\[`--remote-control`\]:\[\]/,
   );
-  assert.doesNotMatch(
+  assert.match(
     patched,
-    /Wz=\[`-c`,`features\.code_mode_host=true`,`app-server`,`--analytics-default-enabled`\]/,
+    /return\[\.\.\.Iz,\.\.\.Lz\.flatMap\(.+`app-server`,\.\.\.codexLinuxRemoteMobileLocalAppServerArgs\(\),`--analytics-default-enabled`\]\}/,
   );
-  assert.match(patched, /Wz=codexLinuxRemoteMobileAppServerArgs\(\)/);
   assert.equal(applyLinuxRemoteMobileAppServerRemoteControlPatch(patched), patched);
 });
 
+test("Linux remote mobile app-server launch does not treat the legacy WSL path as the Desktop transport", () => {
+  const source = syntheticLegacyWslAppServerLaunchBundle();
+
+  assert.equal(applyLinuxRemoteMobileAppServerRemoteControlPatch(source), source);
+});
+
+test("Linux remote mobile extracted-app patch modifies only the local Desktop transport", () => {
+  const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-local-transport-"));
+  try {
+    const buildDir = path.join(tempApp, ".vite", "build");
+    const wslFile = path.join(buildDir, "main-test.js");
+    const localFile = path.join(buildDir, "src-test.js");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(wslFile, syntheticLegacyWslAppServerLaunchBundle());
+    fs.writeFileSync(localFile, syntheticCurrentLocalAppServerLaunchBundle());
+
+    const descriptor = remoteMobilePatchDescriptors.find(
+      ({ id }) => id === "linux-remote-mobile-app-server-remote-control",
+    );
+    const result = descriptor.apply(tempApp);
+
+    assert.deepEqual(result, { matched: 1, changed: 1 });
+    assert.equal(fs.readFileSync(wslFile, "utf8"), syntheticLegacyWslAppServerLaunchBundle());
+    assert.match(fs.readFileSync(localFile, "utf8"), /codexLinuxRemoteMobileLocalAppServerArgs/);
+  } finally {
+    fs.rmSync(tempApp, { recursive: true, force: true });
+  }
+});
+
 test("Linux remote mobile app-server launch keeps a leading use strict directive first", () => {
-  const source = `"use strict";${syntheticAppServerLaunchBundle()}`;
+  const source = `"use strict";${syntheticCurrentLocalAppServerLaunchBundle()}`;
   const patched = applyLinuxRemoteMobileAppServerRemoteControlPatch(source);
 
   assert.notEqual(patched, source);
-  assert.match(patched, /^"use strict";function codexLinuxRemoteMobileAppServerArgs/);
+  assert.match(patched, /^"use strict";function codexLinuxRemoteMobileLocalAppServerArgs/);
   assert.equal(applyLinuxRemoteMobileAppServerRemoteControlPatch(patched), patched);
 });
 
@@ -2566,7 +2601,7 @@ test("remote mobile feature patch report records feature metadata and partial wa
       fs.mkdirSync(buildDir, { recursive: true });
       fs.mkdirSync(assetsDir, { recursive: true });
       fs.writeFileSync(path.join(buildDir, "main.js"), syntheticCurrentMainBundle());
-      fs.writeFileSync(path.join(buildDir, "src-test.js"), syntheticAppServerLaunchBundle());
+      fs.writeFileSync(path.join(buildDir, "src-test.js"), syntheticCurrentLocalAppServerLaunchBundle());
       fs.writeFileSync(path.join(tempApp, "package.json"), JSON.stringify({ name: "codex" }));
       fs.writeFileSync(path.join(assetsDir, "app-test.png"), "");
       fs.writeFileSync(
@@ -3545,7 +3580,10 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         fs.mkdirSync(buildDir, { recursive: true });
         fs.mkdirSync(assetsDir, { recursive: true });
         fs.writeFileSync(path.join(buildDir, "main.js"), source);
-        fs.writeFileSync(path.join(buildDir, "workspace-root-drop-handler-test.js"), syntheticAppServerLaunchBundle());
+        fs.writeFileSync(
+          path.join(buildDir, "workspace-root-drop-handler-test.js"),
+          syntheticCurrentLocalAppServerLaunchBundle(),
+        );
         fs.writeFileSync(
           path.join(assetsDir, CURRENT_REMOTE_RUNTIME_ASSET),
           syntheticRemoteConnectionVisibilityBundle() +
@@ -3639,7 +3677,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         );
         assert.match(patchedFile, /codexLinuxRemoteControlDeviceKeyClient/);
         assert.match(patchedFile, /n\.kind===`local`&&process\.platform!==`linux`/);
-        assert.match(patchedAppServerLaunchFile, /codexLinuxRemoteMobileAppServerArgs/);
+        assert.match(patchedAppServerLaunchFile, /codexLinuxRemoteMobileLocalAppServerArgs/);
         assert.match(patchedAppServerLaunchFile, /`--remote-control`/);
         assert.match(patchedRemoteConnectionVisibilityFile, /codexLinuxRemoteControlLoadGateEnabled/);
         assert.match(patchedAppMainFile, /\{\.\.\.e,remote_control:!0\}/);


### PR DESCRIPTION
## Summary

- retarget the remote-mobile-control app-server patch to the current local Desktop transport
- stop treating the legacy WSL argument array as a successful Desktop patch
- require the complete helper and local launch call before reporting success or staging Desktop ownership
- add regression coverage for WSL-only, partial, mixed, and idempotent patch states

Fixes #1202

## Tests

- `node --test linux-features/remote-mobile-control/test.js` (115 passed)
- `TMPDIR=/home/igor/codex-test-tmp-1202 node --test scripts/patch-linux-window-ui.test.js` (410 passed)
- `node --check linux-features/remote-mobile-control/patch.js`
- `node --check linux-features/remote-mobile-control/test.js`
- `bash -n linux-features/remote-mobile-control/stage.sh`
- `git diff --check`
- verified against the generated `26.727.51351` ASAR: WSL bundle unchanged, local Desktop bundle patched once, complete, and idempotent

## Notes

- The full `node --test linux-features/*/test.js` run passed 852/853 tests. The remaining live `shared-app-server-socket` test exits before creating its socket in this environment and reproduces unchanged on `main`.