### PR TITLE
Fix optional upstream DMG drift

### DIFF
--- a/scripts/lib/linux-update-bridge-patch.js
+++ b/scripts/lib/linux-update-bridge-patch.js
@@ -60,7 +60,7 @@ function applyCurrentBootstrapUpdaterBridgePatch(currentSource) {
   }
 
   const destructureRegex =
-    /let\{startedAtMs:([A-Za-z_$][\w$]*),buildFlavor:([A-Za-z_$][\w$]*),desktopSentry:([A-Za-z_$][\w$]*),sparkleManager:([A-Za-z_$][\w$]*),productionAppcastStateStore:[A-Za-z_$][\w$]*,setSparkleBridgeHandlers:([A-Za-z_$][\w$]*),setSecondInstanceArgsHandler:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)\(\),/;
+    /let\{startedAtMs:([A-Za-z_$][\w$]*),buildFlavor:([A-Za-z_$][\w$]*),desktopSentry:([A-Za-z_$][\w$]*),sparkleManager:([A-Za-z_$][\w$]*),startupPhases:[A-Za-z_$][\w$]*,productionAppcastStateStore:[A-Za-z_$][\w$]*,setSparkleBridgeHandlers:([A-Za-z_$][\w$]*),setSecondInstanceArgsHandler:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)\(\),/;
   const destructureMatch = patchedSource.match(destructureRegex);
   const sparkleVar = destructureMatch?.[4] ?? null;
   const setSparkleBridgeHandlersVar = destructureMatch?.[5] ?? null;
@@ -87,7 +87,7 @@ function applyCurrentBootstrapUpdaterBridgePatch(currentSource) {
 
   if (!patchedSource.includes("codexLinuxPackageUpdateBridge=process.platform===`linux`")) {
     const currentBridgeRegex =
-      /let ([A-Za-z_$][\w$]*)=new [A-Za-z_$][\w$]*,(?:[A-Za-z_$][\w$]*=null,){2}([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*=>\{[^]*?\},(?=[A-Za-z_$][\w$]*=)/;
+      /let ([A-Za-z_$][\w$]*)=new [A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*=null,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)=>\{if\(\3\?\.quitImmediately===!1\)\{\1\.allowQuitTemporarilyForUpdateInstall\(\);return\}\1\.allowQuitTemporarilyForUpdateInstall\(\),[A-Za-z_$][\w$]*\.app\.quit\(\)\},(?=[A-Za-z_$][\w$]*=)/;
     const currentBridgeMatch = patchedSource.match(currentBridgeRegex);
     if (currentBridgeMatch == null) {
       console.warn("WARN: Could not find current updater callback bridge - skipping Linux updater bridge patch");

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -182,6 +182,7 @@ const {
   applyLinuxAppSunsetPatch,
   applyLinuxBrowserUseAvailabilityPatch,
   applyLinuxBrowserUseExternalAvailabilityPatch,
+  patchLinuxBrowserUseExternalAvailabilityAssets,
   applyLinuxBrowserUseWebviewHostRecoveryPatch,
   applyLinuxBrowserUseWebviewRemountStorePatch,
   applyLinuxBrowserUseNonLocalNavigationPatch,
@@ -8637,11 +8638,17 @@ test("keeps already patched external Browser Use availability unchanged", () => 
   assert.equal(applyPatchTwice(applyLinuxBrowserUseExternalAvailabilityPatch, source), source);
 });
 
-test("external Browser Use availability descriptor matches the current monolithic bundle", () => {
+test("external Browser Use availability descriptor patches the complete current extracted-app contract", () => {
   const descriptor = require("./patches/core/all-linux/webview/browser-use-external-availability/patch.js");
 
-  assert.match("app-initial-BTphDPeq.js", descriptor.pattern);
-  assert.doesNotMatch("use-in-app-browser-use-availability-B4Bdb14G.js", descriptor.pattern);
+  assert.equal(descriptor.phase, "extracted-app:post-webview");
+  assert.equal(descriptor.order, 1990);
+  assert.equal(descriptor.ciPolicy, "optional");
+  assert.equal(descriptor.apply, patchLinuxBrowserUseExternalAvailabilityAssets);
+  assert.deepEqual(descriptor.status({ matched: 0, changed: 0 }, []), {
+    status: "skipped-optional",
+    reason: null,
+  });
 });
 
 test("allows Browser Use non-local navigation on Linux without the upstream rollout flag", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1888,9 +1888,9 @@ function currentBootstrapUpdaterBundleFixture() {
     "let r=require(`electron`),i=require(`node:path`),o=require(`node:fs`),u=require(`node:child_process`);",
     "var g6={enabled:!1,running:!1,state:`disabled`};",
     "async function v6(){",
-    "let{startedAtMs:e,buildFlavor:i,desktopSentry:o,sparkleManager:s,productionAppcastStateStore:Q,setSparkleBridgeHandlers:c,setSecondInstanceArgsHandler:l}=n.k(),d=n.P.shouldIncludeSparkle(i,process.platform,process.env)||process.platform===`linux`;",
-    "let ee=new G5,P=null,W=null,te=e=>{if(e?.quitImmediately===!1){ee.allowQuitTemporarilyForUpdateInstall();return}ee.allowQuitTemporarilyForUpdateInstall(),r.app.quit()},F=F3({}),oe=iZ({}),se=oe.getWindowContext();",
-    "c({onDownloadProgressChanged:()=>{se.broadcastAppUpdateState()},onInstallProgressChanged:()=>{T&&se.broadcastAppUpdateState()},onUpdateReadyChanged:()=>{se.broadcastAppUpdateState()},onUpdateLifecycleStateChanged:()=>{se.broadcastAppUpdateState()},onRelaunchNoticeChanged:()=>{se.broadcastAppUpdateState()},onInstallUpdatesRequested:e=>{te(e)},isTrustedIpcEvent:M});",
+    "let{startedAtMs:e,buildFlavor:i,desktopSentry:o,sparkleManager:s,startupPhases:d,productionAppcastStateStore:Q,setSparkleBridgeHandlers:c,setSecondInstanceArgsHandler:l}=n.k(),v=n.P.shouldIncludeSparkle(i,process.platform,process.env)||process.platform===`linux`;",
+    "let ee=new G5,P=null,te=e=>{if(e?.quitImmediately===!1){ee.allowQuitTemporarilyForUpdateInstall();return}ee.allowQuitTemporarilyForUpdateInstall(),r.app.quit()},F=F3({}),oe=iZ({}),se=oe.getWindowContext();",
+    "c({onDownloadProgressChanged:()=>{se.broadcastAppUpdateState()},onDownloadedUpdateAppBrandChanged:()=>{se.broadcastAppUpdateState()},onInstallProgressChanged:()=>{T&&se.broadcastAppUpdateState()},onUpdateReadyChanged:()=>{se.broadcastAppUpdateState()},onUpdateLifecycleStateChanged:()=>{se.broadcastAppUpdateState()},onRelaunchNoticeChanged:()=>{se.broadcastAppUpdateState()},onInstallUpdatesRequested:e=>{te(e)},isTrustedIpcEvent:M});",
     "}exports.runMainAppStartup=v6;",
   ].join("");
 }
@@ -7890,12 +7890,12 @@ test("keeps the current Sparkle menu contract callable across Linux updater prob
 test("fails soft when the current updater callback bridge drifts", () => {
   for (const source of [
     currentBootstrapUpdaterBundleFixture().replace(
-      "let ee=new G5,P=null,W=null,te=e=>",
-      "let ee=G5(),P=null,W=null,te=e=>",
+      "let ee=new G5,P=null,te=e=>",
+      "let ee=G5(),P=null,te=e=>",
     ),
     currentBootstrapUpdaterBundleFixture().replace(
-      "let ee=new G5,P=null,W=null,te=e=>",
-      "let ee=new G5,P=null,te=e=>",
+      "ee.allowQuitTemporarilyForUpdateInstall(),r.app.quit()",
+      "ee.allowQuitTemporarilyForUpdateInstall(),r.app.exit()",
     ),
   ]) {
     const { value: patched, warnings } = captureWarns(() =>
@@ -7909,7 +7909,7 @@ test("fails soft when the current updater callback bridge drifts", () => {
 
 test("enables the existing app update menu on Linux", () => {
   const source =
-    "let{startedAtMs:r,buildFlavor:a,desktopSentry:o,sparkleManager:s,productionAppcastStateStore:P,setSparkleBridgeHandlers:c,setSecondInstanceArgsHandler:l}=t.y(),u=t.Z(a),d=t.C.shouldIncludeSparkle(a,process.platform,process.env),f=t.C.shouldIncludeUpdater(a,process.platform,process.env);Yb({enableSparkle:d});";
+    "let{startedAtMs:r,buildFlavor:a,desktopSentry:o,sparkleManager:s,startupPhases:h,productionAppcastStateStore:P,setSparkleBridgeHandlers:c,setSecondInstanceArgsHandler:l}=t.y(),u=t.Z(a),d=t.C.shouldIncludeSparkle(a,process.platform,process.env),f=t.C.shouldIncludeUpdater(a,process.platform,process.env);Yb({enableSparkle:d});";
   const patched = applyPatchTwice(applyLinuxAppUpdaterMenuPatch, source);
 
   assert.match(
@@ -8612,25 +8612,27 @@ test("enables Browser Use availability on Linux when only the Statsig gate is di
 
 test("enables external Browser Use availability on Linux without the upstream rollout flag", () => {
   const source =
-    "function m(e){let t=(0,l.c)(5),{hostId:n,windowType:r}=e,a=r===void 0?`electron`:r,o=i(`410065390`),s;t[0]===n?s=t[1]:(s={featureName:`browser_use_external`,hostId:n},t[0]=n,t[1]=s);let c=u(s),d=a===`chrome-extension`||o&&c.enabled&&!c.isLoading,f=a===`chrome-extension`?!1:c.isLoading,p;return t[2]!==d||t[3]!==f?(p={allowed:d,available:d,isLoading:f},t[2]=d,t[3]=f,t[4]=p):p=t[4],p}";
+    "function wfi(e){let t=(0,Efi.c)(14),{enabled:n,hostId:r,windowType:i}=e,a=n===void 0||n,o=i===void 0?`electron`:i,s=sh(`410065390`),c;t[0]!==a||t[1]!==r?(c={enabled:a,featureName:`browser_use_external`,hostId:r},t[0]=a,t[1]=r,t[2]=c):c=t[2];let l=pfi(c),u=Np(Cu.runCodexInWsl),d=ey(r),f=u===!0||d.kind===`wsl`,p;t[3]!==l.enabled||t[4]!==l.isLoading||t[5]!==s||t[6]!==f||t[7]!==o?(p=Tfi({isExternalBrowserUseFeatureEnabled:l.enabled,isExternalBrowserUseFeatureLoading:l.isLoading,isExternalBrowserUseGateEnabled:s,runCodexInWsl:f,windowType:o}),t[3]=l.enabled,t[4]=l.isLoading,t[5]=s,t[6]=f,t[7]=o,t[8]=p):p=t[8];return p}function Tfi({isExternalBrowserUseFeatureEnabled:e,isExternalBrowserUseFeatureLoading:t,isExternalBrowserUseGateEnabled:n,runCodexInWsl:r,windowType:i}){return i===`chrome-extension`?`available`:t?`loading`:n?e?r?`wsl-disabled`:`available`:`config-requirement-disabled`:`statsig-disabled`}";
 
   const patched = applyPatchTwice(applyLinuxBrowserUseExternalAvailabilityPatch, source);
 
   assert.match(
     patched,
-    /d=a===`chrome-extension`\|\|navigator\.userAgent\.includes\(`Linux`\)\|\|o&&c\.enabled&&!c\.isLoading/,
+    /return i===`chrome-extension`\|\|navigator\.userAgent\.includes\(`Linux`\)\?`available`:/,
   );
-  assert.match(
-    patched,
-    /f=a===`chrome-extension`\|\|navigator\.userAgent\.includes\(`Linux`\)\?!1:c\.isLoading/,
+  const context = { navigator: { userAgent: "Linux x86_64" } };
+  vm.runInNewContext(
+    `${patched};globalThis.result=Tfi({isExternalBrowserUseFeatureEnabled:!1,isExternalBrowserUseFeatureLoading:!1,isExternalBrowserUseGateEnabled:!1,runCodexInWsl:!1,windowType:\`electron\`})`,
+    context,
   );
+  assert.equal(context.result, "available");
   assert.match(patched, /featureName:`browser_use_external`/);
-  assert.match(patched, /i\(`410065390`\)/);
+  assert.match(patched, /sh\(`410065390`\)/);
 });
 
 test("keeps already patched external Browser Use availability unchanged", () => {
   const source =
-    "function m(e){let t=(0,l.c)(5),{hostId:n,windowType:r}=e,a=r===void 0?`electron`:r,o=i(`410065390`),s;t[0]===n?s=t[1]:(s={featureName:`browser_use_external`,hostId:n},t[0]=n,t[1]=s);let c=u(s),d=a===`chrome-extension`||navigator.userAgent.includes(`Linux`)||o&&c.enabled&&!c.isLoading,f=a===`chrome-extension`||navigator.userAgent.includes(`Linux`)?!1:c.isLoading,p;return p}";
+    "function wfi(){return{featureName:`browser_use_external`,gate:`410065390`}}function Tfi({isExternalBrowserUseFeatureEnabled:e,isExternalBrowserUseFeatureLoading:t,isExternalBrowserUseGateEnabled:n,runCodexInWsl:r,windowType:i}){return i===`chrome-extension`||navigator.userAgent.includes(`Linux`)?`available`:t?`loading`:n?e?r?`wsl-disabled`:`available`:`config-requirement-disabled`:`statsig-disabled`}";
 
   assert.equal(applyPatchTwice(applyLinuxBrowserUseExternalAvailabilityPatch, source), source);
 });

--- a/scripts/patches/core/all-linux/webview/browser-use-external-availability/patch.js
+++ b/scripts/patches/core/all-linux/webview/browser-use-external-availability/patch.js
@@ -1,19 +1,23 @@
 "use strict";
 
 const {
-  webviewAssetPatch,
+  extractedAppPatch,
 } = require("../../../../descriptor.js");
+const { patchStatusFromChange } = require("../../../../../lib/patch-report.js");
 const {
-  applyLinuxBrowserUseExternalAvailabilityPatch,
+  patchLinuxBrowserUseExternalAvailabilityAssets,
 } = require("../../../../impl/webview/index.js");
 
-module.exports = webviewAssetPatch({
+module.exports = extractedAppPatch({
   id: "linux-browser-use-external-availability",
-  phase: "webview-asset",
-  order: 1092,
+  phase: "extracted-app:post-webview",
+  order: 1990,
   ciPolicy: "optional",
-  pattern: /^app-initial-[^.]+\.js$/,
-  missingDescription: "external Browser Use availability bundle",
-  skipDescription: "Linux external Browser Use availability patch",
-  apply: applyLinuxBrowserUseExternalAvailabilityPatch,
+  apply: patchLinuxBrowserUseExternalAvailabilityAssets,
+  status: (result, warnings) => ({
+    status: result?.matched === 0
+      ? "skipped-optional"
+      : patchStatusFromChange((result?.changed ?? 0) > 0, warnings),
+    reason: result?.reason ?? warnings[0] ?? null,
+  }),
 });

--- a/scripts/patches/impl/webview-browser-use-external.test.js
+++ b/scripts/patches/impl/webview-browser-use-external.test.js
@@ -1,0 +1,230 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const {
+  patchLinuxBrowserUseExternalAvailabilityAssets,
+} = require("./webview/index.js");
+
+const currentChromeLinuxRegistry =
+  "linux:{installations:[{commands:[`google-chrome`,`google-chrome-stable`],userDataDirName:`google-chrome`},{commands:[`chromium`,`chromium-browser`],userDataDirName:`chromium`},{commands:[`google-chrome-beta`],userDataDirName:`google-chrome-beta`},{commands:[`google-chrome-unstable`],userDataDirName:`google-chrome-unstable`},{commands:[`google-chrome-for-testing`],userDataDirName:`google-chrome-for-testing`}],nativeMessagingManifestDirectories:[`.config/google-chrome/NativeMessagingHosts`,`.config/chromium/NativeMessagingHosts`,`.config/google-chrome-beta/NativeMessagingHosts`,`.config/google-chrome-unstable/NativeMessagingHosts`,`.config/google-chrome-for-testing/NativeMessagingHosts`],processNames:[`chrome`],userDataDirectorySegments:[`.config`,`google-chrome`]}";
+
+function currentBrowserRegistry(variableName) {
+  return `var ${variableName}={chrome:{backendCompatibilityKey:\`chrome\`,displayName:\`Google Chrome\`,${currentChromeLinuxRegistry}},edge:{backendCompatibilityKey:\`chrome\`,displayName:\`Microsoft Edge\`,linux:{installations:[{commands:[\`microsoft-edge\`,\`microsoft-edge-stable\`],userDataDirName:\`microsoft-edge\`}],nativeMessagingManifestDirectories:[\`.config/microsoft-edge/NativeMessagingHosts\`],processNames:[\`msedge\`],userDataDirectorySegments:[\`.config\`,\`microsoft-edge\`]}}};`;
+}
+
+function currentMainRegistryFixture() {
+  return [
+    currentBrowserRegistry("ob"),
+    "function fb(e){return Object.hasOwn(ob,e)}",
+    "Object.defineProperty(exports,`So`,{enumerable:!0,get:function(){return ob}}),Object.defineProperty(exports,`wo`,{enumerable:!0,get:function(){return fb}});",
+  ].join("");
+}
+
+function currentMainCallerFixture() {
+  return [
+    "let n=exports;function dl(e){return installedCommands.has(e)?`/usr/bin/${e}`:null}async function ml(e,t){launches.push([e,t])}",
+    "async function sne({browserFamily:e,platform:t=process.platform}){return t===`darwin`?!1:t===`win32`?!1:t===`linux`&&Ol(e)!=null}",
+    "async function lne({browserFamily:e,platform:t=process.platform,runCommand:n=ml,url:r}){await El({browserFamily:e,platform:t,runCommand:n,unsupportedPlatformError:`unsupported`,url:r})}",
+    "async function El({browserFamily:e,platform:t,runCommand:r,url:i}){let a=n.So[e];if(t===`linux`){let t=Ol(e);if(t==null)throw Error(`${a.displayName} is not installed`);await r(t,[i]);return}throw Error(`unsupported`)}",
+    "function Ol(e){let t=n.So[e],r=t.linux.installations;for(let e of r){let t=kl(e);if(t!=null)return t}return null}function kl(e){for(let t of e.commands){let e=dl(t);if(e!=null)return e}return null}",
+    "var oce={parse:e=>e},sce=class{async getInstalledBrowserFamilies(){let e=Object.keys(n.So).filter(n.wo);return(await Promise.all(e.map(async e=>({browserFamily:e,installed:await sne({browserFamily:e})})))).flatMap(({browserFamily:e,installed:t})=>t?[e]:[])}async openUrl({browserFamily:e,url:t}){await lne({browserFamily:oce.parse(e),url:t})}};globalThis.BrowserService=sce;",
+  ].join("");
+}
+
+function currentRendererFixture() {
+  return [
+    currentBrowserRegistry("Kl"),
+    "function Gl(e){return Object.hasOwn(Kl,e)}",
+    "function rendererLinuxRegistry(){return Object.keys(Kl).filter(Gl).map(e=>({browserFamily:e,installations:Kl[e].linux.installations,manifestDirectories:Kl[e].linux.nativeMessagingManifestDirectories,processNames:Kl[e].linux.processNames}))}",
+    "function wfi(){return{enabled:!1,featureName:`browser_use_external`,gate:`410065390`}}",
+    "function Tfi({isExternalBrowserUseFeatureEnabled:e,isExternalBrowserUseFeatureLoading:t,isExternalBrowserUseGateEnabled:n,runCodexInWsl:r,windowType:i}){return i===`chrome-extension`?`available`:t?`loading`:n?e?r?`wsl-disabled`:`available`:`config-requirement-disabled`:`statsig-disabled`}",
+    "globalThis.rendererLinuxRegistry=rendererLinuxRegistry;",
+  ].join("");
+}
+
+function createCurrentExternalBrowserUseAssets() {
+  const extractedDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "codex-current-external-browser-use-"),
+  );
+  const buildDir = path.join(extractedDir, ".vite", "build");
+  const assetsDir = path.join(extractedDir, "webview", "assets");
+  fs.mkdirSync(buildDir, { recursive: true });
+  fs.mkdirSync(assetsDir, { recursive: true });
+  const mainPath = path.join(buildDir, "main-DU-1HLYt.js");
+  const srcPath = path.join(buildDir, "src-Bn_6ASpg.js");
+  const rendererPath = path.join(assetsDir, "app-initial-YjNFxVhk.js");
+  fs.writeFileSync(mainPath, currentMainCallerFixture(), "utf8");
+  fs.writeFileSync(srcPath, currentMainRegistryFixture(), "utf8");
+  fs.writeFileSync(rendererPath, currentRendererFixture(), "utf8");
+  return { extractedDir, mainPath, rendererPath, srcPath };
+}
+
+function evaluateMainBrowserService(srcSource, mainSource, installedCommandNames) {
+  const context = {
+    exports: {},
+    installedCommands: new Set(installedCommandNames),
+    launches: [],
+    process: { platform: "linux" },
+  };
+  vm.runInNewContext(`${srcSource};${mainSource}`, context);
+  return { context, service: new context.BrowserService() };
+}
+
+function jsonValue(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test("patches exact-DMG Browser Use availability and both Brave registries atomically", async () => {
+  const fixture = createCurrentExternalBrowserUseAssets();
+  try {
+    assert.deepEqual(
+      patchLinuxBrowserUseExternalAvailabilityAssets(fixture.extractedDir),
+      { matched: 3, changed: 2 },
+    );
+
+    const mainSource = fs.readFileSync(fixture.mainPath, "utf8");
+    const srcSource = fs.readFileSync(fixture.srcPath, "utf8");
+    const rendererSource = fs.readFileSync(fixture.rendererPath, "utf8");
+
+    const braveOnly = evaluateMainBrowserService(srcSource, mainSource, ["brave-browser"]);
+    assert.deepEqual(jsonValue(await braveOnly.service.getInstalledBrowserFamilies()), ["chrome"]);
+    await braveOnly.service.openUrl({ browserFamily: "chrome", url: "https://example.com/brave" });
+    assert.deepEqual(jsonValue(braveOnly.context.launches), [
+      ["/usr/bin/brave-browser", ["https://example.com/brave"]],
+    ]);
+
+    const chromeOnly = evaluateMainBrowserService(srcSource, mainSource, ["google-chrome"]);
+    assert.deepEqual(jsonValue(await chromeOnly.service.getInstalledBrowserFamilies()), ["chrome"]);
+    await chromeOnly.service.openUrl({ browserFamily: "chrome", url: "https://example.com/chrome" });
+    assert.deepEqual(jsonValue(chromeOnly.context.launches), [
+      ["/usr/bin/google-chrome", ["https://example.com/chrome"]],
+    ]);
+
+    const rendererContext = {};
+    vm.runInNewContext(rendererSource, rendererContext);
+    const rendererRegistry = jsonValue(rendererContext.rendererLinuxRegistry());
+    const rendererChrome = rendererRegistry.find(({ browserFamily }) => browserFamily === "chrome");
+    const rendererEdge = rendererRegistry.find(({ browserFamily }) => browserFamily === "edge");
+    assert.ok(rendererChrome.installations.some(({ commands }) => commands.includes("brave-browser")));
+    assert.ok(rendererChrome.installations.some(({ commands }) => commands.includes("google-chrome")));
+    assert.ok(rendererChrome.installations.some(({ commands }) => commands.includes("chromium")));
+    assert.ok(
+      rendererChrome.installations.some(
+        ({ userDataDirName }) => userDataDirName === "BraveSoftware/Brave-Browser",
+      ),
+    );
+    assert.ok(
+      rendererChrome.manifestDirectories.includes(
+        ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",
+      ),
+    );
+    assert.ok(rendererChrome.processNames.includes("brave"));
+    assert.ok(rendererChrome.processNames.includes("brave-browser"));
+    assert.deepEqual(rendererEdge.installations[0].commands, [
+      "microsoft-edge",
+      "microsoft-edge-stable",
+    ]);
+    assert.match(
+      rendererSource,
+      /return i===`chrome-extension`\|\|navigator\.userAgent\.includes\(`Linux`\)\?`available`:/,
+    );
+
+    const beforeSecondPass = new Map([
+      [fixture.srcPath, srcSource],
+      [fixture.rendererPath, rendererSource],
+    ]);
+    assert.deepEqual(
+      patchLinuxBrowserUseExternalAvailabilityAssets(fixture.extractedDir),
+      { matched: 3, changed: 0 },
+    );
+    for (const [filePath, source] of beforeSecondPass) {
+      assert.equal(fs.readFileSync(filePath, "utf8"), source);
+    }
+  } finally {
+    fs.rmSync(fixture.extractedDir, { recursive: true, force: true });
+  }
+});
+
+test("leaves every exact-DMG Browser Use asset unchanged when a registry seam drifts", () => {
+  const fixture = createCurrentExternalBrowserUseAssets();
+  try {
+    fs.writeFileSync(
+      fixture.rendererPath,
+      currentRendererFixture().replace("processNames:[`chrome`]", "processNames:[`chrome`,`chromium`]"),
+      "utf8",
+    );
+    const before = new Map([
+      [fixture.mainPath, fs.readFileSync(fixture.mainPath, "utf8")],
+      [fixture.srcPath, fs.readFileSync(fixture.srcPath, "utf8")],
+      [fixture.rendererPath, fs.readFileSync(fixture.rendererPath, "utf8")],
+    ]);
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(" "));
+    let result;
+    try {
+      result = patchLinuxBrowserUseExternalAvailabilityAssets(fixture.extractedDir);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.deepEqual(result, {
+      matched: 0,
+      changed: 0,
+      reason: "Could not identify complete current Browser Use external availability and browser registry contract",
+    });
+    assert.equal(warnings.length, 1);
+    for (const [filePath, source] of before) {
+      assert.equal(fs.readFileSync(filePath, "utf8"), source);
+    }
+  } finally {
+    fs.rmSync(fixture.extractedDir, { recursive: true, force: true });
+  }
+});
+
+test("rolls back both exact-DMG Browser Use registry files when the second write fails", () => {
+  const fixture = createCurrentExternalBrowserUseAssets();
+  try {
+    const before = new Map([
+      [fixture.srcPath, fs.readFileSync(fixture.srcPath, "utf8")],
+      [fixture.rendererPath, fs.readFileSync(fixture.rendererPath, "utf8")],
+    ]);
+    let writeCount = 0;
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(" "));
+    let result;
+    try {
+      result = patchLinuxBrowserUseExternalAvailabilityAssets(fixture.extractedDir, {
+        writeFileSync(filePath, source, encoding) {
+          writeCount += 1;
+          if (writeCount === 2) {
+            fs.writeFileSync(filePath, "partially-written", encoding);
+            throw new Error("simulated renderer write failure");
+          }
+          fs.writeFileSync(filePath, source, encoding);
+        },
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.deepEqual(result, {
+      matched: 3,
+      changed: 0,
+      reason: "Could not write complete current Browser Use external availability assets: simulated renderer write failure",
+    });
+    assert.equal(warnings.length, 1);
+    for (const [filePath, source] of before) {
+      assert.equal(fs.readFileSync(filePath, "utf8"), source);
+    }
+  } finally {
+    fs.rmSync(fixture.extractedDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -1105,55 +1105,21 @@ function applyLinuxBrowserUseWebviewHostRecoveryPatch(currentSource) {
 function applyLinuxBrowserUseExternalAvailabilityPatch(currentSource) {
   const externalFeatureNeedle = "featureName:`browser_use_external`";
   const statsigNeedle = "410065390";
-  let changed = false;
-
-  const alreadyPatched = () =>
-    /featureName:`browser_use_external`[\s\S]{0,900}?navigator\.userAgent\.includes\(`Linux`\)/.test(currentSource);
-
-  const availabilityPattern =
-    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)===`chrome-extension`\|\|([A-Za-z_$][\w$]*)&&\1\.enabled&&!\1\.isLoading,([A-Za-z_$][\w$]*)=\5===`chrome-extension`\?!1:\1\.isLoading,/g;
-
-  let patchedSource = currentSource.replace(
-    availabilityPattern,
-    (
-      match,
-      featureQueryVar,
-      featureQueryFn,
-      featureQueryArg,
-      availableVar,
-      windowTypeVar,
-      statsigVar,
-      loadingVar,
-      offset,
-    ) => {
-      const contextStart = Math.max(0, offset - 700);
-      const context = currentSource.slice(contextStart, offset + match.length);
-      if (!context.includes(externalFeatureNeedle) || !context.includes(statsigNeedle)) {
-        return match;
-      }
-
-      changed = true;
-      return `let ${featureQueryVar}=${featureQueryFn}(${featureQueryArg}),${availableVar}=${windowTypeVar}===\`chrome-extension\`||navigator.userAgent.includes(\`Linux\`)||${statsigVar}&&${featureQueryVar}.enabled&&!${featureQueryVar}.isLoading,${loadingVar}=${windowTypeVar}===\`chrome-extension\`||navigator.userAgent.includes(\`Linux\`)?!1:${featureQueryVar}.isLoading,`;
-    },
-  );
-
-  if (!changed) {
-    // 26.623 refactored the inline availability gate into a status-string helper:
-    //   function X({isExternalBrowserUseFeatureEnabled:e,isExternalBrowserUseFeatureLoading:t,
-    //     isExternalBrowserUseGateEnabled:n,windowType:r}){return r===`chrome-extension`?`available`:...}
-    // Treat Linux like chrome-extension so the resolved status is `available`.
-    const statusFnPattern =
-      /(function [A-Za-z_$][\w$]*\(\{isExternalBrowserUseFeatureEnabled:[A-Za-z_$][\w$]*,isExternalBrowserUseFeatureLoading:[A-Za-z_$][\w$]*,isExternalBrowserUseGateEnabled:[A-Za-z_$][\w$]*,windowType:([A-Za-z_$][\w$]*)\}\)\{return )\2===`chrome-extension`\?`available`:/;
-    patchedSource = patchedSource.replace(
-      statusFnPattern,
-      (match, prefix, windowTypeVar) => {
-        changed = true;
-        return `${prefix}${windowTypeVar}===\`chrome-extension\`||navigator.userAgent.includes(\`Linux\`)?\`available\`:`;
-      },
-    );
+  const alreadyPatched =
+    /function [A-Za-z_$][\w$]*\(\{isExternalBrowserUseFeatureEnabled:[A-Za-z_$][\w$]*,isExternalBrowserUseFeatureLoading:[A-Za-z_$][\w$]*,isExternalBrowserUseGateEnabled:[A-Za-z_$][\w$]*,runCodexInWsl:[A-Za-z_$][\w$]*,windowType:([A-Za-z_$][\w$]*)\}\)\{return \1===`chrome-extension`\|\|navigator\.userAgent\.includes\(`Linux`\)\?`available`:/;
+  if (alreadyPatched.test(currentSource)) {
+    return currentSource;
   }
 
-  if (changed || alreadyPatched()) {
+  const statusFnPattern =
+    /(function [A-Za-z_$][\w$]*\(\{isExternalBrowserUseFeatureEnabled:[A-Za-z_$][\w$]*,isExternalBrowserUseFeatureLoading:[A-Za-z_$][\w$]*,isExternalBrowserUseGateEnabled:[A-Za-z_$][\w$]*,runCodexInWsl:[A-Za-z_$][\w$]*,windowType:([A-Za-z_$][\w$]*)\}\)\{return )\2===`chrome-extension`\?`available`:/;
+  const patchedSource = currentSource.replace(
+    statusFnPattern,
+    (match, prefix, windowTypeVar) =>
+      `${prefix}${windowTypeVar}===\`chrome-extension\`||navigator.userAgent.includes(\`Linux\`)?\`available\`:`,
+  );
+
+  if (patchedSource !== currentSource) {
     return patchedSource;
   }
 

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -12,6 +12,9 @@ const {
 const {
   patchDelegationState,
 } = require("../../lib/composition-delegation.js");
+const {
+  PatchIntegrityError,
+} = require("../../integrity-error.js");
 
 // Webview asset patches target hashed browser chunks copied out of app.asar.
 // They stay fail-soft because upstream chunk names and minified symbols drift.
@@ -1102,24 +1105,35 @@ function applyLinuxBrowserUseWebviewHostRecoveryPatch(currentSource) {
   );
 }
 
-function applyLinuxBrowserUseExternalAvailabilityPatch(currentSource) {
-  const externalFeatureNeedle = "featureName:`browser_use_external`";
-  const statsigNeedle = "410065390";
-  const alreadyPatched =
-    /function [A-Za-z_$][\w$]*\(\{isExternalBrowserUseFeatureEnabled:[A-Za-z_$][\w$]*,isExternalBrowserUseFeatureLoading:[A-Za-z_$][\w$]*,isExternalBrowserUseGateEnabled:[A-Za-z_$][\w$]*,runCodexInWsl:[A-Za-z_$][\w$]*,windowType:([A-Za-z_$][\w$]*)\}\)\{return \1===`chrome-extension`\|\|navigator\.userAgent\.includes\(`Linux`\)\?`available`:/;
-  if (alreadyPatched.test(currentSource)) {
+const CURRENT_BROWSER_USE_CHROME_LINUX_REGISTRY =
+  "linux:{installations:[{commands:[`google-chrome`,`google-chrome-stable`],userDataDirName:`google-chrome`},{commands:[`chromium`,`chromium-browser`],userDataDirName:`chromium`},{commands:[`google-chrome-beta`],userDataDirName:`google-chrome-beta`},{commands:[`google-chrome-unstable`],userDataDirName:`google-chrome-unstable`},{commands:[`google-chrome-for-testing`],userDataDirName:`google-chrome-for-testing`}],nativeMessagingManifestDirectories:[`.config/google-chrome/NativeMessagingHosts`,`.config/chromium/NativeMessagingHosts`,`.config/google-chrome-beta/NativeMessagingHosts`,`.config/google-chrome-unstable/NativeMessagingHosts`,`.config/google-chrome-for-testing/NativeMessagingHosts`],processNames:[`chrome`],userDataDirectorySegments:[`.config`,`google-chrome`]}";
+const LINUX_BRAVE_BROWSER_USE_CHROME_REGISTRY =
+  "linux:{installations:[{commands:[`google-chrome`,`google-chrome-stable`],userDataDirName:`google-chrome`},{commands:[`brave-browser`,`brave`],userDataDirName:`BraveSoftware/Brave-Browser`},{commands:[`chromium`,`chromium-browser`],userDataDirName:`chromium`},{commands:[`google-chrome-beta`],userDataDirName:`google-chrome-beta`},{commands:[`google-chrome-unstable`],userDataDirName:`google-chrome-unstable`},{commands:[`google-chrome-for-testing`],userDataDirName:`google-chrome-for-testing`}],nativeMessagingManifestDirectories:[`.config/google-chrome/NativeMessagingHosts`,`.config/BraveSoftware/Brave-Browser/NativeMessagingHosts`,`.config/chromium/NativeMessagingHosts`,`.config/google-chrome-beta/NativeMessagingHosts`,`.config/google-chrome-unstable/NativeMessagingHosts`,`.config/google-chrome-for-testing/NativeMessagingHosts`],processNames:[`chrome`,`brave`,`brave-browser`],userDataDirectorySegments:[`.config`,`google-chrome`]}";
+const CURRENT_BROWSER_USE_CONTRACT_MISSING_REASON =
+  "Could not identify complete current Browser Use external availability and browser registry contract";
+
+const externalBrowserUseAvailabilityPatchedPattern =
+  /function [A-Za-z_$][\w$]*\(\{isExternalBrowserUseFeatureEnabled:[A-Za-z_$][\w$]*,isExternalBrowserUseFeatureLoading:[A-Za-z_$][\w$]*,isExternalBrowserUseGateEnabled:[A-Za-z_$][\w$]*,runCodexInWsl:[A-Za-z_$][\w$]*,windowType:([A-Za-z_$][\w$]*)\}\)\{return \1===`chrome-extension`\|\|navigator\.userAgent\.includes\(`Linux`\)\?`available`:/;
+const externalBrowserUseAvailabilityCurrentPattern =
+  /(function [A-Za-z_$][\w$]*\(\{isExternalBrowserUseFeatureEnabled:[A-Za-z_$][\w$]*,isExternalBrowserUseFeatureLoading:[A-Za-z_$][\w$]*,isExternalBrowserUseGateEnabled:[A-Za-z_$][\w$]*,runCodexInWsl:[A-Za-z_$][\w$]*,windowType:([A-Za-z_$][\w$]*)\}\)\{return )\2===`chrome-extension`\?`available`:/;
+
+function patchCurrentExternalBrowserUseAvailabilitySource(currentSource) {
+  if (externalBrowserUseAvailabilityPatchedPattern.test(currentSource)) {
     return currentSource;
   }
-
-  const statusFnPattern =
-    /(function [A-Za-z_$][\w$]*\(\{isExternalBrowserUseFeatureEnabled:[A-Za-z_$][\w$]*,isExternalBrowserUseFeatureLoading:[A-Za-z_$][\w$]*,isExternalBrowserUseGateEnabled:[A-Za-z_$][\w$]*,runCodexInWsl:[A-Za-z_$][\w$]*,windowType:([A-Za-z_$][\w$]*)\}\)\{return )\2===`chrome-extension`\?`available`:/;
   const patchedSource = currentSource.replace(
-    statusFnPattern,
+    externalBrowserUseAvailabilityCurrentPattern,
     (match, prefix, windowTypeVar) =>
       `${prefix}${windowTypeVar}===\`chrome-extension\`||navigator.userAgent.includes(\`Linux\`)?\`available\`:`,
   );
+  return patchedSource === currentSource ? null : patchedSource;
+}
 
-  if (patchedSource !== currentSource) {
+function applyLinuxBrowserUseExternalAvailabilityPatch(currentSource) {
+  const externalFeatureNeedle = "featureName:`browser_use_external`";
+  const statsigNeedle = "410065390";
+  const patchedSource = patchCurrentExternalBrowserUseAvailabilitySource(currentSource);
+  if (patchedSource != null) {
     return patchedSource;
   }
 
@@ -1130,6 +1144,179 @@ function applyLinuxBrowserUseExternalAvailabilityPatch(currentSource) {
   }
 
   return currentSource;
+}
+
+function currentBrowserUseRegistryState(source) {
+  const currentCount = source.split(CURRENT_BROWSER_USE_CHROME_LINUX_REGISTRY).length - 1;
+  const patchedCount = source.split(LINUX_BRAVE_BROWSER_USE_CHROME_REGISTRY).length - 1;
+  if (currentCount === 1 && patchedCount === 0) {
+    return "current";
+  }
+  if (currentCount === 0 && patchedCount === 1) {
+    return "patched";
+  }
+  return "drifted";
+}
+
+function patchCurrentBrowserUseRegistrySource(source) {
+  const state = currentBrowserUseRegistryState(source);
+  if (state === "patched") {
+    return source;
+  }
+  if (state !== "current") {
+    return null;
+  }
+  return source.replace(
+    CURRENT_BROWSER_USE_CHROME_LINUX_REGISTRY,
+    LINUX_BRAVE_BROWSER_USE_CHROME_REGISTRY,
+  );
+}
+
+function currentBrowserUseMainCallerContract(source) {
+  return source.includes("async function sne({browserFamily:") &&
+    source.includes("async function lne({browserFamily:") &&
+    source.includes("function Ol(") &&
+    source.includes("getInstalledBrowserFamilies(){") &&
+    source.includes("async openUrl({browserFamily:");
+}
+
+function currentBrowserUseMainRegistryContract(source) {
+  return currentBrowserUseRegistryState(source) !== "drifted" &&
+    source.includes("function fb(e){return Object.hasOwn(ob,e)}") &&
+    /Object\.defineProperty\(exports,["'`]So["'`],\{enumerable:!0,get:function\(\)\{return ob\}\}\)/u.test(source);
+}
+
+function currentBrowserUseRendererContract(source) {
+  return currentBrowserUseRegistryState(source) !== "drifted" &&
+    source.includes("featureName:`browser_use_external`") &&
+    source.includes("410065390") &&
+    source.includes("function Gl(e){return Object.hasOwn(Kl,e)}") &&
+    source.includes("Object.keys(Kl).filter(Gl)") &&
+    (externalBrowserUseAvailabilityCurrentPattern.test(source) ||
+      externalBrowserUseAvailabilityPatchedPattern.test(source));
+}
+
+function findUniqueCurrentBrowserUseAsset(directory, fileNamePattern, contract) {
+  if (!fs.existsSync(directory)) {
+    return null;
+  }
+  const matches = fs.readdirSync(directory)
+    .filter((fileName) => fileNamePattern.test(fileName))
+    .sort()
+    .map((fileName) => {
+      const filePath = path.join(directory, fileName);
+      return { filePath, source: fs.readFileSync(filePath, "utf8") };
+    })
+    .filter(({ source }) => contract(source));
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function writeCurrentBrowserUseAssetCandidates(candidates, writeFileSync, readFileSync) {
+  const attempted = [];
+  try {
+    for (const candidate of candidates) {
+      attempted.push(candidate);
+      writeFileSync(candidate.filePath, candidate.patched, "utf8");
+    }
+  } catch (error) {
+    const rollbackWriteFailures = [];
+    for (const candidate of attempted.reverse()) {
+      try {
+        writeFileSync(candidate.filePath, candidate.source, "utf8");
+      } catch (rollbackError) {
+        rollbackWriteFailures.push(rollbackError);
+      }
+    }
+    const rollbackVerificationFailures = [];
+    for (const candidate of attempted) {
+      try {
+        if (readFileSync(candidate.filePath, "utf8") !== candidate.source) {
+          rollbackVerificationFailures.push(
+            new Error(`rollback byte verification failed for ${candidate.filePath}`),
+          );
+        }
+      } catch (rollbackError) {
+        rollbackVerificationFailures.push(rollbackError);
+      }
+    }
+    if (rollbackVerificationFailures.length > 0) {
+      const writeFailureContext = rollbackWriteFailures[0] == null
+        ? ""
+        : `; rollback write also failed: ${rollbackWriteFailures[0].message}`;
+      throw new PatchIntegrityError(
+        `Browser Use external availability rollback could not restore original bytes: ${rollbackVerificationFailures[0].message}${writeFailureContext}`,
+      );
+    }
+    throw error;
+  }
+}
+
+function patchLinuxBrowserUseExternalAvailabilityAssets(extractedDir, {
+  writeFileSync = fs.writeFileSync,
+  readFileSync = fs.readFileSync,
+} = {}) {
+  const buildDir = path.join(extractedDir, ".vite", "build");
+  const assetsDir = path.join(extractedDir, "webview", "assets");
+  const mainCaller = findUniqueCurrentBrowserUseAsset(
+    buildDir,
+    /^main-[^.]+\.js$/u,
+    currentBrowserUseMainCallerContract,
+  );
+  const mainRegistry = findUniqueCurrentBrowserUseAsset(
+    buildDir,
+    /^src-[^.]+\.js$/u,
+    currentBrowserUseMainRegistryContract,
+  );
+  const renderer = findUniqueCurrentBrowserUseAsset(
+    assetsDir,
+    /^app-initial-[^.]+\.js$/u,
+    currentBrowserUseRendererContract,
+  );
+  if (mainCaller == null || mainRegistry == null || renderer == null) {
+    console.warn(
+      `WARN: ${CURRENT_BROWSER_USE_CONTRACT_MISSING_REASON} — skipping Linux external Browser Use availability patch`,
+    );
+    return {
+      matched: 0,
+      changed: 0,
+      reason: CURRENT_BROWSER_USE_CONTRACT_MISSING_REASON,
+    };
+  }
+
+  const patchedMainRegistry = patchCurrentBrowserUseRegistrySource(mainRegistry.source);
+  const rendererWithAvailability = patchCurrentExternalBrowserUseAvailabilitySource(renderer.source);
+  const patchedRenderer = rendererWithAvailability == null
+    ? null
+    : patchCurrentBrowserUseRegistrySource(rendererWithAvailability);
+  if (patchedMainRegistry == null || patchedRenderer == null) {
+    console.warn(
+      `WARN: ${CURRENT_BROWSER_USE_CONTRACT_MISSING_REASON} — skipping Linux external Browser Use availability patch`,
+    );
+    return {
+      matched: 0,
+      changed: 0,
+      reason: CURRENT_BROWSER_USE_CONTRACT_MISSING_REASON,
+    };
+  }
+
+  const candidates = [
+    { ...mainRegistry, patched: patchedMainRegistry },
+    { ...renderer, patched: patchedRenderer },
+  ].filter(({ source, patched }) => source !== patched);
+  if (candidates.length === 0) {
+    return { matched: 3, changed: 0 };
+  }
+  try {
+    writeCurrentBrowserUseAssetCandidates(candidates, writeFileSync, readFileSync);
+  } catch (error) {
+    if (error?.code === "PATCH_INTEGRITY_FAILURE") {
+      throw error;
+    }
+    const reason = `Could not write complete current Browser Use external availability assets: ${error.message}`;
+    console.warn(`WARN: ${reason} — leaving Browser Use assets unchanged`);
+    return { matched: 3, changed: 0, reason };
+  }
+  return { matched: 3, changed: candidates.length };
 }
 
 function applyLinuxAppServerFeatureEnablementPatch(currentSource) {
@@ -2287,6 +2474,7 @@ module.exports = {
   applyLinuxChatSearchHydrationPatch,
   applyLinuxBrowserUseAvailabilityPatch,
   applyLinuxBrowserUseExternalAvailabilityPatch,
+  patchLinuxBrowserUseExternalAvailabilityAssets,
   applyLinuxBrowserUseNonLocalNavigationPatch,
   applyLinuxBrowserUseWebviewHostRecoveryPatch,
   applyLinuxBrowserUseWebviewRemountStorePatch,


### PR DESCRIPTION
<!-- optional-upstream-dmg-sha256:e3e3fe0df239028752e7744f336c4aa3652ddd66030bc08bfab69d96e9f8f32b -->
<!-- optional-review-policy:7 -->

## Summary
- repair best-effort optional Linux patch drift for the completed upstream DMG
- preserve the completed main watchdog and Nix campaign

## Validation
- warning-free exact-DMG acceptance recorded by the optional follow-up
- independent read-only review approved head `140bd8f5f26e15321832eac369f2524fe50f0514`
- general review evidence `23d4eff911a22802452b4fced6536a92599318aa8ad22a4e0cf6f91ad7957f21`
- removal audit evidence `not-required`
- all required GitHub checks must pass before guarded merge
