### PR TITLE
fix(directory-watch): route current Parcel working tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - The opt-in shallow repository watcher now patches both current app bundles
   and routes the Linux Parcel working-tree path through the same shallow host,
   restoring bounded watches on the latest upstream DMG.
+- The opt-in directory-only working-tree watcher now routes the current Linux
+  Parcel working-tree path through its existing bounded directory watcher,
+  restoring the feature on the latest upstream DMG, with byte-verified rollback
+  for its paired bundle writes.
 - Computer Use now supports Plasma 5 and 6 KWin scripting, validates every
   ydotool 1.0.3+ command shape it emits, and rejects semantically incompatible
   CLIs even when a daemon socket exists. Hyprland dispatch validation handles

--- a/linux-features/directory-only-working-tree-watch/README.md
+++ b/linux-features/directory-only-working-tree-watch/README.md
@@ -22,6 +22,25 @@ produces an event.
 There are no default name-based exclusions. A tracked directory named `build`
 or `node_modules` remains watched even if its name resembles generated output.
 
+## Current upstream working-tree route
+
+OpenAI Desktop `26.730.61639` has a Linux-specific Parcel working-tree path
+that calls `@parcel/watcher` directly instead of the local `startFileWatch()`
+method this feature intercepts. When the feature is selected, the current-DMG
+patch reroutes that one local working-tree subscription through
+`startFileWatch()`, where the existing directory-only watcher takes ownership.
+Remote watches and non-working-tree file watches retain their upstream routes.
+
+The matcher correlates the Parcel helper, Git execution-host factory, local
+host, route host, route options, and path API by semantic role rather than by
+minified identifier spelling. Missing, duplicate, misplaced, partial, or
+uncorrelated contracts report enabled-feature drift and leave the current
+bundles unchanged.
+
+After both bundle changes are prepared and validated, the patch writes them as
+one transaction. A write error restores and byte-verifies every attempted
+bundle; an unverified rollback is reported as a patch integrity failure.
+
 By default, the watcher uses at most 8192 inotify watches per app process across
 all active working trees, or one eighth of the kernel's
 `fs.inotify.max_user_watches` value when that is lower. The configurable ceiling

--- a/linux-features/directory-only-working-tree-watch/patch.js
+++ b/linux-features/directory-only-working-tree-watch/patch.js
@@ -2,12 +2,81 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
+const {
+  findMatchingBrace,
+} = require("../../scripts/patches/lib/minified-js.js");
+const {
+  PatchIntegrityError,
+} = require("../../scripts/patches/integrity-error.js");
 
 const HELPER_NAME = "codexLinuxStartDirectoryOnlyWorkingTreeWatch";
+const PARCEL_WATCH_MARKER = "codexLinuxDirectoryOnlyParcelWorkingTreeWatch";
 const DEFAULT_MAX_WATCHES = 8192;
 const DEFAULT_IGNORED_DIRECTORY_NAMES = [];
-const LOCAL_FILE_WATCH_METHOD =
-  /async startFileWatch\((?<options>[A-Za-z_$][\w$]*)\)\{(?=let [^{}]{0,180}?await this\.platformPath\(\),[^{}]{0,180}?\(0,[A-Za-z_$][\w$]*\.watch\)\(this\.getFileSystemPath\(\k<options>\.path\),\{recursive:\k<options>\.recursive\})/gu;
+const IDENTIFIER_PATTERN = "[A-Za-z_$][\\w$]*";
+const LOCAL_FILE_WATCH_METHOD_PREFIX =
+  `async startFileWatch\\((?<options>${IDENTIFIER_PATTERN})\\)\\{`;
+const LOCAL_FILE_WATCH_CURRENT_BODY =
+  "(?=let [^{}]{0,180}?await this\\.platformPath\\(\\)," +
+  "[^{}]{0,180}?\\(0,[A-Za-z_$][\\w$]*\\.watch\\)\\(" +
+  "this\\.getFileSystemPath\\(\\k<options>\\.path\\)," +
+  "\\{recursive:\\k<options>\\.recursive\\})";
+const LOCAL_FILE_WATCH_METHOD = new RegExp(
+  `${LOCAL_FILE_WATCH_METHOD_PREFIX}${LOCAL_FILE_WATCH_CURRENT_BODY}`,
+  "gu",
+);
+const CURRENT_LOCAL_HOST_CLASS = new RegExp(
+  `var (?<localHostClass>${IDENTIFIER_PATTERN})=class\\{` +
+    "runsInsideWsl;hostConfig=\\{id:`local`,display_name:`Local`,kind:`local`\\};" +
+    "id=`local`;isLocal=!0;",
+  "gu",
+);
+const PARCEL_WORKING_TREE_WATCH =
+  /process\.platform===`linux`\?[A-Za-z_$][\w$]*\((?<options>[A-Za-z_$][\w$]*),\{ignoredPaths:\[[A-Za-z_$][\w$]*\.posix\.join\(\k<options>\.path,`\.git`\)\]\}\):(?<host>[A-Za-z_$][\w$]*)\.startFileWatch\(\k<options>\)/gu;
+const CURRENT_PARCEL_HELPER = new RegExp(
+  "async function " +
+    `(?<helperName>${IDENTIFIER_PATTERN})\\(` +
+    `(?<helperOptions>${IDENTIFIER_PATTERN}),` +
+    `(?<helperSettings>${IDENTIFIER_PATTERN})\\)\\{return new ` +
+    `(?<parcelWatcher>${IDENTIFIER_PATTERN})\\(await import\\(` +
+    "`@parcel/watcher`" +
+    `\\),\\k<helperOptions>,\\k<helperSettings>\\)\\.start\\(\\)\\}`,
+  "gu",
+);
+const CURRENT_GIT_ROUTE_PREFIX_PATTERN =
+  "case`git`:\\{let " +
+  `(?<localHost>${IDENTIFIER_PATTERN})=new ` +
+  `(?<localHostClass>${IDENTIFIER_PATTERN});return\\{git:\\{createExecutionHost:` +
+  `(?<executionOptions>${IDENTIFIER_PATTERN})=>\\{if\\(` +
+  `(?<mainConnection>${IDENTIFIER_PATTERN})==null\\)` +
+  "throw Error\\(`Git hosts require a main RPC connection`\\);return new " +
+  `(?<remoteHostClass>${IDENTIFIER_PATTERN})\\(` +
+  "\\k<mainConnection>,\\k<executionOptions>\\)\\},";
+const CURRENT_PARCEL_ROUTE_PATTERN =
+  "startWorkingTreeWatch:\\(" +
+  `(?<routeHost>${IDENTIFIER_PATTERN}),` +
+  `(?<routeOptions>${IDENTIFIER_PATTERN})\\)=>` +
+  "\\k<routeHost>\\.isLocal\\?process\\.platform===`linux`\\?" +
+  `(?<routeHelper>${IDENTIFIER_PATTERN})\\(\\k<routeOptions>,\\{ignoredPaths:\\[` +
+  `(?<pathApi>${IDENTIFIER_PATTERN})\\.posix\\.join\\(` +
+  "\\k<routeOptions>\\.path,`\\.git`\\)\\]\\}\\):" +
+  "\\k<localHost>\\.startFileWatch\\(\\k<routeOptions>\\):" +
+  "\\k<routeHost>\\.startFileWatch\\(\\k<routeOptions>\\)";
+const CURRENT_DIRECTORY_ROUTE_PATTERN =
+  "startWorkingTreeWatch:\\(" +
+  `(?<routeHost>${IDENTIFIER_PATTERN}),` +
+  `(?<routeOptions>${IDENTIFIER_PATTERN})\\)=>` +
+  `\\k<routeHost>\\.isLocal\\?/\\*${PARCEL_WATCH_MARKER}\\*/` +
+  "\\k<localHost>\\.startFileWatch\\(\\k<routeOptions>\\):" +
+  "\\k<routeHost>\\.startFileWatch\\(\\k<routeOptions>\\)";
+const CURRENT_PARCEL_ROUTE_CONTRACT = new RegExp(
+  `(?<routePrefix>${CURRENT_GIT_ROUTE_PREFIX_PATTERN})${CURRENT_PARCEL_ROUTE_PATTERN}`,
+  "gu",
+);
+const CURRENT_DIRECTORY_ROUTE_CONTRACT = new RegExp(
+  `(?<routePrefix>${CURRENT_GIT_ROUTE_PREFIX_PATTERN})${CURRENT_DIRECTORY_ROUTE_PATTERN}`,
+  "gu",
+);
 
 function codexLinuxStartDirectoryOnlyWorkingTreeWatch(host, options, configuration) {
   return (async () => {
@@ -2084,6 +2153,9 @@ function codexLinuxStartDirectoryOnlyWorkingTreeWatch(host, options, configurati
   })();
 }
 
+const DIRECTORY_WATCH_HELPER_SOURCE =
+  `${codexLinuxStartDirectoryOnlyWorkingTreeWatch.toString()};`;
+
 function normalizedSettings(context = {}) {
   const settings = context.feature?.settings ?? {};
   const hasSetting = (name) => Object.prototype.hasOwnProperty.call(settings, name);
@@ -2147,43 +2219,278 @@ function normalizedSettings(context = {}) {
   };
 }
 
-function patchWorkerSource(source, settings) {
-  const helperCount = source.split(`function ${HELPER_NAME}(`).length - 1;
-  const branchMarker = `return ${HELPER_NAME}(this,`;
-  const branchCount = source.split(branchMarker).length - 1;
-  if (helperCount === 1 && branchCount === 1) {
-    return { source, matched: 1, changed: 0, reason: null };
-  }
-  if (helperCount !== 0 || branchCount !== 0) {
-    return {
-      source,
-      matched: 0,
-      changed: 0,
-      reason: `Found ${helperCount} helper definitions and ${branchCount} working-tree branches`,
-    };
-  }
+function countSubstring(source, needle) {
+  return source.split(needle).length - 1;
+}
 
-  LOCAL_FILE_WATCH_METHOD.lastIndex = 0;
-  const matches = [...source.matchAll(LOCAL_FILE_WATCH_METHOD)];
-  if (matches.length !== 1) {
-    return {
-      source,
-      matched: 0,
-      changed: 0,
-      reason: `Found ${matches.length} local startFileWatch implementations`,
-    };
-  }
+function patternMatches(source, pattern) {
+  pattern.lastIndex = 0;
+  return [...source.matchAll(pattern)];
+}
 
-  const match = matches[0];
-  const optionsName = match.groups.options;
-  const branch =
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function directoryOnlyLocalBranch(optionsName, settings) {
+  return (
     `if(process.platform===\`linux\`&&${optionsName}.recursive&&` +
     `${optionsName}.renameEventHandling===\`changed-path-with-parent-directory\`)` +
-    `return ${HELPER_NAME}(this,${optionsName},${JSON.stringify(settings)});`;
-  const methodStart = match.index + match[0].length;
-  const withBranch = source.slice(0, methodStart) + branch + source.slice(methodStart);
-  const helper = `${codexLinuxStartDirectoryOnlyWorkingTreeWatch.toString()};`;
-  return { source: helper + withBranch, matched: 1, changed: 1, reason: null };
+    `return ${HELPER_NAME}(this,${optionsName},${JSON.stringify(settings)});`
+  );
+}
+
+function completedLocalFileWatchMethod(settings) {
+  const branch =
+    "if\\(process\\.platform===`linux`&&\\k<options>\\.recursive&&" +
+    "\\k<options>\\.renameEventHandling===`changed-path-with-parent-directory`\\)" +
+    `return ${HELPER_NAME}\\(this,\\k<options>,` +
+    `${escapeRegExp(JSON.stringify(settings))}\\);`;
+  return new RegExp(
+    `${LOCAL_FILE_WATCH_METHOD_PREFIX}${branch}${LOCAL_FILE_WATCH_CURRENT_BODY}`,
+    "gu",
+  );
+}
+
+function currentLocalHostClassForMethod(source, classMatches, methodMatches) {
+  if (classMatches.length !== 1 || methodMatches.length !== 1) return null;
+  const [classMatch] = classMatches;
+  const [methodMatch] = methodMatches;
+  const classTokenStart = source.indexOf("=class{", classMatch.index);
+  if (classTokenStart < 0) return null;
+  const classOpen = classTokenStart + "=class".length;
+  const classClose = findMatchingBrace(source, classOpen);
+  return classClose >= 0 &&
+    methodMatch.index > classOpen &&
+    methodMatch.index < classClose
+    ? classMatch.groups?.localHostClass ?? null
+    : null;
+}
+
+function classifyCurrentBundle(bundlePath, source, settings = normalizedSettings()) {
+  const pristineLocalMatches = patternMatches(source, LOCAL_FILE_WATCH_METHOD);
+  const completedLocalMatches = patternMatches(source, completedLocalFileWatchMethod(settings));
+  const currentLocalHostMatches = patternMatches(source, CURRENT_LOCAL_HOST_CLASS);
+  const localHostClass = currentLocalHostClassForMethod(
+    source,
+    currentLocalHostMatches,
+    [...pristineLocalMatches, ...completedLocalMatches],
+  );
+  const helperDefinitionCount = countSubstring(source, `function ${HELPER_NAME}(`);
+  const helperExactCount = countSubstring(source, DIRECTORY_WATCH_HELPER_SOURCE);
+  const branchCallCount = countSubstring(source, `return ${HELPER_NAME}(this,`);
+  const markerCount = countSubstring(source, PARCEL_WATCH_MARKER);
+  const rawRouteLookalikeCount = patternMatches(source, PARCEL_WORKING_TREE_WATCH).length;
+  const pristineRouteMatches = patternMatches(source, CURRENT_PARCEL_ROUTE_CONTRACT);
+  const completedRouteMatches = patternMatches(source, CURRENT_DIRECTORY_ROUTE_CONTRACT);
+  const parcelHelperMatches = patternMatches(source, CURRENT_PARCEL_HELPER);
+  const correlatedPristineRouteCount = pristineRouteMatches.filter((route) =>
+    parcelHelperMatches.some((helper) =>
+      helper.groups?.helperName === route.groups?.routeHelper &&
+      route.groups?.localHostClass === localHostClass
+    )
+  ).length;
+  const correlatedCompletedRouteCount = completedRouteMatches.filter(
+    (route) => route.groups?.localHostClass === localHostClass,
+  ).length;
+  const parcelImportCount = countSubstring(source, "@parcel/watcher");
+  const relevant =
+    pristineLocalMatches.length > 0 ||
+    completedLocalMatches.length > 0 ||
+    currentLocalHostMatches.length > 0 ||
+    helperDefinitionCount > 0 ||
+    helperExactCount > 0 ||
+    branchCallCount > 0 ||
+    markerCount > 0 ||
+    rawRouteLookalikeCount > 0 ||
+    pristineRouteMatches.length > 0 ||
+    completedRouteMatches.length > 0 ||
+    parcelHelperMatches.length > 0 ||
+    parcelImportCount > 0;
+  return {
+    branchCallCount,
+    bundlePath,
+    completedLocalCount: completedLocalMatches.length,
+    completedRouteCount: completedRouteMatches.length,
+    correlatedCompletedRouteCount,
+    correlatedPristineRouteCount,
+    currentLocalHostCount: currentLocalHostMatches.length,
+    helperDefinitionCount,
+    helperExactCount,
+    localHostClass,
+    markerCount,
+    parcelHelperCount: parcelHelperMatches.length,
+    parcelImportCount,
+    pristineLocalCount: pristineLocalMatches.length,
+    pristineRouteCount: pristineRouteMatches.length,
+    rawRouteLookalikeCount,
+    relevant,
+    source,
+    startsWithExactHelper: source.startsWith(DIRECTORY_WATCH_HELPER_SOURCE),
+  };
+}
+
+function hasPristineLocalContract(record) {
+  return record.pristineLocalCount === 1 &&
+    record.completedLocalCount === 0 &&
+    record.currentLocalHostCount === 1 &&
+    record.localHostClass != null &&
+    record.helperDefinitionCount === 0 &&
+    record.helperExactCount === 0 &&
+    record.branchCallCount === 0;
+}
+
+function hasCompletedLocalContract(record) {
+  return record.pristineLocalCount === 0 &&
+    record.completedLocalCount === 1 &&
+    record.currentLocalHostCount === 1 &&
+    record.localHostClass != null &&
+    record.helperDefinitionCount === 1 &&
+    record.helperExactCount === 1 &&
+    record.branchCallCount === 1 &&
+    record.startsWithExactHelper;
+}
+
+function hasNoParcelRouteContract(record) {
+  return record.markerCount === 0 &&
+    record.rawRouteLookalikeCount === 0 &&
+    record.pristineRouteCount === 0 &&
+    record.completedRouteCount === 0 &&
+    record.parcelHelperCount === 0 &&
+    record.parcelImportCount === 0;
+}
+
+function hasPristineWorkerRouteContract(record) {
+  return record.pristineRouteCount === 1 &&
+    record.correlatedPristineRouteCount === 1 &&
+    record.completedRouteCount === 0 &&
+    record.markerCount === 0 &&
+    record.rawRouteLookalikeCount === 1 &&
+    record.parcelHelperCount === 1 &&
+    record.parcelImportCount === 1;
+}
+
+function hasCompletedWorkerRouteContract(record) {
+  return record.pristineRouteCount === 0 &&
+    record.completedRouteCount === 1 &&
+    record.correlatedCompletedRouteCount === 1 &&
+    record.markerCount === 1 &&
+    record.rawRouteLookalikeCount === 0 &&
+    record.parcelHelperCount === 1 &&
+    record.parcelImportCount === 1;
+}
+
+function currentContractReason(records, bundleCount) {
+  const relevant = records.filter(({ relevant }) => relevant);
+  const targetNames = relevant.map(({ bundlePath }) => path.basename(bundlePath));
+  const localCount = relevant.reduce(
+    (count, record) => count + record.pristineLocalCount,
+    0,
+  );
+  const helpers = relevant.reduce(
+    (count, record) => count + record.helperDefinitionCount,
+    0,
+  );
+  const branches = relevant.reduce(
+    (count, record) => count + record.branchCallCount,
+    0,
+  );
+  const parcelContractCount = relevant.reduce(
+    (count, record) => count + record.pristineRouteCount + record.completedRouteCount,
+    0,
+  );
+  const workerParcelContractCount = relevant
+    .filter(({ bundlePath }) => path.basename(bundlePath) === "worker.js")
+    .reduce(
+      (count, record) => count + record.pristineRouteCount + record.completedRouteCount,
+      0,
+    );
+  const correlatedRouteCount = relevant.reduce(
+    (count, record) => count + record.correlatedPristineRouteCount,
+    0,
+  );
+  const lookalikeCount = relevant.reduce(
+    (count, record) => count + record.rawRouteLookalikeCount,
+    0,
+  );
+  const markerCount = relevant.reduce((count, record) => count + record.markerCount, 0);
+  return (
+    "Current 26.730.61639 working-tree contract rejected: " +
+    `Found ${localCount} local startFileWatch implementations, ${helpers} helpers, ` +
+    `${branches} branches, and ${parcelContractCount} Parcel route contracts ` +
+    `(${workerParcelContractCount} in worker.js) across ${relevant.length} relevant bundles ` +
+    `(${targetNames.join(", ") || "none"}) of ${bundleCount}; ` +
+    `${correlatedRouteCount} route/helper correlations, ${lookalikeCount} raw route ` +
+    `lookalikes, and ${markerCount} completed route markers`
+  );
+}
+
+function directoryWorkingTreeRoute(groups) {
+  return (
+    `startWorkingTreeWatch:(${groups.routeHost},${groups.routeOptions})=>` +
+    `${groups.routeHost}.isLocal?/*${PARCEL_WATCH_MARKER}*/` +
+    `${groups.localHost}.startFileWatch(${groups.routeOptions}):` +
+    `${groups.routeHost}.startFileWatch(${groups.routeOptions})`
+  );
+}
+
+function replaceCurrentParcelRoute(source) {
+  CURRENT_PARCEL_ROUTE_CONTRACT.lastIndex = 0;
+  return source.replace(CURRENT_PARCEL_ROUTE_CONTRACT, (...args) => {
+    const groups = args[args.length - 1];
+    return `${groups.routePrefix}${directoryWorkingTreeRoute(groups)}`;
+  });
+}
+
+function preparePristineBundle(record, settings) {
+  const [localMatch] = patternMatches(record.source, LOCAL_FILE_WATCH_METHOD);
+  const optionsName = localMatch.groups.options;
+  const methodStart = localMatch.index + localMatch[0].length;
+  const withBranch =
+    record.source.slice(0, methodStart) +
+    directoryOnlyLocalBranch(optionsName, settings) +
+    record.source.slice(methodStart);
+  const withRoute = path.basename(record.bundlePath) === "worker.js"
+    ? replaceCurrentParcelRoute(withBranch)
+    : withBranch;
+  return DIRECTORY_WATCH_HELPER_SOURCE + withRoute;
+}
+
+function patchWorkerSource(source, settings) {
+  const currentSettings = settings ?? normalizedSettings();
+  const hasWorkerSignals =
+    patternMatches(source, CURRENT_PARCEL_HELPER).length > 0 ||
+    source.includes(PARCEL_WATCH_MARKER) ||
+    patternMatches(source, PARCEL_WORKING_TREE_WATCH).length > 0;
+  const bundlePath = hasWorkerSignals ? "worker.js" : "src-current.js";
+  const record = classifyCurrentBundle(bundlePath, source, currentSettings);
+  const routePristine = bundlePath === "worker.js"
+    ? hasPristineWorkerRouteContract(record)
+    : hasNoParcelRouteContract(record);
+  const routeCompleted = bundlePath === "worker.js"
+    ? hasCompletedWorkerRouteContract(record)
+    : hasNoParcelRouteContract(record);
+
+  if (hasCompletedLocalContract(record) && routeCompleted) {
+    return { source, matched: 1, changed: 0, reason: null };
+  }
+  if (hasPristineLocalContract(record) && routePristine) {
+    const patchedSource = preparePristineBundle(record, currentSettings);
+    const completed = classifyCurrentBundle(bundlePath, patchedSource, currentSettings);
+    const completedRoute = bundlePath === "worker.js"
+      ? hasCompletedWorkerRouteContract(completed)
+      : hasNoParcelRouteContract(completed);
+    if (hasCompletedLocalContract(completed) && completedRoute) {
+      return { source: patchedSource, matched: 1, changed: 1, reason: null };
+    }
+  }
+
+  return {
+    source,
+    matched: 0,
+    changed: 0,
+    reason: currentContractReason([record], 1),
+  };
 }
 
 function findLocalFileWatchBundles(extractedDir, settings) {
@@ -2196,43 +2503,125 @@ function findLocalFileWatchBundles(extractedDir, settings) {
     .filter((entry) => entry.isFile() && entry.name.endsWith(".js"))
     .map((entry) => path.join(buildDir, entry.name))
     .sort();
-  const targets = [];
-
-  for (const bundlePath of bundlePaths) {
-    const source = fs.readFileSync(bundlePath, "utf8");
-    const helperCount = source.split(`function ${HELPER_NAME}(`).length - 1;
-    const branchCount = source.split(`return ${HELPER_NAME}(this,`).length - 1;
-    if (helperCount > 0 || branchCount > 0) {
-      targets.push({ bundlePath, result: patchWorkerSource(source, settings) });
-      continue;
-    }
-    LOCAL_FILE_WATCH_METHOD.lastIndex = 0;
-    const matches = [...source.matchAll(LOCAL_FILE_WATCH_METHOD)].length;
-    if (matches > 0) {
-      targets.push({ bundlePath, result: patchWorkerSource(source, settings) });
-    }
+  const records = bundlePaths.map((bundlePath) => {
+    const originalBytes = fs.readFileSync(bundlePath);
+    const record = classifyCurrentBundle(bundlePath, originalBytes.toString("utf8"), settings);
+    return record.relevant ? { ...record, originalBytes } : record;
+  });
+  const relevant = records.filter(({ relevant }) => relevant);
+  const workerRecords = relevant.filter(
+    ({ bundlePath }) => path.basename(bundlePath) === "worker.js",
+  );
+  const srcRecords = relevant.filter(({ bundlePath }) =>
+    /^src-[A-Za-z0-9_-]+\.js$/u.test(path.basename(bundlePath)),
+  );
+  const exactPair = relevant.length === 2 &&
+    workerRecords.length === 1 &&
+    srcRecords.length === 1;
+  if (!exactPair) {
+    return { targets: [], reason: currentContractReason(records, bundlePaths.length) };
   }
 
-  const targetNames = targets.map(({ bundlePath }) => path.basename(bundlePath));
-  const hasWorker = targetNames.filter((name) => name === "worker.js").length === 1;
-  const srcCount = targetNames.filter((name) =>
-    /^src-[A-Za-z0-9_-]+\.js$/u.test(name),
-  ).length;
-  if (
-    targets.length !== 2 ||
-    !hasWorker ||
-    srcCount !== 1 ||
-    targets.some(({ result }) => result.matched !== 1)
-  ) {
-    return {
-      targets: [],
-      reason:
-        `Found ${targets.length} current local startFileWatch bundles ` +
-        `(${targetNames.join(", ") || "none"}) across ${bundlePaths.length} build bundles`,
-    };
+  const worker = workerRecords[0];
+  const src = srcRecords[0];
+  const pristine =
+    hasPristineLocalContract(worker) &&
+    hasPristineWorkerRouteContract(worker) &&
+    hasPristineLocalContract(src) &&
+    hasNoParcelRouteContract(src);
+  const completed =
+    hasCompletedLocalContract(worker) &&
+    hasCompletedWorkerRouteContract(worker) &&
+    hasCompletedLocalContract(src) &&
+    hasNoParcelRouteContract(src);
+  if (!pristine && !completed) {
+    return { targets: [], reason: currentContractReason(records, bundlePaths.length) };
   }
 
+  const targets = [src, worker].map((record) => ({
+    bundlePath: record.bundlePath,
+    originalBytes: record.originalBytes,
+    result: completed
+      ? { source: record.source, matched: 1, changed: 0, reason: null }
+      : {
+        source: preparePristineBundle(record, settings),
+        matched: 1,
+        changed: 1,
+        reason: null,
+      },
+  }));
+  const preparedAreComplete = targets.every(({ bundlePath, result }) => {
+    const prepared = classifyCurrentBundle(bundlePath, result.source, settings);
+    return hasCompletedLocalContract(prepared) && (
+      path.basename(bundlePath) === "worker.js"
+        ? hasCompletedWorkerRouteContract(prepared)
+        : hasNoParcelRouteContract(prepared)
+    );
+  });
+  if (!preparedAreComplete) {
+    return { targets: [], reason: currentContractReason(records, bundlePaths.length) };
+  }
   return { targets, reason: null };
+}
+
+function writePreparedBundleTargets(
+  targets,
+  {
+    writeFileSync = fs.writeFileSync,
+    readFileSync = fs.readFileSync,
+  } = {},
+) {
+  const attempted = [];
+  try {
+    for (const target of targets.filter(({ result }) => result.changed === 1)) {
+      attempted.push(target);
+      writeFileSync(target.bundlePath, target.result.source, "utf8");
+    }
+  } catch (error) {
+    const rollbackWriteFailures = [];
+    for (const target of [...attempted].reverse()) {
+      try {
+        writeFileSync(target.bundlePath, target.originalBytes);
+      } catch (rollbackError) {
+        rollbackWriteFailures.push({ bundlePath: target.bundlePath, error: rollbackError });
+      }
+    }
+
+    const rollbackVerificationFailures = [];
+    for (const target of attempted) {
+      try {
+        const restored = readFileSync(target.bundlePath);
+        const restoredBytes = Buffer.isBuffer(restored) ? restored : Buffer.from(restored);
+        if (!restoredBytes.equals(target.originalBytes)) {
+          rollbackVerificationFailures.push(
+            new Error(`rollback byte verification failed for ${target.bundlePath}`),
+          );
+        }
+      } catch (rollbackError) {
+        rollbackVerificationFailures.push(
+          new Error(
+            `rollback byte verification failed for ${target.bundlePath}: ${rollbackError.message}`,
+            { cause: rollbackError },
+          ),
+        );
+      }
+    }
+
+    if (rollbackVerificationFailures.length > 0) {
+      const rollbackWriteFailure = rollbackWriteFailures[0];
+      const writeFailureContext = rollbackWriteFailure == null
+        ? ""
+        : `; rollback write also failed for ${rollbackWriteFailure.bundlePath}: ` +
+          rollbackWriteFailure.error.message;
+      throw new PatchIntegrityError(
+        "Directory-only working-tree bundle rollback could not restore original bytes: " +
+          `${rollbackVerificationFailures[0].message}${writeFailureContext}`,
+        { cause: error },
+      );
+    }
+
+    throw error;
+  }
 }
 
 function patchWorker(extractedDir, context = {}) {
@@ -2243,11 +2632,7 @@ function patchWorker(extractedDir, context = {}) {
     return { matched: 0, changed: 0, reason };
   }
 
-  for (const { bundlePath, result } of discovery.targets) {
-    if (result.changed === 1) {
-      fs.writeFileSync(bundlePath, result.source, "utf8");
-    }
-  }
+  writePreparedBundleTargets(discovery.targets, context);
   const changed = discovery.targets.reduce((count, { result }) => count + result.changed, 0);
   return {
     matched: discovery.targets.length,
@@ -2278,6 +2663,8 @@ module.exports = {
   DEFAULT_MAX_WATCHES,
   HELPER_NAME,
   LOCAL_FILE_WATCH_METHOD,
+  PARCEL_WATCH_MARKER,
+  PARCEL_WORKING_TREE_WATCH,
   codexLinuxStartDirectoryOnlyWorkingTreeWatch,
   descriptors,
   findLocalFileWatchBundles,

--- a/linux-features/directory-only-working-tree-watch/test.js
+++ b/linux-features/directory-only-working-tree-watch/test.js
@@ -11,7 +11,18 @@ const path = require("node:path");
 const test = require("node:test");
 
 const {
+  createPatchReport,
+  enabledFeatureFailuresFromReport,
+} = require("../../scripts/lib/patch-report.js");
+const {
+  applyExtractedAppPatchDescriptors,
+} = require("../../scripts/patches/engine.js");
+
+const {
   DEFAULT_IGNORED_DIRECTORY_NAMES,
+  HELPER_NAME,
+  PARCEL_WATCH_MARKER,
+  PARCEL_WORKING_TREE_WATCH,
   codexLinuxStartDirectoryOnlyWorkingTreeWatch,
   descriptors,
   normalizedSettings,
@@ -23,11 +34,95 @@ const BUDGET_KEY = Symbol.for("codex-linux.directory-only-working-tree-watch.bud
 
 function localWorkerSource() {
   return [
-    "var LocalHost=class{",
+    "var LocalHost=class{runsInsideWsl;hostConfig={id:`local`,display_name:`Local`," +
+      "kind:`local`};id=`local`;isLocal=!0;",
     "async platformPath(){return E.default.posix}",
     "async startFileWatch(e){let t=jH(),n=!1,r=await this.platformPath(),",
     "i=(0,w.watch)(this.getFileSystemPath(e.path),{recursive:e.recursive},()=>{});",
     "return{coverage:{recursive:e.recursive},path:e.path,closed:t.promise}}",
+    "};",
+  ].join("");
+}
+
+// Exact relevant fragments from OpenAI Desktop 26.730.61639. Keep these
+// independent of patch.js so production matcher drift cannot rewrite the
+// fixture into a passing shape.
+const CURRENT_WORKER_LOCAL_FILE_WATCH = [
+  "async startFileWatch(e){let t=sV(),n=!1,r=await this.platformPath(),",
+  "i=(0,w.watch)(this.getFileSystemPath(e.path),{recursive:e.recursive},(t,n)=>{",
+  "let i=n==null?null:r.join(e.path,...n.toString().split(this.runsInsideWsl?",
+  "E.default.win32.sep:E.default.sep)),a=i==null?[]:[i];i!=null&&t===`rename`&&",
+  "e.renameEventHandling===`changed-path-with-parent-directory`&&a.push(r.dirname(i)),",
+  "e.onChange({changedPaths:a})}),a=e=>{n||(n=!0,i.close(),t.resolve(e))};",
+  "return i.on(`error`,e=>{a({reason:`watch-error`,error:e})}),{coverage:{recursive:",
+  "e.recursive,typedPathChanges:!1},path:e.path,closed:t.promise,dispose:async()=>{",
+  "a({reason:`disposed`})}}}",
+].join("");
+
+const CURRENT_SRC_LOCAL_FILE_WATCH = [
+  "async startFileWatch(e){let t=Kb(),n=!1,r=await this.platformPath(),",
+  "a=(0,c.watch)(this.getFileSystemPath(e.path),{recursive:e.recursive},(t,n)=>{",
+  "let a=n==null?null:r.join(e.path,...n.toString().split(this.runsInsideWsl?",
+  "i.default.win32.sep:i.default.sep)),o=a==null?[]:[a];a!=null&&t===`rename`&&",
+  "e.renameEventHandling===`changed-path-with-parent-directory`&&o.push(r.dirname(a)),",
+  "e.onChange({changedPaths:o})}),o=e=>{n||(n=!0,a.close(),t.resolve(e))};",
+  "return a.on(`error`,e=>{o({reason:`watch-error`,error:e})}),{coverage:{recursive:",
+  "e.recursive,typedPathChanges:!1},path:e.path,closed:t.promise,dispose:async()=>{",
+  "o({reason:`disposed`})}}}",
+].join("");
+
+const CURRENT_WORKER_REMOTE_FILE_WATCH = [
+  "async startFileWatch(e){let{onChange:t,...n}=e,r=await this.callHost(e=>",
+  "e.startFileWatch(n,t)),i=!1,a=()=>{i||(i=!0,r[Symbol.dispose]())},o,s;try{",
+  "[o,s]=await Promise.all([r.coverage,r.path])}catch(e){throw a(),e}let c=r.closed()",
+  ".finally(a);return{coverage:o,path:s,closed:c,dispose:async()=>{try{await r.dispose()}",
+  "finally{a()}}}}",
+].join("");
+
+const CURRENT_SRC_REMOTE_FILE_WATCH = [
+  "async startFileWatch(e){let t=await this.startFileWatchSession({onChange:e.onChange,",
+  "path:e.path,watchId:e.watchId});return{coverage:t.coverage,path:t.path,closed:t.closed,",
+  "dispose:async()=>{await t.dispose()}}}",
+].join("");
+
+const CURRENT_PARCEL_HELPER =
+  "async function rye(e,t){return new iye(await import(`@parcel/watcher`),e,t).start()}";
+const CURRENT_GIT_ROUTE_PREFIX =
+  "case`git`:{let e=new Yue;return{git:{createExecutionHost:e=>{if(n==null)" +
+  "throw Error(`Git hosts require a main RPC connection`);return new $ue(n,e)},";
+const CURRENT_PARCEL_ROUTE =
+  "startWorkingTreeWatch:(t,n)=>t.isLocal?process.platform===`linux`?" +
+  "rye(n,{ignoredPaths:[E.posix.join(n.path,`.git`)]}):e.startFileWatch(n):" +
+  "t.startFileWatch(n)";
+const CURRENT_DIRECTORY_ROUTE =
+  `startWorkingTreeWatch:(t,n)=>t.isLocal?/*${PARCEL_WATCH_MARKER}*/` +
+  "e.startFileWatch(n):t.startFileWatch(n)";
+const CURRENT_GIT_ROUTE_SUFFIX = "}}}case`open-in`:";
+
+function currentWorkerSource(route = CURRENT_PARCEL_ROUTE) {
+  return [
+    "var Yue=class{runsInsideWsl;hostConfig={id:`local`,display_name:`Local`," +
+      "kind:`local`};id=`local`;isLocal=!0;",
+    CURRENT_WORKER_LOCAL_FILE_WATCH,
+    "};var CurrentWorkerRemote=class{",
+    CURRENT_WORKER_REMOTE_FILE_WATCH,
+    "};",
+    CURRENT_PARCEL_HELPER,
+    "function currentDependencies(r,n){switch(r){",
+    CURRENT_GIT_ROUTE_PREFIX,
+    route,
+    CURRENT_GIT_ROUTE_SUFFIX,
+    "return{openIn:null}}}",
+  ].join("");
+}
+
+function currentSrcSource() {
+  return [
+    "var CurrentSrcRemote=class{",
+    CURRENT_SRC_REMOTE_FILE_WATCH,
+    "};var $ne=class{runsInsideWsl;hostConfig={id:`local`,display_name:`Local`," +
+      "kind:`local`};id=`local`;isLocal=!0;",
+    CURRENT_SRC_LOCAL_FILE_WATCH,
     "};",
   ].join("");
 }
@@ -165,6 +260,58 @@ test("feature patch targets only the local recursive working-tree host", () => {
   assert.equal(second.source, first.source);
 });
 
+test("routes the current OpenAI Parcel working tree through the existing feature host", () => {
+  const settings = normalizedSettings();
+  const first = patchWorkerSource(currentWorkerSource(), settings);
+
+  assert.equal(first.matched, 1);
+  assert.equal(first.changed, 1);
+  assert.equal(first.source.split(PARCEL_WATCH_MARKER).length - 1, 1);
+  PARCEL_WORKING_TREE_WATCH.lastIndex = 0;
+  assert.equal(PARCEL_WORKING_TREE_WATCH.test(first.source), false);
+  assert.ok(first.source.includes(CURRENT_DIRECTORY_ROUTE));
+  assert.ok(first.source.includes(CURRENT_PARCEL_HELPER));
+  assert.ok(first.source.includes(CURRENT_WORKER_REMOTE_FILE_WATCH));
+  assert.match(
+    first.source,
+    /e\.recursive&&e\.renameEventHandling===`changed-path-with-parent-directory`\)return codexLinuxStartDirectoryOnlyWorkingTreeWatch/u,
+  );
+
+  assert.deepEqual(
+    patchWorkerSource(first.source, settings),
+    { source: first.source, matched: 1, changed: 0, reason: null },
+  );
+});
+
+test("correlates current route roles without pinning minified aliases", () => {
+  const parcelHelper =
+    "async function parcelStart(root,settings){return new ParcelWatcher(" +
+    "await import(`@parcel/watcher`),root,settings).start()}";
+  const gitRoutePrefix =
+    "case`git`:{let localHost=new LocalHost;return{git:{" +
+    "createExecutionHost:executionOptions=>{if(mainConnection==null)" +
+    "throw Error(`Git hosts require a main RPC connection`);" +
+    "return new RemoteHost(mainConnection,executionOptions)},";
+  const parcelRoute =
+    "startWorkingTreeWatch:(host,options)=>host.isLocal?process.platform===`linux`?" +
+    "parcelStart(options,{ignoredPaths:[pathApi.posix.join(options.path,`.git`)]}):" +
+    "localHost.startFileWatch(options):host.startFileWatch(options)";
+  const source = currentWorkerSource(parcelRoute)
+    .replace(CURRENT_PARCEL_HELPER, parcelHelper)
+    .replace(CURRENT_GIT_ROUTE_PREFIX, gitRoutePrefix)
+    .replace("var Yue=class{", "var LocalHost=class{");
+
+  const first = patchWorkerSource(source, normalizedSettings());
+  assert.equal(first.matched, 1);
+  assert.equal(first.changed, 1);
+  assert.ok(first.source.includes(parcelHelper));
+  assert.ok(first.source.includes(
+    `startWorkingTreeWatch:(host,options)=>host.isLocal?/*${PARCEL_WATCH_MARKER}*/` +
+      "localHost.startFileWatch(options):host.startFileWatch(options)",
+  ));
+  assert.doesNotMatch(first.source, /parcelStart\(options,/u);
+});
+
 test("feature patch reports drift instead of patching an ambiguous worker", () => {
   const source = `${localWorkerSource()}${localWorkerSource()}`;
   const result = patchWorkerSource(source, normalizedSettings());
@@ -179,16 +326,16 @@ test("feature patches the current local host copies in src and worker bundles", 
   await withTempTree((root) => {
     const buildDir = path.join(root, ".vite", "build");
     const workerPath = path.join(buildDir, "worker.js");
-    const localHostPath = path.join(buildDir, "src-current.js");
+    const localHostPath = path.join(buildDir, "src-Bn_6ASpg.js");
     fs.mkdirSync(buildDir, { recursive: true });
-    fs.writeFileSync(workerPath, localWorkerSource());
-    fs.writeFileSync(localHostPath, localWorkerSource());
+    fs.writeFileSync(workerPath, currentWorkerSource());
+    fs.writeFileSync(localHostPath, currentSrcSource());
 
     const first = patchWorker(root);
     assert.equal(first.matched, 2);
     assert.equal(first.changed, 2);
     assert.deepEqual(first.targets, [
-      path.join(".vite", "build", "src-current.js"),
+      path.join(".vite", "build", "src-Bn_6ASpg.js"),
       path.join(".vite", "build", "worker.js"),
     ]);
     for (const bundlePath of [localHostPath, workerPath]) {
@@ -196,11 +343,385 @@ test("feature patches the current local host copies in src and worker bundles", 
       assert.match(patched, /function codexLinuxStartDirectoryOnlyWorkingTreeWatch\(/);
       assert.doesNotThrow(() => new Function(patched));
     }
+    assert.ok(fs.readFileSync(workerPath, "utf8").includes(CURRENT_DIRECTORY_ROUTE));
 
     const second = patchWorker(root);
     assert.equal(second.matched, 2);
     assert.equal(second.changed, 0);
     assert.deepEqual(second.targets, first.targets);
+  });
+});
+
+test("second bundle write failure restores every attempted target and permits retry", async () => {
+  await withTempTree((root) => {
+    const buildDir = path.join(root, ".vite", "build");
+    const srcPath = path.join(buildDir, "src-Bn_6ASpg.js");
+    const workerPath = path.join(buildDir, "worker.js");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(srcPath, currentSrcSource());
+    fs.writeFileSync(workerPath, currentWorkerSource());
+    const originalBytes = new Map([
+      [srcPath, fs.readFileSync(srcPath)],
+      [workerPath, fs.readFileSync(workerPath)],
+    ]);
+    let writeCount = 0;
+    const baseDescriptor = descriptors.find(({ id }) => id === "worker-directory-watch");
+    const descriptor = {
+      ...baseDescriptor,
+      id: "feature:directory-only-working-tree-watch:worker-directory-watch",
+      name: "feature:directory-only-working-tree-watch:worker-directory-watch",
+      sourceKind: "feature",
+      featureId: "directory-only-working-tree-watch",
+      apply: (extractedDir, context) => patchWorker(extractedDir, {
+        ...context,
+        writeFileSync(filePath, source, encoding) {
+          writeCount += 1;
+          if (writeCount === 2) {
+            fs.writeFileSync(filePath, "partially-written", encoding);
+            throw new Error("simulated second bundle write failure");
+          }
+          fs.writeFileSync(filePath, source, encoding);
+        },
+      }),
+    };
+    const report = createPatchReport();
+    report.enabledFeatures = ["directory-only-working-tree-watch"];
+
+    captureWarnings(() => applyExtractedAppPatchDescriptors(
+      root,
+      [descriptor],
+      {},
+      report,
+      descriptor.phase,
+    ));
+    assert.equal(writeCount, 4);
+    for (const [filePath, expected] of originalBytes) {
+      assert.deepEqual(fs.readFileSync(filePath), expected);
+    }
+    const [failure] = enabledFeatureFailuresFromReport(report);
+    assert.equal(failure?.name, descriptor.id);
+    assert.equal(failure?.status, "skipped-optional");
+    assert.match(failure?.reason ?? "", /simulated second bundle write failure/u);
+
+    const retry = patchWorker(root);
+    assert.equal(retry.matched, 2);
+    assert.equal(retry.changed, 2);
+    const idempotent = patchWorker(root);
+    assert.equal(idempotent.matched, 2);
+    assert.equal(idempotent.changed, 0);
+  });
+});
+
+test("rollback byte-verification failure reports failed-integrity", async () => {
+  await withTempTree((root) => {
+    const buildDir = path.join(root, ".vite", "build");
+    const srcPath = path.join(buildDir, "src-Bn_6ASpg.js");
+    const workerPath = path.join(buildDir, "worker.js");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(srcPath, currentSrcSource());
+    fs.writeFileSync(workerPath, currentWorkerSource());
+    const originalWorker = fs.readFileSync(workerPath);
+    let writeCount = 0;
+    const baseDescriptor = descriptors.find(({ id }) => id === "worker-directory-watch");
+    const descriptor = {
+      ...baseDescriptor,
+      id: "feature:directory-only-working-tree-watch:worker-directory-watch",
+      name: "feature:directory-only-working-tree-watch:worker-directory-watch",
+      sourceKind: "feature",
+      featureId: "directory-only-working-tree-watch",
+      apply: (extractedDir, context) => patchWorker(extractedDir, {
+        ...context,
+        writeFileSync(filePath, source, encoding) {
+          writeCount += 1;
+          if (writeCount === 2) {
+            fs.writeFileSync(filePath, "partially-written", encoding);
+            throw new Error("simulated second bundle write failure");
+          }
+          if (writeCount === 4) {
+            fs.writeFileSync(filePath, "rollback-corrupt", encoding);
+            return;
+          }
+          fs.writeFileSync(filePath, source, encoding);
+        },
+      }),
+    };
+    const report = createPatchReport();
+    report.enabledFeatures = ["directory-only-working-tree-watch"];
+
+    assert.throws(
+      () => captureWarnings(() => applyExtractedAppPatchDescriptors(
+        root,
+        [descriptor],
+        {},
+        report,
+        descriptor.phase,
+      )),
+      (error) =>
+        error?.code === "PATCH_INTEGRITY_FAILURE" &&
+        /rollback could not restore original bytes.*rollback byte verification failed/iu.test(
+          error.message,
+        ),
+    );
+    assert.equal(writeCount, 4);
+    assert.equal(fs.readFileSync(srcPath, "utf8"), "rollback-corrupt");
+    assert.deepEqual(fs.readFileSync(workerPath), originalWorker);
+    const [failure] = enabledFeatureFailuresFromReport(report);
+    assert.equal(failure?.name, descriptor.id);
+    assert.equal(failure?.status, "failed-integrity");
+    assert.match(failure?.reason ?? "", /rollback byte verification failed/iu);
+  });
+});
+
+test("current-DMG route drift leaves every bundle byte-identical", async () => {
+  await withTempTree((root) => {
+    const directLocalRoute =
+      "startWorkingTreeWatch:(t,n)=>t.isLocal?e.startFileWatch(n):t.startFileWatch(n)";
+    const currentSettings = normalizedSettings();
+    const completedWorker = patchWorkerSource(
+      currentWorkerSource(),
+      currentSettings,
+    ).source;
+    const completedSrc = patchWorkerSource(currentSrcSource(), currentSettings).source;
+    const completedHelper = completedWorker.slice(0, completedWorker.indexOf("var Yue=class{"));
+    const completedBranch =
+      "if(process.platform===`linux`&&e.recursive&&" +
+      "e.renameEventHandling===`changed-path-with-parent-directory`)" +
+      `return ${HELPER_NAME}(this,e,${JSON.stringify(currentSettings)});`;
+    const staleSettings = { ...currentSettings, maxWatches: 4096 };
+    const staleWorker = patchWorkerSource(currentWorkerSource(), staleSettings).source;
+    const staleSrc = patchWorkerSource(currentSrcSource(), staleSettings).source;
+    const dualOwnerRoute =
+      `startWorkingTreeWatch:(t,n)=>t.isLocal?/*${PARCEL_WATCH_MARKER}*/` +
+      "(rye(n,{ignoredPaths:[E.posix.join(n.path,`.git`)]}),e.startFileWatch(n)):" +
+      "t.startFileWatch(n)";
+    const unrelatedLookalike =
+      "function unrelated(n,e){return process.platform===`linux`?" +
+      "rye(n,{ignoredPaths:[E.posix.join(n.path,`.git`)]}):e.startFileWatch(n)}";
+    const cases = [
+      {
+        name: "missing route",
+        sources: new Map([
+          ["src-current.js", currentSrcSource()],
+          ["worker.js", currentWorkerSource(directLocalRoute)],
+        ]),
+        reason: /0 Parcel route contracts/u,
+      },
+      {
+        name: "duplicate route",
+        sources: new Map([
+          ["src-current.js", currentSrcSource()],
+          [
+            "worker.js",
+            `${currentWorkerSource()}${CURRENT_GIT_ROUTE_PREFIX}` +
+              `${CURRENT_PARCEL_ROUTE}${CURRENT_GIT_ROUTE_SUFFIX}`,
+          ],
+        ]),
+        reason: /2 Parcel route contracts/u,
+      },
+      {
+        name: "uncorrelated helper alias",
+        sources: new Map([
+          ["src-current.js", currentSrcSource()],
+          ["worker.js", currentWorkerSource(CURRENT_PARCEL_ROUTE.replace("rye(n,", "Qve(n,"))],
+        ]),
+        reason: /0 route\/helper correlations/u,
+      },
+      {
+        name: "uncorrelated local host class",
+        sources: new Map([
+          ["src-current.js", currentSrcSource()],
+          ["worker.js", currentWorkerSource().replace("let e=new Yue", "let e=new OtherHost")],
+        ]),
+        reason: /0 route\/helper correlations/u,
+      },
+      {
+        name: "local method moved outside the routed class",
+        sources: new Map([
+          ["src-current.js", currentSrcSource()],
+          [
+            "worker.js",
+            currentWorkerSource().replace(
+              CURRENT_WORKER_LOCAL_FILE_WATCH,
+              `};var OtherHost=class extends BaseHost{${CURRENT_WORKER_LOCAL_FILE_WATCH}`,
+            ),
+          ],
+        ]),
+        reason: /0 route\/helper correlations/u,
+      },
+      {
+        name: "uncorrelated main connection alias",
+        sources: new Map([
+          ["src-current.js", currentSrcSource()],
+          ["worker.js", currentWorkerSource().replace("new $ue(n,e)", "new $ue(other,e)")],
+        ]),
+        reason: /0 route\/helper correlations/u,
+      },
+      {
+        name: "marker beside a live Parcel route",
+        sources: new Map([
+          ["src-current.js", currentSrcSource()],
+          ["worker.js", `/*${PARCEL_WATCH_MARKER}*/${currentWorkerSource()}`],
+        ]),
+        reason: /current 26\.730\.61639 working-tree contract rejected/iu,
+      },
+      {
+        name: "marker in the src bundle",
+        sources: new Map([
+          ["src-current.js", `/*${PARCEL_WATCH_MARKER}*/${currentSrcSource()}`],
+          ["worker.js", currentWorkerSource()],
+        ]),
+        reason: /current 26\.730\.61639 working-tree contract rejected/iu,
+      },
+      {
+        name: "dual Parcel and directory ownership",
+        sources: new Map([
+          ["src-current.js", currentSrcSource()],
+          ["worker.js", currentWorkerSource(dualOwnerRoute)],
+        ]),
+        reason: /current 26\.730\.61639 working-tree contract rejected/iu,
+      },
+      {
+        name: "unrelated raw route lookalike",
+        sources: new Map([
+          ["src-current.js", currentSrcSource()],
+          ["worker.js", `${currentWorkerSource(directLocalRoute)}${unrelatedLookalike}`],
+        ]),
+        reason: /current 26\.730\.61639 working-tree contract rejected/iu,
+      },
+      {
+        name: "route outside worker.js",
+        sources: new Map([
+          [
+            "src-current.js",
+            `${currentSrcSource()}${CURRENT_PARCEL_HELPER}${CURRENT_GIT_ROUTE_PREFIX}` +
+              `${CURRENT_PARCEL_ROUTE}${CURRENT_GIT_ROUTE_SUFFIX}`,
+          ],
+          ["worker.js", currentWorkerSource(directLocalRoute)],
+        ]),
+        reason: /1 Parcel route contracts \(0 in worker\.js\)/u,
+      },
+      {
+        name: "partially completed pair",
+        sources: new Map([
+          ["src-current.js", currentSrcSource()],
+          ["worker.js", completedWorker],
+        ]),
+        reason: /current 26\.730\.61639 working-tree contract rejected/iu,
+      },
+      {
+        name: "damaged completed helper",
+        sources: new Map([
+          ["src-current.js", completedSrc],
+          [
+            "worker.js",
+            completedWorker.replace(
+              "const GIT_QUERY_TIMEOUT_MS = 5000;",
+              "const GIT_QUERY_TIMEOUT_MS = 5001;",
+            ),
+          ],
+        ]),
+        reason: /current 26\.730\.61639 working-tree contract rejected/iu,
+      },
+      {
+        name: "altered completed platform guard",
+        sources: new Map([
+          ["src-current.js", completedSrc],
+          [
+            "worker.js",
+            completedWorker.replace(
+              "if(process.platform===`linux`&&e.recursive&&",
+              "if(process.platform===`darwin`&&e.recursive&&",
+            ),
+          ],
+        ]),
+        reason: /current 26\.730\.61639 working-tree contract rejected/iu,
+      },
+      {
+        name: "duplicate completed helper",
+        sources: new Map([
+          ["src-current.js", completedSrc],
+          ["worker.js", `${completedHelper}${completedWorker}`],
+        ]),
+        reason: /current 26\.730\.61639 working-tree contract rejected/iu,
+      },
+      {
+        name: "duplicate completed branch",
+        sources: new Map([
+          ["src-current.js", completedSrc],
+          ["worker.js", completedWorker.replace(completedBranch, completedBranch.repeat(2))],
+        ]),
+        reason: /current 26\.730\.61639 working-tree contract rejected/iu,
+      },
+      {
+        name: "stale completed settings",
+        sources: new Map([
+          ["src-current.js", staleSrc],
+          ["worker.js", staleWorker],
+        ]),
+        reason: /current 26\.730\.61639 working-tree contract rejected/iu,
+      },
+    ];
+
+    for (const [index, entry] of cases.entries()) {
+      const buildDir = path.join(root, `case-${index}`, ".vite", "build");
+      fs.mkdirSync(buildDir, { recursive: true });
+      for (const [name, source] of entry.sources) {
+        fs.writeFileSync(path.join(buildDir, name), source);
+      }
+
+      const { value: result } = captureWarnings(() => patchWorker(path.dirname(path.dirname(buildDir))));
+      assert.equal(result.matched, 0, entry.name);
+      assert.equal(result.changed, 0, entry.name);
+      assert.match(result.reason, entry.reason, entry.name);
+      for (const [name, source] of entry.sources) {
+        assert.equal(fs.readFileSync(path.join(buildDir, name), "utf8"), source, entry.name);
+      }
+    }
+  });
+});
+
+test("current-DMG route drift is an enabled-feature acceptance failure", async () => {
+  await withTempTree((root) => {
+    const buildDir = path.join(root, ".vite", "build");
+    const sources = new Map([
+      ["src-Bn_6ASpg.js", currentSrcSource()],
+      [
+        "worker.js",
+        currentWorkerSource(
+          "startWorkingTreeWatch:(t,n)=>t.isLocal?e.startFileWatch(n):t.startFileWatch(n)",
+        ),
+      ],
+    ]);
+    fs.mkdirSync(buildDir, { recursive: true });
+    for (const [name, source] of sources) {
+      fs.writeFileSync(path.join(buildDir, name), source);
+    }
+
+    const baseDescriptor = descriptors.find(({ id }) => id === "worker-directory-watch");
+    const descriptor = {
+      ...baseDescriptor,
+      id: "feature:directory-only-working-tree-watch:worker-directory-watch",
+      name: "feature:directory-only-working-tree-watch:worker-directory-watch",
+      sourceKind: "feature",
+      featureId: "directory-only-working-tree-watch",
+    };
+    const report = createPatchReport();
+    report.enabledFeatures = ["directory-only-working-tree-watch"];
+    captureWarnings(() => applyExtractedAppPatchDescriptors(
+      root,
+      [descriptor],
+      {},
+      report,
+      descriptor.phase,
+    ));
+
+    const [failure] = enabledFeatureFailuresFromReport(report);
+    assert.equal(failure?.name, descriptor.id);
+    assert.equal(failure?.status, "skipped-optional");
+    assert.match(failure?.reason ?? "", /current|Parcel|route|contract/iu);
+    for (const [name, source] of sources) {
+      assert.equal(fs.readFileSync(path.join(buildDir, name), "utf8"), source);
+    }
   });
 });
 
@@ -222,7 +743,7 @@ test("feature rejects local host copies outside the current src and worker pair"
     }
     assert.equal(result.matched, 0);
     assert.equal(result.changed, 0);
-    assert.match(result.reason, /Found 3 current local startFileWatch bundles/);
+    assert.match(result.reason, /Found 3 local startFileWatch implementations/);
   });
 });
 


### PR DESCRIPTION
## Summary

OpenAI Desktop 26.730.61639 sends local Git working-tree subscriptions directly through `@parcel/watcher`, bypassing the existing `startFileWatch()` interception used by the opt-in `directory-only-working-tree-watch` feature. This change restores the feature by routing only that current local Parcel handoff through the existing local host's `startFileWatch()` method.

The matcher correlates the current minified helper, local host, Git execution host, main connection, route arguments, and path API without depending on their exact alias spellings. It also proves that the patched method belongs to the routed local-host class and validates the complete helper, Linux guard, settings-aware branch, and route before treating an installation as already patched.

Remote watches and non-working-tree file watches retain their upstream behavior. Missing, duplicated, misplaced, partial, stale, dual-owner, or otherwise uncorrelated contracts report enabled-feature drift and leave both bundles unchanged. The feature remains disabled by default.

This is the narrowly scoped current-DMG routing fix requested during review. It intentionally excludes the Watchbound dependency migration, global Electron runtime qualification, shared transactional infrastructure, Nix pin changes, ambiguous-rename package ownership work, and platform or ARM policy changes.  (See #1232).

## Validation

- `node linux-features/directory-only-working-tree-watch/test.js` — 116 tests passed
- `node --test scripts/lib/linux-features.test.js linux-features/shallow-repository-watches/test.js scripts/ci/upstream-dmg-acceptance.test.js scripts/ci/upstream-dmg-issue.test.js` — passed
- `bash scripts/ci/run-node-checks.sh syntax` — passed
- `nix flake check --no-build --no-write-lock-file --extra-experimental-features 'nix-command flakes'` — passed
- `nix build .#checks.x86_64-linux.watchdog-linux-features --no-link --print-build-logs --max-jobs 1 --extra-experimental-features 'nix-command flakes'` — passed against DMG 26.730.61639 with no integrity failures and `directory-only-working-tree-watch: applied=1`
- Direct validation against the current ASAR bundles confirmed that both exact bundle contracts matched, the prepared output parsed successfully, and a second application was idempotent
- `git diff --check upstream/main...HEAD` — passed
- Required GitHub CI checks have not run yet, so the corresponding checklist item remains unchecked

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.