### PR TITLE
fix(chrome): stage legacy extension metadata

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1330,6 +1330,7 @@ sync_chrome_bundled_plugin_cache() {
             scripts/check-extension-installed.js \
             scripts/check-native-host-manifest.js \
             scripts/chrome-is-running.js \
+            scripts/extension-id.json \
             scripts/extension-ids.json \
             scripts/installed-browsers.js \
             scripts/open-chrome-window.js; do

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -1084,6 +1084,50 @@ normalize_plugin_script_executable_modes() {
     done < <(find "$scripts_dir" -maxdepth 1 -type f -name '*.js' -print0)
 }
 
+write_chrome_extension_id_compatibility_metadata() {
+    local target_plugin="$1"
+    local source_metadata="$target_plugin/scripts/extension-ids.json"
+    local compatibility_metadata="$target_plugin/scripts/extension-id.json"
+
+    python3 - "$source_metadata" "$compatibility_metadata" <<'PY'
+import json
+from pathlib import Path
+import re
+import sys
+
+source = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+
+try:
+    metadata = json.loads(source.read_text(encoding="utf-8"))
+except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+    raise SystemExit(f"Invalid Chrome extension metadata: {exc}")
+
+extension_ids = metadata.get("extensionIds")
+host_name = metadata.get("extensionHostName")
+if (
+    not isinstance(extension_ids, list)
+    or not extension_ids
+    or not isinstance(extension_ids[0], str)
+    or re.fullmatch(r"[a-p]{32}", extension_ids[0]) is None
+):
+    raise SystemExit("Invalid Chrome extension id in bundled plugin metadata")
+if not isinstance(host_name, str) or re.fullmatch(r"[A-Za-z0-9_.]+", host_name) is None:
+    raise SystemExit("Invalid Chrome native host name in bundled plugin metadata")
+
+destination.write_text(
+    json.dumps(
+        {
+            "extensionId": extension_ids[0],
+            "extensionHostName": host_name,
+        },
+        separators=(",", ":"),
+    ) + "\n",
+    encoding="utf-8",
+)
+PY
+}
+
 stage_chrome_plugin_from_upstream() {
     local source_plugin="$1"
     local target_plugins="$2"
@@ -1111,6 +1155,15 @@ stage_chrome_plugin_from_upstream() {
     cp -R "$source_plugin" "$target_plugin"
     remove_macos_sidecar_files "$target_plugin"
     patch_chrome_plugin_for_linux "$target_plugin"
+    # The current Electron bundle still reads extension-id.json while the
+    # current Chrome plugin publishes canonical extension-ids.json metadata.
+    # Stage the singular file from that canonical metadata so both components
+    # agree without preserving an upstream-version fallback branch.
+    if ! write_chrome_extension_id_compatibility_metadata "$target_plugin"; then
+        rm -rf "$target_plugin"
+        warn "Chrome plugin extension metadata could not be normalized; skipping Chrome"
+        return 1
+    fi
     patch_browser_use_node_repl_process_env_import "$target_plugin/scripts/browser-client.mjs"
     patch_browser_use_node_repl_env_guard "$target_plugin/scripts/browser-client.mjs"
     patch_browser_use_node_repl_config_shim "$target_plugin/scripts/browser-client.mjs"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6395,6 +6395,7 @@ EOF
     assert_contains "$REPO_DIR/launcher/start.sh.template" "clear_bundled_marketplace_tmp_cache"
     assert_not_contains "$REPO_DIR/launcher/start.sh.template" "monitor_bundled_marketplace_tmp_permissions"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "extension-ids.json"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "scripts/extension-id.json"
     assert_not_contains "$REPO_DIR/launcher/start.sh.template" 'scripts_dir / "extension-id.json"'
     assert_contains "$REPO_DIR/launcher/start.sh.template" ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
     assert_contains "$REPO_DIR/launcher/start.sh.template" ".config/chromium/NativeMessagingHosts"
@@ -8704,6 +8705,17 @@ test_chrome_plugin_staging() {
     assert_mode "$chrome_dir/scripts/chrome-is-running.js" "755"
     assert_mode "$chrome_dir/scripts/check-extension-installed.js" "755"
     assert_mode "$chrome_dir/scripts/open-chrome-window.js" "755"
+    assert_file_exists "$chrome_dir/scripts/extension-id.json"
+    node - "$chrome_dir/scripts/extension-id.json" <<'NODE'
+const fs = require("fs");
+const metadata = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+if (
+  metadata.extensionId !== "hehggadaopoacecdllhhajmbjkdcmajg" ||
+  metadata.extensionHostName !== "com.openai.codexextension"
+) {
+  throw new Error("Chrome compatibility metadata did not match extension-ids.json");
+}
+NODE
     assert_contains "$chrome_dir/scripts/installManifest.mjs" "BraveSoftware/Brave-Browser/NativeMessagingHosts"
     assert_contains "$chrome_dir/scripts/installManifest.mjs" ".config/chromium/NativeMessagingHosts"
     assert_contains "$chrome_dir/scripts/installed-browsers.js" "Brave Browser"


### PR DESCRIPTION
## Summary
- generate the legacy `scripts/extension-id.json` adapter from canonical `extension-ids.json` when staging the Chrome plugin
- include the generated metadata in Chrome cache freshness checks
- add a staging regression test for its contents

The Electron bundle currently reads singular `extension-id.json`, while the current Chrome plugin supplies only plural `extension-ids.json`. Without the adapter, Chrome extension synchronization fails before a browser session can attach.

## Validation
- `bash -n scripts/lib/bundled-plugins.sh launcher/start.sh.template`
- `bash tests/scripts_smoke.sh`