### PR TITLE
Fix Chrome plugin env compatibility and stale cache refresh

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1251,6 +1251,7 @@ sync_chrome_bundled_plugin_cache() {
     local managed_cache_plugin
     local managed_cache_client
     local managed_tmp_plugin
+    local managed_backup_plugin
     local marketplace_root
     local marketplace_plugins_dir
     local marketplace_plugin_link
@@ -1397,16 +1398,33 @@ sync_chrome_bundled_plugin_cache() {
         [ -d "$managed_cache_plugin" ] && [ ! -L "$managed_cache_plugin" ] && \
         { [ ! -f "$managed_cache_client" ] || ! cmp -s "$source_client" "$managed_cache_client"; }; then
         managed_tmp_plugin="$managed_cache_root/.chrome-$version.linux-refresh.$$"
-        remove_tree_if_exists "$managed_tmp_plugin"
-        if cp -R "$source_plugin" "$managed_tmp_plugin"; then
-            find "$managed_tmp_plugin" -type f -name '*:com.apple.*' -delete
+        managed_backup_plugin="$managed_cache_root/.chrome-$version.linux-backup.$$"
+        if ! remove_tree_if_exists "$managed_tmp_plugin" || \
+           ! remove_tree_if_exists "$managed_backup_plugin"; then
+            echo "Chrome app-server cache refresh preparation failed; continuing with the existing install."
+        elif cp -R "$source_plugin" "$managed_tmp_plugin"; then
             make_tree_owner_writable "$managed_tmp_plugin"
             chmod --reference="$managed_cache_plugin" "$managed_tmp_plugin" 2>/dev/null || true
-            remove_tree_if_exists "$managed_cache_plugin"
-            mv "$managed_tmp_plugin" "$managed_cache_plugin"
-            echo "Chrome app-server cache refreshed from bundled resources: $managed_cache_plugin"
+            if ! find "$managed_tmp_plugin" -type f -name '*:com.apple.*' -delete; then
+                remove_tree_if_exists "$managed_tmp_plugin" || true
+                echo "Chrome app-server cache refresh cleanup failed; continuing with the existing install."
+            elif ! mv -T -- "$managed_cache_plugin" "$managed_backup_plugin"; then
+                remove_tree_if_exists "$managed_tmp_plugin" || true
+                echo "Chrome app-server cache refresh failed; existing cache was preserved."
+            elif mv -T -- "$managed_tmp_plugin" "$managed_cache_plugin"; then
+                remove_tree_if_exists "$managed_backup_plugin" || \
+                    echo "Chrome app-server cache backup cleanup failed: $managed_backup_plugin"
+                echo "Chrome app-server cache refreshed from bundled resources: $managed_cache_plugin"
+            else
+                remove_tree_if_exists "$managed_tmp_plugin" || true
+                if mv -T -- "$managed_backup_plugin" "$managed_cache_plugin"; then
+                    echo "Chrome app-server cache refresh failed; previous cache was restored."
+                else
+                    echo "Chrome app-server cache refresh failed and the previous cache could not be restored: $managed_backup_plugin"
+                fi
+            fi
         else
-            remove_tree_if_exists "$managed_tmp_plugin"
+            remove_tree_if_exists "$managed_tmp_plugin" || true
             echo "Chrome app-server cache refresh failed; continuing with the existing install."
         fi
     fi

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1247,6 +1247,10 @@ sync_chrome_bundled_plugin_cache() {
     local cache_install_manifest
     local cache_parent
     local tmp_plugin
+    local managed_cache_root
+    local managed_cache_plugin
+    local managed_cache_client
+    local managed_tmp_plugin
     local marketplace_root
     local marketplace_plugins_dir
     local marketplace_plugin_link
@@ -1379,6 +1383,33 @@ sync_chrome_bundled_plugin_cache() {
         return 0
     fi
     replace_symlink "$version" "$cache_root/latest"
+
+    # app-server keys its managed plugin cache by the upstream version. Linux
+    # compatibility patches do not change that version, so an already-installed
+    # Chrome plugin can otherwise keep stale JavaScript after an RPM upgrade.
+    # Refresh an existing same-version install from the bundled source while
+    # leaving this app-server-owned tree writable and outside the trusted native
+    # host/runtime cache above.
+    managed_cache_root="$codex_home/plugins/cache/openai-bundled/chrome"
+    managed_cache_plugin="$managed_cache_root/$version"
+    managed_cache_client="$managed_cache_plugin/scripts/browser-client.mjs"
+    if [ -d "$managed_cache_root" ] && [ ! -L "$managed_cache_root" ] && \
+        [ -d "$managed_cache_plugin" ] && [ ! -L "$managed_cache_plugin" ] && \
+        { [ ! -f "$managed_cache_client" ] || ! cmp -s "$source_client" "$managed_cache_client"; }; then
+        managed_tmp_plugin="$managed_cache_root/.chrome-$version.linux-refresh.$$"
+        remove_tree_if_exists "$managed_tmp_plugin"
+        if cp -R "$source_plugin" "$managed_tmp_plugin"; then
+            find "$managed_tmp_plugin" -type f -name '*:com.apple.*' -delete
+            make_tree_owner_writable "$managed_tmp_plugin"
+            chmod --reference="$managed_cache_plugin" "$managed_tmp_plugin" 2>/dev/null || true
+            remove_tree_if_exists "$managed_cache_plugin"
+            mv "$managed_tmp_plugin" "$managed_cache_plugin"
+            echo "Chrome app-server cache refreshed from bundled resources: $managed_cache_plugin"
+        else
+            remove_tree_if_exists "$managed_tmp_plugin"
+            echo "Chrome app-server cache refresh failed; continuing with the existing install."
+        fi
+    fi
 
     marketplace_root="$codex_home/.tmp/bundled-marketplaces/openai-bundled"
     marketplace_plugins_dir="$marketplace_root/.agents/plugins"

--- a/scripts/lib/browser-client-node-repl-runtime.test.js
+++ b/scripts/lib/browser-client-node-repl-runtime.test.js
@@ -2,8 +2,9 @@
 "use strict";
 
 const assert = require("node:assert/strict");
-const { spawn } = require("node:child_process");
+const { spawn, spawnSync } = require("node:child_process");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const readline = require("node:readline");
 const test = require("node:test");
@@ -108,6 +109,63 @@ function runNodeReplImport(runtime, clients) {
     });
   });
 }
+
+test("guards every Browser client nodeRepl env read", () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "browser-client-env-guard-"));
+  const clientPath = path.join(fixtureRoot, "browser-client.mjs");
+  const patcher = path.join(__dirname, "bundled-plugins.sh");
+  const client = [
+    'var Es="BROWSER_USE_SECURITY_MODE",Bl="BROWSER_USE_AUTOMATED_SAFETY_PRECHECKS_ENABLED",Ai;',
+    'function ye(){return globalThis.nodeRepl}',
+    'function sT(e){if(Ai!=null)return()=>{};let t=Object.freeze({nodeRepl:e,createElicitation:e.createElicitation,env:e.env,securityMode:e.env[Es],enabled:e.env[Bl]==="1"});return Ai=t,()=>{Ai===t&&(Ai=void 0)}}',
+    'function Bm(){let e=Ai;if(e==null)return!0;let t=ye();return t===e.nodeRepl&&t.env===e.env&&t.createElicitation===e.createElicitation&&t.env[Es]===e.securityMode&&t.env[Bl]==="1"===e.enabled}',
+    'function Ou(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}',
+  ].join("");
+
+  try {
+    fs.writeFileSync(clientPath, client, "utf8");
+    const applyGuard = () =>
+      spawnSync(
+        "bash",
+        [
+          "-c",
+          'source "$1"; patch_browser_use_node_repl_env_guard "$2"',
+          "browser-client-env-guard",
+          patcher,
+          clientPath,
+        ],
+        { encoding: "utf8" },
+      );
+
+    const first = applyGuard();
+    assert.equal(first.status, 0, first.stderr);
+    const patched = fs.readFileSync(clientPath, "utf8");
+    assert.match(patched, /codexLinuxBrowserUseNodeReplEnvGuard/);
+    assert.match(patched, /globalThis\.nodeRepl\?\.env\?\.\[e\]/);
+    assert.doesNotMatch(patched, /\b[A-Za-z_$][\w$]*\.env\[[^\]]+\]/);
+    assert.equal((patched.match(/\.env\?\.\[/g) ?? []).length, 5);
+
+    const second = applyGuard();
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(fs.readFileSync(clientPath, "utf8"), patched);
+
+    const previousNodeRepl = globalThis.nodeRepl;
+    try {
+      globalThis.nodeRepl = {};
+      const initializeSecurityState = new Function(
+        `${patched};return {dispose:sT(globalThis.nodeRepl),valid:Bm()}`,
+      );
+      const securityState = initializeSecurityState();
+      assert.equal(securityState.valid, true);
+      assert.equal(typeof securityState.dispose, "function");
+      securityState.dispose();
+    } finally {
+      globalThis.nodeRepl = previousNodeRepl;
+    }
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
 
 test(
   "staged Browser and Chrome clients import through the real node_repl runtime",

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -1253,7 +1253,7 @@ PY
 patch_browser_use_node_repl_env_guard() {
     local client="$1"
 
-    if grep -Eq 'globalThis\.nodeRepl\?\.env\?\.\[[^]]+\]' "$client"; then
+    if grep -q "codexLinuxBrowserUseNodeReplEnvGuard" "$client"; then
         return 0
     fi
 
@@ -1264,28 +1264,53 @@ import sys
 
 path = Path(sys.argv[1])
 source = path.read_text(encoding="utf-8")
-pattern = re.compile(
+helper_pattern = re.compile(
     r'function (?P<helper>[A-Za-z_$][\w$]*)\((?P<key>[A-Za-z_$][\w$]*)\)\{'
     r'let (?P<value>[A-Za-z_$][\w$]*)=globalThis\.nodeRepl\?\.env\[(?P=key)\];'
     r'return typeof (?P=value)=="string"\?(?P=value):void 0\}'
 )
-match = pattern.search(source)
-if match is None:
+helper_match = helper_pattern.search(source)
+if helper_match is not None:
+    helper = helper_match.group("helper")
+    key = helper_match.group("key")
+    value = helper_match.group("value")
+    replacement = (
+        f'function {helper}({key}){{'
+        f'let {value}=globalThis.nodeRepl?.env?.[{key}];'
+        f'return typeof {value}=="string"?{value}:void 0}}'
+    )
+    source = source[:helper_match.start()] + replacement + source[helper_match.end():]
+
+# Newer Browser clients snapshot privileged node_repl state before creating the
+# browser agent. Older Linux node_repl runtimes do not expose `env`, so every
+# direct property read must preserve the upstream default behavior when it is
+# absent. Keep the object identity comparison itself unchanged.
+direct_env_pattern = re.compile(
+    r'(?P<object>\b[A-Za-z_$][\w$]*)\.env\[(?P<key>[^\]]+)\]'
+)
+source, direct_env_count = direct_env_pattern.subn(
+    r'\g<object>.env?.[\g<key>]',
+    source,
+)
+
+if helper_match is None and direct_env_count == 0:
     print(
         "WARN: Could not find Browser Use nodeRepl env guard insertion point — leaving browser-client.mjs unchanged",
         file=sys.stderr,
     )
     raise SystemExit(0)
 
-helper = match.group("helper")
-key = match.group("key")
-value = match.group("value")
-replacement = (
-    f'function {helper}({key}){{'
-    f'let {value}=globalThis.nodeRepl?.env?.[{key}];'
-    f'return typeof {value}=="string"?{value}:void 0}}'
+marker_target = (
+    "globalThis.nodeRepl?.env?.["
+    if "globalThis.nodeRepl?.env?.[" in source
+    else ".env?.["
 )
-path.write_text(source[:match.start()] + replacement + source[match.end():], encoding="utf-8")
+source = source.replace(
+    marker_target,
+    f"/*codexLinuxBrowserUseNodeReplEnvGuard*/{marker_target}",
+    1,
+)
+path.write_text(source, encoding="utf-8")
 PY
 }
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6524,6 +6524,9 @@ for (const required of [
   'make_tree_owner_trusted "$tmp_plugin"',
   'make_tree_owner_trusted "$cache_plugin"',
   'managed_cache_root="$codex_home/plugins/cache/openai-bundled/chrome"',
+  'managed_backup_plugin="$managed_cache_root/.chrome-$version.linux-backup.$$"',
+  'mv -T -- "$managed_cache_plugin" "$managed_backup_plugin"',
+  'previous cache was restored',
   'Chrome app-server cache refreshed from bundled resources',
   'write_chrome_native_host_manifests "$host_path" "$cache_root/latest"',
 ]) {
@@ -6594,6 +6597,7 @@ SCRIPT_DIR="$root/app"
 HOME="$root/home"
 CODEX_HOME="$HOME/.codex"
 source_plugin="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/chrome"
+source_client="$source_plugin/scripts/browser-client.mjs"
 cache_root="$CODEX_HOME/plugins/linux-runtime-cache/openai-bundled/chrome"
 cache_plugin="$cache_root/26.test"
 
@@ -6679,6 +6683,31 @@ sync_chrome_bundled_plugin_cache
 
 grep -qx trusted-module "$cache_plugin/scripts/node_modules/classic-level.mjs"
 grep -qx trusted-client "$official_client"
+
+# A failed promotion must restore the previous app-server-owned cache and must
+# not abort the cold-start sync under set -e.
+printf '%s\n' replacement-client > "$source_client"
+mv() {
+  local args=("$@")
+  local argc="${#args[@]}"
+  local source="${args[$((argc - 2))]}"
+  local destination="${args[$((argc - 1))]}"
+  if [[ "$source" == *".linux-refresh."* ]] && [ "$destination" = "$official_plugin" ]; then
+    return 73
+  fi
+  command mv "$@"
+}
+sync_chrome_bundled_plugin_cache > "$root/managed-cache-promotion-failure.log" 2>&1
+grep -qx trusted-client "$official_client"
+grep -q "previous cache was restored" "$root/managed-cache-promotion-failure.log"
+if find "$official_cache" -mindepth 1 -maxdepth 1 -type d \
+    \( -name '*.linux-refresh.*' -o -name '*.linux-backup.*' \) -print -quit | grep -q .; then
+  echo "Chrome app-server cache refresh left temporary or backup directories after restoration" >&2
+  exit 1
+fi
+unset -f mv
+printf '%s\n' trusted-client > "$source_client"
+
 for trusted_path in \
   "$CODEX_HOME" \
   "$CODEX_HOME/plugins" \

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6523,6 +6523,8 @@ for (const required of [
   'cache_was_untrusted=1',
   'make_tree_owner_trusted "$tmp_plugin"',
   'make_tree_owner_trusted "$cache_plugin"',
+  'managed_cache_root="$codex_home/plugins/cache/openai-bundled/chrome"',
+  'Chrome app-server cache refreshed from bundled resources',
   'write_chrome_native_host_manifests "$host_path" "$cache_root/latest"',
 ]) {
   if (!chromeBody.includes(required)) {
@@ -6655,11 +6657,13 @@ chmod -R go-w "$SCRIPT_DIR"
 official_cache="$CODEX_HOME/plugins/cache/openai-bundled/chrome"
 official_plugin="$official_cache/26.test"
 official_host="$official_plugin/extension-host/linux/x64/extension-host"
-mkdir -p "$(dirname "$official_host")"
+official_client="$official_plugin/scripts/browser-client.mjs"
+mkdir -p "$(dirname "$official_host")" "$(dirname "$official_client")"
 cat > "$official_host" <<'HOST'
 #!/usr/bin/env bash
 printf '%s\n' OFFICIAL
 HOST
+printf '%s\n' stale-client > "$official_client"
 chmod 0755 "$official_host"
 ln -s 26.test "$official_cache/latest"
 chmod 0775 \
@@ -6674,6 +6678,7 @@ chmod 0775 \
 sync_chrome_bundled_plugin_cache
 
 grep -qx trusted-module "$cache_plugin/scripts/node_modules/classic-level.mjs"
+grep -qx trusted-client "$official_client"
 for trusted_path in \
   "$CODEX_HOME" \
   "$CODEX_HOME/plugins" \


### PR DESCRIPTION
## Summary

- guard every direct Browser/Chrome client `nodeRepl.env[...]` read when staging the current upstream plugin
- atomically refresh an existing same-version app-server Chrome plugin cache from the patched bundled source on cold start
- keep the app-server-owned install separate from the hardened Linux native-host/runtime cache
- add regression coverage for the current minified security-state code and stale managed-cache behavior

## Root cause

The current upstream Browser client snapshots security settings through several direct `env` reads. The Linux fallback `node_repl` runtime does not expose `env`, while the compatibility patch only guarded the older global helper read. Browser setup therefore crashed before it could connect to Chrome.

After fixing the staged client, existing installations could still load the unpatched JavaScript because app-server keys its managed plugin cache by the unchanged upstream plugin version. Installing a rebuilt native package did not invalidate that same-version cache.

## User impact

Chrome browser control can initialize with the Linux fallback runtime even when `nodeRepl.env` is absent. Native package upgrades also repair an existing stale same-version Chrome install during cold-start cache synchronization instead of requiring users to delete `~/.codex` state manually.

## Validation

- `bash -n launcher/start.sh.template`
- `bash -n scripts/lib/bundled-plugins.sh`
- `node --test scripts/lib/browser-client-node-repl-runtime.test.js`
- real staged Browser and Chrome clients imported through the bundled Linux `node_repl` runtime
- transactional candidate rebuild accepted against the current upstream DMG
- RPM built and inspected for both the env-guard marker and managed-cache refresh logic
- `bash tests/scripts_smoke.sh` passed the relevant Chrome cache/permission probes; its final warm-start recovery check could not run because the installed desktop app was intentionally still running and was detected as a conflicting instance

The fix was also verified end-to-end against a running Chrome extension session after refreshing the stale managed cache.
