### PR TITLE
Retarget enabled Linux features to Codex 26.727

### DIFF
--- a/linux-features/project-group-last-updated-sort/patch.js
+++ b/linux-features/project-group-last-updated-sort/patch.js
@@ -1,14 +1,14 @@
 "use strict";
 
 const currentGroupSorter =
-  "function h2o({groups:e,items:t,projectOrder:n}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return iZi(e.map((e,t)=>({group:e,index:t,recencyAt:y2o(e,r)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e),n)}";
+  "function Aos({groups:e,items:t,projectOrder:n}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return Sca(e.map((e,t)=>({group:e,index:t,recencyAt:e.threadKeys.reduce((e,t)=>Math.max(e,r.get(t)??0),e.projectUpdatedAt??0)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e),n)}";
 const patchedGroupSorter =
-  "function h2o({groups:e,items:t,projectOrder:n,sortMode:codexLinuxProjectSortMode}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return((codexLinuxRecencySortedGroups)=>codexLinuxProjectSortMode===`updated_at`?codexLinuxRecencySortedGroups:iZi(codexLinuxRecencySortedGroups,n))(e.map((e,t)=>({group:e,index:t,recencyAt:y2o(e,r)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e))}";
+  "function Aos({groups:e,items:t,projectOrder:n,sortMode:codexLinuxProjectSortMode}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return((codexLinuxRecencySortedGroups)=>codexLinuxProjectSortMode===`updated_at`?codexLinuxRecencySortedGroups:Sca(codexLinuxRecencySortedGroups,n))(e.map((e,t)=>({group:e,index:t,recencyAt:e.threadKeys.reduce((e,t)=>Math.max(e,r.get(t)??0),e.projectUpdatedAt??0)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e))}";
 
 const currentGroupSorterCall =
-  "T=h2o({groups:m2o({groups:C,items:s}),items:s,projectOrder:ap(t,zl.PROJECT_ORDER)})";
+  "A=Aos({groups:kos({groups:O,items:f}),items:f,projectOrder:Cp(t,Il.PROJECT_ORDER)})";
 const patchedGroupSorterCall =
-  "T=h2o({groups:m2o({groups:C,items:s}),items:s,projectOrder:ap(t,zl.PROJECT_ORDER),sortMode:t(Ez).projectSortMode})";
+  "A=Aos({groups:kos({groups:O,items:f}),items:f,projectOrder:Cp(t,Il.PROJECT_ORDER),sortMode:t(Sz).projectSortMode})";
 
 function countOccurrences(source, needle) {
   return source.split(needle).length - 1;

--- a/linux-features/project-group-last-updated-sort/test.js
+++ b/linux-features/project-group-last-updated-sort/test.js
@@ -18,13 +18,12 @@ const {
 } = require("./patch.js");
 
 const currentProjectSource = [
-  "function iZi(e,t){let n=new Map(t.map((e,t)=>[e,t]));return[...e].sort((e,t)=>(n.get(e.projectId)??2**53-1)-(n.get(t.projectId)??2**53-1))}",
-  "function y2o(e,t){let n=e.projectUpdatedAt??0;for(let r of e.threadKeys)n=Math.max(n,t.get(r)??0);return n}",
-  "function h2o({groups:e,items:t,projectOrder:n}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return iZi(e.map((e,t)=>({group:e,index:t,recencyAt:y2o(e,r)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e),n)}",
+  "function Sca(e,t){let n=new Map(t.map((e,t)=>[e,t]));return[...e].sort((e,t)=>(n.get(e.projectId)??2**53-1)-(n.get(t.projectId)??2**53-1))}",
+  "function Aos({groups:e,items:t,projectOrder:n}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return Sca(e.map((e,t)=>({group:e,index:t,recencyAt:e.threadKeys.reduce((e,t)=>Math.max(e,r.get(t)??0),e.projectUpdatedAt??0)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e),n)}",
   "const prioritySortId=`sidebarElectron.sortMenu.priority`;",
   "const updatedSortId=`sidebarElectron.sortMenu.updated`;",
   "const manualSortId=`sidebarElectron.sortMenu.manual`;",
-  "T=h2o({groups:m2o({groups:C,items:s}),items:s,projectOrder:ap(t,zl.PROJECT_ORDER)});",
+  "A=Aos({groups:kos({groups:O,items:f}),items:f,projectOrder:Cp(t,Il.PROJECT_ORDER)});",
 ].join("");
 
 function captureWarns(fn) {
@@ -70,7 +69,7 @@ function withFeatureConfig(enabled, fn) {
 function evaluateGroupSorter(source) {
   const context = {};
   const sorterSource = source.slice(0, source.indexOf("const prioritySortId"));
-  vm.runInNewContext(`${sorterSource};globalThis.sortProjectGroups=h2o`, context);
+  vm.runInNewContext(`${sorterSource};globalThis.sortProjectGroups=Aos`, context);
   return context.sortProjectGroups;
 }
 
@@ -154,15 +153,15 @@ test("patch passes the selected project sort mode into the group sorter", () => 
   const patched = applyPatchTwice(currentProjectSource);
   assert.ok(
     patched.includes(
-      "projectOrder:ap(t,zl.PROJECT_ORDER),sortMode:t(Ez).projectSortMode",
+      "projectOrder:Cp(t,Il.PROJECT_ORDER),sortMode:t(Sz).projectSortMode",
     ),
   );
 });
 
 test("drift leaves the asset byte-identical", () => {
   const source = currentProjectSource.replace(
-    "function h2o({groups:e,items:t,projectOrder:n})",
-    "function h2o({groups:e,items:t,projectOrder:n,unknown:o})",
+    "function Aos({groups:e,items:t,projectOrder:n})",
+    "function Aos({groups:e,items:t,projectOrder:n,unknown:o})",
   );
   const { value, warnings } = captureWarns(() =>
     applyProjectGroupLastUpdatedSortPatch(source),
@@ -175,7 +174,7 @@ test("drift leaves the asset byte-identical", () => {
 
 test("missing current call site leaves the asset byte-identical", () => {
   const source = currentProjectSource.replace(
-    "projectOrder:ap(t,zl.PROJECT_ORDER)",
+    "projectOrder:Cp(t,Il.PROJECT_ORDER)",
     "projectOrder:unknownProjectOrder",
   );
   const { value, warnings } = captureWarns(() =>
@@ -208,7 +207,7 @@ test("descriptor targets and patches only the current project sidebar chunk", ()
     const assetsDir = path.join(tempDir, "webview", "assets");
     const assetPath = path.join(
       assetsDir,
-      "app-initial-BHB6SClA.js",
+      "app-initial-iBPGfcXU.js",
     );
     fs.mkdirSync(assetsDir, { recursive: true });
     fs.writeFileSync(assetPath, currentProjectSource);

--- a/linux-features/shared-app-server-socket/patch.js
+++ b/linux-features/shared-app-server-socket/patch.js
@@ -19,7 +19,7 @@ function findTransportSymbols(source) {
   const [, namespace, webSocketClass, webSocketUrl] = webSocketMatch;
   const lifecycleMatch = sshClassSource.match(
     new RegExp(
-      `return ${namespace}\\.(${IDENT})\\((${IDENT}),\\{onPongTimeout:[\\s\\S]{0,160}?\\}\\),new ${namespace}\\.(${IDENT})\\(\\2\\)`,
+      `${namespace}\\.(${IDENT})\\((${IDENT}),\\{onPongTimeout:[\\s\\S]{0,220}?new ${namespace}\\.(${IDENT})\\(\\2\\)`,
     ),
   );
   if (lifecycleMatch == null) return null;

--- a/linux-features/shared-app-server-socket/test.js
+++ b/linux-features/shared-app-server-socket/test.js
@@ -175,14 +175,15 @@ async function closeServer(server) {
 
 function syntheticBundle() {
   return [
-    "var Ky=class{options;kind=`websocket`;logger=r.i(`AppServerTransportSshWebsocket`);proxyStreams=new Set;supportsReconnect(){return!0}",
-    "async connect(){let t={current:null},r=new n.zn(Fy,{perMessageDeflate:!1,createConnection:()=>",
-    "(t.current=this.createSshProxyStream(),t.current)});return n.Ln(r,{onPongTimeout:()=>r.terminate()}),new n.Rn(r)}};",
-    "function n6(e){let t=Jy(e.hostConfig);if(t)return Z.info(`selected app-server transport`),new Ky(t);",
+    "var gC=class{options;kind=`websocket`;logger=i.i(`AppServerTransportSshWebsocket`);proxyStreams=new Set;hasConnected=!1;supportsReconnect(){return!0}",
+    "async connect(){let t={current:null},r=new n.kn(qae,{perMessageDeflate:!1,createConnection:()=>",
+    "(t.current=this.createSshProxyStream(),t.current)});r.once(`close`,()=>{t.current?.destroy()});try{await Xae(r)}catch(e){throw r.once(`error`,()=>void 0),t.current?.destroy(),r.terminate(),e}",
+    "return n.Dn(r,{onPongTimeout:()=>{r.terminate()}}),this.hasConnected=!0,new n.On(r)}};",
+    "function b5(e){let t=_C(e.hostConfig);if(t)return v5.info(`[ssh-websocket-v0] selected app-server transport`),new gC(t);",
     "if(e.transportKind===`remote-control`)return new Remote(e);",
-    "if(n.io(e.hostConfig))return new Wsl({hostConfig:e.hostConfig,repoRoot:e.repoRoot,resourcesPath:e.resourcesPath,defaultOriginator:e.defaultOriginator});",
-    "let r=r6(e.hostConfig);if(r){e.desktopAuthAppServerClient;let t=p8(e.hostConfig,r);return new n.Fn({hostConfig:e.hostConfig,websocketUrl:r,getWebsocketProtocols:void 0,...t==null?{}:{socksProxyUrl:t}})}",
-    "return new n.Nn({hostConfig:e.hostConfig,repoRoot:e.repoRoot,resourcesPath:e.resourcesPath,defaultOriginator:e.defaultOriginator})}function afterFactory(){}",
+    "if(n.no(e.hostConfig))return new hoe({hostConfig:e.hostConfig,repoRoot:e.repoRoot,resourcesPath:e.resourcesPath,defaultOriginator:e.defaultOriginator});",
+    "let r=x5(e.hostConfig);if(r){e.desktopAuthAppServerClient;let t=vbe(e.hostConfig,r);return new n.Tn({hostConfig:e.hostConfig,websocketUrl:r,getWebsocketProtocols:void 0,...t==null?{}:{socksProxyUrl:t}})}",
+    "return new n.Cn({hostConfig:e.hostConfig,repoRoot:e.repoRoot,resourcesPath:e.resourcesPath,defaultOriginator:e.defaultOriginator})}function afterFactory(){}",
   ].join("");
 }
 
@@ -229,8 +230,8 @@ test("patch selects the bridge only for the local host and is idempotent", () =>
   assert.match(patched, /reclaimStaleLock/);
   assert.match(patched, /this\.sameIdentity\(this\.socketIdentity,e\)/);
   assert.match(patched, /requires CODEX_CLI_PATH/);
-  assert.match(patched, /new n\.zn\(Fy,/);
-  assert.match(patched, /new n\.Rn\(/);
+  assert.match(patched, /new n\.kn\(qae,/);
+  assert.match(patched, /new n\.On\(/);
   assert.match(patched, /supportsReconnect\(\)\{return!0\}/);
 });
 
@@ -248,7 +249,7 @@ test("patch leaves unsupported bundle shapes unchanged with a warning", () => {
 
 test("patch rejects the previous SSH transport class shape", () => {
   const source = syntheticBundle().replace(
-    "class{options;kind=`websocket`;logger=r.i(`AppServerTransportSshWebsocket`);",
+    "class{options;kind=`websocket`;logger=i.i(`AppServerTransportSshWebsocket`);",
     "class{kind=`websocket`;",
   );
   const warnings = [];


### PR DESCRIPTION
## Summary

- retarget `project-group-last-updated-sort` to the current Codex 26.727 project-group sorter and call-site symbols
- refresh `shared-app-server-socket` detection for the current SSH WebSocket readiness and adapter lifecycle
- update both feature fixtures while keeping drift fail-soft and second-pass patching byte-identical

## Root cause

Codex `26.727.51351` changed the minified project sidebar symbols and inlined project recency calculation. It also inserted explicit WebSocket readiness handling and a connection-state assignment between SSH keepalive setup and adapter construction.

Both opt-in feature descriptors therefore skipped their current insertion points. Because the features were enabled locally, upstream-DMG acceptance correctly rejected candidate promotion with `enabled-feature-drift` blockers.

## User-visible behavior

Users who enable either feature can rebuild from the current upstream DMG without those descriptors being rejected as stale. Non-updated project sort modes still preserve upstream saved ordering, and unsupported future bundle shapes remain unchanged with warnings.

## Validation

- `env -u CODEX_CLI_PATH node --test linux-features/project-group-last-updated-sort/test.js linux-features/shared-app-server-socket/test.js` — 35 passed, 1 opt-in real-CLI integration skipped
- Codex DMG `26.727.51351` — both patches change their real extracted assets and produce byte-identical output on a second pass
- `git diff --check origin/main...HEAD`

## Scope

This PR contains only the four descriptor and fixture files for the two enabled-feature drift blockers. The separate shared app-server orphan-recovery change remains in #1209.

The full transactional native rebuild was not rerun to completion after the local handoff; validation uses the focused suites and freshly extracted real DMG assets.
