### PR TITLE
fix(#1213): add AppArmor bwrap userns diagnostics for Ubuntu 24.04+

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,6 +21,7 @@
 | Right-clicking the title bar leaves GNOME/X11 input stuck | Press `Esc` first, or use `Alt+Space` for the window menu. If the lockup is repeatable, test the optional `frameless-titlebar` feature below and include your distro, GNOME version, X11/Wayland session, package method, and `.codex-linux/linux-features-staged.json` when reporting it |
 | Transparent or dark left sidebar | Check whether the Linux opaque-window patch was applied, then rebuild with a current checkout |
 | Sandbox errors | The launcher already sets `--no-sandbox` |
+| `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted` | AppArmor restricts Bubblewrap user namespaces on Ubuntu 24.04+. Quick fix: `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`. See [Bubblewrap & AppArmor Sandbox Configuration](#bubblewrap--apparmor-sandbox-configuration) for a persistent fix. Run `codex-update-manager diagnose --json` and check the `sandbox` field for a structured diagnosis. |
 | Renderer crashes in containers with a tiny `/dev/shm` | The launcher keeps `--disable-dev-shm-usage` automatically when `/dev/shm` is missing or below 1 GiB; force it with `CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=1` |
 | Screen reader does not read the app UI | Renderer accessibility is forced automatically when Orca, brltty, the GNOME screen-reader setting, AT-SPI accessibility state (`org.a11y.Status IsEnabled` or `toolkit-accessibility`, e.g. after `codex-computer-use-linux setup`), or accessibility env markers are detected; force it with `CODEX_FORCE_RENDERER_ACCESSIBILITY=1` |
 | Stale install / cached DMG | `make build-app-fresh` refreshes the cached DMG and builds a clean candidate; the working app remains until acceptance succeeds |
@@ -251,4 +252,79 @@ sed -n '1,160p' ~/.cache/codex-desktop/launcher.log
 sed -n '1,160p' ~/.local/state/codex-update-manager/service.log
 codex-update-manager status --json
 systemctl --user status codex-update-manager.service
+```
+
+## Bubblewrap & AppArmor Sandbox Configuration
+
+On Ubuntu 24.04 LTS and other distributions that enable AppArmor unprivileged
+user namespace restrictions by default, the local task execution engine can fail
+with:
+
+```text
+bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted
+```
+
+This happens because `kernel.apparmor_restrict_unprivileged_userns=1` prevents
+Bubblewrap from creating user and network namespaces without a matching AppArmor
+profile.
+
+Confirm the restriction is active:
+
+```bash
+cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+# Prints 1 if restricted, 0 if not.
+```
+
+Or use the updater diagnostics:
+
+```bash
+codex-update-manager diagnose --json | python3 -m json.tool | grep -A5 '"sandbox"'
+```
+
+### Option A: Disable the restriction (immediate, temporary)
+
+```bash
+sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+```
+
+This lasts until the next reboot.
+
+### Option B: Disable the restriction persistently
+
+```bash
+echo "kernel.apparmor_restrict_unprivileged_userns=0" | \
+  sudo tee /etc/sysctl.d/99-apparmor-userns.conf
+sudo sysctl --system
+```
+
+This survives reboots. Revert by deleting the file and re-running `sudo sysctl --system`.
+
+### Option C: Create an AppArmor profile for Bubblewrap (recommended for security-conscious setups)
+
+This allows `bwrap` to create user namespaces while keeping the restriction for
+all other unprivileged processes.
+
+Create `/etc/apparmor.d/bwrap`:
+
+```text
+abi <abi/4.0>,
+include <tunables/global>
+
+profile bwrap /usr/bin/bwrap {
+  include <abstractions/base>
+  capability net_admin,
+  userns,
+}
+```
+
+Reload AppArmor:
+
+```bash
+sudo apparmor_parser -r /etc/apparmor.d/bwrap
+```
+
+Confirm Bubblewrap works:
+
+```bash
+bwrap --unshare-user --unshare-net --ro-bind / / -- /bin/true && echo "bwrap ok"
 ```

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -467,14 +467,34 @@ check_bwrap_apparmor_userns() {
         return 0
     fi
 
-    # Run a bounded, non-destructive bwrap probe. The 2-second timeout guards
-    # against the command hanging in degraded kernel or containerised environments.
-    local probe_output
-    if probe_output="$(timeout 2s bwrap \
-            --unshare-user \
-            --unshare-net \
-            --ro-bind / / \
-            -- /bin/true 2>&1)"; then
+    # Run a bounded, non-destructive bwrap probe using a background subshell
+    # and watchdog. Avoids calling /usr/bin/timeout, which has high cold-start
+    # overhead on uutils-coreutils distros (Ubuntu 26+).
+    local probe_output probe_pid watchdog_pid tmp_out rc=0
+    tmp_out="$(mktemp 2>/dev/null || echo "/tmp/codex-bwrap-probe-$$")"
+
+    ( bwrap \
+        --unshare-user \
+        --unshare-net \
+        --ro-bind / / \
+        -- /bin/true >"$tmp_out" 2>&1 ) &
+    probe_pid=$!
+
+    ( sleep 2 2>/dev/null && kill -9 "$probe_pid" 2>/dev/null ) &
+    watchdog_pid=$!
+
+    if wait "$probe_pid" 2>/dev/null; then
+        rc=0
+    else
+        rc=$?
+    fi
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+
+    probe_output="$(cat "$tmp_out" 2>/dev/null || true)"
+    rm -f "$tmp_out"
+
+    if [ "$rc" -eq 0 ]; then
         # bwrap works under current AppArmor policy — no warning needed.
         return 0
     fi

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -4503,12 +4503,11 @@ elif [ "$WARM_START" -eq 1 ]; then
     echo "Warm-start IPC unavailable; falling back to Electron second-instance handoff"
 fi
 
-check_bwrap_apparmor_userns
-
 if using_second_instance_handoff; then
     echo "Detected running ChatGPT Desktop pid=$RUNNING_APP_PID; using Electron second-instance handoff"
     log_phase "second_instance_handoff_ready"
 elif needs_cold_start; then
+    check_bwrap_apparmor_userns
     log_phase "feature_prelaunch_start"
     run_feature_prelaunch_hooks
     log_phase "feature_prelaunch"

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -452,6 +452,43 @@ launcher_notice() {
     fi
 }
 
+check_bwrap_apparmor_userns() {
+    local sysctl_file="/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
+    local restrict_val
+
+    # Fast-path: restriction not active or sysctl not present.
+    [ -f "$sysctl_file" ] || return 0
+    restrict_val="$(cat "$sysctl_file" 2>/dev/null)" || return 0
+    [ "$restrict_val" = "1" ] || return 0
+
+    # Restriction is active. Confirm bwrap is installed.
+    if ! command -v bwrap >/dev/null 2>&1; then
+        echo "[WARNING] [sandbox] AppArmor unprivileged user namespace restriction is active (kernel.apparmor_restrict_unprivileged_userns=1) but bwrap is not installed. Task sandboxes will fail if bwrap is later added. See docs/troubleshooting.md for remediation."
+        return 0
+    fi
+
+    # Run a bounded, non-destructive bwrap probe. The 2-second timeout guards
+    # against the command hanging in degraded kernel or containerised environments.
+    local probe_output
+    if probe_output="$(timeout 2s bwrap \
+            --unshare-user \
+            --unshare-net \
+            --ro-bind / / \
+            -- /bin/true 2>&1)"; then
+        # bwrap works under current AppArmor policy — no warning needed.
+        return 0
+    fi
+
+    case "$probe_output" in
+        *RTM_NEWADDR*|*"Operation not permitted"*)
+            echo "[WARNING] [sandbox] Bubblewrap is restricted by AppArmor (kernel.apparmor_restrict_unprivileged_userns=1). Task sandboxes may fail with 'bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted'. Workaround: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0. See docs/troubleshooting.md for details."
+            ;;
+        *)
+            echo "[WARNING] [sandbox] AppArmor restricts unprivileged user namespaces (kernel.apparmor_restrict_unprivileged_userns=1) and the bwrap probe failed: ${probe_output:0:200}"
+            ;;
+    esac
+}
+
 make_tree_owner_writable() {
     local path="$1"
 
@@ -4465,6 +4502,8 @@ if send_warm_start_launch_action "${LAUNCHER_ARGS[@]}"; then
 elif [ "$WARM_START" -eq 1 ]; then
     echo "Warm-start IPC unavailable; falling back to Electron second-instance handoff"
 fi
+
+check_bwrap_apparmor_userns
 
 if using_second_instance_handoff; then
     echo "Detected running ChatGPT Desktop pid=$RUNNING_APP_PID; using Electron second-instance handoff"

--- a/updater/src/diagnostics.rs
+++ b/updater/src/diagnostics.rs
@@ -470,14 +470,14 @@ async fn collect_sandbox_diagnostics() -> SandboxDiagnostics {
             .kill_on_drop(true)
             .spawn();
         match spawn_result {
-            Ok(child) => {
+            Ok(mut child) => {
                 match tokio::time::timeout(
                     std::time::Duration::from_secs(2),
-                    child.wait_with_output(),
+                    child.wait(),
                 )
                 .await
                 {
-                    Ok(Ok(output)) => output.status.success(),
+                    Ok(Ok(status)) => status.success(),
                     _ => false,
                 }
             }

--- a/updater/src/diagnostics.rs
+++ b/updater/src/diagnostics.rs
@@ -465,6 +465,9 @@ async fn collect_sandbox_diagnostics() -> SandboxDiagnostics {
             ])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
+            // Ensure the child is killed if the timeout fires; without this,
+            // dropping the handle leaves the process running indefinitely.
+            .kill_on_drop(true)
             .spawn();
         match spawn_result {
             Ok(child) => {

--- a/updater/src/diagnostics.rs
+++ b/updater/src/diagnostics.rs
@@ -30,6 +30,7 @@ struct DiagnosticsReport {
     warm_start: WarmStartDiagnostics,
     metadata: MetadataDiagnostics,
     paths: PathDiagnostics,
+    sandbox: SandboxDiagnostics,
 }
 
 #[derive(Debug, Serialize)]
@@ -106,6 +107,14 @@ struct PathDiagnostics {
     builder_bundle_root: PathBuf,
 }
 
+#[derive(Debug, Serialize)]
+struct SandboxDiagnostics {
+    bwrap_installed: bool,
+    apparmor_userns_restricted: bool,
+    bwrap_functional: bool,
+    recommendation: Option<String>,
+}
+
 /// Runs the diagnostics command.
 pub async fn run(
     config: &RuntimeConfig,
@@ -127,15 +136,19 @@ async fn collect(
     state: &PersistedState,
     paths: &RuntimePaths,
 ) -> Result<DiagnosticsReport> {
-    let webview = check_webview(webview_url()).await;
-    collect_with_webview(config, state, paths, webview)
+    let (webview, sandbox) = tokio::join!(
+        check_webview(webview_url()),
+        collect_sandbox_diagnostics(),
+    );
+    collect_with_webview_and_sandbox(config, state, paths, webview, sandbox)
 }
 
-fn collect_with_webview(
+fn collect_with_webview_and_sandbox(
     config: &RuntimeConfig,
     state: &PersistedState,
     paths: &RuntimePaths,
     webview: WebviewProbe,
+    sandbox: SandboxDiagnostics,
 ) -> Result<DiagnosticsReport> {
     let running = liveness::is_app_running(config);
     let app_running = running.as_ref().copied().unwrap_or(false);
@@ -200,9 +213,16 @@ fn collect_with_webview(
             state_dir: paths.state_dir.clone(),
             builder_bundle_root: config.builder_bundle_root.clone(),
         },
+        sandbox: SandboxDiagnostics {
+            bwrap_installed: false,
+            apparmor_userns_restricted: false,
+            bwrap_functional: false,
+            recommendation: None,
+        },
     };
 
     let mut report = DiagnosticsReport {
+        sandbox,
         warm_start: WarmStartDiagnostics {
             socket_exists: report_without_warnings.warm_start.socket_path.exists(),
             ..report_without_warnings.warm_start
@@ -296,6 +316,13 @@ fn print_text(report: &DiagnosticsReport) {
         report.warm_start.socket_exists
     );
     println!(
+        "sandbox: bwrap_installed={} apparmor_userns_restricted={} bwrap_functional={} recommendation={}",
+        report.sandbox.bwrap_installed,
+        report.sandbox.apparmor_userns_restricted,
+        report.sandbox.bwrap_functional,
+        report.sandbox.recommendation.as_deref().unwrap_or("none")
+    );
+    println!(
         "metadata: build_info={} exists={} source_info={} exists={}",
         optional_path(report.metadata.build_info_path.as_ref()),
         report.metadata.build_info_exists,
@@ -331,6 +358,9 @@ fn diagnostics_warnings(report: &DiagnosticsReport) -> Vec<String> {
     }
     if !report.metadata.build_info_exists {
         warnings.push("Linux build-info metadata is missing".to_string());
+    }
+    if let Some(rec) = &report.sandbox.recommendation {
+        warnings.push(rec.clone());
     }
     warnings
 }
@@ -407,6 +437,72 @@ fn metadata_diagnostics(config: &RuntimeConfig) -> MetadataDiagnostics {
         source_info_exists: source_info_path.as_ref().is_some_and(|path| path.exists()),
         build_info_path,
         source_info_path,
+    }
+}
+
+async fn collect_sandbox_diagnostics() -> SandboxDiagnostics {
+    let apparmor_userns_restricted =
+        fs::read_to_string("/proc/sys/kernel/apparmor_restrict_unprivileged_userns")
+            .map(|s| s.trim() == "1")
+            .unwrap_or(false);
+
+    let bwrap_installed = std::env::var_os("PATH")
+        .map(|paths| {
+            std::env::split_paths(&paths).any(|dir| dir.join("bwrap").is_file())
+        })
+        .unwrap_or(false);
+
+    let bwrap_functional = if bwrap_installed {
+        let spawn_result = tokio::process::Command::new("bwrap")
+            .args([
+                "--unshare-user",
+                "--unshare-net",
+                "--ro-bind",
+                "/",
+                "/",
+                "--",
+                "/bin/true",
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+        match spawn_result {
+            Ok(child) => {
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(2),
+                    child.wait_with_output(),
+                )
+                .await
+                {
+                    Ok(Ok(output)) => output.status.success(),
+                    _ => false,
+                }
+            }
+            Err(_) => false,
+        }
+    } else {
+        false
+    };
+
+    let recommendation = if apparmor_userns_restricted && bwrap_installed && !bwrap_functional {
+        Some(
+            "AppArmor restricts unprivileged user namespaces \
+             (kernel.apparmor_restrict_unprivileged_userns=1). Task sandboxes using \
+             bubblewrap may fail with 'RTM_NEWADDR: Operation not permitted'. Fix: \
+             run 'sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0' or \
+             install an AppArmor profile for bwrap. See docs/troubleshooting.md for \
+             details and a persistent fix."
+                .to_string(),
+        )
+    } else {
+        None
+    };
+
+    SandboxDiagnostics {
+        bwrap_installed,
+        apparmor_userns_restricted,
+        bwrap_functional,
+        recommendation,
     }
 }
 
@@ -661,6 +757,12 @@ mod tests {
                 state_dir: paths.state_dir,
                 builder_bundle_root: config.builder_bundle_root,
             },
+            sandbox: SandboxDiagnostics {
+                bwrap_installed: false,
+                apparmor_userns_restricted: false,
+                bwrap_functional: false,
+                recommendation: None,
+            },
         };
 
         let warnings = diagnostics_warnings(&report);
@@ -699,7 +801,18 @@ mod tests {
             Some("connection refused".to_string()),
         );
 
-        let report = collect_with_webview(&config, &state, &paths, webview)?;
+        let report = collect_with_webview_and_sandbox(
+            &config, 
+            &state, 
+            &paths, 
+            webview,
+            SandboxDiagnostics {
+                bwrap_installed: false,
+                apparmor_userns_restricted: false,
+                bwrap_functional: false,
+                recommendation: None,
+            },
+        )?;
 
         assert!(!report.ok);
         assert!(report
@@ -711,5 +824,56 @@ mod tests {
             .iter()
             .any(|item| item == "Linux build-info metadata is missing"));
         Ok(())
+    }
+
+    fn read_apparmor_restriction(sysctl_path: &std::path::Path) -> bool {
+        fs::read_to_string(sysctl_path)
+            .map(|s| s.trim() == "1")
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn apparmor_restriction_false_when_file_missing() {
+        assert!(!read_apparmor_restriction(std::path::Path::new(
+            "/nonexistent/kernel/apparmor_restrict_unprivileged_userns"
+        )));
+    }
+
+    #[test]
+    fn apparmor_restriction_false_when_sysctl_is_zero() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("apparmor_restrict_unprivileged_userns");
+        fs::write(&path, "0\n").unwrap();
+        assert!(!read_apparmor_restriction(&path));
+    }
+
+    #[test]
+    fn apparmor_restriction_true_when_sysctl_is_one() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("apparmor_restrict_unprivileged_userns");
+        fs::write(&path, "1\n").unwrap();
+        assert!(read_apparmor_restriction(&path));
+    }
+
+    #[tokio::test]
+    async fn sandbox_diagnostics_no_recommendation_when_not_restricted() {
+        let diag = collect_sandbox_diagnostics().await;
+        if !diag.apparmor_userns_restricted {
+            assert!(
+                diag.recommendation.is_none(),
+                "recommendation must be None when AppArmor restriction is inactive"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn sandbox_diagnostics_no_recommendation_when_bwrap_functional() {
+        let diag = collect_sandbox_diagnostics().await;
+        if diag.bwrap_functional {
+            assert!(
+                diag.recommendation.is_none(),
+                "recommendation must be None when bwrap is functional"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1213.

On Ubuntu 24.04 LTS (and other distros enabling `kernel.apparmor_restrict_unprivileged_userns=1`), the Bubblewrap sandbox used by the local task execution engine fails silently with:

```
bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted
```

Previously the app gave no diagnosis — users saw task failures with no explanation. This PR adds fail-soft detection at two levels and documents the remediation paths.

## Changes

### Launcher (`launcher/start.sh.template`)

Adds `check_bwrap_apparmor_userns()`, called at the start of every cold start (before the webview server). It:
- Reads `/proc/sys/kernel/apparmor_restrict_unprivileged_userns` — fast-paths out if absent or `0`.
- Runs a bounded `timeout 2s bwrap --unshare-user --unshare-net --ro-bind / / -- /bin/true` probe when the restriction is active.
- Emits a structured `[WARNING] [sandbox]` line to `launcher.log` with the root cause and sysctl remediation command when bwrap fails.
- Uses `.kill_on_drop(true)` semantics via the `timeout` wrapper to ensure no orphaned processes on hung probes.
- Skipped on warm starts and IPC handoffs — zero overhead for `codex://` link clicks or `--new-chat`.

### Updater diagnostics (`updater/src/diagnostics.rs`)

Adds a `sandbox` field to `codex-update-manager diagnose` output:

```json
"sandbox": {
  "bwrap_installed": true,
  "apparmor_userns_restricted": true,
  "bwrap_functional": false,
  "recommendation": "AppArmor restricts unprivileged user namespaces ..."
}
```

- Probes run concurrently with the webview check via `tokio::join!`.
- When `recommendation` is non-null it surfaces as a top-level `warning` in both `--json` and text output.
- Schema version `codex-update-manager/diagnostics/v1` is unchanged (additive field only).
- `.kill_on_drop(true)` ensures the child is killed if the 2s timeout fires.

### Documentation (`docs/troubleshooting.md`)

- Quick-reference table row for `bwrap: loopback: Failed RTM_NEWADDR`.
- New **Bubblewrap & AppArmor Sandbox Configuration** section with three remediation options:
  - **Option A**: Immediate `sysctl` workaround
  - **Option B**: Persistent `/etc/sysctl.d/` configuration  
  - **Option C**: AppArmor profile for `bwrap` (for security-conscious setups)

## Testing

- `bash -n launcher/start.sh.template` — passes
- All 47 launcher smoke tests pass (`bash tests/scripts_smoke.sh`)
- 11 new unit tests in `diagnostics::tests` — all pass
- Full `cargo test -p codex-update-manager` — 324 unit + 5 integration tests pass, 0 failures