### PR TITLE
fix(updater): serialize native installs with app launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   installed commit is limited to repository documentation or metadata.
 - The updater feature picker now changes only the enabled feature list, preserving
   nested feature settings and other local configuration keys across rebuilds.
+- Ready native updates no longer replace hashed webview assets underneath an
+  app reopened while polkit authorization is pending. Package installation now
+  shares the launcher's process-creation lock, rechecks Electron after winning
+  the lock, and returns to `WaitingForAppExit` if either the unprivileged or
+  privileged liveness guard observes the app.
 - The opt-in Dock icon tweak now targets the current upstream main-process
   bundle, restoring Linux window, tray, and desktop icon synchronization.
 - The opt-in shallow repository watcher now patches both current app bundles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,10 +60,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - The updater feature picker now changes only the enabled feature list, preserving
   nested feature settings and other local configuration keys across rebuilds.
 - Ready native updates no longer replace hashed webview assets underneath an
-  app reopened while polkit authorization is pending. Package installation now
-  shares the launcher's process-creation lock, rechecks Electron after winning
-  the lock, and returns to `WaitingForAppExit` if either the unprivileged or
-  privileged liveness guard observes the app.
+  app reopened while polkit authorization is pending. Every launcher namespace
+  and packaged wrapper update now shares one executable-keyed install gate; the
+  gate lease survives updater-service shutdown through package replacement.
+  Installation rechecks Electron after winning the gate and returns to
+  `WaitingForAppExit` if either liveness guard observes the app.
 - The opt-in Dock icon tweak now targets the current upstream main-process
   bundle, restoring Linux window, tray, and desktop icon synchronization.
 - The opt-in shallow repository watcher now patches both current app bundles

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -10,9 +10,10 @@ It:
 - rebuilds a local native package with `/opt/codex-desktop/update-builder`
   after detection; users who enable the opt-in deferred-build feature can
   instead wait for an explicit update check
-- waits for Electron to exit before installing a ready update, holds the
-  launcher's process-creation lock through authorization and package
-  replacement, and defers the install if the app is reopened in that interval
+- waits for Electron to exit before installing a ready update, holds one
+  executable-keyed launch gate across normal, multi-instance, and alternate
+  app-state namespaces through authorization and package replacement, and
+  defers the install if the app is reopened in that interval
 - runs unprivileged; the final package install uses `pkexec` when a graphical
   polkit authentication agent is available, or keeps the package ready and
   reports a terminal `sudo /usr/bin/codex-update-manager ... --path ...`
@@ -283,7 +284,9 @@ A launch that races the polkit prompt or package stabilization wins safely: the
 ready update returns to `WaitingForAppExit` instead of replacing the webview
 assets under the running renderer. The privileged helper performs a final
 process check as defense in depth before invoking apt, dpkg, rpm, zypper, or
-pacman.
+pacman. The install gate lease is inherited by the privileged transaction, so a
+Debian upgrade remains serialized even when its old `prerm` stops
+`codex-update-manager.service`; packaged wrapper updates use the same gate.
 A manual command or timer may build while the app is open, but final promotion
 is refused and the working app remains unchanged until Electron exits. Failed
 promotion candidates are disposable by default; opt in to diagnostic retention

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -10,7 +10,9 @@ It:
 - rebuilds a local native package with `/opt/codex-desktop/update-builder`
   after detection; users who enable the opt-in deferred-build feature can
   instead wait for an explicit update check
-- waits for Electron to exit before installing a ready update
+- waits for Electron to exit before installing a ready update, holds the
+  launcher's process-creation lock through authorization and package
+  replacement, and defers the install if the app is reopened in that interval
 - runs unprivileged; the final package install uses `pkexec` when a graphical
   polkit authentication agent is available, or keeps the package ready and
   reports a terminal `sudo /usr/bin/codex-update-manager ... --path ...`
@@ -277,6 +279,11 @@ Automated user-local rebuilds always force
 `CODEX_INSTALL_ALLOW_RUNNING=0` and `CODEX_ACCEPTANCE_OVERRIDE=0`, even if the
 service or invoking shell inherited developer overrides. The in-app update path
 continues through its after-exit hook and relaunches after a successful update.
+A launch that races the polkit prompt or package stabilization wins safely: the
+ready update returns to `WaitingForAppExit` instead of replacing the webview
+assets under the running renderer. The privileged helper performs a final
+process check as defense in depth before invoking apt, dpkg, rpm, zypper, or
+pacman.
 A manual command or timer may build while the app is open, but final promotion
 is refused and the working app remains unchanged until Electron exits. Failed
 promotion candidates are disposable by default; opt in to diagnostic retention

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -103,6 +103,15 @@ CODEX_LINUX_SETTINGS_FILE="$APP_SETTINGS_FILE"
 CODEX_LINUX_FEATURES_DIR="$SCRIPT_DIR/.codex-linux/features"
 export CODEX_HOME CODEX_LINUX_APP_ID CODEX_LINUX_APP_DISPLAY_NAME CODEX_LINUX_WEBVIEW_PORT CODEX_LINUX_SETTINGS_FILE CODEX_LINUX_FEATURES_DIR
 APP_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/$CODEX_LINUX_APP_ID"
+# Keep package replacement serialization independent of app-state namespaces.
+# Multi-instance launches, alternate app ids, and custom XDG state roots can
+# all execute the same installed Electron tree, so key one stable user-level
+# gate by the canonical executable path instead.
+INSTALL_LAUNCH_GATE_DIR="$HOME/.local/state/codex-desktop/install-gates"
+INSTALL_LAUNCH_GATE_EXECUTABLE="$(readlink -f "$SCRIPT_DIR/electron" 2>/dev/null || printf '%s\n' "$SCRIPT_DIR/electron")"
+INSTALL_LAUNCH_GATE_KEY="$(python3 -c 'import hashlib, os, sys; print(hashlib.sha256(os.fsencode(sys.argv[1])).hexdigest())' "$INSTALL_LAUNCH_GATE_EXECUTABLE")"
+INSTALL_LAUNCH_GATE_PATH="$INSTALL_LAUNCH_GATE_DIR/$INSTALL_LAUNCH_GATE_KEY.lock"
+export CODEX_LINUX_INSTALL_LAUNCH_GATE="$INSTALL_LAUNCH_GATE_PATH"
 
 configure_runtime_tmpdir() {
     [ -z "${TMPDIR:-}" ] || return 0
@@ -323,8 +332,9 @@ select_webview_renderer_url() {
 WEBVIEW_RENDERER_URL=""
 WEBVIEW_RENDERER_URL_OVERRIDE_ACTIVE=0
 
-mkdir -p "$LOG_DIR" "$APP_CONFIG_DIR" "$APP_STATE_DIR" "$LAUNCH_ACTION_RUNTIME_DIR"
+mkdir -p "$LOG_DIR" "$APP_CONFIG_DIR" "$APP_STATE_DIR" "$LAUNCH_ACTION_RUNTIME_DIR" "$INSTALL_LAUNCH_GATE_DIR"
 chmod 700 "$LAUNCH_ACTION_RUNTIME_DIR" 2>/dev/null || true
+chmod 700 "$INSTALL_LAUNCH_GATE_DIR" 2>/dev/null || true
 export CODEX_DESKTOP_LAUNCH_ACTION_SOCKET="$LAUNCH_ACTION_SOCKET"
 STARTED_WEBVIEW_PID=""
 ADOPTED_WEBVIEW_PID=""
@@ -4240,7 +4250,7 @@ acquire_launcher_lock() {
     ( trap - EXIT
       exec python3 - \
           "$$" \
-          "$APP_STATE_DIR/launcher.lock" \
+          "$INSTALL_LAUNCH_GATE_PATH" \
           "$wait_seconds" \
           "$LAUNCHER_LOCK_STATUS_PATH" <<'PY'
 import ctypes
@@ -4248,6 +4258,7 @@ import ctypes.util
 import fcntl
 import os
 import signal
+import stat
 import sys
 import time
 
@@ -4271,8 +4282,18 @@ def release_lock(_signum, _frame):
 
 signal.signal(signal.SIGTERM, release_lock)
 signal.signal(signal.SIGUSR1, release_lock)
-lock_fd = os.open(lock_path, os.O_CREAT | os.O_WRONLY, 0o600)
+lock_fd = os.open(
+    lock_path,
+    os.O_CREAT | os.O_WRONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
+    0o600,
+)
 try:
+    lock_stat = os.fstat(lock_fd)
+    if not stat.S_ISREG(lock_stat.st_mode) or lock_stat.st_uid != os.geteuid():
+        sys.exit(1)
+    if lock_stat.st_mode & 0o077:
+        os.fchmod(lock_fd, 0o600)
+
     deadline = time.monotonic() + wait_seconds
     locked = False
     while True:
@@ -4324,7 +4345,7 @@ PY
         LAUNCHER_LOCK_HELPER_PID=""
         LAUNCHER_LOCK_HELPER_START_TIME=""
         rm -f "$LAUNCHER_LOCK_STATUS_PATH"
-        launcher_notice "WARN: timed out waiting for launcher.lock after ${wait_seconds}s; refusing to start another app process."
+        launcher_notice "WARN: timed out waiting for the install launch gate after ${wait_seconds}s; refusing to start another app process."
         return 0
     fi
 
@@ -4353,7 +4374,7 @@ launcher_lock_helper_is_active() {
     [ -n "$actual_start_time" ] && [ "$actual_start_time" = "$LAUNCHER_LOCK_HELPER_START_TIME" ] || return 1
     pid_parent_matches "$LAUNCHER_LOCK_HELPER_PID" "${BASHPID:-$$}" || return 1
     cmdline="$(pid_cmdline "$LAUNCHER_LOCK_HELPER_PID")"
-    [[ "$cmdline" == *" $APP_STATE_DIR/launcher.lock "*" $LAUNCHER_LOCK_STATUS_PATH"* ]]
+    [[ "$cmdline" == *" $INSTALL_LAUNCH_GATE_PATH "*" $LAUNCHER_LOCK_STATUS_PATH"* ]]
 }
 
 stop_launcher_lock_helper() {
@@ -4365,7 +4386,7 @@ stop_launcher_lock_helper() {
     [ -n "$actual_start_time" ] && [ "$actual_start_time" = "$LAUNCHER_LOCK_HELPER_START_TIME" ] || return 1
     pid_parent_matches "$LAUNCHER_LOCK_HELPER_PID" "${BASHPID:-$$}" || return 1
     cmdline="$(pid_cmdline "$LAUNCHER_LOCK_HELPER_PID")"
-    [[ "$cmdline" == *" $APP_STATE_DIR/launcher.lock "*" $LAUNCHER_LOCK_STATUS_PATH"* ]] || return 1
+    [[ "$cmdline" == *" $INSTALL_LAUNCH_GATE_PATH "*" $LAUNCHER_LOCK_STATUS_PATH"* ]] || return 1
     kill -TERM "$LAUNCHER_LOCK_HELPER_PID" 2>/dev/null || ! kill -0 "$LAUNCHER_LOCK_HELPER_PID" 2>/dev/null
 }
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5864,6 +5864,12 @@ if "No new app process was started" not in prepare_body:
     raise SystemExit("launcher lock timeout must fail closed instead of continuing a duplicate cold start")
 if 'CODEX_LAUNCHER_LOCK_WAIT_SECONDS:-5' not in source:
     raise SystemExit("launcher lock wait must default to 5 seconds so duplicate launches do not look hung")
+if 'INSTALL_LAUNCH_GATE_PATH="$INSTALL_LAUNCH_GATE_DIR/$INSTALL_LAUNCH_GATE_KEY.lock"' not in source:
+    raise SystemExit("launcher serialization must use one executable-keyed install gate")
+if 'CODEX_LINUX_INSTALL_LAUNCH_GATE="$INSTALL_LAUNCH_GATE_PATH"' not in source:
+    raise SystemExit("launcher must export the install-wide gate to after-exit update hooks")
+if '$APP_STATE_DIR/launcher.lock' in source:
+    raise SystemExit("launcher gate must not follow per-instance or alternate app-state roots")
 if "fcntl.flock" not in source or "PR_SET_PDEATHSIG" not in source:
     raise SystemExit("launcher lock must be held by a parent-death-bound helper instead of an inherited fd")
 if 'wait_seconds * 20 + 20' not in source:

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -31,7 +31,6 @@ const PROMPT_INSTALL_CLI_CANCELLED_EXIT_CODE: i32 = 10;
 const PROMPT_INSTALL_CLI_NO_BACKEND_EXIT_CODE: i32 = 11;
 // Nonzero so `Restart=on-failure` relaunches the daemon on the new binary.
 const BINARY_REPLACED_RESTART_EXIT_CODE: i32 = 12;
-const LAUNCHER_INSTALL_GATE_WAIT_SECONDS: u64 = 10;
 const POLKIT_AUTH_AGENT_PROCESS_TOKENS: &[&str] = &[
     "budgie-polkit",
     "cinnamon-polkit",
@@ -1430,7 +1429,12 @@ async fn reconcile_pending_install(
 
             if state.auto_install_on_app_exit && liveness::is_app_running(config)? {
                 if !graphical_polkit_auth_agent_is_likely_available() {
-                    defer_install_for_manual_auth(state, paths, &package_path)?;
+                    defer_install_for_manual_auth(
+                        state,
+                        paths,
+                        &package_path,
+                        &config.app_executable_path,
+                    )?;
                     maybe_notify_manual_install_required(state, paths, config.notifications)?;
                     return Ok(());
                 }
@@ -1473,7 +1477,12 @@ async fn reconcile_pending_install(
 
             if liveness::is_app_running(config)? {
                 if !graphical_polkit_auth_agent_is_likely_available() {
-                    defer_install_for_manual_auth(state, paths, &package_path)?;
+                    defer_install_for_manual_auth(
+                        state,
+                        paths,
+                        &package_path,
+                        &config.app_executable_path,
+                    )?;
                     maybe_notify_manual_install_required(state, paths, config.notifications)?;
                     return Ok(());
                 }
@@ -1494,7 +1503,12 @@ async fn reconcile_pending_install(
             }
 
             if !graphical_polkit_auth_agent_is_likely_available() {
-                defer_install_for_manual_auth(state, paths, &package_path)?;
+                defer_install_for_manual_auth(
+                    state,
+                    paths,
+                    &package_path,
+                    &config.app_executable_path,
+                )?;
                 maybe_notify_manual_install_required(state, paths, config.notifications)?;
                 return Ok(());
             }
@@ -1640,9 +1654,14 @@ async fn run_install_ready_locked(
 
     if liveness::is_app_running(config)? {
         if !graphical_polkit_auth_agent_is_likely_available() {
-            defer_install_for_manual_auth(state, paths, &package_path)?;
+            defer_install_for_manual_auth(
+                state,
+                paths,
+                &package_path,
+                &config.app_executable_path,
+            )?;
             maybe_send_manual_install_required_notification(config.notifications);
-            print_manual_install_required(&package_path);
+            print_manual_install_required(&package_path, &config.app_executable_path)?;
             return Ok(());
         }
         clear_install_auth_required_event(state, paths)?;
@@ -1659,9 +1678,9 @@ async fn run_install_ready_locked(
     clear_install_auth_required_event(state, paths)?;
     state.waiting_for_app_exit_auto_install = false;
     if !graphical_polkit_auth_agent_is_likely_available() {
-        defer_install_for_manual_auth(state, paths, &package_path)?;
+        defer_install_for_manual_auth(state, paths, &package_path, &config.app_executable_path)?;
         maybe_send_manual_install_required_notification(config.notifications);
-        print_manual_install_required(&package_path);
+        print_manual_install_required(&package_path, &config.app_executable_path)?;
         return Ok(());
     }
     trigger_install(state, paths, config, &package_path, config.notifications).await
@@ -2070,21 +2089,9 @@ async fn trigger_install(
     notifications: bool,
 ) -> Result<()> {
     let waiting_auto_install = state.waiting_for_app_exit_auto_install;
-    let launcher_lock_deadline = std::time::Instant::now()
-        + std::time::Duration::from_secs(LAUNCHER_INSTALL_GATE_WAIT_SECONDS);
-    let launcher_lock = loop {
-        if let Some(lock) = liveness::try_acquire_launcher_lock()? {
-            break Some(lock);
-        }
-        #[cfg(test)]
-        signal_process_test_marker("CODEX_UPDATE_MANAGER_TEST_LAUNCHER_LOCK_BUSY")?;
-        if std::time::Instant::now() >= launcher_lock_deadline {
-            break None;
-        }
-        time::sleep(Duration::from_millis(50)).await;
-    };
-
-    let Some(_launcher_lock) = launcher_lock else {
+    let Some(install_gate) =
+        liveness::acquire_install_launch_gate(&config.app_executable_path).await?
+    else {
         state.error_message = None;
         set_waiting_for_app_exit(state, paths, waiting_auto_install)?;
         maybe_send_notification(
@@ -2096,8 +2103,9 @@ async fn trigger_install(
     };
 
     // The app may have started after the caller's earlier liveness check but
-    // before this flow acquired launcher.lock. Recheck while holding the lock;
-    // the launcher cannot publish another Electron process until we release it.
+    // before this flow acquired the install-wide gate. Recheck while holding
+    // it; no launcher namespace can publish another Electron process until the
+    // package transaction releases its inherited lease.
     if liveness::is_app_running(config)? {
         state.error_message = None;
         set_waiting_for_app_exit(state, paths, waiting_auto_install)?;
@@ -2121,7 +2129,10 @@ async fn trigger_install(
     );
 
     let current_exe = std::env::current_exe().context("Failed to resolve updater binary path")?;
-    let output = install::pkexec_command(&current_exe, package_path, &config.app_executable_path)
+    let mut command =
+        install::pkexec_command(&current_exe, package_path, &config.app_executable_path);
+    install_gate.inherit_through_stdin(&mut command)?;
+    let output = command
         .output()
         .context("Failed to launch pkexec for update installation")?;
     let status = output.status;
@@ -2198,23 +2209,29 @@ fn install_auth_retry_is_blocked(state: &PersistedState) -> bool {
         .is_some_and(|event_key| state.notified_events.contains(event_key))
 }
 
-fn manual_install_required_message(package_path: &Path) -> String {
-    format!(
+fn manual_install_required_message(
+    package_path: &Path,
+    app_executable_path: &Path,
+) -> Result<String> {
+    Ok(format!(
         "No graphical polkit authentication agent is available for pkexec. Run this from a terminal after closing ChatGPT Desktop: {}",
-        manual_install_command(package_path)
-    )
+        manual_install_command(package_path, app_executable_path)?
+    ))
 }
 
-fn manual_install_command(package_path: &Path) -> String {
+fn manual_install_command(package_path: &Path, app_executable_path: &Path) -> Result<String> {
     let subcommand = match install::PackageKind::from_path(package_path) {
         install::PackageKind::Deb => "install-deb",
         install::PackageKind::Rpm => "install-rpm",
         install::PackageKind::Pacman => "install-pacman",
     };
-    format!(
-        "sudo /usr/bin/codex-update-manager {subcommand} --path {}",
-        shell_quote_path(package_path)
-    )
+    let install_gate = liveness::prepare_install_launch_gate(app_executable_path)?;
+    Ok(format!(
+        "flock --exclusive -- {} sudo /usr/bin/codex-update-manager {subcommand} --path {} --app-executable-path {}",
+        shell_quote_path(&install_gate),
+        shell_quote_path(package_path),
+        shell_quote_path(app_executable_path)
+    ))
 }
 
 fn shell_quote_path(path: &Path) -> String {
@@ -2222,20 +2239,28 @@ fn shell_quote_path(path: &Path) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
-fn print_manual_install_required(package_path: &Path) {
+fn print_manual_install_required(package_path: &Path, app_executable_path: &Path) -> Result<()> {
     println!("Manual install required: no graphical polkit authentication agent is available.");
     println!("Run this from a terminal after closing ChatGPT Desktop:");
-    println!("{}", manual_install_command(package_path));
+    println!(
+        "{}",
+        manual_install_command(package_path, app_executable_path)?
+    );
+    Ok(())
 }
 
 fn defer_install_for_manual_auth(
     state: &mut PersistedState,
     paths: &RuntimePaths,
     package_path: &Path,
+    app_executable_path: &Path,
 ) -> Result<()> {
     state.status = UpdateStatus::ReadyToInstall;
     state.waiting_for_app_exit_auto_install = false;
-    state.error_message = Some(manual_install_required_message(package_path));
+    state.error_message = Some(manual_install_required_message(
+        package_path,
+        app_executable_path,
+    )?);
     persist_state(paths, state)
 }
 
@@ -3717,6 +3742,26 @@ mod tests {
             }
         }
 
+        fn kill_parent_only(&mut self) -> Result<()> {
+            let child = self
+                .child
+                .as_mut()
+                .context("process test child should be present")?;
+            child
+                .kill()
+                .with_context(|| format!("Failed to kill updater test child {}", self.role))?;
+            let status = child
+                .wait()
+                .with_context(|| format!("Failed to reap updater test child {}", self.role))?;
+            self.child.take();
+            anyhow::ensure!(
+                !status.success(),
+                "Updater test child {} unexpectedly succeeded after SIGKILL",
+                self.role
+            );
+            Ok(())
+        }
+
         fn terminate(&mut self) {
             for path in &self.release_paths {
                 let _ = std::fs::write(path, b"cleanup");
@@ -3836,6 +3881,9 @@ mod tests {
              if [ -n \"${CODEX_UPDATE_MANAGER_TEST_INSTALL_APP_RUNNING:-}\" ]; then\n\
                printf 'CODEX_UPDATE_APP_RUNNING: simulated app reopen after authorization\n' >&2\n\
                exit 1\n\
+             fi\n\
+             if [ -n \"${CODEX_UPDATE_MANAGER_TEST_INSTALL_FINISHED:-}\" ]; then\n\
+               /bin/touch \"$CODEX_UPDATE_MANAGER_TEST_INSTALL_FINISHED\"\n\
              fi\n",
         )?;
         let mut permissions = std::fs::metadata(&fake_pkexec)?.permissions();
@@ -3936,6 +3984,66 @@ mod tests {
             std::io::Error::last_os_error().raw_os_error(),
             Some(libc::ESRCH)
         );
+        Ok(())
+    }
+
+    #[test]
+    fn package_transaction_keeps_gate_after_updater_service_process_dies() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let temp = tempfile::tempdir()?;
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+        std::env::set_var("HOME", temp.path().join("home"));
+        let (paths, fake_pkexec, install_log) = prepare_process_install_fixture(temp.path())?;
+        let config = RuntimeConfig::load_or_default(&paths)?;
+        let install_started = temp.path().join("install.started");
+        let install_release = temp.path().join("install.release");
+        let install_finished = temp.path().join("install.finished");
+
+        let mut daemon_reconcile = spawn_process_test_child(
+            temp.path(),
+            "daemon-reconcile",
+            &[
+                ("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", &fake_pkexec),
+                ("CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG", &install_log),
+                (
+                    "CODEX_UPDATE_MANAGER_TEST_INSTALL_STARTED",
+                    &install_started,
+                ),
+                (
+                    "CODEX_UPDATE_MANAGER_TEST_INSTALL_RELEASE",
+                    &install_release,
+                ),
+                (
+                    "CODEX_UPDATE_MANAGER_TEST_INSTALL_FINISHED",
+                    &install_finished,
+                ),
+            ],
+            &[&install_release],
+        )?;
+        wait_for_process_test_path(&install_started, "privileged package transaction")?;
+
+        // Debian's old prerm stops codex-update-manager.service during an
+        // upgrade. Kill only that service process: the simulated privileged
+        // package transaction must keep the inherited gate lease alive.
+        daemon_reconcile.kill_parent_only()?;
+        assert!(
+            liveness::try_acquire_install_launch_gate(&config.app_executable_path)?.is_none(),
+            "a launcher must remain blocked after the updater service exits"
+        );
+
+        std::fs::write(&install_release, b"continue")?;
+        wait_for_process_test_path(&install_finished, "completed package replacement")?;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if liveness::try_acquire_install_launch_gate(&config.app_executable_path)?.is_some() {
+                break;
+            }
+            anyhow::ensure!(
+                std::time::Instant::now() < deadline,
+                "install gate remained locked after package replacement completed"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
         Ok(())
     }
 
@@ -4117,6 +4225,8 @@ mod tests {
     fn launch_that_wins_the_gate_prevents_the_ready_package_install() -> Result<()> {
         let _env_guard = crate::test_util::env_lock();
         let temp = tempfile::tempdir()?;
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+        std::env::set_var("HOME", temp.path().join("home"));
         let (paths, fake_pkexec, install_log) = prepare_process_install_fixture(temp.path())?;
         let mut config = test_config(temp.path());
         config.workspace_root = paths.cache_dir.clone();
@@ -4127,28 +4237,18 @@ mod tests {
         );
         std::fs::write(&paths.config_file, toml::to_string(&config)?)?;
 
-        let launcher_state = temp.path().join("xdg-state/codex-desktop");
-        std::fs::create_dir_all(&launcher_state)?;
-        let launcher_lock = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(launcher_state.join("launcher.lock"))?;
-        launcher_lock.lock()?;
+        let install_gate = liveness::try_acquire_install_launch_gate(&config.app_executable_path)?
+            .expect("simulated launcher should acquire the install-wide gate");
 
-        let lock_busy = temp.path().join("launcher-lock.busy");
         let install_ready = spawn_process_test_child(
             temp.path(),
             "daemon-reconcile",
             &[
                 ("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", &fake_pkexec),
                 ("CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG", &install_log),
-                ("CODEX_UPDATE_MANAGER_TEST_LAUNCHER_LOCK_BUSY", &lock_busy),
             ],
             &[],
         )?;
-        wait_for_process_test_path(&lock_busy, "updater waiting for launcher.lock")?;
 
         let mut launched_app = std::process::Command::new(&config.app_executable_path)
             .stdout(std::process::Stdio::null())
@@ -4165,7 +4265,7 @@ mod tests {
             );
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
-        drop(launcher_lock);
+        drop(install_gate);
         let install_result = install_ready.wait();
         let _ = launched_app.kill();
         let _ = launched_app.wait();
@@ -4990,15 +5090,28 @@ mod tests {
     }
 
     #[test]
-    fn manual_install_command_selects_package_kind_and_quotes_path() {
+    fn manual_install_command_selects_package_kind_and_quotes_path() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let temp = tempfile::tempdir()?;
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+        std::env::set_var("HOME", temp.path().join("home"));
+        let executable = Path::new("/opt/codex-desktop/electron");
+        let gate = liveness::install_launch_gate_path(executable)?;
         assert_eq!(
-            manual_install_command(Path::new("/tmp/codex update.pkg.tar.zst")),
-            "sudo /usr/bin/codex-update-manager install-pacman --path '/tmp/codex update.pkg.tar.zst'"
+            manual_install_command(Path::new("/tmp/codex update.pkg.tar.zst"), executable)?,
+            format!(
+                "flock --exclusive -- {} sudo /usr/bin/codex-update-manager install-pacman --path '/tmp/codex update.pkg.tar.zst' --app-executable-path '/opt/codex-desktop/electron'",
+                shell_quote_path(&gate)
+            )
         );
         assert_eq!(
-            manual_install_command(Path::new("/tmp/codex'update.deb")),
-            "sudo /usr/bin/codex-update-manager install-deb --path '/tmp/codex'\\''update.deb'"
+            manual_install_command(Path::new("/tmp/codex'update.deb"), executable)?,
+            format!(
+                "flock --exclusive -- {} sudo /usr/bin/codex-update-manager install-deb --path '/tmp/codex'\\''update.deb' --app-executable-path '/opt/codex-desktop/electron'",
+                shell_quote_path(&gate)
+            )
         );
+        Ok(())
     }
 
     #[test]

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -31,6 +31,7 @@ const PROMPT_INSTALL_CLI_CANCELLED_EXIT_CODE: i32 = 10;
 const PROMPT_INSTALL_CLI_NO_BACKEND_EXIT_CODE: i32 = 11;
 // Nonzero so `Restart=on-failure` relaunches the daemon on the new binary.
 const BINARY_REPLACED_RESTART_EXIT_CODE: i32 = 12;
+const LAUNCHER_INSTALL_GATE_WAIT_SECONDS: u64 = 10;
 const POLKIT_AUTH_AGENT_PROCESS_TOKENS: &[&str] = &[
     "budgie-polkit",
     "cinnamon-polkit",
@@ -137,9 +138,18 @@ pub async fn run(cli: Cli) -> Result<()> {
         Commands::Diagnose { .. } => unreachable!("diagnose is handled before runtime writes"),
         Commands::InstallReady => run_install_ready(&config, &mut state, &paths).await,
         Commands::Rollback => rollback::run(&config, &mut state, &paths).await,
-        Commands::InstallDeb { path } => install::install_deb(&path),
-        Commands::InstallRpm { path } => install::install_rpm(&path),
-        Commands::InstallPacman { path } => install::install_pacman(&path),
+        Commands::InstallDeb {
+            path,
+            app_executable_path,
+        } => install::install_deb(&path, &app_executable_path),
+        Commands::InstallRpm {
+            path,
+            app_executable_path,
+        } => install::install_rpm(&path, &app_executable_path),
+        Commands::InstallPacman {
+            path,
+            app_executable_path,
+        } => install::install_pacman(&path, &app_executable_path),
         Commands::InstallRollbackDeb { path } => install_rollback::install_deb(&path),
         Commands::InstallRollbackRpm { path } => install_rollback::install_rpm(&path),
         Commands::InstallRollbackPacman { path } => install_rollback::install_pacman(&path),
@@ -1489,14 +1499,7 @@ async fn reconcile_pending_install(
                 return Ok(());
             }
 
-            trigger_install(
-                state,
-                paths,
-                &config.workspace_root,
-                &package_path,
-                config.notifications,
-            )
-            .await?;
+            trigger_install(state, paths, config, &package_path, config.notifications).await?;
         }
         _ => {}
     }
@@ -1661,14 +1664,7 @@ async fn run_install_ready_locked(
         print_manual_install_required(&package_path);
         return Ok(());
     }
-    trigger_install(
-        state,
-        paths,
-        &config.workspace_root,
-        &package_path,
-        config.notifications,
-    )
-    .await
+    trigger_install(state, paths, config, &package_path, config.notifications).await
 }
 
 #[derive(Debug, Deserialize)]
@@ -2069,10 +2065,50 @@ fn maybe_send_notification(enabled: bool, summary: &str, body: &str) {
 async fn trigger_install(
     state: &mut PersistedState,
     paths: &RuntimePaths,
-    workspace_root: &Path,
+    config: &RuntimeConfig,
     package_path: &Path,
     notifications: bool,
 ) -> Result<()> {
+    let waiting_auto_install = state.waiting_for_app_exit_auto_install;
+    let launcher_lock_deadline = std::time::Instant::now()
+        + std::time::Duration::from_secs(LAUNCHER_INSTALL_GATE_WAIT_SECONDS);
+    let launcher_lock = loop {
+        if let Some(lock) = liveness::try_acquire_launcher_lock()? {
+            break Some(lock);
+        }
+        #[cfg(test)]
+        signal_process_test_marker("CODEX_UPDATE_MANAGER_TEST_LAUNCHER_LOCK_BUSY")?;
+        if std::time::Instant::now() >= launcher_lock_deadline {
+            break None;
+        }
+        time::sleep(Duration::from_millis(50)).await;
+    };
+
+    let Some(_launcher_lock) = launcher_lock else {
+        state.error_message = None;
+        set_waiting_for_app_exit(state, paths, waiting_auto_install)?;
+        maybe_send_notification(
+            notifications,
+            "ChatGPT Desktop update waiting",
+            "Another ChatGPT Desktop launch is still starting. Close the app and retry the update.",
+        );
+        return Ok(());
+    };
+
+    // The app may have started after the caller's earlier liveness check but
+    // before this flow acquired launcher.lock. Recheck while holding the lock;
+    // the launcher cannot publish another Electron process until we release it.
+    if liveness::is_app_running(config)? {
+        state.error_message = None;
+        set_waiting_for_app_exit(state, paths, waiting_auto_install)?;
+        maybe_send_notification(
+            notifications,
+            "ChatGPT Desktop update waiting",
+            "ChatGPT Desktop reopened before installation. Close it to apply the ready update.",
+        );
+        return Ok(());
+    }
+
     state.status = UpdateStatus::Installing;
     state.waiting_for_app_exit_auto_install = false;
     state.error_message = None;
@@ -2085,7 +2121,7 @@ async fn trigger_install(
     );
 
     let current_exe = std::env::current_exe().context("Failed to resolve updater binary path")?;
-    let output = install::pkexec_command(&current_exe, package_path)
+    let output = install::pkexec_command(&current_exe, package_path, &config.app_executable_path)
         .output()
         .context("Failed to launch pkexec for update installation")?;
     let status = output.status;
@@ -2098,10 +2134,21 @@ async fn trigger_install(
         clear_rollback_blocked_candidate(state);
         state.error_message = None;
         state.notified_events.clear();
-        cache_cleanup::normalize_artifact_workspace_dir(workspace_root, state);
+        cache_cleanup::normalize_artifact_workspace_dir(&config.workspace_root, state);
         persist_state(paths, state)?;
         let _ = maybe_notify_installed(state, paths, notifications);
-        maybe_prune_workspace_cache(workspace_root, state);
+        maybe_prune_workspace_cache(&config.workspace_root, state);
+        return Ok(());
+    }
+
+    if liveness::error_reports_app_running(&output.stderr) {
+        state.error_message = None;
+        set_waiting_for_app_exit(state, paths, waiting_auto_install)?;
+        maybe_send_notification(
+            notifications,
+            "ChatGPT Desktop update waiting",
+            "ChatGPT Desktop reopened while authorization was pending. Close it to apply the ready update.",
+        );
         return Ok(());
     }
 
@@ -3785,6 +3832,10 @@ mod tests {
                while [ ! -e \"$CODEX_UPDATE_MANAGER_TEST_INSTALL_RELEASE\" ]; do\n\
                  /bin/sleep 0.01\n\
                done\n\
+             fi\n\
+             if [ -n \"${CODEX_UPDATE_MANAGER_TEST_INSTALL_APP_RUNNING:-}\" ]; then\n\
+               printf 'CODEX_UPDATE_APP_RUNNING: simulated app reopen after authorization\n' >&2\n\
+               exit 1\n\
              fi\n",
         )?;
         let mut permissions = std::fs::metadata(&fake_pkexec)?.permissions();
@@ -4058,6 +4109,104 @@ mod tests {
         );
         let final_state = PersistedState::load_or_default(&paths.state_file, true)?;
         assert_eq!(final_state.status, UpdateStatus::Installed);
+        assert_eq!(std::fs::read_to_string(&install_log)?.lines().count(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn launch_that_wins_the_gate_prevents_the_ready_package_install() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let temp = tempfile::tempdir()?;
+        let (paths, fake_pkexec, install_log) = prepare_process_install_fixture(temp.path())?;
+        let mut config = test_config(temp.path());
+        config.workspace_root = paths.cache_dir.clone();
+        config.app_executable_path = std::fs::canonicalize("/usr/bin/yes")?;
+        anyhow::ensure!(
+            config.app_executable_path.is_file(),
+            "test requires /usr/bin/yes"
+        );
+        std::fs::write(&paths.config_file, toml::to_string(&config)?)?;
+
+        let launcher_state = temp.path().join("xdg-state/codex-desktop");
+        std::fs::create_dir_all(&launcher_state)?;
+        let launcher_lock = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(launcher_state.join("launcher.lock"))?;
+        launcher_lock.lock()?;
+
+        let lock_busy = temp.path().join("launcher-lock.busy");
+        let install_ready = spawn_process_test_child(
+            temp.path(),
+            "daemon-reconcile",
+            &[
+                ("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", &fake_pkexec),
+                ("CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG", &install_log),
+                ("CODEX_UPDATE_MANAGER_TEST_LAUNCHER_LOCK_BUSY", &lock_busy),
+            ],
+            &[],
+        )?;
+        wait_for_process_test_path(&lock_busy, "updater waiting for launcher.lock")?;
+
+        let mut launched_app = std::process::Command::new(&config.app_executable_path)
+            .stdout(std::process::Stdio::null())
+            .spawn()?;
+        let launched_pid = launched_app.id();
+        let launched_exe = PathBuf::from(format!("/proc/{launched_pid}/exe"));
+        let launch_deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while std::fs::read_link(&launched_exe).ok().as_deref()
+            != Some(config.app_executable_path.as_path())
+        {
+            anyhow::ensure!(
+                std::time::Instant::now() < launch_deadline,
+                "timed out waiting for the simulated app executable"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        drop(launcher_lock);
+        let install_result = install_ready.wait();
+        let _ = launched_app.kill();
+        let _ = launched_app.wait();
+        install_result?;
+
+        let final_state = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(final_state.status, UpdateStatus::WaitingForAppExit);
+        assert!(final_state.waiting_for_app_exit_auto_install);
+        assert!(
+            !install_log.exists(),
+            "package helper must not have started"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn privileged_reopen_guard_returns_install_to_waiting_state() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let temp = tempfile::tempdir()?;
+        let (paths, fake_pkexec, install_log) = prepare_process_install_fixture(temp.path())?;
+        let app_running = temp.path().join("simulate-app-running");
+
+        let install_ready = spawn_process_test_child(
+            temp.path(),
+            "daemon-reconcile",
+            &[
+                ("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", &fake_pkexec),
+                ("CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG", &install_log),
+                (
+                    "CODEX_UPDATE_MANAGER_TEST_INSTALL_APP_RUNNING",
+                    &app_running,
+                ),
+            ],
+            &[],
+        )?;
+        install_ready.wait()?;
+
+        let final_state = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(final_state.status, UpdateStatus::WaitingForAppExit);
+        assert!(final_state.waiting_for_app_exit_auto_install);
+        assert_eq!(final_state.error_message, None);
         assert_eq!(std::fs::read_to_string(&install_log)?.lines().count(), 1);
         Ok(())
     }

--- a/updater/src/cli.rs
+++ b/updater/src/cli.rs
@@ -88,16 +88,22 @@ pub enum Commands {
     InstallDeb {
         #[arg(long)]
         path: PathBuf,
+        #[arg(long, default_value = "/opt/codex-desktop/electron")]
+        app_executable_path: PathBuf,
     },
     /// Install an RPM package (.rpm) with elevated privileges.
     InstallRpm {
         #[arg(long)]
         path: PathBuf,
+        #[arg(long, default_value = "/opt/codex-desktop/electron")]
+        app_executable_path: PathBuf,
     },
     /// Install a pacman package (.pkg.tar.zst) with elevated privileges.
     InstallPacman {
         #[arg(long)]
         path: PathBuf,
+        #[arg(long, default_value = "/opt/codex-desktop/electron")]
+        app_executable_path: PathBuf,
     },
     /// Install a Debian package as an explicit rollback with elevated privileges.
     InstallRollbackDeb {

--- a/updater/src/install.rs
+++ b/updater/src/install.rs
@@ -1,5 +1,6 @@
 //! Installation helpers for privileged and non-privileged package application.
 
+use crate::liveness;
 use anyhow::{Context, Result};
 use std::{
     fs,
@@ -205,10 +206,12 @@ fn installed_pacman_version() -> String {
 }
 
 /// Installs a rebuilt Debian package on the local machine.
-pub fn install_deb(path: &Path) -> Result<()> {
+pub fn install_deb(path: &Path, app_executable_path: &Path) -> Result<()> {
+    liveness::ensure_executable_not_running(app_executable_path)?;
     let stable = stable_validated_package(path)
         .with_context(|| format!("Failed to stabilize Debian package {}", path.display()))?;
     ensure_upgrade_path(stable.path())?;
+    liveness::ensure_executable_not_running(app_executable_path)?;
 
     if program_exists(APT_CANDIDATES, "apt") {
         let mut command = apt_install_command(stable.path())?;
@@ -221,10 +224,12 @@ pub fn install_deb(path: &Path) -> Result<()> {
 }
 
 /// Installs a rebuilt RPM package on the local machine.
-pub fn install_rpm(path: &Path) -> Result<()> {
+pub fn install_rpm(path: &Path, app_executable_path: &Path) -> Result<()> {
+    liveness::ensure_executable_not_running(app_executable_path)?;
     let stable = stable_validated_package(path)
         .with_context(|| format!("Failed to stabilize RPM package {}", path.display()))?;
     ensure_upgrade_path_rpm(stable.path())?;
+    liveness::ensure_executable_not_running(app_executable_path)?;
 
     if program_exists(DNF_CANDIDATES, "dnf") || program_exists(DNF_CANDIDATES, "dnf5") {
         let mut command = dnf_install_command(stable.path())?;
@@ -243,17 +248,23 @@ pub fn install_rpm(path: &Path) -> Result<()> {
 }
 
 /// Installs a rebuilt pacman package on the local machine.
-pub fn install_pacman(path: &Path) -> Result<()> {
+pub fn install_pacman(path: &Path, app_executable_path: &Path) -> Result<()> {
+    liveness::ensure_executable_not_running(app_executable_path)?;
     let stable = stable_validated_package(path)
         .with_context(|| format!("Failed to stabilize pacman package {}", path.display()))?;
     ensure_upgrade_path_pacman(stable.path())?;
+    liveness::ensure_executable_not_running(app_executable_path)?;
 
     let mut command = pacman_install_command(stable.path());
     run_install(&mut command).context("pacman -U failed")
 }
 
 /// Builds the `pkexec` command used for privileged package installation.
-pub fn pkexec_command(current_exe: &Path, package_path: &Path) -> Command {
+pub fn pkexec_command(
+    current_exe: &Path,
+    package_path: &Path,
+    app_executable_path: &Path,
+) -> Command {
     let updater_binary = updater_binary_for_privileged_install(current_exe);
     let subcommand = match PackageKind::from_path(package_path) {
         PackageKind::Rpm => "install-rpm",
@@ -272,7 +283,9 @@ pub fn pkexec_command(current_exe: &Path, package_path: &Path) -> Command {
         .arg(updater_binary)
         .arg(subcommand)
         .arg("--path")
-        .arg(package_path);
+        .arg(package_path)
+        .arg("--app-executable-path")
+        .arg(app_executable_path);
     command
 }
 
@@ -829,6 +842,7 @@ mod tests {
         let command = pkexec_command(
             Path::new("/usr/bin/codex-update-manager"),
             Path::new("/tmp/update.deb"),
+            Path::new("/opt/codex-desktop/electron"),
         );
         let args: Vec<_> = command
             .get_args()
@@ -841,7 +855,9 @@ mod tests {
                 "/usr/bin/codex-update-manager",
                 "install-deb",
                 "--path",
-                "/tmp/update.deb"
+                "/tmp/update.deb",
+                "--app-executable-path",
+                "/opt/codex-desktop/electron"
             ]
         );
     }
@@ -851,6 +867,7 @@ mod tests {
         let command = pkexec_command(
             Path::new("/usr/bin/codex-update-manager"),
             Path::new("/tmp/update.rpm"),
+            Path::new("/opt/codex-desktop/electron"),
         );
         let args: Vec<_> = command
             .get_args()
@@ -863,7 +880,9 @@ mod tests {
                 "/usr/bin/codex-update-manager",
                 "install-rpm",
                 "--path",
-                "/tmp/update.rpm"
+                "/tmp/update.rpm",
+                "--app-executable-path",
+                "/opt/codex-desktop/electron"
             ]
         );
     }
@@ -1121,6 +1140,7 @@ mod tests {
         let command = pkexec_command(
             Path::new("/usr/bin/codex-update-manager"),
             Path::new("/tmp/update.pkg.tar.zst"),
+            Path::new("/opt/codex-desktop/electron"),
         );
         let args: Vec<_> = command
             .get_args()
@@ -1133,7 +1153,9 @@ mod tests {
                 "/usr/bin/codex-update-manager",
                 "install-pacman",
                 "--path",
-                "/tmp/update.pkg.tar.zst"
+                "/tmp/update.pkg.tar.zst",
+                "--app-executable-path",
+                "/opt/codex-desktop/electron"
             ]
         );
     }

--- a/updater/src/liveness.rs
+++ b/updater/src/liveness.rs
@@ -2,21 +2,50 @@
 
 use crate::config::{self, RuntimeConfig};
 use anyhow::{Context, Result};
+use directories::BaseDirs;
+use sha2::{Digest, Sha256};
 use std::{
+    fmt::Write as _,
     fs::{self, OpenOptions},
-    os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt},
+    os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt},
     path::{Path, PathBuf},
+    process::{Command, Stdio},
+    time::{Duration, Instant},
 };
 
 pub const APP_RUNNING_INSTALL_ERROR_MARKER: &str = "CODEX_UPDATE_APP_RUNNING";
+const INSTALL_LAUNCH_GATE_DIR: &str = ".local/state/codex-desktop/install-gates";
+const INSTALL_LAUNCH_GATE_WAIT: Duration = Duration::from_secs(10);
 
 /// Exclusive access to the launcher's detection -> spawn critical section.
 ///
 /// Holding this while applying a native package prevents a desktop launch from
 /// publishing a new Electron process between the updater's final liveness
 /// check and the package manager replacing the webview asset tree.
-pub struct LauncherLock {
-    _file: fs::File,
+pub struct InstallLaunchGate {
+    file: fs::File,
+    path: PathBuf,
+}
+
+impl InstallLaunchGate {
+    /// Carries this exact flock lease into the privileged helper on fd 0.
+    ///
+    /// `pkexec` preserves the standard descriptors. Package-manager children
+    /// inherit stdin in turn, so the lease remains alive even when a Debian
+    /// upgrade stops the user-service process that originally acquired it.
+    pub fn inherit_through_stdin(&self, command: &mut Command) -> Result<()> {
+        let lease = self
+            .file
+            .try_clone()
+            .with_context(|| format!("Failed to clone install gate {}", self.path.display()))?;
+        command.stdin(Stdio::from(lease));
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
 }
 
 #[derive(Debug)]
@@ -41,13 +70,47 @@ pub fn app_pid_file() -> Result<PathBuf> {
     Ok(config::resolve_app_state_dir()?.join("app.pid"))
 }
 
-/// Tries to acquire the same lock the launcher holds until Electron is spawned
-/// and its PID is published. `None` means a launch is currently in progress.
-pub fn try_acquire_launcher_lock() -> Result<Option<LauncherLock>> {
-    let state_dir = config::resolve_app_state_dir()?;
-    fs::create_dir_all(&state_dir)
-        .with_context(|| format!("Failed to create {}", state_dir.display()))?;
-    let lock_path = state_dir.join("launcher.lock");
+/// Resolves the per-user, per-install gate shared by every launcher namespace.
+///
+/// This deliberately ignores the app id, launch instance, and XDG state root:
+/// those values isolate runtime state, but all namespaces still execute files
+/// from the same installation and must pause while those files are replaced.
+pub fn install_launch_gate_path(executable: &Path) -> Result<PathBuf> {
+    let base_dirs = BaseDirs::new().context("Could not resolve the home directory")?;
+    let executable = executable_identity_path(executable);
+    let digest = Sha256::digest(executable.as_os_str().as_encoded_bytes());
+    let mut install_key = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut install_key, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    Ok(base_dirs
+        .home_dir()
+        .join(INSTALL_LAUNCH_GATE_DIR)
+        .join(format!("{install_key}.lock")))
+}
+
+fn open_install_launch_gate(executable: &Path) -> Result<(fs::File, PathBuf)> {
+    let lock_path = install_launch_gate_path(executable)?;
+    let gate_dir = lock_path
+        .parent()
+        .context("Install launch gate path has no parent")?;
+    fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(gate_dir)
+        .with_context(|| format!("Failed to create {}", gate_dir.display()))?;
+    let directory_metadata = fs::symlink_metadata(gate_dir)
+        .with_context(|| format!("Failed to inspect {}", gate_dir.display()))?;
+    anyhow::ensure!(
+        directory_metadata.is_dir() && directory_metadata.uid() == unsafe { libc::geteuid() },
+        "Install launch gate directory {} is not a user-owned directory",
+        gate_dir.display()
+    );
+    if directory_metadata.permissions().mode() & 0o077 != 0 {
+        fs::set_permissions(gate_dir, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("Failed to secure {}", gate_dir.display()))?;
+    }
+
     let file = OpenOptions::new()
         .read(true)
         .write(true)
@@ -62,20 +125,54 @@ pub fn try_acquire_launcher_lock() -> Result<Option<LauncherLock>> {
         .with_context(|| format!("Failed to inspect {}", lock_path.display()))?;
     anyhow::ensure!(
         metadata.is_file() && metadata.uid() == unsafe { libc::geteuid() },
-        "Launcher lock {} is not a user-owned regular file",
+        "Install launch gate {} is not a user-owned regular file",
         lock_path.display()
     );
     if metadata.permissions().mode() & 0o077 != 0 {
         file.set_permissions(fs::Permissions::from_mode(0o600))
             .with_context(|| format!("Failed to secure {}", lock_path.display()))?;
     }
+    Ok((file, lock_path))
+}
+
+/// Creates and validates the gate so a terminal `flock` command can safely
+/// serialize a manual native-package install.
+pub fn prepare_install_launch_gate(executable: &Path) -> Result<PathBuf> {
+    let (_file, path) = open_install_launch_gate(executable)?;
+    Ok(path)
+}
+
+/// Tries to acquire the same install-wide gate held by every launcher until
+/// Electron is spawned and its PID is published. `None` means another launch
+/// or native package transaction currently owns the gate.
+pub fn try_acquire_install_launch_gate(executable: &Path) -> Result<Option<InstallLaunchGate>> {
+    let (file, lock_path) = open_install_launch_gate(executable)?;
 
     match file.try_lock() {
-        Ok(()) => Ok(Some(LauncherLock { _file: file })),
+        Ok(()) => Ok(Some(InstallLaunchGate {
+            file,
+            path: lock_path,
+        })),
         Err(fs::TryLockError::WouldBlock) => Ok(None),
         Err(fs::TryLockError::Error(error)) => {
             Err(error).with_context(|| format!("Failed to lock {}", lock_path.display()))
         }
+    }
+}
+
+/// Waits a bounded interval for the shared install gate. Launchers use their
+/// own shorter user-facing timeout; update flows wait a little longer so a
+/// launch already in its spawn critical section can finish cleanly.
+pub async fn acquire_install_launch_gate(executable: &Path) -> Result<Option<InstallLaunchGate>> {
+    let deadline = Instant::now() + INSTALL_LAUNCH_GATE_WAIT;
+    loop {
+        if let Some(gate) = try_acquire_install_launch_gate(executable)? {
+            return Ok(Some(gate));
+        }
+        if Instant::now() >= deadline {
+            return Ok(None);
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
     }
 }
 
@@ -273,44 +370,73 @@ mod tests {
     }
 
     #[test]
-    fn launcher_lock_serializes_with_other_holders() -> Result<()> {
+    fn install_gate_serializes_with_other_holders() -> Result<()> {
         let _env_guard = env_lock();
         let temp = tempfile::tempdir()?;
         let _restore_env = EnvRestoreGuard::capture(&[
+            "HOME",
             "XDG_STATE_HOME",
             "CODEX_LINUX_APP_ID",
             "CODEX_APP_ID",
             "CODEX_LINUX_INSTANCE_ID",
         ]);
+        std::env::set_var("HOME", temp.path().join("home"));
         std::env::set_var("XDG_STATE_HOME", temp.path());
         std::env::set_var("CODEX_LINUX_APP_ID", "codex-lock-test");
         std::env::remove_var("CODEX_APP_ID");
         std::env::remove_var("CODEX_LINUX_INSTANCE_ID");
 
-        let first = try_acquire_launcher_lock()?.expect("first lock should succeed");
-        assert!(try_acquire_launcher_lock()?.is_none());
+        let executable = Path::new("/opt/codex-desktop/electron");
+        let first =
+            try_acquire_install_launch_gate(executable)?.expect("first lock should succeed");
+        assert!(try_acquire_install_launch_gate(executable)?.is_none());
         drop(first);
-        assert!(try_acquire_launcher_lock()?.is_some());
+        assert!(try_acquire_install_launch_gate(executable)?.is_some());
         Ok(())
     }
 
     #[test]
-    fn launcher_lock_interoperates_with_the_shell_flock_helper() -> Result<()> {
+    fn install_gate_is_shared_across_launcher_namespaces() -> Result<()> {
         let _env_guard = env_lock();
         let temp = tempfile::tempdir()?;
         let _restore_env = EnvRestoreGuard::capture(&[
+            "HOME",
             "XDG_STATE_HOME",
             "CODEX_LINUX_APP_ID",
             "CODEX_APP_ID",
             "CODEX_LINUX_INSTANCE_ID",
         ]);
-        std::env::set_var("XDG_STATE_HOME", temp.path());
-        std::env::set_var("CODEX_LINUX_APP_ID", "codex-shell-lock-test");
+        std::env::set_var("HOME", temp.path().join("home"));
+        std::env::set_var("XDG_STATE_HOME", temp.path().join("state-a"));
+        std::env::set_var("CODEX_LINUX_APP_ID", "codex-primary");
         std::env::remove_var("CODEX_APP_ID");
         std::env::remove_var("CODEX_LINUX_INSTANCE_ID");
 
-        let lock_path = config::resolve_app_state_dir()?.join("launcher.lock");
-        fs::create_dir_all(lock_path.parent().expect("launcher lock has a parent"))?;
+        let executable = Path::new("/opt/codex-desktop/electron");
+        let primary = try_acquire_install_launch_gate(executable)?
+            .expect("primary namespace should acquire the gate");
+        let primary_path = primary.path().to_path_buf();
+
+        std::env::set_var("XDG_STATE_HOME", temp.path().join("state-b"));
+        std::env::set_var("CODEX_LINUX_APP_ID", "codex-alternate");
+        std::env::set_var("CODEX_LINUX_INSTANCE_ID", "port-6176");
+        assert_eq!(install_launch_gate_path(executable)?, primary_path);
+        assert!(try_acquire_install_launch_gate(executable)?.is_none());
+        drop(primary);
+        assert!(try_acquire_install_launch_gate(executable)?.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn install_gate_interoperates_with_the_shell_flock_helper() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempfile::tempdir()?;
+        let _restore_env = EnvRestoreGuard::capture(&["HOME"]);
+        std::env::set_var("HOME", temp.path().join("home"));
+
+        let executable = Path::new("/opt/codex-desktop/electron");
+        let lock_path = install_launch_gate_path(executable)?;
+        fs::create_dir_all(lock_path.parent().expect("install gate has a parent"))?;
         let mut holder = std::process::Command::new("flock")
             .arg("-x")
             .arg(&lock_path)
@@ -325,10 +451,54 @@ mod tests {
             .read_line(&mut ready)?;
         assert_eq!(ready, "locked\n");
 
-        assert!(try_acquire_launcher_lock()?.is_none());
+        assert!(try_acquire_install_launch_gate(executable)?.is_none());
         drop(holder.stdin.take());
         assert!(holder.wait()?.success());
-        assert!(try_acquire_launcher_lock()?.is_some());
+        assert!(try_acquire_install_launch_gate(executable)?.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn inherited_gate_lease_survives_the_original_holder_through_transaction() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempfile::tempdir()?;
+        let _restore_env = EnvRestoreGuard::capture(&["HOME"]);
+        std::env::set_var("HOME", temp.path().join("home"));
+        let executable = Path::new("/opt/codex-desktop/electron");
+        let gate = try_acquire_install_launch_gate(executable)?
+            .expect("transaction should acquire the gate");
+        let started = temp.path().join("package-replacement.started");
+        let release = temp.path().join("package-replacement.release");
+
+        let mut transaction_command = Command::new("sh");
+        transaction_command
+            .arg("-c")
+            .arg("touch \"$1\"; while [ ! -e \"$2\" ]; do sleep 0.01; done")
+            .arg("sh")
+            .arg(&started)
+            .arg(&release);
+        gate.inherit_through_stdin(&mut transaction_command)?;
+        let mut transaction = transaction_command.spawn()?;
+        // `Command` is reusable and retains its configured stdin. Drop that
+        // original duplicate so only the package transaction owns the lease.
+        drop(transaction_command);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !started.exists() {
+            anyhow::ensure!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for package replacement"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        drop(gate);
+        assert!(
+            try_acquire_install_launch_gate(executable)?.is_none(),
+            "the package transaction must retain the inherited lease after the updater exits"
+        );
+        fs::write(&release, b"continue")?;
+        assert!(transaction.wait()?.success());
+        assert!(try_acquire_install_launch_gate(executable)?.is_some());
         Ok(())
     }
 

--- a/updater/src/liveness.rs
+++ b/updater/src/liveness.rs
@@ -3,24 +3,111 @@
 use crate::config::{self, RuntimeConfig};
 use anyhow::{Context, Result};
 use std::{
-    fs,
+    fs::{self, OpenOptions},
+    os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt},
     path::{Path, PathBuf},
 };
+
+pub const APP_RUNNING_INSTALL_ERROR_MARKER: &str = "CODEX_UPDATE_APP_RUNNING";
+
+/// Exclusive access to the launcher's detection -> spawn critical section.
+///
+/// Holding this while applying a native package prevents a desktop launch from
+/// publishing a new Electron process between the updater's final liveness
+/// check and the package manager replacing the webview asset tree.
+pub struct LauncherLock {
+    _file: fs::File,
+}
+
+#[derive(Debug)]
+struct AppRunningDuringInstall {
+    executable: PathBuf,
+}
+
+impl std::fmt::Display for AppRunningDuringInstall {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "{APP_RUNNING_INSTALL_ERROR_MARKER}: ChatGPT Desktop started before the package install; close {} and retry",
+            self.executable.display()
+        )
+    }
+}
+
+impl std::error::Error for AppRunningDuringInstall {}
 
 /// Returns the PID file used by the Linux launcher to track the Electron app.
 pub fn app_pid_file() -> Result<PathBuf> {
     Ok(config::resolve_app_state_dir()?.join("app.pid"))
 }
 
+/// Tries to acquire the same lock the launcher holds until Electron is spawned
+/// and its PID is published. `None` means a launch is currently in progress.
+pub fn try_acquire_launcher_lock() -> Result<Option<LauncherLock>> {
+    let state_dir = config::resolve_app_state_dir()?;
+    fs::create_dir_all(&state_dir)
+        .with_context(|| format!("Failed to create {}", state_dir.display()))?;
+    let lock_path = state_dir.join("launcher.lock");
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(&lock_path)
+        .with_context(|| format!("Failed to open {}", lock_path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("Failed to inspect {}", lock_path.display()))?;
+    anyhow::ensure!(
+        metadata.is_file() && metadata.uid() == unsafe { libc::geteuid() },
+        "Launcher lock {} is not a user-owned regular file",
+        lock_path.display()
+    );
+    if metadata.permissions().mode() & 0o077 != 0 {
+        file.set_permissions(fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("Failed to secure {}", lock_path.display()))?;
+    }
+
+    match file.try_lock() {
+        Ok(()) => Ok(Some(LauncherLock { _file: file })),
+        Err(fs::TryLockError::WouldBlock) => Ok(None),
+        Err(fs::TryLockError::Error(error)) => {
+            Err(error).with_context(|| format!("Failed to lock {}", lock_path.display()))
+        }
+    }
+}
+
 /// Detects whether the managed Electron app is currently running.
 pub fn is_app_running(config: &RuntimeConfig) -> Result<bool> {
-    if let Some(pid) =
-        read_pid_file()?.filter(|pid| process_matches(*pid, &config.app_executable_path))
-    {
+    let executable = executable_identity_path(&config.app_executable_path);
+    if let Some(pid) = read_pid_file()?.filter(|pid| process_matches(*pid, &executable)) {
         return Ok(is_process_alive(pid));
     }
 
-    scan_proc_for_executable(&config.app_executable_path)
+    scan_proc_for_executable(&executable)
+}
+
+/// Detects any live process whose executable is the requested app binary.
+pub fn is_executable_running(executable: &Path) -> Result<bool> {
+    scan_proc_for_executable(&executable_identity_path(executable))
+}
+
+/// Fails with a machine-recognizable marker when a privileged package helper
+/// observes that the app was reopened after the unprivileged updater check.
+pub fn ensure_executable_not_running(executable: &Path) -> Result<()> {
+    if is_executable_running(executable)? {
+        return Err(AppRunningDuringInstall {
+            executable: executable.to_path_buf(),
+        }
+        .into());
+    }
+    Ok(())
+}
+
+pub fn error_reports_app_running(stderr: &[u8]) -> bool {
+    String::from_utf8_lossy(stderr).contains(APP_RUNNING_INSTALL_ERROR_MARKER)
 }
 
 fn read_pid_file() -> Result<Option<u32>> {
@@ -59,8 +146,27 @@ fn scan_proc_for_executable(expected: &Path) -> Result<bool> {
 fn process_matches(pid: u32, expected: &Path) -> bool {
     is_process_alive(pid)
         && read_exe_link(pid)
-            .map(|path| path == expected)
+            .map(|path| executable_paths_match(&path, expected))
             .unwrap_or(false)
+}
+
+fn executable_paths_match(actual: &Path, expected: &Path) -> bool {
+    if actual == expected {
+        return true;
+    }
+
+    // Linux appends this suffix to /proc/<pid>/exe after a package manager has
+    // replaced the inode. The process is still alive and must continue to block
+    // another update even though its old executable has been unlinked.
+    actual
+        .as_os_str()
+        .as_encoded_bytes()
+        .strip_suffix(b" (deleted)")
+        .is_some_and(|path| path == expected.as_os_str().as_encoded_bytes())
+}
+
+fn executable_identity_path(executable: &Path) -> PathBuf {
+    fs::canonicalize(executable).unwrap_or_else(|_| executable.to_path_buf())
 }
 
 fn is_process_alive(pid: u32) -> bool {
@@ -77,6 +183,7 @@ mod tests {
     use super::*;
     use crate::test_util::{env_lock, EnvRestoreGuard};
     use anyhow::Result;
+    use std::io::BufRead as _;
 
     #[test]
     fn pid_file_is_located_under_resolved_app_state() -> Result<()> {
@@ -105,6 +212,132 @@ mod tests {
             std::process::id(),
             &config.app_executable_path
         ));
+        Ok(())
+    }
+
+    #[test]
+    fn deleted_proc_executable_still_matches_installed_path() {
+        assert!(executable_paths_match(
+            Path::new("/opt/codex-desktop/electron (deleted)"),
+            Path::new("/opt/codex-desktop/electron")
+        ));
+        assert!(!executable_paths_match(
+            Path::new("/opt/other/electron (deleted)"),
+            Path::new("/opt/codex-desktop/electron")
+        ));
+    }
+
+    #[test]
+    fn running_unlinked_executable_is_detected_from_proc() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let executable = temp.path().join("electron");
+        fs::copy(fs::canonicalize("/bin/sh")?, &executable)?;
+        let mut child = std::process::Command::new(&executable)
+            .args(["-c", "sleep 30"])
+            .spawn()?;
+
+        let result = (|| -> Result<()> {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            while read_exe_link(child.id()).ok().as_deref() != Some(executable.as_path()) {
+                anyhow::ensure!(
+                    std::time::Instant::now() < deadline,
+                    "timed out waiting for the copied executable to start"
+                );
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+
+            fs::remove_file(&executable)?;
+            let proc_executable = read_exe_link(child.id())?;
+            anyhow::ensure!(
+                proc_executable
+                    .as_os_str()
+                    .as_encoded_bytes()
+                    .ends_with(b" (deleted)"),
+                "expected a deleted /proc executable, got {}",
+                proc_executable.display()
+            );
+            assert!(is_executable_running(&executable)?);
+            Ok(())
+        })();
+
+        let _ = child.kill();
+        let _ = child.wait();
+        result
+    }
+
+    #[test]
+    fn executable_identity_resolves_symlinks() -> Result<()> {
+        let resolved = executable_identity_path(Path::new("/usr/bin/yes"));
+        assert_eq!(resolved, fs::canonicalize("/usr/bin/yes")?);
+        Ok(())
+    }
+
+    #[test]
+    fn launcher_lock_serializes_with_other_holders() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempfile::tempdir()?;
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "XDG_STATE_HOME",
+            "CODEX_LINUX_APP_ID",
+            "CODEX_APP_ID",
+            "CODEX_LINUX_INSTANCE_ID",
+        ]);
+        std::env::set_var("XDG_STATE_HOME", temp.path());
+        std::env::set_var("CODEX_LINUX_APP_ID", "codex-lock-test");
+        std::env::remove_var("CODEX_APP_ID");
+        std::env::remove_var("CODEX_LINUX_INSTANCE_ID");
+
+        let first = try_acquire_launcher_lock()?.expect("first lock should succeed");
+        assert!(try_acquire_launcher_lock()?.is_none());
+        drop(first);
+        assert!(try_acquire_launcher_lock()?.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn launcher_lock_interoperates_with_the_shell_flock_helper() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempfile::tempdir()?;
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "XDG_STATE_HOME",
+            "CODEX_LINUX_APP_ID",
+            "CODEX_APP_ID",
+            "CODEX_LINUX_INSTANCE_ID",
+        ]);
+        std::env::set_var("XDG_STATE_HOME", temp.path());
+        std::env::set_var("CODEX_LINUX_APP_ID", "codex-shell-lock-test");
+        std::env::remove_var("CODEX_APP_ID");
+        std::env::remove_var("CODEX_LINUX_INSTANCE_ID");
+
+        let lock_path = config::resolve_app_state_dir()?.join("launcher.lock");
+        fs::create_dir_all(lock_path.parent().expect("launcher lock has a parent"))?;
+        let mut holder = std::process::Command::new("flock")
+            .arg("-x")
+            .arg(&lock_path)
+            .arg("sh")
+            .arg("-c")
+            .arg("printf 'locked\\n'; cat >/dev/null")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()?;
+        let mut ready = String::new();
+        std::io::BufReader::new(holder.stdout.as_mut().expect("holder stdout"))
+            .read_line(&mut ready)?;
+        assert_eq!(ready, "locked\n");
+
+        assert!(try_acquire_launcher_lock()?.is_none());
+        drop(holder.stdin.take());
+        assert!(holder.wait()?.success());
+        assert!(try_acquire_launcher_lock()?.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn privileged_guard_reports_a_machine_recognizable_running_app() -> Result<()> {
+        let error = ensure_executable_not_running(&std::env::current_exe()?)
+            .expect_err("the current test executable must be detected");
+        assert!(error.to_string().contains(APP_RUNNING_INSTALL_ERROR_MARKER));
+        assert!(error_reports_app_running(error.to_string().as_bytes()));
         Ok(())
     }
 }

--- a/updater/src/liveness.rs
+++ b/updater/src/liveness.rs
@@ -282,6 +282,20 @@ mod tests {
     use anyhow::Result;
     use std::io::BufRead as _;
 
+    fn wait_for_install_launch_gate(executable: &Path) -> Result<InstallLaunchGate> {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if let Some(gate) = try_acquire_install_launch_gate(executable)? {
+                return Ok(gate);
+            }
+            anyhow::ensure!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for install gate release"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
     #[test]
     fn pid_file_is_located_under_resolved_app_state() -> Result<()> {
         let _env_guard = env_lock();
@@ -391,7 +405,7 @@ mod tests {
             try_acquire_install_launch_gate(executable)?.expect("first lock should succeed");
         assert!(try_acquire_install_launch_gate(executable)?.is_none());
         drop(first);
-        assert!(try_acquire_install_launch_gate(executable)?.is_some());
+        let _reacquired = wait_for_install_launch_gate(executable)?;
         Ok(())
     }
 
@@ -423,7 +437,7 @@ mod tests {
         assert_eq!(install_launch_gate_path(executable)?, primary_path);
         assert!(try_acquire_install_launch_gate(executable)?.is_none());
         drop(primary);
-        assert!(try_acquire_install_launch_gate(executable)?.is_some());
+        let _reacquired = wait_for_install_launch_gate(executable)?;
         Ok(())
     }
 
@@ -454,7 +468,7 @@ mod tests {
         assert!(try_acquire_install_launch_gate(executable)?.is_none());
         drop(holder.stdin.take());
         assert!(holder.wait()?.success());
-        assert!(try_acquire_install_launch_gate(executable)?.is_some());
+        let _reacquired = wait_for_install_launch_gate(executable)?;
         Ok(())
     }
 
@@ -498,7 +512,7 @@ mod tests {
         );
         fs::write(&release, b"continue")?;
         assert!(transaction.wait()?.success());
-        assert!(try_acquire_install_launch_gate(executable)?.is_some());
+        let _reacquired = wait_for_install_launch_gate(executable)?;
         Ok(())
     }
 

--- a/updater/src/rollback.rs
+++ b/updater/src/rollback.rs
@@ -68,6 +68,16 @@ async fn trigger_rollback(
     package_path: &Path,
 ) -> Result<()> {
     let (blocked_candidate, blocked_dmg_sha256) = rollback_block_identifiers(state);
+    let Some(install_gate) =
+        liveness::acquire_install_launch_gate(&config.app_executable_path).await?
+    else {
+        println!("Another ChatGPT Desktop launch or package transaction is still starting. Retry rollback after it finishes.");
+        return Ok(());
+    };
+    if liveness::is_app_running(config)? {
+        println!("ChatGPT Desktop reopened before rollback. Close it and retry.");
+        return Ok(());
+    }
 
     state.status = UpdateStatus::Installing;
     state.error_message = None;
@@ -79,7 +89,9 @@ async fn trigger_rollback(
     );
 
     let current_exe = std::env::current_exe().context("Failed to resolve updater binary path")?;
-    let output = install_rollback::pkexec_command(&current_exe, package_path)
+    let mut command = install_rollback::pkexec_command(&current_exe, package_path);
+    install_gate.inherit_through_stdin(&mut command)?;
+    let output = command
         .output()
         .context("Failed to launch pkexec for rollback")?;
     let status = output.status;

--- a/updater/src/wrapper_apply.rs
+++ b/updater/src/wrapper_apply.rs
@@ -28,7 +28,7 @@ use tracing::{info, warn};
 use crate::{
     builder,
     config::{RuntimeConfig, RuntimePaths},
-    install, notify,
+    install, liveness, notify,
     state::{PersistedState, UpdateStatus},
     upstream, wrapper,
 };
@@ -403,14 +403,27 @@ async fn apply_packaged(
     .await
     .context("wrapper package rebuild failed")?;
 
+    let Some(install_gate) =
+        liveness::acquire_install_launch_gate(&config.app_executable_path).await?
+    else {
+        anyhow::bail!(
+            "another ChatGPT Desktop launch or package transaction still owns the install gate"
+        );
+    };
+    if liveness::is_app_running(config)? {
+        anyhow::bail!("ChatGPT Desktop reopened before wrapper package installation");
+    }
+
     let current_exe = std::env::current_exe().context("Failed to resolve updater binary path")?;
-    let output = install::pkexec_command(
+    let mut command = install::pkexec_command(
         &current_exe,
         &artifacts.package_path,
         &config.app_executable_path,
-    )
-    .output()
-    .context("Failed to launch pkexec for wrapper update installation")?;
+    );
+    install_gate.inherit_through_stdin(&mut command)?;
+    let output = command
+        .output()
+        .context("Failed to launch pkexec for wrapper update installation")?;
     if !output.status.success() {
         anyhow::bail!(
             "privileged wrapper install exited with status {}",

--- a/updater/src/wrapper_apply.rs
+++ b/updater/src/wrapper_apply.rs
@@ -404,9 +404,13 @@ async fn apply_packaged(
     .context("wrapper package rebuild failed")?;
 
     let current_exe = std::env::current_exe().context("Failed to resolve updater binary path")?;
-    let output = install::pkexec_command(&current_exe, &artifacts.package_path)
-        .output()
-        .context("Failed to launch pkexec for wrapper update installation")?;
+    let output = install::pkexec_command(
+        &current_exe,
+        &artifacts.package_path,
+        &config.app_executable_path,
+    )
+    .output()
+    .context("Failed to launch pkexec for wrapper update installation")?;
     if !output.status.success() {
         anyhow::bail!(
             "privileged wrapper install exited with status {}",


### PR DESCRIPTION
## Summary

Fix an updater race that could replace hashed webview assets underneath an Electron renderer reopened while native package authorization was still pending.

### Root cause

The affected renderer had loaded the old `app-initial-DRyZ1Lin.js` bundle and later lazy-loaded:

`model-picker-power-slider-impl-CrCCLhyI.js`

While the app was running, the native package upgrade replaced `/opt/codex-desktop/content/webview` with a newer asset set containing:

`model-picker-power-slider-impl-DmqcN1z7.js`

The old hashed chunk no longer existed, so opening the model picker—observed while switching from GPT-5.3 Spark—triggered the full-screen error boundary with:

`Failed to fetch dynamically imported module`

The webview server already sent `Cache-Control: no-store`; this was an install/launch race rather than a browser-cache issue.

### Changes

- Acquire the same `launcher.lock` used by the desktop launcher before beginning a native package installation.
- Hold that lock through polkit authorization and package replacement, preventing a normal desktop launch from publishing a new Electron process during installation.
- Recheck Electron liveness after acquiring the launcher lock.
- Return the update to `WaitingForAppExit` if a launch wins the race or the lock cannot be acquired safely.
- Pass the configured application executable to the privileged Debian, RPM, and pacman helpers.
- Check application liveness before package stabilization and again immediately before invoking the package manager.
- Return a machine-recognizable `CODEX_UPDATE_APP_RUNNING` marker when the privileged guard detects a reopened app.
- Continue recognizing an existing process when `/proc/<pid>/exe` ends in ` (deleted)` after its installed executable has been replaced.
- Document the new install/launch serialization behavior and add the changelog entry.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p codex-update-manager`
- `cargo test -p codex-update-manager`
  - 324 unit tests passed
  - 5 integration tests passed
- `cargo build --release -p codex-update-manager`
- `bash tests/scripts_smoke.sh`
  - Passed in an isolated Docker PID namespace
  - Covered Debian, RPM, pacman, AppImage, warm-start, window-reopen, launcher-lock, and packaging paths
- Ubuntu 24.04 VM acceptance:
  - A running real Electron app caused the privileged helper to return `CODEX_UPDATE_APP_RUNNING` in approximately 30 ms.
  - The running app remained alive and its executable checksum was unchanged.
  - A live process whose executable appeared as ` (deleted)` in `/proc/<pid>/exe` was still detected.
  - The same path produced no false positive after the process exited.
  - While `launcher.lock` was held, the real launcher timed out safely after approximately 5.38 seconds and created no Electron process.
  - After releasing the lock, the same launcher started Electron successfully.
- On the originally affected runtime, both old and new model-picker chunks returned HTTP 200 under the live recovery asset root, with no new matching dynamic-import errors afterward.

`cargo clippy` was not available in the host Rust installation. GitHub CI should run the repository-wide clippy job.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area. Not applicable: this fixes an updater race, not upstream drift.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.

