### PR TITLE
fix(api-key-model-visibility): match refactored upstream model gate

### DIFF
--- a/linux-features/api-key-model-visibility/patch.js
+++ b/linux-features/api-key-model-visibility/patch.js
@@ -8,7 +8,34 @@ function warn(message, patchName) {
 }
 
 function applyApiKeyModelVisibilityPatch(source) {
-  const modelVisibilityPattern = new RegExp(
+  if (source.includes(PATCH_MARKER)) {
+    return source;
+  }
+
+  // Current upstream shape (refactored): the allowlist gate lives in a
+  // per-model visibility helper, e.g.
+  //   function q$r({additionalAvailableModels:e,authMethod:t,availableModels:n,model:r,useHiddenModels:i}){return e?.has(r.model)===!0||(i&&t!==`amazonBedrock`?n.has(r.model):!r.hidden)}
+  // Bypass the allowlist for API-key authenticated hosts the same way it is
+  // already bypassed for non-ChatGPT hosts: add `&&authMethod!==`apikey``.
+  const helperPattern = new RegExp(
+    `(function ${JS_IDENT}\\(\\{additionalAvailableModels:${JS_IDENT},authMethod:(${JS_IDENT}),` +
+      `availableModels:${JS_IDENT},model:${JS_IDENT},useHiddenModels:(${JS_IDENT})\\}\\)\\{return` +
+      `[\\s\\S]{0,300}?)\\3&&\\2!==\\\`amazonBedrock\\\`(?=[,;?])`,
+    "g",
+  );
+  const patched = source.replace(
+    helperPattern,
+    (_match, prefix, authMethodVar, useHiddenModelsVar) =>
+      `${prefix}${useHiddenModelsVar}&&${authMethodVar}!==\`amazonBedrock\`&&` +
+      `${authMethodVar}!==\`apikey\`/*${PATCH_MARKER}*/`,
+  );
+  if (patched !== source) {
+    return patched;
+  }
+
+  // Legacy upstream shape: inline gate in the catalog filter function with
+  // authMethod as the first destructured parameter.
+  const legacyPattern = new RegExp(
     `(function ${JS_IDENT}\\(\\{authMethod:(${JS_IDENT}),availableModels:${JS_IDENT},` +
       `defaultModel:${JS_IDENT},enabledReasoningEfforts:${JS_IDENT},` +
       `includeUltraReasoningEffort:${JS_IDENT},models:${JS_IDENT},` +
@@ -16,27 +43,14 @@ function applyApiKeyModelVisibilityPatch(source) {
       `\\3&&\\2!==\\\`amazonBedrock\\\`(?=[,;])`,
     "g",
   );
-  const patchedVisibilityPattern = new RegExp(
-    `function ${JS_IDENT}\\(\\{authMethod:(${JS_IDENT}),availableModels:${JS_IDENT},` +
-      `defaultModel:${JS_IDENT},enabledReasoningEfforts:${JS_IDENT},` +
-      `includeUltraReasoningEffort:${JS_IDENT},models:${JS_IDENT},` +
-      `useHiddenModels:(${JS_IDENT})\\}\\)\\{let[\\s\\S]{0,600}?[,;]${JS_IDENT}=` +
-      `\\2&&\\1!==\\\`amazonBedrock\\\`&&\\1!==\\\`apikey\\\`/\\*${PATCH_MARKER}\\*/(?=[,;])`,
-  );
-
-  const patched = source.replace(
-    modelVisibilityPattern,
+  const patchedLegacy = source.replace(
+    legacyPattern,
     (_match, prefix, authMethodVar, useHiddenModelsVar) =>
       `${prefix}${useHiddenModelsVar}&&${authMethodVar}!==\`amazonBedrock\`&&` +
       `${authMethodVar}!==\`apikey\`/*${PATCH_MARKER}*/`,
   );
-
-  if (patched !== source) {
-    return patched;
-  }
-
-  if (patchedVisibilityPattern.test(source)) {
-    return source;
+  if (patchedLegacy !== source) {
+    return patchedLegacy;
   }
 
   if (
@@ -55,7 +69,9 @@ const descriptors = [
     phase: "webview-asset",
     order: 20550,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~.*\.js$/,
+    // Upstream renamed the app main webview chunk from `app-initial~app-main~*.js`
+    // to `app-initial-*.js` (vite split the combined chunk); match both shapes.
+    pattern: /^app-initial(~app-main~|-).*\.js$/,
     missingDescription: "app main webview bundle",
     skipDescription: "API key model visibility patch",
     apply: applyApiKeyModelVisibilityPatch,

--- a/linux-features/api-key-model-visibility/patch.js
+++ b/linux-features/api-key-model-visibility/patch.js
@@ -18,39 +18,31 @@ function applyApiKeyModelVisibilityPatch(source) {
   // Bypass the allowlist for API-key authenticated hosts the same way it is
   // already bypassed for non-ChatGPT hosts: add `&&authMethod!==`apikey``.
   const helperPattern = new RegExp(
-    `(function ${JS_IDENT}\\(\\{additionalAvailableModels:${JS_IDENT},authMethod:(${JS_IDENT}),` +
-      `availableModels:${JS_IDENT},model:${JS_IDENT},useHiddenModels:(${JS_IDENT})\\}\\)\\{return` +
-      `[\\s\\S]{0,300}?)\\3&&\\2!==\\\`amazonBedrock\\\`(?=[,;?])`,
+    `(function ${JS_IDENT}\\(\\{additionalAvailableModels:(${JS_IDENT}),` +
+      `authMethod:(${JS_IDENT}),availableModels:(${JS_IDENT}),model:(${JS_IDENT}),` +
+      `useHiddenModels:(${JS_IDENT})\\}\\)\\{return ` +
+      `\\2\\?\\.has\\(\\5\\.model\\)===!0\\|\\|\\()` +
+      `\\6&&\\3!==\\\`amazonBedrock\\\`` +
+      `(\\?\\4\\.has\\(\\5\\.model\\):!\\5\\.hidden\\)\\})`,
     "g",
   );
   const patched = source.replace(
     helperPattern,
-    (_match, prefix, authMethodVar, useHiddenModelsVar) =>
+    (
+      _match,
+      prefix,
+      _additionalAvailableModelsVar,
+      authMethodVar,
+      _availableModelsVar,
+      _modelVar,
+      useHiddenModelsVar,
+      suffix,
+    ) =>
       `${prefix}${useHiddenModelsVar}&&${authMethodVar}!==\`amazonBedrock\`&&` +
-      `${authMethodVar}!==\`apikey\`/*${PATCH_MARKER}*/`,
+      `${authMethodVar}!==\`apikey\`/*${PATCH_MARKER}*/${suffix}`,
   );
   if (patched !== source) {
     return patched;
-  }
-
-  // Legacy upstream shape: inline gate in the catalog filter function with
-  // authMethod as the first destructured parameter.
-  const legacyPattern = new RegExp(
-    `(function ${JS_IDENT}\\(\\{authMethod:(${JS_IDENT}),availableModels:${JS_IDENT},` +
-      `defaultModel:${JS_IDENT},enabledReasoningEfforts:${JS_IDENT},` +
-      `includeUltraReasoningEffort:${JS_IDENT},models:${JS_IDENT},` +
-      `useHiddenModels:(${JS_IDENT})\\}\\)\\{let[\\s\\S]{0,600}?[,;]${JS_IDENT}=)` +
-      `\\3&&\\2!==\\\`amazonBedrock\\\`(?=[,;])`,
-    "g",
-  );
-  const patchedLegacy = source.replace(
-    legacyPattern,
-    (_match, prefix, authMethodVar, useHiddenModelsVar) =>
-      `${prefix}${useHiddenModelsVar}&&${authMethodVar}!==\`amazonBedrock\`&&` +
-      `${authMethodVar}!==\`apikey\`/*${PATCH_MARKER}*/`,
-  );
-  if (patchedLegacy !== source) {
-    return patchedLegacy;
   }
 
   if (
@@ -69,9 +61,7 @@ const descriptors = [
     phase: "webview-asset",
     order: 20550,
     ciPolicy: "optional",
-    // Upstream renamed the app main webview chunk from `app-initial~app-main~*.js`
-    // to `app-initial-*.js` (vite split the combined chunk); match both shapes.
-    pattern: /^app-initial(~app-main~|-).*\.js$/,
+    pattern: /^app-initial-[^.]+\.js$/,
     missingDescription: "app main webview bundle",
     skipDescription: "API key model visibility patch",
     apply: applyApiKeyModelVisibilityPatch,

--- a/linux-features/api-key-model-visibility/test.js
+++ b/linux-features/api-key-model-visibility/test.js
@@ -30,7 +30,9 @@ function applyPatchTwice(patchFn, source) {
 }
 
 function modelCatalogFixture() {
-  return "function vbe({authMethod:e,availableModels:t,defaultModel:n,enabledReasoningEfforts:r,includeUltraReasoningEffort:i,models:a,useHiddenModels:o}){let s=[],c=null,l=o&&e!==`amazonBedrock`;return a.forEach(n=>{if(l?t.has(n.model):!n.hidden){s.push(n),n.isDefault&&(c=n)}}),c??=s.find(e=>e.model===n)??null,{models:s,defaultModel:c}}";
+  // Current upstream shape (refactored): catalog filter delegates per-model
+  // visibility to a q$r-style helper that owns the allowlist gate.
+  return "function vbe({additionalAvailableModels:e,authMethod:t,availableModels:n,defaultModel:r,enabledReasoningEfforts:i,includeUltraReasoningEffort:a,models:o,useHiddenModels:s}){let c=[],l=null;return o.forEach(r=>{if(q$r({additionalAvailableModels:e,authMethod:t,availableModels:n,model:r,useHiddenModels:s})){c.push(r),r.isDefault&&(l=r)}}),l??=c.find(e=>e.model===r)??null,{models:c,defaultModel:l}}function q$r({additionalAvailableModels:e,authMethod:t,availableModels:n,model:r,useHiddenModels:i}){return e?.has(r.model)===!0||(i&&t!==`amazonBedrock`?n.has(r.model):!r.hidden)}";
 }
 
 function serviceTierCompatibleFixture() {
@@ -107,6 +109,7 @@ test("descriptor is optional and targets app main webview chunks", () => {
     [["api-key-model-visibility-ui", "webview-asset", "optional"]],
   );
   assert.equal(descriptors[0].pattern.test("app-initial~app-main~onboarding-page-abc.js"), true);
+  assert.equal(descriptors[0].pattern.test("app-initial-iBPGfcXU.js"), true);
   assert.equal(descriptors[0].pattern.test("settings-page-abc.js"), false);
 });
 
@@ -114,7 +117,7 @@ test("API-key hosts use visible CLI models instead of the desktop allowlist", ()
   const patched = applyPatchTwice(applyApiKeyModelVisibilityPatch, modelCatalogFixture());
   const catalog = evaluateCatalog(patched, "apikey");
 
-  assert.match(patched, /e!==`apikey`\/\*codexLinuxApiKeyModelVisibility\*\//);
+  assert.match(patched, /!==`apikey`\/\*codexLinuxApiKeyModelVisibility\*\//);
   assert.deepEqual(modelNames(catalog), [
     "gpt-5.6-sol",
     "gpt-5.6-terra",
@@ -166,8 +169,8 @@ test("model visibility and API key service tier patches compose in either order"
 
 test("extended upstream model gates fail soft instead of patching mid-expression", () => {
   const source = modelCatalogFixture().replace(
-    "l=o&&e!==`amazonBedrock`;",
-    "l=o&&e!==`amazonBedrock`&&featureGate;",
+    "t!==`amazonBedrock`?n.has(r.model)",
+    "t!==`amazonBedrock`&&featureGate?n.has(r.model)",
   );
 
   assert.equal(applyApiKeyModelVisibilityPatch(source), source);
@@ -177,7 +180,7 @@ test("enabled descriptor patches a matching extracted webview asset", () => {
   withFeatureConfig(["api-key-model-visibility"], (featuresRoot) => {
     withTempDir((extractedDir) => {
       const assetsDir = path.join(extractedDir, "webview", "assets");
-      const assetPath = path.join(assetsDir, "app-initial~app-main~fixture.js");
+      const assetPath = path.join(assetsDir, "app-initial-iBPGfcXU.js");
       fs.mkdirSync(assetsDir, { recursive: true });
       fs.writeFileSync(assetPath, modelCatalogFixture());
 

--- a/linux-features/api-key-model-visibility/test.js
+++ b/linux-features/api-key-model-visibility/test.js
@@ -15,9 +15,6 @@ const {
   loadLinuxFeaturePatchDescriptors,
 } = require("../../scripts/lib/linux-features.js");
 const {
-  applyApiKeyServiceTierPatch,
-} = require("../api-key-service-tier/patch.js");
-const {
   applyApiKeyModelVisibilityPatch,
   descriptors,
 } = require("./patch.js");
@@ -29,14 +26,14 @@ function applyPatchTwice(patchFn, source) {
   return once;
 }
 
+function modelVisibilityHelperFixture() {
+  return "function q$r({additionalAvailableModels:e,authMethod:t,availableModels:n,model:r,useHiddenModels:i}){return e?.has(r.model)===!0||(i&&t!==`amazonBedrock`?n.has(r.model):!r.hidden)}";
+}
+
 function modelCatalogFixture() {
   // Current upstream shape (refactored): catalog filter delegates per-model
   // visibility to a q$r-style helper that owns the allowlist gate.
-  return "function vbe({additionalAvailableModels:e,authMethod:t,availableModels:n,defaultModel:r,enabledReasoningEfforts:i,includeUltraReasoningEffort:a,models:o,useHiddenModels:s}){let c=[],l=null;return o.forEach(r=>{if(q$r({additionalAvailableModels:e,authMethod:t,availableModels:n,model:r,useHiddenModels:s})){c.push(r),r.isDefault&&(l=r)}}),l??=c.find(e=>e.model===r)??null,{models:c,defaultModel:l}}function q$r({additionalAvailableModels:e,authMethod:t,availableModels:n,model:r,useHiddenModels:i}){return e?.has(r.model)===!0||(i&&t!==`amazonBedrock`?n.has(r.model):!r.hidden)}";
-}
-
-function serviceTierCompatibleFixture() {
-  return "function vbe({authMethod:e,availableModels:t,defaultModel:n,enabledReasoningEfforts:r,includeUltraReasoningEffort:i,models:a,useHiddenModels:o}){let s=[],c=null,l=o&&e!==`amazonBedrock`,u=a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`max`)),d=i&&a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`ultra`));return a.forEach(n=>{if(l?t.has(n.model):!n.hidden){let t=i?n.supportedReasoningEfforts:n.supportedReasoningEfforts.filter(({reasoningEffort:e})=>e!==`ultra`),a=(e===`copilot`?[t.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:t).filter(({reasoningEffort:e})=>Gx(e)&&r.has(e)),o={...n,supportedReasoningEfforts:a};s.push(o),n.isDefault&&(c=o)}}),c??=s.find(e=>e.model===n)??null,{models:s,defaultModel:c}}";
+  return "function vbe({additionalAvailableModels:e,authMethod:t,availableModels:n,defaultModel:r,enabledReasoningEfforts:i,includeUltraReasoningEffort:a,models:o,useHiddenModels:s}){let c=[],l=null;return o.forEach(r=>{if(q$r({additionalAvailableModels:e,authMethod:t,availableModels:n,model:r,useHiddenModels:s})){c.push(r),r.isDefault&&(l=r)}}),l??=c.find(e=>e.model===r)??null,{models:c,defaultModel:l}}" + modelVisibilityHelperFixture();
 }
 
 function evaluateCatalog(source, authMethod, useHiddenModels = true) {
@@ -108,8 +105,8 @@ test("descriptor is optional and targets app main webview chunks", () => {
     descriptors.map((descriptor) => [descriptor.id, descriptor.phase, descriptor.ciPolicy]),
     [["api-key-model-visibility-ui", "webview-asset", "optional"]],
   );
-  assert.equal(descriptors[0].pattern.test("app-initial~app-main~onboarding-page-abc.js"), true);
-  assert.equal(descriptors[0].pattern.test("app-initial-iBPGfcXU.js"), true);
+  assert.equal(descriptors[0].pattern.test("app-initial~app-main~onboarding-page-abc.js"), false);
+  assert.equal(descriptors[0].pattern.test("app-initial-CKNQDTeE.js"), true);
   assert.equal(descriptors[0].pattern.test("settings-page-abc.js"), false);
 });
 
@@ -137,6 +134,7 @@ test("ChatGPT and existing no-allowlist paths keep their upstream behavior", () 
   const patched = applyApiKeyModelVisibilityPatch(modelCatalogFixture());
 
   assert.deepEqual(modelNames(evaluateCatalog(patched, "chatgpt")), ["gpt-5.5"]);
+  assert.deepEqual(modelNames(evaluateCatalog(patched, "copilot")), ["gpt-5.5"]);
   assert.deepEqual(modelNames(evaluateCatalog(patched, "chatgpt", false)), [
     "gpt-5.6-sol",
     "gpt-5.6-terra",
@@ -151,36 +149,31 @@ test("ChatGPT and existing no-allowlist paths keep their upstream behavior", () 
   ]);
 });
 
-test("model visibility and API key service tier patches compose in either order", () => {
-  const source = serviceTierCompatibleFixture();
-  const visibilityFirst = applyApiKeyServiceTierPatch(
-    applyApiKeyModelVisibilityPatch(source),
-  );
-  const serviceTierFirst = applyApiKeyModelVisibilityPatch(
-    applyApiKeyServiceTierPatch(source),
-  );
+test("drifted model visibility helpers fail soft and stay byte-identical", () => {
+  const helper = modelVisibilityHelperFixture();
+  const driftedHelpers = [
+    "function q$r({additionalAvailableModels:e,authMethod:t,availableModels:n,model:r,useHiddenModels:i}){return i&&t!==`amazonBedrock`;}",
+    "function q$r({additionalAvailableModels:e,authMethod:t,availableModels:n,model:r,useHiddenModels:i}){return i&&t!==`amazonBedrock`,n.has(r.model)}",
+    helper.replace(
+      "?n.has(r.model):!r.hidden",
+      "?featureGate&&n.has(r.model):!r.hidden",
+    ),
+    helper.replace(
+      "?n.has(r.model):!r.hidden",
+      "?n.has(r.model):featureGate&&!r.hidden",
+    ),
+  ];
 
-  assert.equal(visibilityFirst, serviceTierFirst);
-  for (const patched of [visibilityFirst, serviceTierFirst]) {
-    assert.match(patched, /codexLinuxApiKeyModelVisibility/);
-    assert.match(patched, /codexLinuxApiKeyServiceTierModel:e===`apikey`/);
+  for (const source of driftedHelpers) {
+    assert.equal(applyApiKeyModelVisibilityPatch(source), source);
   }
-});
-
-test("extended upstream model gates fail soft instead of patching mid-expression", () => {
-  const source = modelCatalogFixture().replace(
-    "t!==`amazonBedrock`?n.has(r.model)",
-    "t!==`amazonBedrock`&&featureGate?n.has(r.model)",
-  );
-
-  assert.equal(applyApiKeyModelVisibilityPatch(source), source);
 });
 
 test("enabled descriptor patches a matching extracted webview asset", () => {
   withFeatureConfig(["api-key-model-visibility"], (featuresRoot) => {
     withTempDir((extractedDir) => {
       const assetsDir = path.join(extractedDir, "webview", "assets");
-      const assetPath = path.join(assetsDir, "app-initial-iBPGfcXU.js");
+      const assetPath = path.join(assetsDir, "app-initial-CKNQDTeE.js");
       fs.mkdirSync(assetsDir, { recursive: true });
       fs.writeFileSync(assetPath, modelCatalogFixture());
 


### PR DESCRIPTION
The api-key-model-visibility feature patch no longer matches the current upstream app bundle: vite split the app main webview chunk (`app-initial~app-main~*.js` -> `app-initial-*.js`) and the allowlist gate was refactored out of the catalog filter function into a per-model visibility helper with an `additionalAvailableModels` parameter. As a result the descriptor was skipped on current DMGs and API-key-authenticated custom providers had their models hidden behind the desktop Statsig allowlist (only models overlapping the allowlist, e.g. gpt-5.6-luna, appeared in the picker).

Changes:
- Descriptor pattern now matches both `app-initial~app-main~*.js` and `app-initial-*.js`.
- Patch targets the refactored helper gate, adding `&&authMethod!==\`apikey\`` to bypass the allowlist for API-key hosts (same treatment already given to non-ChatGPT hosts).
- Legacy inline-gate pattern kept as a fail-soft fallback for older bundle shapes.
- Idempotency guard (marker) and `(?=[,;?])` lookahead so we never double-patch or patch mid-expression.
- Tests updated to the current bundle shape; 8/8 pass, including hidden-model exclusion, ChatGPT/amazonBedrock behavior preservation, and compose-with-service-tier.

Verified end-to-end on Fedora 44 with a custom OpenAI-compatible provider: model picker now lists the full provider catalog.