### PR TITLE
fix(updater): preserve feature picker settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- The updater feature picker now changes only the enabled feature list, preserving
+  nested feature settings and other local configuration keys across rebuilds.
 - The opt-in Dock icon tweak now targets the current upstream main-process
   bundle, restoring Linux window, tray, and desktop icon synchronization.
 - The opt-in shallow repository watcher now patches both current app bundles

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2021"
 
 [dependencies]

--- a/updater/src/feature_picker.rs
+++ b/updater/src/feature_picker.rs
@@ -475,9 +475,14 @@ fn write_feature_config(enabled: &[String]) -> Result<()> {
         std::fs::create_dir_all(dir)
             .with_context(|| format!("Failed to create {}", dir.display()))?;
     }
-    let value = serde_json::json!({ "enabled": enabled });
+    let mut object = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    object.insert("enabled".to_string(), serde_json::json!(enabled));
     let serialized =
-        serde_json::to_string_pretty(&value).context("Failed to serialize feature config")?;
+        serde_json::to_string_pretty(&object).context("Failed to serialize feature config")?;
     std::fs::write(&path, format!("{serialized}\n"))
         .with_context(|| format!("Failed to write {}", path.display()))?;
     Ok(())
@@ -939,6 +944,69 @@ if (arg === "--features-json") {
             enabled,
             vec!["beta".to_string(), "private-local-feature".to_string()]
         );
+
+        if let Some(prev) = prev_path {
+            std::env::set_var("PATH", prev);
+        }
+        std::env::remove_var("CODEX_LINUX_SETTINGS_FILE");
+        std::env::remove_var("DISPLAY");
+    }
+
+    #[test]
+    fn selection_preserves_existing_feature_settings_and_unknown_keys() {
+        let _g = env_lock();
+        let root = tempdir().unwrap();
+        let settings = tempdir().unwrap();
+        write_fake_catalog_script(root.path());
+        let config = base_config(root.path());
+        let paths = runtime_paths(root.path());
+
+        let settings_file = settings.path().join("settings.json");
+        let feature_config = settings.path().join("linux-features.json");
+        let preserved_settings = serde_json::json!({
+            "alpha": {
+                "nested": {
+                    "enabled": true
+                }
+            }
+        });
+        let preserved_metadata = serde_json::json!({
+            "owner": "local",
+            "version": 2
+        });
+        std::fs::write(
+            &feature_config,
+            format!(
+                "{}\n",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "enabled": ["alpha"],
+                    "settings": preserved_settings,
+                    "metadata": preserved_metadata
+                }))
+                .unwrap()
+            ),
+        )
+        .unwrap();
+        std::env::set_var("CODEX_LINUX_SETTINGS_FILE", &settings_file);
+        std::env::set_var("DISPLAY", ":99");
+        std::env::remove_var("WAYLAND_DISPLAY");
+
+        let (_d, fake_path) = fake_dialog("zenity", "beta\nalpha", 0);
+        let prev_path = std::env::var_os("PATH");
+        let mut joined = fake_path.clone();
+        if let Some(prev) = &prev_path {
+            joined.push(":");
+            joined.push(prev);
+        }
+        std::env::set_var("PATH", &joined);
+
+        run_pick_features(&config, &paths, false).unwrap();
+
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&feature_config).unwrap()).unwrap();
+        assert_eq!(value["enabled"], serde_json::json!(["alpha", "beta"]));
+        assert_eq!(value["settings"], preserved_settings);
+        assert_eq!(value["metadata"], preserved_metadata);
 
         if let Some(prev) = prev_path {
             std::env::set_var("PATH", prev);

--- a/updater/src/feature_picker.rs
+++ b/updater/src/feature_picker.rs
@@ -142,7 +142,7 @@ fn pick(config: &RuntimeConfig, paths: &RuntimePaths) -> Result<PickOutcome> {
                 return Ok(PickOutcome::Skipped("invalid-selection"));
             }
 
-            write_feature_config(&picked)?;
+            write_feature_config(config, &picked)?;
             if dont_ask {
                 if let Err(error) = config::write_feature_picker_on_update(false) {
                     warn!(?error, "could not persist don't-ask-again preference");
@@ -469,14 +469,14 @@ fn show_selection_error(tool: &DialogTool, message: &str) {
 }
 
 /// Writes the chosen enabled set to the stable feature-config path.
-fn write_feature_config(enabled: &[String]) -> Result<()> {
+fn write_feature_config(config: &RuntimeConfig, enabled: &[String]) -> Result<()> {
     let path = config::feature_config_path().context("could not resolve feature config path")?;
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir)
             .with_context(|| format!("Failed to create {}", dir.display()))?;
     }
-    let mut object = std::fs::read_to_string(&path)
-        .ok()
+    let mut object = config::effective_feature_config_path(config)
+        .and_then(|source| std::fs::read_to_string(source).ok())
         .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
         .and_then(|value| value.as_object().cloned())
         .unwrap_or_default();
@@ -943,6 +943,76 @@ if (arg === "--features-json") {
         assert_eq!(
             enabled,
             vec!["beta".to_string(), "private-local-feature".to_string()]
+        );
+
+        if let Some(prev) = prev_path {
+            std::env::set_var("PATH", prev);
+        }
+        std::env::remove_var("CODEX_LINUX_SETTINGS_FILE");
+        std::env::remove_var("DISPLAY");
+    }
+
+    #[test]
+    fn first_selection_preserves_effective_bundled_feature_config() {
+        let _g = env_lock();
+        let root = tempdir().unwrap();
+        let settings = tempdir().unwrap();
+        write_fake_catalog_script(root.path());
+        let config = base_config(root.path());
+        let paths = runtime_paths(root.path());
+
+        let settings_file = settings.path().join("settings.json");
+        let feature_config = settings.path().join("linux-features.json");
+        let bundled_dir = root.path().join("linux-features");
+        let bundled_config = bundled_dir.join("features.json");
+        let preserved_settings = serde_json::json!({
+            "alpha": {
+                "nested": {
+                    "enabled": true
+                }
+            }
+        });
+        let preserved_metadata = serde_json::json!({
+            "owner": "bundled",
+            "version": 3
+        });
+        std::fs::create_dir_all(&bundled_dir).unwrap();
+        let original_bundled = format!(
+            "{}\n",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "enabled": ["alpha", "private-local-feature"],
+                "settings": preserved_settings,
+                "metadata": preserved_metadata
+            }))
+            .unwrap()
+        );
+        std::fs::write(&bundled_config, &original_bundled).unwrap();
+        std::env::set_var("CODEX_LINUX_SETTINGS_FILE", &settings_file);
+        std::env::set_var("DISPLAY", ":99");
+        std::env::remove_var("WAYLAND_DISPLAY");
+
+        let (_d, fake_path) = fake_dialog("zenity", "beta", 0);
+        let prev_path = std::env::var_os("PATH");
+        let mut joined = fake_path.clone();
+        if let Some(prev) = &prev_path {
+            joined.push(":");
+            joined.push(prev);
+        }
+        std::env::set_var("PATH", &joined);
+
+        run_pick_features(&config, &paths, false).unwrap();
+
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&feature_config).unwrap()).unwrap();
+        assert_eq!(
+            value["enabled"],
+            serde_json::json!(["beta", "private-local-feature"])
+        );
+        assert_eq!(value["settings"], preserved_settings);
+        assert_eq!(value["metadata"], preserved_metadata);
+        assert_eq!(
+            std::fs::read_to_string(&bundled_config).unwrap(),
+            original_bundled
         );
 
         if let Some(prev) = prev_path {


### PR DESCRIPTION
## Summary

- preserve the effective Linux feature configuration object whenever the updater feature picker saves a selection
- replace only the `enabled` list, keeping nested feature settings and unknown local keys intact on both first save and later saves
- bump `codex-update-manager` to `0.10.5` and add regressions for both persistence paths

## Problem

The updater feature picker rewrote `linux-features.json` as only:

```json
{"enabled":["..."]}
```

That silently removed settings owned by enabled features. In the reported update, `ui-tweaks` remained enabled but its nested Dock Icon and Suggested Prompts opt-ins disappeared, so the following rebuild reported all seven related descriptors as `skipped-disabled`.

The initial fix preserved an existing per-user `linux-features.json`, but the first picker save still started from an empty object. At that point the effective configuration comes from the bundled `linux-features/features.json`, so nested settings would still be lost when the per-user file was first created.

## Invariant

Completing the picker may change the selected feature IDs, but it must not mutate configuration owned by those features or other local top-level keys. Cancelled and invalid selections retain their existing no-write behavior.

`updater/src/feature_picker.rs` remains the only behavioral owner changed. The writer now seeds from `effective_feature_config_path`: the saved per-user object when it exists, otherwise the bundled feature config. It then replaces only `enabled` and writes the result to the stable per-user path. Missing, malformed, or non-object effective configuration retains the existing fresh-object fallback.

The first-save regression also proves that the bundled source file remains unchanged and that an unknown enabled feature ID survives the selection.

## Validation

Regression oracle before the original fix:

```text
selection_preserves_existing_feature_settings_and_unknown_keys ... FAILED
left: Null
right: Object {"alpha": Object {"nested": Object {"enabled": Bool(true)}}}
```

Final checks:

- `cargo test -p codex-update-manager feature_picker::tests` (15 passed)
- `cargo test -p codex-update-manager` (336 passed across 15 suites on the host)
- `cargo check -p codex-update-manager`
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- isolated `codex-update-manager pick-features --json` subprocess with no per-user feature config: preserved nested Dock Icon, Suggested Prompts, metadata, and an unknown local feature ID while leaving the bundled source unchanged
- the sandboxed full Rust suite was expectedly unable to bind wiremock sockets; the same suite passed outside the sandbox

Current upstream build evidence from the original implementation commit (`480b956`):

- DMG SHA-256: `45ec006a0f3f0fa004b6fd4d6d5529979a05361f995ca2c51de3a3b04deee123`
- ETag: `0x8DEEF605E2457C7`
- Last-Modified: `Sat, 01 Aug 2026 00:03:50 GMT`
- Size: `609312441` bytes
- App: `26.727.51351`
- Electron: `42.3.0`
- acceptance: `accepted_with_warnings`, no blockers or integrity failures
- patch report: 111 applied, 18 already applied, one unrelated optional Computer Use UI descriptor skipped
- enabled `ui-tweaks`: 12 descriptors applied, including all three Dock Icon and all four Suggested Prompts descriptors

The review follow-up changes only updater config persistence, its tests, and updater package metadata; it does not alter ASAR patch descriptors or the candidate app payload.

## Scope

This does not change feature defaults, selection validation, config paths, updater state, package formats, or the behavior for malformed configuration. It does not attempt to repair unrelated optional feature drift.
