### PR TITLE
Document Raspberry Pi 5 validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ cd codex-desktop-linux
 | Platform | Recommended path | Notes |
 |---|---|---|
 | Debian, Ubuntu, Pop!_OS, Mint, Elementary | `make bootstrap-native` | Builds and installs a `.deb` |
+| Raspberry Pi 5 (64-bit) | `make bootstrap-native` | Validated on a 16 GB Pi 5; see [Raspberry Pi 5](docs/raspberry-pi-5.md) |
 | Fedora | `make bootstrap-native` | Builds and installs an `.rpm` |
 | openSUSE | `make bootstrap-native` | Builds and installs an `.rpm` |
 | Arch, Manjaro, EndeavourOS | `make bootstrap-native` | Builds and installs a pacman package |
@@ -360,6 +361,7 @@ Full list: [Troubleshooting](docs/troubleshooting.md).
 ## Project Docs
 
 - [Native setup](docs/native-setup.md)
+- [Raspberry Pi 5](docs/raspberry-pi-5.md)
 - [Nix](docs/nix.md)
 - [Linux Computer Use](docs/linux-computer-use.md)
 - [Record and Replay on Linux](docs/record-and-replay-linux.md)

--- a/docs/raspberry-pi-5.md
+++ b/docs/raspberry-pi-5.md
@@ -1,0 +1,114 @@
+# Raspberry Pi 5
+
+The core ChatGPT Desktop for Linux build has been validated on a 16 GB
+Raspberry Pi 5. The existing upstream ARM64 support built and ran without a
+Pi-specific source patch.
+
+This page records a field test, not a separate Raspberry Pi port. ARM64 support
+comes from the work already maintained in this repository by
+[@ilysenko](https://github.com/ilysenko) and its contributors.
+
+## Validated environment
+
+The successful test used:
+
+- Raspberry Pi 5 with 16 GB RAM
+- 64-bit Debian 13 (trixie), `aarch64`
+- NVMe storage
+- LightDM with the Raspberry Pi Labwc Wayland desktop
+- 1920x1080 display output
+- repository version `0.10.4` at commit `ab314923b5bf`
+- upstream ChatGPT app version `26.727.51351`
+- Electron `42.3.0`
+
+The native build acceptance verdict was `accepted`, with no blockers or
+warnings. The generated Debian package reported `Architecture: arm64`, and the
+Electron executable, native Node modules, Linux helpers, and Codex CLI platform
+binary were verified as AArch64 executables.
+
+## Build and install
+
+Use a 64-bit operating system. Active cooling and SSD or NVMe storage are
+recommended for the native build.
+
+The repository's normal Debian-family setup path should be used:
+
+```bash
+git clone https://github.com/ilysenko/codex-desktop-linux.git
+cd codex-desktop-linux
+PACKAGE_WITH_UPDATER=0 MAX_BUILD_THREADS=4 make bootstrap-native
+```
+
+`PACKAGE_WITH_UPDATER=0` keeps the first Pi installation simple by omitting the
+automatic rebuild service. After the baseline is stable, it can be evaluated
+separately. Limiting build parallelism to four jobs is a conservative starting
+point for Pi thermals and responsiveness.
+
+The tested run performed the same stages separately:
+
+```bash
+bash scripts/install-deps.sh
+PACKAGE_WITH_UPDATER=0 MAX_BUILD_THREADS=4 make build-app-fresh
+PACKAGE_WITH_UPDATER=0 MAX_BUILD_THREADS=4 make deb
+```
+
+Install the generated package from `dist/` with the normal Debian package
+manager. Do not download or redistribute someone else's generated package:
+this project intentionally performs the conversion locally from the official
+upstream application.
+
+## Desktop setup
+
+The application needs a graphical desktop session. A Pi configured for
+console-only boot must have its existing display manager enabled before the
+desktop launcher can be tested. The validated system used LightDM automatic
+login with the Raspberry Pi Labwc session.
+
+After installation, start **ChatGPT** from the desktop menu. The first launch
+may install or update the Codex CLI. If manual setup is needed, include the
+optional platform dependency:
+
+```bash
+npm install -g --include=optional --prefix ~/.local @openai/codex
+```
+
+## Validation results
+
+The following checks passed on the test Pi:
+
+- clean ARM64 app build and native module rebuild
+- native `arm64` Debian package creation and installation
+- graphical reboot into the Labwc Wayland desktop
+- application launch from the live desktop session
+- correctly rendered ChatGPT sign-in window
+- account sign-in
+- Codex app-server startup using the ARM64 Codex CLI
+- workspace file creation and editing
+- integrated command execution
+- Python, SQLite, automated test, and local Git workflows
+
+## Remaining validation
+
+The baseline proves the core desktop and Codex workflow, but it does not cover
+every optional integration. Browser Use and Computer Use should be tested and
+reported separately. In particular, the repository's Browser Use `node_repl`
+fallback resource is currently x86-64-only when no compatible upstream or
+user-supplied ARM64 binary is available.
+
+Long-running thermal behavior, peak memory use, and the automatic update
+manager were not measured during this first validation.
+
+## Reporting Pi issues
+
+Include the following when reporting a Raspberry Pi problem:
+
+- Pi model and RAM size
+- operating system and architecture from `uname -m`
+- desktop environment and X11 or Wayland session type
+- repository commit and upstream app version
+- exact build command
+- package format
+- relevant output from `~/.cache/codex-desktop/launcher.log`
+
+Keep generated applications and packages out of pull requests. Documentation,
+diagnostics, tests, and fixes should target the repository sources.

--- a/docs/raspberry-pi-5.md
+++ b/docs/raspberry-pi-5.md
@@ -87,13 +87,20 @@ The following checks passed on the test Pi:
 - integrated command execution
 - Python, SQLite, automated test, and local Git workflows
 
-## Remaining validation
+## Optional capability results
 
-The baseline proves the core desktop and Codex workflow, but it does not cover
-every optional integration. Browser Use and Computer Use should be tested and
-reported separately. In particular, the repository's Browser Use `node_repl`
-fallback resource is currently x86-64-only when no compatible upstream or
-user-supplied ARM64 binary is available.
+Browser Use and Computer Use were not available in the validated Pi session.
+The core workflow test did not diagnose a single cause for both features, so
+their absence should not be attributed solely to ARM64. Computer Use UI access
+can also depend on local opt-in and upstream account rollout.
+
+One known architecture-specific gap remains: the repository's Browser Use
+`node_repl` fallback resource is currently x86-64-only when no compatible
+upstream or user-supplied ARM64 binary is available. Treat Browser Use and
+Computer Use as unavailable on this validated baseline until separate ARM64
+testing demonstrates otherwise.
+
+## Remaining validation
 
 Long-running thermal behavior, peak memory use, and the automatic update
 manager were not measured during this first validation.


### PR DESCRIPTION
## Summary

- document a successful native ARM64 build and runtime validation on a 16 GB Raspberry Pi 5
- add the Pi 5 path to the installation matrix and project documentation index
- credit the repository's existing ARM64 implementation and clarify that this is field validation, not a separate port
- record the tested build commands, desktop setup, results, and optional capability gaps

## Why

The repository already contains substantial ARM64 support, but Raspberry Pi 5 users did not have a focused, hardware-validated setup and acceptance record. This change gives them a conservative reproduction path and distinguishes verified core behavior from optional areas that were unavailable during testing.

## User impact

Raspberry Pi 5 users can follow the standard Debian-family local build flow with a known-good core baseline. The guide records Browser Use and Computer Use as unavailable in the tested session without assigning an unverified common root cause. It also reinforces the repository policy that generated OpenAI application packages must not be redistributed.

## Validation

- `git diff --check`
- verified all new internal Markdown links resolve in the checkout
- built the current upstream app on a Raspberry Pi 5 using `PACKAGE_WITH_UPDATER=0 MAX_BUILD_THREADS=4 make build-app-fresh`
- received an `accepted` build verdict with no blockers or warnings
- generated and installed a native `arm64` Debian package
- verified Electron, native Node modules, Linux helpers, and Codex CLI as AArch64 executables
- rebooted into LightDM and the Raspberry Pi Labwc Wayland desktop at 1920x1080
- completed ChatGPT sign-in and a Codex workspace test covering file edits, command execution, Python, SQLite, automated tests, and local Git
- observed that Browser Use and Computer Use were unavailable in the validated Pi session

Not yet validated: sustained thermals and memory use, and the automatic update manager.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed `CONTRIBUTING.md`, kept the change focused, edited source documentation rather than generated output, and removed unrelated changes.
- [x] This does not modify upstream-DMG compatibility behavior.
- [x] I ran the relevant documentation and real-hardware validation listed above.
- [x] I reviewed the final diff for accuracy, attribution, scope, and repository policy compliance.
