### PR TITLE
Retarget Dock icon to the current main bundle

### DIFF
--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -224,16 +224,32 @@ test("main patch rejects drift at every current-DMG insertion point byte-identic
   }
 });
 
-test("main patch rejects mixed patched and clean contracts byte-identically", () => {
-  const mixed = applyDockIconMainPatch(currentMainSource).replace(
+test("main patch rejects drift at every patched insertion point byte-identically", () => {
+  const patched = applyDockIconMainPatch(currentMainSource);
+  const insertionPoints = [
+    "if(process.platform!==`darwin`&&process.platform!==`linux`||t==null)return null",
+    "function codexLinuxDockIconResourcePath(e){return process.platform===`linux`",
+    "E=e=>{if(!l.app.isPackaged&&process.platform!==`linux`)return null",
+    "P=function codexLinuxApplyDockIcon(t){",
     "F=()=>{if(!v&&process.platform!==`linux`)return",
-    "F=()=>{if(!v)return",
-  );
-  const { value, warnings } = captureWarns(() => applyDockIconMainPatch(mixed));
+    "if(v||process.platform===`linux`){F();let e=()=>",
+    "onWindowRegistered:e=>{I?.registerWindow(e),C?.(e),process.platform===`linux`&&setImmediate(F)}",
+    "n=codexLinuxRegisterTray(new l.Tray(process.platform===`linux`&&globalThis.codexLinuxDockIconImage&&!globalThis.codexLinuxDockIconImage.isEmpty()?globalThis.codexLinuxDockIconImage:t.defaultIcon));if(!W9)return",
+  ];
 
-  assert.equal(value, mixed);
-  assert.equal(warnings.length, 1);
-  assert.match(warnings[0], /current Dock icon main-process contract/);
+  for (const insertionPoint of insertionPoints) {
+    assert.equal(patched.includes(insertionPoint), true, insertionPoint);
+    const splitAt = Math.floor(insertionPoint.length / 2);
+    const drifted = patched.replace(
+      insertionPoint,
+      `${insertionPoint.slice(0, splitAt)}drift${insertionPoint.slice(splitAt)}`,
+    );
+    const { value, warnings } = captureWarns(() => applyDockIconMainPatch(drifted));
+
+    assert.equal(value, drifted, insertionPoint);
+    assert.equal(warnings.length, 1, insertionPoint);
+    assert.match(warnings[0], /current Dock icon main-process contract/);
+  }
 });
 
 test("main patch rejects duplicate clean, patched, and mixed contracts byte-identically", () => {
@@ -249,19 +265,6 @@ test("main patch rejects duplicate clean, patched, and mixed contracts byte-iden
     assert.equal(warnings.length, 1);
     assert.match(warnings[0], /current Dock icon main-process contract/);
   }
-});
-
-test("main patch rejects the previous DMG contract byte-identically", () => {
-  const previousDmgSource = currentMainSource
-    .replaceAll("MS(", "_S(")
-    .replace("n.gc.ChatGPT", "n.Ec.ChatGPT")
-    .replace("Yce({preference", "Gce({preference")
-    .replace("I?.registerWindow(e)", "ee?.registerWindow(e)");
-  const { value, warnings } = captureWarns(() => applyDockIconMainPatch(previousDmgSource));
-
-  assert.equal(value, previousDmgSource);
-  assert.equal(warnings.length, 1);
-  assert.match(warnings[0], /current Dock icon main-process contract/);
 });
 
 test("settings patch exposes the native row on Linux", () => {

--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -28,8 +28,8 @@ const {
 const currentAppInfoSource = [
   "function F_(e,t){return`icon-chatgpt`}",
   "function I_(e){return{dark:`icon-codex-dark-color.png`,light:`icon-codex-light.png`}}",
-  "function R_(e,t){if(process.platform!==`darwin`||t==null)return null;let n=I_(e),r=_S(`${F_(e,t)}.png`),i=_S(n.dark),a=_S(n.light);return r==null||i==null||a==null?null:{appDefault:r,codexDark:i,codexLight:a}}",
-  "function _S(e){if(e==null)return null;let t=l.app.isPackaged?(0,p.join)(process.resourcesPath,e):null,n=t!=null&&(0,_.existsSync)(t)?t:(0,p.join)(l.app.getAppPath(),`src`,`icons`,e),r=l.nativeImage.createFromPath(n);return r.isEmpty()?null:r.resize({width:128,height:128,quality:`best`}).toDataURL()}",
+  "function R_(e,t){if(process.platform!==`darwin`||t==null)return null;let n=I_(e),r=MS(`${F_(e,t)}.png`),i=MS(n.dark),a=MS(n.light);return r==null||i==null||a==null?null:{appDefault:r,codexDark:i,codexLight:a}}",
+  "function MS(e){if(e==null)return null;let t=l.app.isPackaged?(0,p.join)(process.resourcesPath,e):null,n=t!=null&&(0,_.existsSync)(t)?t:(0,p.join)(l.app.getAppPath(),`src`,`icons`,e),r=l.nativeImage.createFromPath(n);return r.isEmpty()?null:r.resize({width:128,height:128,quality:`best`}).toDataURL()}",
 ].join("");
 
 const currentRuntimeSource = [
@@ -37,11 +37,11 @@ const currentRuntimeSource = [
   "let T=(0,p.join)(g,`electron`,`src`,`icons`),E=e=>{if(!l.app.isPackaged)return null;let t=(0,p.join)(process.resourcesPath,e);return(0,_.existsSync)(t)?t:null},",
   "D=e=>null,O=e=>E(e)??D(e),k=()=>f.get(n.js.DOCK_ICON_PREFERENCE)??`app-default`,",
   "A=()=>O(`${hS(i,e)}.png`),j=process.platform===`linux`?W5(i,e,T):null,M=gS(i),N=()=>l.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?M.dark:M.light,",
-  "P=t=>{if(t===`app-default`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.Ec.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)},",
-  "F=()=>{if(!v)return;let e=k();P(e),Gce({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})};",
+  "P=t=>{if(t===`app-default`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.gc.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)},",
+  "F=()=>{if(!v)return;let e=k();P(e),Yce({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})};",
   "if(v){F();let e=()=>{let e=k();e===`codex-system`&&P(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}",
-  "let ee=null,I=new xwe({onWindowRegistered:e=>{ee?.registerWindow(e),C?.(e)}});",
-  "return{updateDockIcon:F,windowManager:I}}",
+  "let I=null,L=new xwe({onWindowRegistered:e=>{I?.registerWindow(e),C?.(e)}});",
+  "return{updateDockIcon:F,windowManager:L}}",
 ].join("");
 
 const currentTraySource =
@@ -166,8 +166,8 @@ test("main patch enables official previews and synchronizes Linux window and tra
   assert.match(patched, /codexLinuxDockIconResourcePath/);
   assert.match(patched, /codexLinuxApplyDockIcon/);
   assert.match(patched, /i!==a\.a\.Dev/);
-  assert.match(patched, /e===n\.Ec\.ChatGPT/);
-  assert.doesNotMatch(patched, /n\.Ml\.ChatGPT/);
+  assert.match(patched, /e===n\.gc\.ChatGPT/);
+  assert.doesNotMatch(patched, /n\.Ec\.ChatGPT/);
   assert.match(patched, /process\.platform!==`darwin`&&process\.platform!==`linux`/);
   assert.match(
     patched,
@@ -190,7 +190,7 @@ test("main patch enables official previews and synchronizes Linux window and tra
   );
   assert.match(
     patched,
-    /onWindowRegistered:e=>\{ee\?\.registerWindow\(e\),C\?\.\(e\),process\.platform===`linux`&&setImmediate\(F\)\}/,
+    /onWindowRegistered:e=>\{I\?\.registerWindow\(e\),C\?\.\(e\),process\.platform===`linux`&&setImmediate\(F\)\}/,
   );
   assert.ok(
     patched.indexOf("setImmediate(F)") > 0,
@@ -200,12 +200,12 @@ test("main patch enables official previews and synchronizes Linux window and tra
 test("main patch rejects drift at every current-DMG insertion point byte-identically", () => {
   const insertionPoints = [
     "if(process.platform!==`darwin`||t==null)return null",
-    "function _S(e){if(e==null)return null",
+    "function MS(e){if(e==null)return null",
     "E=e=>{if(!l.app.isPackaged)return null",
     "P=t=>{if(t===`app-default`",
     "F=()=>{if(!v)return",
     "if(v){F();let e=()=>",
-    "onWindowRegistered:e=>{ee?.registerWindow(e),C?.(e)}",
+    "onWindowRegistered:e=>{I?.registerWindow(e),C?.(e)}",
     "codexLinuxRegisterTray(new l.Tray(t.defaultIcon))",
   ];
 
@@ -232,6 +232,34 @@ test("main patch rejects mixed patched and clean contracts byte-identically", ()
   const { value, warnings } = captureWarns(() => applyDockIconMainPatch(mixed));
 
   assert.equal(value, mixed);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /current Dock icon main-process contract/);
+});
+
+test("main patch rejects duplicate clean, patched, and mixed contracts byte-identically", () => {
+  const patched = applyDockIconMainPatch(currentMainSource);
+  for (const source of [
+    currentMainSource + currentMainSource,
+    patched + patched,
+    currentMainSource + patched,
+  ]) {
+    const { value, warnings } = captureWarns(() => applyDockIconMainPatch(source));
+
+    assert.equal(value, source);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /current Dock icon main-process contract/);
+  }
+});
+
+test("main patch rejects the previous DMG contract byte-identically", () => {
+  const previousDmgSource = currentMainSource
+    .replaceAll("MS(", "_S(")
+    .replace("n.gc.ChatGPT", "n.Ec.ChatGPT")
+    .replace("Yce({preference", "Gce({preference")
+    .replace("I?.registerWindow(e)", "ee?.registerWindow(e)");
+  const { value, warnings } = captureWarns(() => applyDockIconMainPatch(previousDmgSource));
+
+  assert.equal(value, previousDmgSource);
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /current Dock icon main-process contract/);
 });

--- a/linux-features/ui-tweaks/patches/dock-icon.js
+++ b/linux-features/ui-tweaks/patches/dock-icon.js
@@ -4,29 +4,29 @@ const currentPreviewGate = "if(process.platform!==`darwin`||t==null)return null"
 const patchedPreviewGate =
   "if(process.platform!==`darwin`&&process.platform!==`linux`||t==null)return null";
 const currentAppInfoResource =
-  "function _S(e){if(e==null)return null;let t=l.app.isPackaged?(0,p.join)(process.resourcesPath,e):null";
+  "function MS(e){if(e==null)return null;let t=l.app.isPackaged?(0,p.join)(process.resourcesPath,e):null";
 const patchedAppInfoResource =
-  "function codexLinuxDockIconResourcePath(e){return process.platform===`linux`?(0,p.join)(process.resourcesPath,`dock-icon`,e):(0,p.join)(process.resourcesPath,e)}function _S(e){if(e==null)return null;let t=l.app.isPackaged||process.platform===`linux`?codexLinuxDockIconResourcePath(e):null";
+  "function codexLinuxDockIconResourcePath(e){return process.platform===`linux`?(0,p.join)(process.resourcesPath,`dock-icon`,e):(0,p.join)(process.resourcesPath,e)}function MS(e){if(e==null)return null;let t=l.app.isPackaged||process.platform===`linux`?codexLinuxDockIconResourcePath(e):null";
 const currentWindowResource =
   "E=e=>{if(!l.app.isPackaged)return null;let t=(0,p.join)(process.resourcesPath,e);return(0,_.existsSync)(t)?t:null}";
 const patchedWindowResource =
   "E=e=>{if(!l.app.isPackaged&&process.platform!==`linux`)return null;let t=codexLinuxDockIconResourcePath(e);return(0,_.existsSync)(t)?t:null}";
 const currentApplyIcon =
-  "P=t=>{if(t===`app-default`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.Ec.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)}";
+  "P=t=>{if(t===`app-default`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.gc.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)}";
 const patchedApplyIcon =
-  "P=function codexLinuxApplyDockIcon(t){if(t===`app-default`&&process.platform!==`linux`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.Ec.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);if(s.isEmpty())return;if(process.platform===`linux`){let codexLinuxIconSelection=t===`codex-system`?(l.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?`codex-dark`:`codex-light`):`chatgpt`;codexLinuxIconSelection===`codex-dark`?s=s.crop({x:34,y:34,width:956,height:956}):codexLinuxIconSelection===`codex-light`&&(s=s.crop({x:13,y:23,width:998,height:998}));globalThis.codexLinuxDockIconImage=s;for(let e of l.BrowserWindow.getAllWindows())e.isDestroyed()||e.setIcon(s);codexLinuxTray!=null&&!codexLinuxTray.isDestroyed()&&codexLinuxTray.setImage(s);let codexLinuxSyncScript=codexLinuxDockIconResourcePath(`sync-desktop-icon.sh`);if(_.existsSync(codexLinuxSyncScript))try{let e=require(`node:child_process`).spawn(codexLinuxSyncScript,[codexLinuxIconSelection],{detached:!0,stdio:[`pipe`,`ignore`,`ignore`]});e.on(`error`,()=>{}),e.stdin.on(`error`,()=>{}),e.stdin.end(s.toPNG()),e.unref()}catch(e){}return}l.app.dock?.setIcon(s)}";
+  "P=function codexLinuxApplyDockIcon(t){if(t===`app-default`&&process.platform!==`linux`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.gc.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);if(s.isEmpty())return;if(process.platform===`linux`){let codexLinuxIconSelection=t===`codex-system`?(l.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?`codex-dark`:`codex-light`):`chatgpt`;codexLinuxIconSelection===`codex-dark`?s=s.crop({x:34,y:34,width:956,height:956}):codexLinuxIconSelection===`codex-light`&&(s=s.crop({x:13,y:23,width:998,height:998}));globalThis.codexLinuxDockIconImage=s;for(let e of l.BrowserWindow.getAllWindows())e.isDestroyed()||e.setIcon(s);codexLinuxTray!=null&&!codexLinuxTray.isDestroyed()&&codexLinuxTray.setImage(s);let codexLinuxSyncScript=codexLinuxDockIconResourcePath(`sync-desktop-icon.sh`);if(_.existsSync(codexLinuxSyncScript))try{let e=require(`node:child_process`).spawn(codexLinuxSyncScript,[codexLinuxIconSelection],{detached:!0,stdio:[`pipe`,`ignore`,`ignore`]});e.on(`error`,()=>{}),e.stdin.on(`error`,()=>{}),e.stdin.end(s.toPNG()),e.unref()}catch(e){}return}l.app.dock?.setIcon(s)}";
 const currentUpdateGate =
-  "F=()=>{if(!v)return;let e=k();P(e),Gce({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})}";
+  "F=()=>{if(!v)return;let e=k();P(e),Yce({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})}";
 const patchedUpdateGate =
-  "F=()=>{if(!v&&process.platform!==`linux`)return;let e=k();P(e),Gce({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})}";
+  "F=()=>{if(!v&&process.platform!==`linux`)return;let e=k();P(e),Yce({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})}";
 const currentThemeGate =
   "if(v){F();let e=()=>{let e=k();e===`codex-system`&&P(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}";
 const patchedThemeGate =
   "if(v||process.platform===`linux`){F();let e=()=>{let e=k();e===`codex-system`&&P(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}";
 const currentWindowRegistration =
-  "onWindowRegistered:e=>{ee?.registerWindow(e),C?.(e)}";
+  "onWindowRegistered:e=>{I?.registerWindow(e),C?.(e)}";
 const patchedWindowRegistration =
-  "onWindowRegistered:e=>{ee?.registerWindow(e),C?.(e),process.platform===`linux`&&setImmediate(F)}";
+  "onWindowRegistered:e=>{I?.registerWindow(e),C?.(e),process.platform===`linux`&&setImmediate(F)}";
 const currentTrayRegistration =
   "n=codexLinuxRegisterTray(new l.Tray(t.defaultIcon));if(!W9)return";
 const patchedTrayRegistration =


### PR DESCRIPTION
## Summary

- retarget the Dock icon main-process descriptor to the current `26.730.61639` desktop bundle aliases
- keep the patch current-DMG-only by replacing the obsolete aliases instead of retaining fallbacks
- reject incomplete, duplicate, and mixed clean/patched contracts byte-identically across all eight insertion points

On `origin/main`, a rebuild with the enabled Dock icon tweak was rejected only because `feature:ui-tweaks:appearance-dock-icon-main-process` no longer matched the active main bundle. The settings and search descriptors, plus all Suggested Prompts descriptors, still applied.

Current upstream identity:

- SHA-256: `33ad4701a1f723733313af05eb2816392b68b367eba0921dbe078d2d579719b5`
- HTTP fingerprint: `etag=0x8DEF2A335160056|last_modified=Wed, 05 Aug 2026 03:39:51 GMT|content_length=618651816`
- size: `618651816` bytes
- app version: `26.730.61639`
- Electron: `42.3.0`
- active main asset: `main-i-HoRaar.js`

## Validation

- `/usr/bin/node --check linux-features/ui-tweaks/patches/dock-icon.js`
- `/usr/bin/node --check linux-features/ui-tweaks/dock-icon.test.js`
- Dock icon feature tests: `27/27` passed
- complete UI Tweaks suite: `92/92` passed with `TMPDIR=/tmp`
- patcher suite: `411/411` passed with `TMPDIR=/tmp`
- Suggested Prompts feature tests passed unchanged as part of the UI Tweaks suite
- `git diff --check`
- current-DMG candidate acceptance from exact `a999a08` with Git provenance and `dirty=false`: `accepted_with_warnings`, no blockers
- the only acceptance warning was the pre-existing optional `linux-computer-use-ui-availability` drift, outside this Dock icon change
- full second pass was byte-identical (`8ba0db664f67e4c25c439ec25b85481c5fad76726e7e3ae3d08d07fd761aa372` before and after), with zero `applied` or `failed-integrity` descriptors
- all three Dock icon and all four Suggested Prompts descriptors reported `already-applied` on the second pass
- active `main-i-HoRaar.js`: `node --check` passed

Side-by-side runtime on KDE Plasma/Wayland:

- the exact clean candidate cold-started with the persisted ChatGPT Dock icon (`2048x2048`) while the installed daily driver remained separate
- `range-diff` confirmed the final rebase did not change any of the three commits; the remaining lifecycle checks below were run on that identical source diff before the rebase
- Appearance exposed all three official Dock icon choices; General still exposed Suggested Prompts
- changing Codex to ChatGPT updated only the candidate StatusNotifier icon immediately (`956x956` to `2048x2048`)
- a second candidate instance inherited the ChatGPT selection and its BrowserWindow/tray icon
- close-to-tray kept the second process and notifier alive; notifier activation restored the window
- tray Quit stopped only the selected candidate instance; the other candidate and installed daily driver remained alive

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] This targets only the latest `CODEX.DMG` and removes obsolete aliases without fallback code or historical fixtures.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
