### PR TITLE
Correct Raspberry Pi Computer Use results

### DIFF
--- a/docs/raspberry-pi-5.md
+++ b/docs/raspberry-pi-5.md
@@ -86,25 +86,27 @@ The following checks passed on the test Pi:
 - workspace file creation and editing
 - integrated command execution
 - Python, SQLite, automated test, and local Git workflows
-- Chromium control through Linux Computer Use, including navigation, accessible
-  element discovery, clicking, typing, publishing, and result verification
+- a Chromium publishing workflow using Linux Computer Use for screen capture,
+  accessible element discovery, and global pointer and keyboard input, with
+  external manual `wlrctl` shell commands for Labwc window listing and focus
 
 ## Optional capability results
 
-Linux Computer Use was validated end to end on the Labwc Wayland session after
-the desktop-control dependencies were completed. Initially, screenshots worked
-but accessibility discovery, window targeting, pointer input, and keyboard
-input were incomplete.
+A combined Chromium workflow was validated on the Labwc Wayland session after
+the desktop-control dependencies were completed. Initially, screenshots worked,
+but accessibility discovery, pointer input, and keyboard input were incomplete.
+Labwc is not currently a supported window-control backend, so window listing
+and focus were supplied separately through manual `wlrctl` shell commands.
 
 The successful Pi configuration added:
 
 - `at-spi2-core` and toolkit accessibility for AT-SPI element discovery
-- `wlrctl` for window discovery and focus through Labwc's wlroots
-  foreign-toplevel interface
+- external manual use of `wlrctl` for window listing and focus through Labwc's
+  wlroots foreign-toplevel interface; the Computer Use backend did not invoke
+  these commands
 - an ARM64 build of `ydotool` 1.0.3 or newer and an enabled per-user
   `ydotoold.service`
 - membership of the desktop user in the `input` group
-- positive Chromium focus verification before keyboard injection
 
 A scoped udev rule granted the `input` group read/write access to
 `/dev/uinput`:
@@ -117,13 +119,21 @@ Debian 13 did not offer a `ydotool` package on the validated image, so
 `ydotool` and `ydotoold` were built for ARM64 and installed under
 `/usr/local/bin`. The daemon exposed its socket at
 `$XDG_RUNTIME_DIR/.ydotool_socket`. See [Linux Computer Use](linux-computer-use.md)
-for the general dependency, daemon, UI opt-in, and readiness instructions.
+for the general dependency, daemon, UI opt-in, and supported-backend readiness
+instructions.
 
-The final test used Chromium through Linux Computer Use to open an external
-user-owned web application, inspect its accessibility tree, complete a content
-form, publish a persistent test item, and read back its public URL. One initial
-keyboard attempt reached the wrong window before explicit Chromium focus
-verification was added; the completed workflow then succeeded.
+The final test combined Linux Computer Use screen capture, AT-SPI inspection,
+and global pointer and keyboard input with external `wlrctl` shell focus to
+open an external user-owned web application, complete a content form, publish
+a persistent test item, and read back its public URL. One initial keyboard
+attempt reached the wrong window; the manual focus step was added before the
+successful retry.
+
+The public item verifies that the combined workflow published and persisted the
+result. It does not establish that the backend's built-in `list_windows`,
+`focused_window`, or targeted-input verification supported Labwc. Treat those
+window-control capabilities as unavailable on Labwc until a dedicated backend
+is implemented.
 
 Granting access to `/dev/uinput` and running `ydotoold` allows synthetic input.
 Limit access to trusted local users, keep the device rule group-scoped, and do

--- a/docs/raspberry-pi-5.md
+++ b/docs/raspberry-pi-5.md
@@ -121,7 +121,7 @@ for the general dependency, daemon, UI opt-in, and readiness instructions.
 
 The final test used Chromium through Linux Computer Use to open an external
 user-owned web application, inspect its accessibility tree, complete a content
-form, publish a temporary test item, and read back its public URL. One initial
+form, publish a persistent test item, and read back its public URL. One initial
 keyboard attempt reached the wrong window before explicit Chromium focus
 verification was added; the completed workflow then succeeded.
 

--- a/docs/raspberry-pi-5.md
+++ b/docs/raspberry-pi-5.md
@@ -86,19 +86,56 @@ The following checks passed on the test Pi:
 - workspace file creation and editing
 - integrated command execution
 - Python, SQLite, automated test, and local Git workflows
+- Chromium control through Linux Computer Use, including navigation, accessible
+  element discovery, clicking, typing, publishing, and result verification
 
 ## Optional capability results
 
-Browser Use and Computer Use were not available in the validated Pi session.
-The core workflow test did not diagnose a single cause for both features, so
-their absence should not be attributed solely to ARM64. Computer Use UI access
-can also depend on local opt-in and upstream account rollout.
+Linux Computer Use was validated end to end on the Labwc Wayland session after
+the desktop-control dependencies were completed. Initially, screenshots worked
+but accessibility discovery, window targeting, pointer input, and keyboard
+input were incomplete.
+
+The successful Pi configuration added:
+
+- `at-spi2-core` and toolkit accessibility for AT-SPI element discovery
+- `wlrctl` for window discovery and focus through Labwc's wlroots
+  foreign-toplevel interface
+- an ARM64 build of `ydotool` 1.0.3 or newer and an enabled per-user
+  `ydotoold.service`
+- membership of the desktop user in the `input` group
+- positive Chromium focus verification before keyboard injection
+
+A scoped udev rule granted the `input` group read/write access to
+`/dev/uinput`:
+
+```udev
+KERNEL=="uinput", GROUP="input", MODE="0660"
+```
+
+Debian 13 did not offer a `ydotool` package on the validated image, so
+`ydotool` and `ydotoold` were built for ARM64 and installed under
+`/usr/local/bin`. The daemon exposed its socket at
+`$XDG_RUNTIME_DIR/.ydotool_socket`. See [Linux Computer Use](linux-computer-use.md)
+for the general dependency, daemon, UI opt-in, and readiness instructions.
+
+The final test used Chromium through Linux Computer Use to open an external
+user-owned web application, inspect its accessibility tree, complete a content
+form, publish a temporary test item, and read back its public URL. One initial
+keyboard attempt reached the wrong window before explicit Chromium focus
+verification was added; the completed workflow then succeeded.
+
+Granting access to `/dev/uinput` and running `ydotoold` allows synthetic input.
+Limit access to trusted local users, keep the device rule group-scoped, and do
+not use a world-writable device mode.
 
 One known architecture-specific gap remains: the repository's Browser Use
 `node_repl` fallback resource is currently x86-64-only when no compatible
-upstream or user-supplied ARM64 binary is available. Treat Browser Use and
-Computer Use as unavailable on this validated baseline until separate ARM64
-testing demonstrates otherwise.
+upstream or user-supplied ARM64 binary is available. The Browser and Chrome
+plugins were enabled and discoverable during this test, but the demonstrated
+workflow used Chromium through Linux Computer Use. Treat Browser Use as a
+separate capability until its execution path is independently validated on
+ARM64.
 
 ## Remaining validation
 


### PR DESCRIPTION
## Summary

- follow up on #1212 by correcting the Raspberry Pi result from unavailable to a validated combined Chromium workflow
- document the Pi-specific AT-SPI, ARM64 `ydotool`, `ydotoold`, input-group, and `/dev/uinput` setup
- make explicit that Labwc window listing and focus used external manual `wlrctl` shell commands, not a built-in Computer Use window backend
- record the initial wrong-window keyboard attempt and the successful retry after manual Chromium focus
- preserve the distinction between Chromium driven through Linux Computer Use and the separate Browser Use execution path
- add a security note for synthetic input access

## Why

The first Pi validation ended before the optional desktop-control dependencies were configured, so #1212 accurately recorded the result known at that moment. Continued testing showed that screenshots already worked and that the remaining gaps were accessibility discovery and global pointer and keyboard injection—not an ARM64 incompatibility in those Linux Computer Use layers.

Labwc is not currently covered by the backend's built-in window listing, focus, readiness, or targeted-input verification. The successful test combined Computer Use screen capture, AT-SPI inspection, and global input with external manual `wlrctl` shell commands for Labwc window listing and focus.

## User impact

Raspberry Pi users now have an evidence-backed description of the working combined Labwc workflow and its security boundary. The guide avoids implying that Labwc has a built-in Computer Use window backend or that the separate Browser Use path was validated by this workflow.

## Validation

- `git diff --check`
- inspected the live Pi configuration:
  - `at-spi2-core` 2.56.2 and `wlrctl` 0.2.2 installed as ARM64 packages
  - ARM64 `ydotool` and `ydotoold` installed under `/usr/local/bin`
  - enabled and active per-user `ydotoold.service`
  - user-scoped socket at `$XDG_RUNTIME_DIR/.ydotool_socket`
  - desktop user in the `input` group
  - `/dev/uinput` owned by `root:input` with mode `0660`
- verified the [published validation report](https://www.halolumin.io/paul-richardson/codex-desktop-on-raspberry-pi-browser-and-computer-use-worki?view=1)
- independently opened and read the [test item created through the combined workflow](https://www.halolumin.io/paul-richardson/computer-use-test-halo-2?view=1)
- the successful workflow covered Chromium launch, navigation, accessibility inspection, clicking, manual external window focus, typing, publishing, and result URL verification

The public item verifies that the result persisted; it does not establish that built-in Computer Use window targeting supported Labwc.

This is a documentation-only correction; no generated application or package artifact is included.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed `CONTRIBUTING.md`, kept the change focused, edited source documentation rather than generated output, and removed unrelated changes.
- [x] This does not modify upstream-DMG compatibility behavior.
- [x] I ran the relevant documentation and real-hardware validation listed above.
- [x] I reviewed the final diff for accuracy, attribution, scope, and repository policy compliance.