### PR TITLE
fix(updater): use scope-safe module imports

### DIFF
--- a/scripts/lib/linux-update-bridge-patch.js
+++ b/scripts/lib/linux-update-bridge-patch.js
@@ -1,11 +1,6 @@
 const fs = require("fs");
 const path = require("path");
 
-function requireName(source, moduleName) {
-  const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return source.match(new RegExp(`([A-Za-z_$][\\w$]*)=require\\([\\\`'"]${escaped}[\\\`'"]\\)`))?.[1] ?? null;
-}
-
 function buildUpdateManagerEnvSource() {
   return "function codexLinuxUpdateManagerEnv(){let e={...process.env},t=process.env.CODEX_LINUX_ORIGINAL_LD_LIBRARY_PATH_STATE,n=t==null?void 0:process.env.CODEX_LINUX_HOST_LD_LIBRARY_PATH_STATE??t,r=process.env.CODEX_LINUX_HOST_LD_LIBRARY_PATH_STATE==null?process.env.CODEX_LINUX_ORIGINAL_LD_LIBRARY_PATH_VALUE:process.env.CODEX_LINUX_HOST_LD_LIBRARY_PATH_VALUE;n===`unset`?delete e.LD_LIBRARY_PATH:n===`empty`?e.LD_LIBRARY_PATH=``:n===`value`&&typeof r==`string`&&(e.LD_LIBRARY_PATH=r);for(let t of[`CODEX_LINUX_ORIGINAL_LD_LIBRARY_PATH_STATE`,`CODEX_LINUX_ORIGINAL_LD_LIBRARY_PATH_VALUE`,`CODEX_LINUX_HOST_LD_LIBRARY_PATH_STATE`,`CODEX_LINUX_HOST_LD_LIBRARY_PATH_VALUE`])delete e[t];return e}";
 }
@@ -44,13 +39,9 @@ function applyCurrentBootstrapUpdaterBridgePatch(currentSource) {
     return currentSource;
   }
 
-  const childProcessVar = requireName(currentSource, "node:child_process");
-  const fsVar = requireName(currentSource, "node:fs");
-  const pathVar = requireName(currentSource, "node:path");
-  if (childProcessVar == null || fsVar == null || pathVar == null) {
-    console.warn("WARN: Could not find updater bridge module bindings - skipping Linux updater bridge patch");
-    return currentSource;
-  }
+  const childProcessVar = "require(`node:child_process`)";
+  const fsVar = "require(`node:fs`)";
+  const pathVar = "require(`node:path`)";
 
   let patchedSource = currentSource;
   if (!patchedSource.includes("function codexLinuxCreatePackageUpdateManager(")) {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -7752,6 +7752,10 @@ test("adds Linux package updater to current bootstrap updater wiring", () => {
   assert.match(patched, /s=codexLinuxPackageUpdateBridge\.manager/);
   assert.match(patched, /te=codexLinuxPackageUpdateBridge\.quitForUpdate/);
   assert.match(patched, /async function codexLinuxProbeUpdateManager\(\)/);
+  assert.match(patched, /require\(`node:child_process`\)\.execFile\(codexLinuxUpdateManagerPath\(\)/);
+  assert.match(patched, /require\(`node:fs`\)\.existsSync\(e\)/);
+  assert.match(patched, /require\(`node:path`\)\.join/);
+  assert.doesNotMatch(patched, /__codexChild\.execFile\(codexLinuxUpdateManagerPath\(\)/);
   assert.match(patched, /codexLinuxRunUpdateManager\(\[`--help`\]\)/);
   assert.match(patched, /async function codexLinuxRefreshUpdateState\(\)\{return codexLinuxReadUpdateState\(\)\}/);
   assert.match(patched, /codexLinuxProbeUpdateManager\(\)\.then\(\(\)=>\{s=!0,i\(\),a\(\);return!0\}\)/);
@@ -7762,6 +7766,23 @@ test("adds Linux package updater to current bootstrap updater wiring", () => {
   assert.match(patched, /e\.stdout\?\.includes\(`Manual install required:`\)\?await codexLinuxShowUpdateMessage/);
   assert.match(patched, /refresh:async\(\)=>\{if\(await c\)\{try\{await codexLinuxRefreshUpdateState\(\)\}/);
   assert.doesNotMatch(patched, /codexLinuxRunUpdateManager\(\[`status`,`--json`\]\)/);
+});
+
+test("does not reuse function-scoped module bindings in the Linux updater bridge", () => {
+  const source =
+    "function helper(){let __codexChild=require(`node:child_process`)," +
+    "__codexFs=require(`node:fs`),__codexPath=require(`node:path`);" +
+    "return[__codexChild,__codexFs,__codexPath]}" +
+    currentBootstrapUpdaterBundleFixture();
+
+  const patched = applyLinuxAppUpdaterBridgePatch(source);
+
+  assert.match(patched, /require\(`node:child_process`\)\.execFile\(codexLinuxUpdateManagerPath\(\)/);
+  assert.match(patched, /require\(`node:fs`\)\.existsSync\(e\)/);
+  assert.match(patched, /require\(`node:path`\)\.join/);
+  assert.doesNotMatch(patched, /__codexChild\.execFile\(codexLinuxUpdateManagerPath\(\)/);
+  assert.doesNotMatch(patched, /__codexFs\.existsSync\(e\)/);
+  assert.doesNotMatch(patched, /__codexPath\.join/);
 });
 
 test("implements the current Sparkle AppView, menu, and RPC contract on Linux", () => {


### PR DESCRIPTION
## Summary

- replace scope-unaware CommonJS binding discovery in the Linux updater bridge with direct module expressions for `node:child_process`, `node:fs`, and `node:path`
- prevent generated updater code from referencing function-scoped or injected minified bindings outside their lexical scope
- add regression coverage with deliberately nested module bindings matching the current patched bundle failure

This restores the packaged **Check for Updates** path when `codex-update-manager` is installed and healthy.

Closes #1207.

## Validation

- `node --check scripts/lib/linux-update-bridge-patch.js`
- `node --check scripts/patch-linux-window-ui.test.js`
- focused updater bridge tests: 5/5 passed
- full `scripts/patch-linux-window-ui.test.js`: 411/411 passed
- `git diff --check origin/main...HEAD`
- `bash tests/scripts_smoke.sh`: packaging, installer, updater, and launcher checks passed until the warm-start recovery test; that test could not start its fixture because the daily-driver `/opt/codex-desktop` process was running with the same `codex-desktop` app ID. No running-app guard was bypassed.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required focused checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
