### PR TITLE
fix(shared-app-server-socket): support systemd user adoption

### DIFF
--- a/linux-features/shared-app-server-socket/README.md
+++ b/linux-features/shared-app-server-socket/README.md
@@ -37,14 +37,15 @@ than the authority startup timeout, before they can be reclaimed when no socket
 exists.
 
 The launcher also cleans up a live authority orphaned by a terminated Desktop
-process. Cleanup is limited to a same-user, reparented `codex app-server
---listen unix://PATH` process serving the exact locked socket. Once the authority
-is ready, its PID and process-start identity are recorded in the ownership lock.
-The lock owner, socket inode, listener identity, command line, and process start
-identities are rechecked before signaling it. Unknown listeners, live Desktop
-owners, changed identities, and pathnames with multiple live listener inodes
-remain untouched. The same cleanup runs after Electron exits and before a later
-cold start.
+process. Cleanup is limited to a same-user `codex app-server --listen unix://PATH`
+process serving the exact locked socket after direct PID 1 adoption or adoption
+by a verified same-user `systemd --user` manager whose own parent is PID 1. Once
+the authority is ready, its PID and process-start identity are recorded in the
+ownership lock. The lock owner, socket inode, listener identity, command line,
+and process start identities are rechecked before signaling it. Unknown
+listeners, live Desktop owners, changed identities, and pathnames with multiple
+live listener inodes remain untouched. The same cleanup runs after Electron exits
+and before a later cold start.
 
 ## SSH setup
 

--- a/linux-features/shared-app-server-socket/orphan-reaper.js
+++ b/linux-features/shared-app-server-socket/orphan-reaper.js
@@ -2,6 +2,7 @@
 "use strict";
 
 const fs = require("node:fs");
+const path = require("node:path");
 
 const socketPath = process.argv[2];
 if (!socketPath) {
@@ -21,7 +22,8 @@ function readProcess(pid) {
     const procStat = fs.statSync(procPath);
     const rawStat = fs.readFileSync(`${procPath}/stat`, "utf8");
     const commandEnd = rawStat.lastIndexOf(")");
-    if (commandEnd < 0) return null;
+    const commandStart = rawStat.indexOf("(");
+    if (commandStart < 0 || commandEnd < 0) return null;
     const fields = rawStat.slice(commandEnd + 2).trim().split(/\s+/);
     const commandLine = fs
       .readFileSync(`${procPath}/cmdline`)
@@ -34,6 +36,7 @@ function readProcess(pid) {
       state: fields[0],
       ppid: Number(fields[1]),
       startTime: fields[19] ?? null,
+      comm: rawStat.slice(commandStart + 1, commandEnd),
       commandLine,
     };
   } catch (error) {
@@ -109,15 +112,42 @@ function isExpectedAuthority(processInfo) {
   );
 }
 
+function isVerifiedSystemdUserManager(processInfo) {
+  const executable = processInfo.commandLine[0];
+  return (
+    processInfo.comm === "systemd" &&
+    path.isAbsolute(executable) &&
+    path.basename(executable) === "systemd" &&
+    processInfo.commandLine.includes("--user")
+  );
+}
+
+function hasExpectedOrphanAdoption(authority) {
+  if (authority.ppid === 1) return true;
+
+  const adopter = readProcess(authority.ppid);
+  return (
+    adopter != null &&
+    isRunning(adopter) &&
+    (expectedUid == null || adopter.uid === expectedUid) &&
+    adopter.ppid === 1 &&
+    isVerifiedSystemdUserManager(adopter)
+  );
+}
+
+function isExpectedLockedAuthority(lock, authority) {
+  return (
+    authority != null &&
+    authority.startTime === lock.authorityStartTime &&
+    (expectedUid == null || authority.uid === expectedUid) &&
+    hasExpectedOrphanAdoption(authority) &&
+    isExpectedAuthority(authority)
+  );
+}
+
 function verifiedOrphanTargets(lock, listeners) {
   const authority = readProcess(lock.authorityPid);
-  if (
-    authority == null ||
-    authority.startTime !== lock.authorityStartTime ||
-    (expectedUid != null && authority.uid !== expectedUid) ||
-    authority.ppid !== 1 ||
-    !isExpectedAuthority(authority)
-  ) {
+  if (!isExpectedLockedAuthority(lock, authority)) {
     throw new Error("locked authority is not the expected reparented Codex process");
   }
 
@@ -220,12 +250,14 @@ async function reapOrphan() {
   const targets = verifiedOrphanTargets(lock, listeners);
 
   const verifiedInodes = listenerInodes();
+  const currentAuthority = readProcess(lock.authorityPid);
   if (
     !unchangedLock(lock) ||
     !ownerIsDead(lock.ownerPid, lock.ownerStartTime) ||
     socketPathState(socket) !== "same" ||
     verifiedInodes.length !== 1 ||
     verifiedInodes[0] !== inode ||
+    !isExpectedLockedAuthority(lock, currentAuthority) ||
     targets.some((target) => !isRunning(target))
   ) {
     throw new Error("shared app-server ownership changed during orphan verification");

--- a/linux-features/shared-app-server-socket/test.js
+++ b/linux-features/shared-app-server-socket/test.js
@@ -25,6 +25,210 @@ const {
 const socketEnvHook = path.join(__dirname, "socket-env.sh");
 const orphanReaper = path.join(__dirname, "orphan-reaper.js");
 
+function createProcessSnapshotFs(processesByPid) {
+  const snapshotsByPid = new Map();
+  const processForPath = (procPath) => {
+    const match = procPath.match(/^\/proc\/(\d+)(?:\/(stat|cmdline))?$/);
+    if (match == null) throw new Error(`unexpected proc path: ${procPath}`);
+    const pid = Number(match[1]);
+    const file = match[2];
+    if (file == null) {
+      const entry = processesByPid.get(pid);
+      const processInfo = typeof entry === "function" ? entry() : entry;
+      if (processInfo != null) snapshotsByPid.set(pid, processInfo);
+    }
+    const processInfo = snapshotsByPid.get(pid);
+    if (processInfo == null) {
+      const error = new Error(`process ${pid} does not exist`);
+      error.code = "ENOENT";
+      throw error;
+    }
+    return { processInfo, file };
+  };
+
+  return {
+    statSync(procPath) {
+      return { uid: processForPath(procPath).processInfo.uid };
+    },
+    readFileSync(procPath) {
+      const { processInfo, file } = processForPath(procPath);
+      if (file === "stat") {
+        return `0 (${processInfo.comm ?? path.basename(processInfo.commandLine[0])}) ${processInfo.state} ${processInfo.ppid} ${Array(17)
+          .fill("0")
+          .join(" ")} ${processInfo.startTime}`;
+      }
+      if (file === "cmdline") return Buffer.from(`${processInfo.commandLine.join("\0")}\0`);
+      throw new Error(`unexpected proc file read: ${procPath}`);
+    },
+  };
+}
+
+function loadOrphanReaperVerifier(processesByPid) {
+  const source = fs.readFileSync(orphanReaper, "utf8");
+  const verifierSource = source.replace(
+    /reapOrphan\(\)\.catch\(\(error\) => \{[\s\S]*?\n\}\);\s*$/,
+    "globalThis.orphanReaperVerifier = { verifiedOrphanTargets };\n",
+  );
+  assert.notEqual(verifierSource, source, "orphan reaper entrypoint must remain replaceable");
+
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  const mockFs = createProcessSnapshotFs(processesByPid);
+  const context = {
+    process: {
+      argv: [process.execPath, orphanReaper, "/test/app-server.sock"],
+      getuid: () => uid,
+    },
+    require(id) {
+      if (id === "node:fs") return mockFs;
+      if (id === "node:path") return path;
+      throw new Error(`unexpected orphan reaper dependency: ${id}`);
+    },
+  };
+  vm.runInNewContext(verifierSource, context, { filename: orphanReaper });
+  return context.orphanReaperVerifier.verifiedOrphanTargets;
+}
+
+function loadOrphanReaperAdoptionPredicate() {
+  const source = fs.readFileSync(orphanReaper, "utf8");
+  const predicateSource = source.replace(
+    /reapOrphan\(\)\.catch\(\(error\) => \{[\s\S]*?\n\}\);\s*$/,
+    "globalThis.orphanReaperAdoption = { readProcess, hasExpectedOrphanAdoption };\n",
+  );
+  assert.notEqual(predicateSource, source, "orphan reaper entrypoint must remain replaceable");
+
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  const context = {
+    process: {
+      argv: [process.execPath, orphanReaper, "/test/app-server.sock"],
+      getuid: () => uid,
+    },
+    require(id) {
+      if (id === "node:fs") return fs;
+      if (id === "node:path") return path;
+      throw new Error(`unexpected orphan reaper dependency: ${id}`);
+    },
+  };
+  vm.runInNewContext(predicateSource, context, { filename: orphanReaper });
+  return context.orphanReaperAdoption;
+}
+
+const orphanReaperAdoption = loadOrphanReaperAdoptionPredicate();
+
+function startOrphanReaperWithChangedAdopter() {
+  const socketPath = "/test/app-server.sock";
+  const lockPath = `${socketPath}.lock`;
+  const lockContents = "99999999 1 2001 100\n";
+  const uid = process.getuid();
+  const authority = {
+    pid: 2001,
+    uid,
+    state: "S",
+    ppid: 1235,
+    startTime: "100",
+    comm: "codex",
+    commandLine: ["/usr/bin/codex", "app-server", "--listen", `unix://${socketPath}`],
+  };
+  const validAdopter = {
+    pid: 1235,
+    uid,
+    state: "S",
+    ppid: 1,
+    startTime: "99",
+    comm: "systemd",
+    commandLine: ["/nix/store/0123456789abcdef-systemd-257.6/lib/systemd/systemd", "--user"],
+  };
+  const changedAdopter = { ...validAdopter, ppid: 321 };
+  let adopterReads = 0;
+  const processesByPid = new Map([
+    [authority.pid, authority],
+    [validAdopter.pid, () => (adopterReads++ < 2 ? validAdopter : changedAdopter)],
+  ]);
+  const procFs = createProcessSnapshotFs(processesByPid);
+  const socket = { dev: 1, ino: 2, uid, isSocket: () => true };
+  const lock = { dev: 3, ino: 4 };
+  const listenerInode = "9876";
+  const signals = [];
+  const mockFs = {
+    openSync(filePath) {
+      if (filePath === lockPath) return 17;
+      throw new Error(`unexpected open: ${filePath}`);
+    },
+    fstatSync(descriptor) {
+      if (descriptor === 17) return lock;
+      throw new Error(`unexpected descriptor: ${descriptor}`);
+    },
+    closeSync() {},
+    statSync: procFs.statSync,
+    lstatSync(filePath) {
+      if (filePath === socketPath) return socket;
+      if (filePath === lockPath) return lock;
+      const error = new Error(`missing path: ${filePath}`);
+      error.code = "ENOENT";
+      throw error;
+    },
+    readFileSync(filePath) {
+      if (filePath === 17 || filePath === lockPath) return lockContents;
+      if (filePath === "/proc/net/unix") {
+        return `0000000000000000: 00000002 00000000 00010000 0001 01 ${listenerInode} ${socketPath}\n`;
+      }
+      return procFs.readFileSync(filePath);
+    },
+    readdirSync(filePath) {
+      if (filePath === "/proc") {
+        return [{ name: String(authority.pid), isDirectory: () => true }];
+      }
+      if (filePath === `/proc/${authority.pid}/fd`) return ["5"];
+      throw new Error(`unexpected directory read: ${filePath}`);
+    },
+    readlinkSync(filePath) {
+      if (filePath === `/proc/${authority.pid}/fd/5`) return `socket:[${listenerInode}]`;
+      throw new Error(`unexpected link read: ${filePath}`);
+    },
+  };
+  const source = fs.readFileSync(orphanReaper, "utf8");
+  const reaperSource = source.replace(
+    /reapOrphan\(\)\.catch\(\(error\) => \{[\s\S]*?\n\}\);\s*$/,
+    "globalThis.reaperPromise = reapOrphan();\n",
+  );
+  assert.notEqual(reaperSource, source, "orphan reaper entrypoint must remain replaceable");
+  const context = {
+    process: {
+      argv: [process.execPath, orphanReaper, socketPath],
+      getuid: () => uid,
+      kill(pid, signal) {
+        signals.push({ pid, signal });
+        return true;
+      },
+    },
+    console: { error() {} },
+    require(id) {
+      if (id === "node:fs") return mockFs;
+      if (id === "node:path") return path;
+      throw new Error(`unexpected orphan reaper dependency: ${id}`);
+    },
+  };
+  vm.runInNewContext(reaperSource, context, { filename: orphanReaper });
+  return { reaperPromise: context.reaperPromise, signals };
+}
+
+function authorityProcess({ pid, ppid }) {
+  return {
+    pid,
+    uid: process.getuid(),
+    state: "S",
+    ppid,
+    startTime: "100",
+    commandLine: ["/usr/bin/codex", "app-server", "--listen", "unix:///test/app-server.sock"],
+  };
+}
+
+function lockedAuthority(authority) {
+  return {
+    authorityPid: authority.pid,
+    authorityStartTime: authority.startTime,
+  };
+}
+
 function withFeatureConfig(enabled, callback) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "shared-app-server-socket-feature-"));
   const configPath = path.join(tempDir, "features.json");
@@ -187,6 +391,11 @@ function processStartTime(pid) {
   }
 }
 
+function hasLegitimateOrphanAdoption(pid) {
+  const authority = orphanReaperAdoption.readProcess(pid);
+  return authority != null && orphanReaperAdoption.hasExpectedOrphanAdoption(authority);
+}
+
 function unixListenerInodes(socketPath) {
   const inodes = new Set();
   for (const line of fs.readFileSync("/proc/net/unix", "utf8").split("\n")) {
@@ -257,18 +466,8 @@ async function spawnOrphanAuthority(socketPath) {
   const startTime = processStartTime(pid);
   assert.notEqual(startTime, null);
   await waitForCondition(
-    () => {
-      try {
-        const rawStat = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
-        const commandEnd = rawStat.lastIndexOf(")");
-        const fields = rawStat.slice(commandEnd + 2).trim().split(/\s+/);
-        return Number(fields[1]) === 1 && fs.existsSync(socketPath);
-      } catch (error) {
-        if (error.code === "ENOENT") return false;
-        throw error;
-      }
-    },
-    "detached authority to be reparented",
+    () => hasLegitimateOrphanAdoption(pid) && fs.existsSync(socketPath),
+    "detached authority to be adopted by PID 1 or the systemd user manager",
   );
   return { pid, startTime };
 }
@@ -466,6 +665,142 @@ test("orphan reaper fails closed on an unknown live listener", async () => {
     await closeServer(server);
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
+});
+
+test("orphan reaper accepts an authority adopted directly by PID 1", () => {
+  const authority = authorityProcess({ pid: 2001, ppid: 1 });
+  const verifiedOrphanTargets = loadOrphanReaperVerifier(new Map([[authority.pid, authority]]));
+
+  assert.deepEqual(
+    Array.from(verifiedOrphanTargets(lockedAuthority(authority), [])).map((target) => target.pid),
+    [authority.pid],
+  );
+});
+
+test("orphan reaper accepts an authority adopted by the verified systemd user manager", () => {
+  const adopter = {
+    pid: 1235,
+    uid: process.getuid(),
+    state: "S",
+    ppid: 1,
+    startTime: "99",
+    comm: "systemd",
+    commandLine: ["/usr/lib/systemd/systemd", "--user", "--deserialize=10"],
+  };
+  const authority = authorityProcess({ pid: 2001, ppid: adopter.pid });
+  const verifiedOrphanTargets = loadOrphanReaperVerifier(
+    new Map([
+      [authority.pid, authority],
+      [adopter.pid, adopter],
+    ]),
+  );
+
+  assert.deepEqual(
+    Array.from(verifiedOrphanTargets(lockedAuthority(authority), [])).map((target) => target.pid),
+    [authority.pid],
+  );
+});
+
+test("orphan reaper accepts an authority adopted by a verified Nix systemd user manager", () => {
+  const adopter = {
+    pid: 1235,
+    uid: process.getuid(),
+    state: "S",
+    ppid: 1,
+    startTime: "99",
+    comm: "systemd",
+    commandLine: [
+      "/nix/store/0123456789abcdef-systemd-257.6/lib/systemd/systemd",
+      "--user",
+      "--deserialize=10",
+    ],
+  };
+  const authority = authorityProcess({ pid: 2001, ppid: adopter.pid });
+  const verifiedOrphanTargets = loadOrphanReaperVerifier(
+    new Map([
+      [authority.pid, authority],
+      [adopter.pid, adopter],
+    ]),
+  );
+
+  assert.deepEqual(
+    Array.from(verifiedOrphanTargets(lockedAuthority(authority), [])).map((target) => target.pid),
+    [authority.pid],
+  );
+});
+
+test("orphan reaper rejects every invalid systemd user manager adopter identity", () => {
+  const validAdopter = {
+    pid: 1235,
+    uid: process.getuid(),
+    state: "S",
+    ppid: 1,
+    startTime: "99",
+    comm: "systemd",
+    commandLine: ["/nix/store/0123456789abcdef-systemd-257.6/lib/systemd/systemd", "--user"],
+  };
+  const cases = [
+    ["wrong uid", () => ({ ...validAdopter, uid: validAdopter.uid + 1 })],
+    ["zombie", () => ({ ...validAdopter, state: "Z" })],
+    ["missing", () => null],
+    ["reused pid", () => {
+      let reads = 0;
+      return () => ({ ...validAdopter, startTime: reads++ === 0 ? "99" : "100" });
+    }],
+    ["non-init parent", () => ({ ...validAdopter, ppid: 321 })],
+    ["wrong comm", () => ({ ...validAdopter, comm: "init" })],
+    ["missing --user", () => ({ ...validAdopter, commandLine: [validAdopter.commandLine[0]] })],
+    ["relative executable", () => ({ ...validAdopter, commandLine: ["systemd", "--user"] })],
+    ["wrong executable basename", () => ({
+      ...validAdopter,
+      commandLine: ["/nix/store/0123456789abcdef-systemd-257.6/lib/systemd/systemd-wrapper", "--user"],
+    })],
+  ];
+
+  for (const [description, makeAdopter] of cases) {
+    const authority = authorityProcess({ pid: 2001, ppid: validAdopter.pid });
+    const adopter = makeAdopter();
+    const processes = new Map([[authority.pid, authority]]);
+    if (adopter != null) processes.set(validAdopter.pid, adopter);
+    const verifiedOrphanTargets = loadOrphanReaperVerifier(processes);
+
+    assert.throws(
+      () => verifiedOrphanTargets(lockedAuthority(authority), []),
+      /not the expected reparented Codex process/,
+      description,
+    );
+  }
+});
+
+test("orphan reaper rechecks adopter identity before signaling", async () => {
+  const { reaperPromise, signals } = startOrphanReaperWithChangedAdopter();
+
+  await assert.rejects(reaperPromise, /ownership changed during orphan verification/);
+  assert.deepEqual(signals, []);
+});
+
+test("orphan reaper rejects an authority adopted by an unrelated live parent", () => {
+  const adopter = {
+    pid: 1235,
+    uid: process.getuid(),
+    state: "S",
+    ppid: 1,
+    startTime: "99",
+    comm: "node",
+    commandLine: ["/usr/bin/node", "supervisor.js"],
+  };
+  const authority = authorityProcess({ pid: 2001, ppid: adopter.pid });
+  const verifiedOrphanTargets = loadOrphanReaperVerifier(
+    new Map([
+      [authority.pid, authority],
+      [adopter.pid, adopter],
+    ]),
+  );
+
+  assert.throws(
+    () => verifiedOrphanTargets(lockedAuthority(authority), []),
+    /not the expected reparented Codex process/,
+  );
 });
 
 test("orphan reaper stops an exact reparented authority and removes stale ownership", async () => {


### PR DESCRIPTION
## Summary

Normal systemd user sessions can adopt a detached shared app-server authority under `systemd --user` rather than directly under PID 1. Current orphan cleanup requires the authority's direct parent to be PID 1, so it refuses this valid topology and leaves the orphaned authority running.

This pull request:

- accepts authorities adopted directly by PID 1 or by a verified same-user `systemd --user` manager whose own parent is PID 1
- preserves the existing lock owner, authority PID/start-time, UID, command-line, socket identity, listener ownership, and pre-signal race checks
- keeps unrelated parents and invalid systemd-user identities fail-closed
- adds deterministic coverage for direct PID-1 adoption, conventional and Nix systemd-user paths, invalid adopter identities, unrelated parents, and adopter changes before signaling
- updates the feature documentation to describe the supported adoption topologies

The source-of-truth files changed are:

- `linux-features/shared-app-server-socket/orphan-reaper.js`
- `linux-features/shared-app-server-socket/test.js`
- `linux-features/shared-app-server-socket/README.md`

There is no linked issue.

The verified systemd-user allowance requires a live, stable adopter with the same UID, PID 1 as its parent, `systemd` as its process name, an absolute executable argument whose basename is `systemd`, and an exact `--user` argument. It does not rely on `/proc/<pid>/exe`, which can be unreadable under normal host procfs policy.

## Validation

- Reproduced on untouched `upstream/main` at `20825ea9a907adbce8e5a10e466543704c5aaef6`:
  - `node --test linux-features/shared-app-server-socket/test.js`
  - 31 passed, exactly 2 timed out, and 1 optional integration test was skipped
  - both failures waited for direct PID-1 adoption while the authority was adopted by the same-user `systemd --user` manager
- Invoked untouched main's production orphan reaper against the reproduced topology and confirmed that it refused cleanup and left the authority running
- `node --test linux-features/shared-app-server-socket/test.js`
  - 39 passed, 0 failed, and 1 optional integration test was skipped
- `node --test --test-name-pattern='orphan reaper (stops an exact reparented authority|refuses two live listener inodes)' linux-features/shared-app-server-socket/test.js`
  - 2 passed under a normal systemd user session
- `./scripts/ci-local.sh pr`
  - passed the complete core, Debian, RPM, and pacman PR matrix
- `git diff --check upstream/main...HEAD`
  - passed

The optional real-Codex proxy integration test was not run because `CODEX_CLI_PATH` was not configured.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
