### PR TITLE
Fix upstream DMG drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           bash -n scripts/build-rpm.sh
           bash -n scripts/build-pacman.sh
           bash -n scripts/build-appimage.sh
+          bash -n scripts/ci/download-upstream-dmg.sh
           bash -n scripts/ci/update-nix-hashes.sh
           bash -n scripts/ci/validate-nix-pins.sh
 

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -10,6 +10,7 @@ on:
       - scripts/patch-linux-window-ui.js
       - scripts/patch-linux-window-ui.test.js
       - scripts/patches/**
+      - scripts/ci/download-upstream-dmg.sh
       - scripts/ci/validate-patch-report.js
       - scripts/ci/upstream-dmg-*.js
       - scripts/validate-upstream-dmg.js
@@ -33,6 +34,7 @@ on:
       - scripts/patch-linux-window-ui.js
       - scripts/patch-linux-window-ui.test.js
       - scripts/patches/**
+      - scripts/ci/download-upstream-dmg.sh
       - scripts/ci/validate-patch-report.js
       - scripts/ci/upstream-dmg-*.js
       - scripts/validate-upstream-dmg.js
@@ -124,11 +126,12 @@ jobs:
           key: upstream-dmg-${{ env.DMG_CACHE_SCHEMA_VERSION }}-${{ steps.upstream-metadata.outputs.cache_segment }}
 
       - name: Download upstream DMG
-        if: steps.dmg-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          mkdir -p "$(dirname "$UPSTREAM_DMG_PATH")"
-          curl -fL --retry 3 -o "$UPSTREAM_DMG_PATH" "$UPSTREAM_DMG_URL"
+          scripts/ci/download-upstream-dmg.sh \
+            "$UPSTREAM_DMG_URL" \
+            "$UPSTREAM_DMG_PATH" \
+            --reuse-existing
 
       - name: Record local DMG fingerprint
         id: local-dmg

--- a/docs/windowless-warm-start-fix-report.md
+++ b/docs/windowless-warm-start-fix-report.md
@@ -26,8 +26,8 @@ would route work into a partially destroyed application context.
 The current upstream main bundle has one targeted lifecycle `will-quit` handler
 with two cleanup branches:
 
-- a reduced branch stops Codex Micro and flushes tracing;
-- a full branch also flushes global state and settings.
+- a reduced branch flushes global state, stops Codex Micro, and flushes tracing;
+- a full branch additionally flushes settings.
 
 Both branches call `preventDefault()`, run lifecycle disposers, wait with
 `Promise.allSettled()`, dispose the application context and shared disposable

--- a/flake.nix
+++ b/flake.nix
@@ -94,10 +94,10 @@
 
         codexDmg = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg";
-          hash = "sha256-M61HAaH3I3MzE68F6ygWOStos2froJIdvgeNLVeXGbU=";
+          hash = "sha256-+KWnSss4qrSlmsCtf+87tLtPKAp+0l88t+9hRd9eh0c=";
         };
 
-        codexVersion = "26.730.61639";
+        codexVersion = "26.803.41515";
         electronVersion = "42.3.0";
         electronPlatform =
           {

--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -147,7 +147,7 @@ Config keys:
 
 ### `reasoning.keepEffortLabelsEnglish`
 
-Leaves the reasoning effort values as `None`, `Minimal`, `Low`, `Medium`,
+Leaves the current reasoning effort values as `None`, `Minimal`, `Medium`,
 `High`, `XHigh`, `Max`, and `Ultra` in the Simplified Chinese locale. The
 surrounding picker title and usage warning remain translated. This avoids
 collapsing distinct upstream values such as `XHigh` and `Ultra` into the same

--- a/linux-features/ui-tweaks/patches/reasoning-effort-labels.js
+++ b/linux-features/ui-tweaks/patches/reasoning-effort-labels.js
@@ -4,7 +4,6 @@ const ZH_CN_LOCALE_ASSET_PATTERN = /^zh-CN-[^.]+\.js$/;
 const ENGLISH_REASONING_LABELS = Object.freeze({
   "composer.mode.local.reasoning.none.label": "None",
   "composer.mode.local.reasoning.minimal.label": "Minimal",
-  "composer.mode.local.reasoning.low.label": "Low",
   "composer.mode.local.reasoning.medium.label": "Medium",
   "composer.mode.local.reasoning.high.label": "High",
   "composer.mode.local.reasoning.xhigh.label": "XHigh",

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -104,7 +104,6 @@ function simplifiedChineseLocaleFixture() {
   const labels = {
     "composer.mode.local.reasoning.none.label": "无",
     "composer.mode.local.reasoning.minimal.label": "极低",
-    "composer.mode.local.reasoning.low.label": "轻度",
     "composer.mode.local.reasoning.medium.label": "中",
     "composer.mode.local.reasoning.high.label": "高",
     "composer.mode.local.reasoning.xhigh.label": "极高",
@@ -310,6 +309,10 @@ test("reasoning effort labels stay in English in the Simplified Chinese locale",
   const source = simplifiedChineseLocaleFixture();
   const patched = applyEnglishReasoningLabels(source);
 
+  assert.equal(
+    Object.hasOwn(ENGLISH_REASONING_LABELS, "composer.mode.local.reasoning.low.label"),
+    false,
+  );
   for (const [key, label] of Object.entries(ENGLISH_REASONING_LABELS)) {
     assert.match(patched, new RegExp(`"${key.replaceAll(".", "\\.")}":\\\`${label}\\\``));
   }

--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -691,7 +691,7 @@ run_upstream_job() {
 
     if [ ! -s "$dmg_path" ]; then
         info "Downloading upstream DMG"
-        curl -fL --retry 3 -o "$dmg_path" "$UPSTREAM_DMG_URL"
+        scripts/ci/download-upstream-dmg.sh "$UPSTREAM_DMG_URL" "$dmg_path"
     else
         info "Using cached upstream DMG: $dmg_path"
     fi

--- a/scripts/ci/download-upstream-dmg.sh
+++ b/scripts/ci/download-upstream-dmg.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 <upstream-dmg-url> <destination> [--reuse-existing]" >&2
+    exit 2
+}
+
+[ "$#" -ge 2 ] && [ "$#" -le 3 ] || usage
+
+UPSTREAM_DMG_URL="$1"
+UPSTREAM_DMG_PATH="$2"
+REUSE_EXISTING="${3:-}"
+DOWNLOAD_ATTEMPTS="${CODEX_DMG_DOWNLOAD_ATTEMPTS:-3}"
+RETRY_DELAY_SECONDS="${CODEX_DMG_RETRY_DELAY_SECONDS:-1}"
+
+case "$REUSE_EXISTING" in
+    ""|--reuse-existing) ;;
+    *) usage ;;
+esac
+case "$DOWNLOAD_ATTEMPTS" in
+    *[!0-9]*|0)
+        echo "CODEX_DMG_DOWNLOAD_ATTEMPTS must be a positive integer" >&2
+        exit 2
+        ;;
+esac
+case "$RETRY_DELAY_SECONDS" in
+    *[!0-9]*)
+        echo "CODEX_DMG_RETRY_DELAY_SECONDS must be a non-negative integer" >&2
+        exit 2
+        ;;
+esac
+case "$UPSTREAM_DMG_URL" in
+    https://*) ;;
+    *)
+        echo "Upstream DMG URL must use HTTPS" >&2
+        exit 2
+        ;;
+esac
+
+if [ "$REUSE_EXISTING" = "--reuse-existing" ] && [ -s "$UPSTREAM_DMG_PATH" ]; then
+    echo "Using cached upstream DMG: $UPSTREAM_DMG_PATH"
+    exit 0
+fi
+
+mkdir -p "$(dirname "$UPSTREAM_DMG_PATH")"
+PART_PATH="$UPSTREAM_DMG_PATH.part"
+
+cleanup() {
+    rm -f -- "$PART_PATH"
+}
+trap cleanup EXIT HUP INT TERM
+
+attempt=1
+while [ "$attempt" -le "$DOWNLOAD_ATTEMPTS" ]; do
+    rm -f -- "$PART_PATH"
+    if curl \
+            -fL \
+            --retry 2 \
+            --retry-all-errors \
+            --connect-timeout 30 \
+            --max-time 900 \
+            -o "$PART_PATH" \
+            -- "$UPSTREAM_DMG_URL"; then
+        if [ -s "$PART_PATH" ]; then
+            mv -f -- "$PART_PATH" "$UPSTREAM_DMG_PATH"
+            trap - EXIT HUP INT TERM
+            echo "Downloaded upstream DMG: $UPSTREAM_DMG_PATH"
+            exit 0
+        fi
+        echo "Upstream DMG download attempt $attempt produced an empty file" >&2
+    else
+        echo "Upstream DMG download attempt $attempt failed" >&2
+    fi
+
+    if [ "$attempt" -lt "$DOWNLOAD_ATTEMPTS" ] && [ "$RETRY_DELAY_SECONDS" -gt 0 ]; then
+        sleep "$RETRY_DELAY_SECONDS"
+    fi
+    attempt=$((attempt + 1))
+done
+
+echo "Could not download a non-empty upstream DMG after $DOWNLOAD_ATTEMPTS attempts" >&2
+exit 1

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -167,8 +167,7 @@ nix_pin_files_changed() {
 }
 
 main() {
-    mkdir -p "$(dirname "$UPSTREAM_DMG_PATH")"
-    curl -fL --retry 3 -o "$UPSTREAM_DMG_PATH" "$UPSTREAM_DMG_URL"
+    "$REPO_DIR/scripts/ci/download-upstream-dmg.sh" "$UPSTREAM_DMG_URL" "$UPSTREAM_DMG_PATH"
 
     new_dmg_hash="$(nix hash file --sri --type sha256 "$UPSTREAM_DMG_PATH")"
     if ! validate_sri_hash "$new_dmg_hash"; then

--- a/scripts/ci/upstream-dmg-acceptance.test.js
+++ b/scripts/ci/upstream-dmg-acceptance.test.js
@@ -211,10 +211,112 @@ test("upstream workflow concurrency is isolated per PR or ref", () => {
   );
   assert.doesNotMatch(workflow, /group: upstream-dmg-acceptance-\$\{\{ github\.event_name \}\}\s*$/m);
   assert.equal((workflow.match(/- linux-features\/\*\*/g) ?? []).length, 2);
+  assert.equal((workflow.match(/- scripts\/ci\/download-upstream-dmg\.sh/g) ?? []).length, 2);
   assert.equal((workflow.match(/- scripts\/lib\/linux-features\.js/g) ?? []).length, 2);
   assert.doesNotMatch(workflow, /uses:\s+[^\s]+@v\d/);
   assert.match(workflow, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
   assert.match(workflow, /persist-credentials: false/);
+  assert.match(
+    workflow,
+    /scripts\/ci\/download-upstream-dmg\.sh[\s\S]*--reuse-existing/,
+  );
+});
+
+test("CI DMG downloader retries empty responses and promotes only non-empty files", () => withFixture(({ root }) => {
+  const bin = path.join(root, "bin");
+  const destination = path.join(root, "Codex.dmg");
+  const attempts = path.join(root, "attempts");
+  const curl = path.join(bin, "curl");
+  fs.mkdirSync(bin);
+  fs.writeFileSync(curl, `#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+count=0
+[ ! -f "$TEST_ATTEMPTS" ] || count="$(cat "$TEST_ATTEMPTS")"
+count=$((count + 1))
+printf '%s\\n' "$count" > "$TEST_ATTEMPTS"
+if [ "$count" -eq 1 ]; then
+  : > "$output"
+else
+  printf '%s' 'complete dmg' > "$output"
+fi
+`);
+  fs.chmodSync(curl, 0o755);
+
+  const result = spawnSync("bash", [
+    path.resolve(__dirname, "download-upstream-dmg.sh"),
+    "https://example.test/Codex.dmg",
+    destination,
+  ], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH}`,
+      TEST_ATTEMPTS: attempts,
+      CODEX_DMG_RETRY_DELAY_SECONDS: "0",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.readFileSync(attempts, "utf8").trim(), "2");
+  assert.equal(fs.readFileSync(destination, "utf8"), "complete dmg");
+  assert.equal(fs.existsSync(`${destination}.part`), false);
+}));
+
+test("CI DMG downloader preserves the previous file when every response is empty", () => withFixture(({ root }) => {
+  const bin = path.join(root, "bin");
+  const destination = path.join(root, "Codex.dmg");
+  const curl = path.join(bin, "curl");
+  fs.mkdirSync(bin);
+  fs.writeFileSync(destination, "previous dmg");
+  fs.writeFileSync(curl, `#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+: > "$output"
+`);
+  fs.chmodSync(curl, 0o755);
+
+  const result = spawnSync("bash", [
+    path.resolve(__dirname, "download-upstream-dmg.sh"),
+    "https://example.test/Codex.dmg",
+    destination,
+  ], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH}`,
+      CODEX_DMG_DOWNLOAD_ATTEMPTS: "2",
+      CODEX_DMG_RETRY_DELAY_SECONDS: "0",
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(fs.readFileSync(destination, "utf8"), "previous dmg");
+  assert.equal(fs.existsSync(`${destination}.part`), false);
+}));
+
+test("all CI upstream DMG consumers use the non-empty atomic downloader", () => {
+  for (const relativePath of [
+    "container-entrypoint.sh",
+    "update-nix-hashes.sh",
+    "validate-nix-pins.sh",
+  ]) {
+    const source = fs.readFileSync(path.resolve(__dirname, relativePath), "utf8");
+    assert.match(source, /scripts\/ci\/download-upstream-dmg\.sh/);
+    assert.doesNotMatch(source, /curl -fL --retry 3 -o [^\n]*UPSTREAM_DMG/);
+  }
 });
 
 test("Nix refresh serializes campaigns and deduplicates refresh and exact-head CI", () => {

--- a/scripts/ci/validate-nix-pins.sh
+++ b/scripts/ci/validate-nix-pins.sh
@@ -193,8 +193,7 @@ assert_equal() {
 }
 
 if [ ! -s "$UPSTREAM_DMG_PATH" ]; then
-    mkdir -p "$(dirname "$UPSTREAM_DMG_PATH")"
-    curl -fL --retry 3 -o "$UPSTREAM_DMG_PATH" "$UPSTREAM_DMG_URL"
+    "$REPO_DIR/scripts/ci/download-upstream-dmg.sh" "$UPSTREAM_DMG_URL" "$UPSTREAM_DMG_PATH"
 fi
 
 SEVEN_ZIP_CMD="$(find_seven_zip)" || fail "7z/7zz/7za not found"

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1403,7 +1403,7 @@ function beforeQuitConfirmationBundleFixture() {
 
 function willQuitDrainBundleFixture() {
   return [
-    "l.app.on(`will-quit`,e=>{if(y=!0,v)return;let t=()=>{U5(h,N5).then(()=>{g.dispose(),l.app.quit()})};if(r.shouldSkipDrainBeforeQuit()){e.preventDefault(),v=!0,c.dispose(),u.dispose(),Promise.allSettled([p(),m()]).then(t);return}e.preventDefault(),v=!0,c.dispose(),u.dispose(),Promise.allSettled([d.flush(),f.flush(),p(),m()]).then(t)});",
+    "l.app.on(`will-quit`,e=>{if(y=!0,v)return;let t=()=>{U5(h,N5).then(()=>{g.dispose(),l.app.quit()})};if(r.shouldSkipDrainBeforeQuit()){e.preventDefault(),v=!0,c.dispose(),u.dispose(),Promise.allSettled([d.flush(),p(),m()]).then(t);return}e.preventDefault(),v=!0,c.dispose(),u.dispose(),Promise.allSettled([d.flush(),f.flush(),p(),m()]).then(t)});",
   ].join("");
 }
 
@@ -1903,17 +1903,19 @@ function currentSparkleUpdateMenuContractFixture() {
 function latestAvatarOverlayBundleFixture() {
   return [
     "let c=require(`electron`),h=require(`node:child_process`);",
+    "function Bs(e,t){return typeof e.setInputShape==`function`&&e.setInputShape(t)===!0}",
     "function eo(e,{addon:t,electronAppPath:n,platform:r=process.platform,resourcesPath:i=process.resourcesPath}={}){if(r!==`darwin`)return!1;try{return(t??Sa({electronAppPath:n??c.app.getAppPath(),resourcesPath:i})).setRemoteHostedPIPContentComputerUseCursorLocationHandler(e)}catch{return!1}}",
     "var d5=`/avatar-overlay`,of={width:356,height:320},m5={width:112,height:121},y5={width:0,height:0},v5={width:276,height:131};",
-    "var fV=class{window=null;layout=null;mascotSize=m5;traySize=null;pointerInteractive=!1;mousePassthroughEnabled=!1;layoutMode=`native`;compositionHost={setOverlayWindow(){},isNativeMaterialAttached(){return!1},getCursorPosition(){return null},performWindowDrag(){return!1},updateMascotRect(){},publishRemoteHostedPIPContentHost(){}};nativePositionController={clear(){}};",
+    "var fV=class{supportsInputShape=!0;window=null;layout=null;mascotSize=m5;traySize=null;pointerInteractive=!1;mousePassthroughEnabled=!1;inputShape=null;layoutMode=`native`;compositionHost={setOverlayWindow(){},isNativeMaterialAttached(){return!1},getCursorPosition(){return null},performWindowDrag(){return!1},updateMascotRect(){},publishRemoteHostedPIPContentHost(){}};nativePositionController={clear(){}};",
     "startDrag(e,t,n=!1){let r=this.window;if(r==null||r.isDestroyed()||r.webContents.id!==e)return;this.cancelMomentum();let i=this.getLayout(r),a=this.compositionHost.getCursorPosition(),o=t.pointerScreenX!=null?{x:t.pointerScreenX,y:t.pointerScreenY}:c.screen.getCursorScreenPoint();this.dragState=new a5(a==null?`renderer`:`native`,t.pointerWindowX-i.mascot.left,t.pointerWindowY-i.mascot.top,c.screen.getDisplayNearestPoint(o).bounds,n),this.windowServerDragActive=this.layoutMode===`native`&&!n&&this.compositionHost.performWindowDrag(),this.windowServerDragActive||(this.windowServerDragWindowX=null)}",
     "endDrag(e,t){let n=this.window;if(n==null||n.isDestroyed()||n.webContents.id!==e)return;let r=this.dragState,i=this.windowServerDragActive,a=null;this.dragState=null,this.windowServerDragActive=!1,this.windowServerDragWindowX=null,i?this.persistWindowBounds(n,a??this.getCurrentDisplay()):this.reclampWindowToVisibleDisplay({shouldPersist:!0});let o=this.dockTarget;o!=null&&this.dockPresentation(o.anchor,o.onDock)}",
     "setElementSize(e,{elementSizeRevision:t,isTrayVisible:n,mascot:r,nativeCompositionEnabled:i,tray:a}){let o=this.window;if(o==null||o.isDestroyed()||o.webContents.id!==e)return;this.mascotSize=r,this.traySize=a,this.applyLatestElementSizes(o),this.stageWindowForNativePresentation(o),this.showWindowIfReady(o)}",
-    "async createWindow(){let e=await this.windowManager.createWindow({title:c.app.getName(),width:of.width,height:of.height,appearance:`avatarOverlay`,focusable:!1,show:!1,initialRoute:d5});return this.window=e,this.compositionHost.setOverlayWindow(e),this.dragState=null,this.layout=null,this.mousePassthroughEnabled=!1,this.traySize=null,e.on(`closed`,()=>{if(this.window!==e)return;let t=this.presentationVisibility!=null;this.cancelMomentum(),this.clearMovedWindowPersist(),this.window=null,this.dragState=null,this.pointerInteractive=!1,this.mousePassthroughEnabled=!1,this.compositionHost.setOverlayWindow(null),this.broadcastOpenState()}),e}",
+    "async createWindow(){let e=await this.windowManager.createWindow({title:c.app.getName(),width:of.width,height:of.height,appearance:`avatarOverlay`,supportsWindowTiling:!1,focusable:!1,show:!1,initialRoute:d5});return this.window=e,this.compositionHost.setOverlayWindow(e),this.dragState=null,this.layout=null,this.mousePassthroughEnabled=!1,this.inputShape=null,this.traySize=null,e.on(`closed`,()=>{if(this.window!==e)return;let t=this.presentationVisibility!=null||this.startupPresentationVisibility!=null;this.cancelMomentum(),this.clearMovedWindowPersist(),this.window=null,this.dragState=null,this.pointerInteractive=!1,this.mousePassthroughEnabled=!1,this.compositionHost.setOverlayWindow(null),this.broadcastOpenState()}),e}",
     "getLayoutForDisplay(e){return pf({anchor:this.anchor,displayBounds:this.layoutMode===`native`?e.workArea:e.bounds,mode:this.layoutMode,mascotSize:this.mascotSize,nativeMaterialAttached:this.compositionHost.isNativeMaterialAttached(),previousPlacement:this.placement,traySize:this.traySize??(this.layoutMode===`native`?y5:v5)})}",
     "applyLayout(e,t=this.getCurrentDisplay(),n=!1,r=!0,i=null){if(e.isDestroyed())return;let a=this.getLayoutForDisplay(t);this.layout=a,this.setWindowBounds(e,a.windowBounds,n,r),this.compositionHost.updateMascotRect(a.mascot),this.sendLayoutToRenderer(e,i),this.computerUseCursorLocation!=null&&this.dragState==null&&this.sendComputerUseCursorLocationToRenderer(e)}",
     "showWindow(e){if(e.isDestroyed())return;let t=this.isOpen();e.moveTop(),e.showInactive(),this.compositionHost.publishRemoteHostedPIPContentHost(),!t&&this.isOpen()&&this.broadcastOpenState()}",
-    "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1;return}let t=!this.pointerInteractive;if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}",
+    "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1;return}if(this.applyInputShape(e))return;let t=!this.pointerInteractive;if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}",
+    "applyInputShape(e){if(!this.supportsInputShape||this.inputShape==null)return!1;this.mousePassthroughEnabled&&=(e.setIgnoreMouseEvents(!1),!1);let t=Bs(e,this.inputShape.map(({height:e,left:t,top:n,width:r})=>({height:e,width:r,x:t,y:n})));return t&&(this.mousePassthroughEnabled=!1),t}",
     "setComputerUseCursorLocation(e){this.computerUseCursorLocation=e,this.computerUseCursorPoint=e.isActive?{x:e.x,y:e.y}:null}",
     "sendComputerUseCursorLocationToRenderer(e){this.windowManager.sendMessageToWebContents(e.webContents,{type:`avatar-overlay-computer-use-cursor-changed`})}",
     "refreshCursorAtCurrentMousePosition(e){let t=c.screen.getCursorScreenPoint();return this.sendCursorPointToAvatarOverlay(e,t,!1)}",
@@ -2840,7 +2842,7 @@ test("Linux reduced will-quit branch shares the complete cleanup deadline", asyn
 
   assert.equal(contextDisposeCalls, 1);
   assert.equal(disposablesCalls, 1);
-  assert.equal(globalStateFlushCalls, 0);
+  assert.equal(globalStateFlushCalls, 1);
   assert.equal(settingsFlushCalls, 0);
   assert.equal(stopCodexMicroCalls, 1);
   assert.equal(flushTracingCalls, 1);
@@ -2982,6 +2984,10 @@ test("current will-quit drift fails the required lifecycle patch", () => {
 test("missing, renamed, or ambiguous will-quit targets fail the required lifecycle patch", () => {
   const sources = [
     willQuitDrainBundleFixture().replace(
+      "Promise.allSettled([d.flush(),p(),m()])",
+      "Promise.allSettled([p(),m()])",
+    ),
+    willQuitDrainBundleFixture().replace(
       "shouldSkipDrainBeforeQuit()",
       "skipDrainBeforeQuit()",
     ),
@@ -3053,7 +3059,7 @@ test("does not accept damaged Linux quit cleanup factory bodies", () => {
   );
   const sources = [
     patched.replace(
-      "codexLinuxRunQuitCleanup(()=>{c.dispose(),u.dispose();return Promise.allSettled([p(),m()])})",
+      "codexLinuxRunQuitCleanup(()=>{c.dispose(),u.dispose();return Promise.allSettled([d.flush(),p(),m()])})",
       "codexLinuxRunQuitCleanup(()=>{return Promise.resolve()})",
     ),
     patched.replace(
@@ -4498,8 +4504,7 @@ test("adds Linux avatar overlay mouse passthrough recovery", () => {
   assert.match(patched, /codexLinuxStartAvatarPassthroughRecovery\(\)/);
   assert.match(patched, /codexLinuxStopAvatarPassthroughRecovery\(\)/);
   assert.match(patched, /codexLinuxSyncAvatarPointerInteractivity\(e\)/);
-  assert.match(patched, /codexLinuxBuildAvatarInputShape\(e\)/);
-  assert.match(patched, /codexLinuxApplyAvatarInputShape\(e\)/);
+  assert.match(patched, /codexLinuxInputShape\(e\)/);
   assert.match(patched, /codexLinuxShouldUseWholeWindowInput\(\)\{return this\.codexLinuxWholeWindowInput===!0\}/);
   assert.match(patched, /codexLinuxIsI3Session\(\)/);
   assert.match(patched, /process\.env\.I3SOCK/);
@@ -4516,23 +4521,15 @@ test("adds Linux avatar overlay mouse passthrough recovery", () => {
   assert.match(patched, /Number\(__codexAvatarWidth\)!==t\.width/);
   assert.match(patched, /Number\(__codexAvatarHeight\)!==t\.height/);
   assert.doesNotMatch(patched, /let\[,l,h,d,f\]=c/);
-  assert.doesNotMatch(patched, /this\.codexLinuxIsI3Session\(\)\)\{this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.pointerInteractive=!0,this\.mousePassthroughEnabled&&\(this\.mousePassthroughEnabled=!1\),e\.setIgnoreMouseEvents\(!1\);return\}/);
-  assert.match(patched, /if\(this\.codexLinuxIsAvatarShapeBackend\(\)&&typeof e\.setShape==`function`\)\{/);
-  assert.match(patched, /if\(this\.codexLinuxIsAvatarShapeBackend\(\)&&typeof e\.setShape==`function`\)\{this\.codexLinuxStartAvatarPassthroughRecovery\(\),/);
-  assert.match(patched, /codexLinuxIsAvatarShapeBackend\(\)\{/);
-  assert.match(patched, /getSwitchValue\(`ozone-platform`\)/);
-  assert.match(patched, /return e===`x11`\|\|e===``&&!process\.env\.WAYLAND_DISPLAY/);
-  assert.doesNotMatch(patched, /XDG_SESSION_TYPE/);
-  assert.doesNotMatch(patched, /if\(process\.platform===`linux`&&typeof e\.setShape==`function`\)\{this\.codexLinuxStopAvatarPassthroughRecovery\(\),/);
-  assert.doesNotMatch(patched, /typeof e\.setShape==`function`&&!this\.codexLinuxIsI3Session\(\)/);
-  assert.match(patched, /if\(t==null\)return null/);
-  assert.match(patched, /try\{let t=this\.codexLinuxBuildAvatarInputShape\(e\);if\(t==null\)return!1;let n=JSON\.stringify\(t\)/);
-  assert.match(patched, /e\.setShape\(t\),this\.codexLinuxAvatarInputShapeKey=n;return!0/);
-  assert.match(patched, /return\[i\(t\.mascot\),i\(t\.tray\)\]\.filter\(Boolean\)/);
+  assert.match(patched, /if\(this\.applyInputShape\(e\)\)\{this\.codexLinuxStopAvatarPassthroughRecovery\(\);return\}/);
+  assert.match(patched, /Bs\(e,this\.codexLinuxInputShape\(e\)\.map\(/);
+  assert.match(patched, /return n==null\|\|!Number\.isFinite\(n\.width\)\|\|!Number\.isFinite\(n\.height\)\?t:\[\{height:n\.height,left:0,top:0,width:n\.width\}\]/);
+  assert.doesNotMatch(patched, /codexLinuxIsAvatarShapeBackend/);
+  assert.doesNotMatch(patched, /codexLinuxApplyAvatarInputShape/);
+  assert.doesNotMatch(patched, /\.setShape\(/);
   assert.match(patched, /process\.platform!==`linux`/);
   assert.match(patched, /setInterval\(\(\)=>\{let e=this\.window/);
   assert.match(patched, /\},32\)/);
-  assert.doesNotMatch(patched, /typeof e\.setShape==`function`\)return;this\.codexLinuxAvatarPassthroughRecoveryTimer=setInterval/);
   assert.match(patched, /this\.dragState!=null/);
   assert.match(patched, /this\.codexLinuxIsCursorInAvatarInteractiveRegion\(e\)/);
   assert.match(patched, /__codexWindowHit=__codexX>=0&&__codexY>=0&&__codexX<=__codexBounds\.width&&__codexY<=__codexBounds\.height/);
@@ -4549,7 +4546,28 @@ test("adds Linux avatar overlay mouse passthrough recovery", () => {
   assert.match(patched, /this\.sendComputerUseCursorLocationToRenderer\(e\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)\}showWindow/);
   assert.match(patched, /e\.moveTop\(\),e\.showInactive\(\),process\.platform===`linux`&&this\.codexLinuxApplyAvatarCompositorHints\(e\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/);
   assert.doesNotMatch(patched, /codexLinuxRecoverAvatarPointerInteractivity/);
-  assert.match(patched, /if\(this\.window!==e\)return;let t=this\.presentationVisibility!=null;this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.cancelMomentum\(\)/);
+  assert.match(patched, /if\(this\.window!==e\)return;let t=this\.presentationVisibility!=null\|\|this\.startupPresentationVisibility!=null;this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.cancelMomentum\(\)/);
+});
+
+test("obsolete avatar overlay interactivity policy fails the required patch", () => {
+  const source = latestAvatarOverlayBundleFixture().replace(
+    "if(this.applyInputShape(e))return;",
+    "",
+  );
+  const descriptor = corePatchDescriptors().find(
+    (candidate) => candidate.id === "linux-avatar-overlay-mouse-passthrough",
+  );
+  const report = createPatchReport();
+  const { value: result, warnings } = captureWarns(() =>
+    applyMainBundlePatchDescriptors(source, [descriptor], {}, report),
+  );
+
+  assert.equal(result.patchedSource, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not find avatar overlay mouse passthrough policy — skipping Linux avatar overlay passthrough recovery patch",
+  ]);
+  assert.equal(report.patches[0]?.status, "failed-required");
+  assert.equal(report.patches[0]?.reason, warnings[0]);
 });
 
 test("keeps the avatar overlay core patch idempotent after pet overlay composition", () => {
@@ -4576,7 +4594,6 @@ test("pet overlay opts into full-window input on X11 and Wayland", () => {
     ),
   );
   const cursor = { x: 100, y: 100 };
-  let ozonePlatform = "x11";
   const context = {
     globalThis: {},
     clearInterval() {},
@@ -4585,7 +4602,7 @@ test("pet overlay opts into full-window input on X11 and Wayland", () => {
       if (moduleName === "node:child_process") return { execFile() {} };
       assert.equal(moduleName, "electron");
       return {
-        app: { commandLine: { getSwitchValue: () => ozonePlatform }, getName: () => "Codex" },
+        app: { getName: () => "Codex" },
         screen: { getCursorScreenPoint: () => cursor },
       };
     },
@@ -4602,26 +4619,28 @@ test("pet overlay opts into full-window input on X11 and Wayland", () => {
     mascot: { left: 220, top: 190, width: 113, height: 122 },
     tray: { left: 57, top: 55, width: 276, height: 131 },
   };
+  controller.inputShape = [
+    { left: 220, top: 190, width: 113, height: 122 },
+    { left: 57, top: 55, width: 276, height: 131 },
+  ];
   const window = {
     getContentBounds: () => ({ x: 0, y: 0, width: 356, height: 320 }),
     isDestroyed: () => false,
     isVisible: () => true,
     setIgnoreMouseEvents() {},
-    setShape() {},
+    setInputShape: () => true,
   };
 
   controller.codexPetOverlaySyncWindow(window);
   assert.equal(controller.codexLinuxWholeWindowInput, true);
 
-  assert.deepEqual(JSON.parse(JSON.stringify(controller.codexLinuxBuildAvatarInputShape(window))), [
-    { x: 0, y: 0, width: 356, height: 320 },
+  assert.deepEqual(JSON.parse(JSON.stringify(controller.codexLinuxInputShape(window))), [
+    { left: 0, top: 0, width: 356, height: 320 },
   ]);
   cursor.x = 10;
   cursor.y = 300;
   assert.equal(controller.codexLinuxIsCursorInAvatarInteractiveRegion(window), true);
-  ozonePlatform = "wayland";
   controller.pointerInteractive = false;
-  assert.equal(controller.codexLinuxIsAvatarShapeBackend(), false);
   assert.equal(controller.codexLinuxSyncAvatarPointerInteractivity(window), true);
   assert.equal(controller.pointerInteractive, true);
 });
@@ -4636,7 +4655,6 @@ test("locked pet overlay keeps only mascot and tray interactive on X11 and Wayla
     { feature: { manifest: { petOverlay: { lockPosition: true } }, settings: {} } },
   );
   const cursor = { x: 10, y: 300 };
-  let ozonePlatform = "x11";
   const context = {
     globalThis: {},
     clearInterval() {},
@@ -4645,7 +4663,7 @@ test("locked pet overlay keeps only mascot and tray interactive on X11 and Wayla
       if (moduleName === "node:child_process") return { execFile() {} };
       assert.equal(moduleName, "electron");
       return {
-        app: { commandLine: { getSwitchValue: () => ozonePlatform }, getName: () => "Codex" },
+        app: { getName: () => "Codex" },
         screen: { getCursorScreenPoint: () => cursor },
       };
     },
@@ -4662,29 +4680,31 @@ test("locked pet overlay keeps only mascot and tray interactive on X11 and Wayla
     mascot: { left: 220, top: 190, width: 113, height: 122 },
     tray: { left: 57, top: 55, width: 276, height: 131 },
   };
+  controller.inputShape = [
+    { left: 220, top: 190, width: 113, height: 122 },
+    { left: 57, top: 55, width: 276, height: 131 },
+  ];
   const ignored = [];
   const window = {
     getContentBounds: () => ({ x: 0, y: 0, width: 356, height: 320 }),
     isDestroyed: () => false,
     isVisible: () => true,
     setIgnoreMouseEvents: (...args) => ignored.push(args),
-    setShape() {},
+    setInputShape: () => true,
   };
 
   controller.codexPetOverlaySyncWindow(window);
   assert.equal(controller.codexLinuxWholeWindowInput, false);
-  assert.deepEqual(JSON.parse(JSON.stringify(controller.codexLinuxBuildAvatarInputShape(window))), [
-    { x: 220, y: 190, width: 113, height: 122 },
-    { x: 57, y: 55, width: 276, height: 131 },
+  assert.deepEqual(JSON.parse(JSON.stringify(controller.codexLinuxInputShape(window))), [
+    { left: 220, top: 190, width: 113, height: 122 },
+    { left: 57, top: 55, width: 276, height: 131 },
   ]);
 
-  ozonePlatform = "wayland";
   controller.window = window;
   controller.pointerInteractive = true;
-  assert.equal(controller.codexLinuxIsAvatarShapeBackend(), false);
   assert.equal(controller.codexLinuxIsCursorInAvatarInteractiveRegion(window), false);
   controller.applyPointerInteractivityPolicy();
-  assert.deepEqual(JSON.parse(JSON.stringify(ignored)), [[true, { forward: true }]]);
+  assert.deepEqual(JSON.parse(JSON.stringify(ignored)), []);
 });
 
 test("keeps Linux avatar overlay above the app while reply inputs are focusable", () => {
@@ -4695,9 +4715,9 @@ test("keeps Linux avatar overlay above the app while reply inputs are focusable"
 
   assert.match(
     patched,
-    /appearance:`avatarOverlay`,alwaysOnTop:process\.platform===`linux`,skipTaskbar:process\.platform===`linux`,focusable:process\.platform===`linux`\?!0:!1,show:!1/,
+    /appearance:`avatarOverlay`,supportsWindowTiling:!1,alwaysOnTop:process\.platform===`linux`,skipTaskbar:process\.platform===`linux`,focusable:process\.platform===`linux`\?!0:!1,show:!1/,
   );
-  assert.doesNotMatch(patched, /appearance:`avatarOverlay`,focusable:!1,show:!1/);
+  assert.doesNotMatch(patched, /appearance:`avatarOverlay`,supportsWindowTiling:!1,focusable:!1,show:!1/);
 
   const nonAvatarSource = "async createWindow(){return this.windowManager.createWindow({appearance:`main`,focusable:!1,show:!1})}";
   assert.equal(
@@ -4712,7 +4732,6 @@ test("Linux avatar overlay interactivity is bounded to avatar regions", () => {
     latestAvatarOverlayBundleFixture(),
   );
   const cursor = { x: 5843, y: 1036 };
-  let ozonePlatform = "";
   const context = {
     globalThis: {},
     process: {
@@ -4728,7 +4747,6 @@ test("Linux avatar overlay interactivity is bounded to avatar regions", () => {
       return {
       app: {
         getName: () => "Codex",
-        commandLine: { getSwitchValue: () => ozonePlatform },
       },
       screen: {
         getCursorScreenPoint: () => cursor,
@@ -4769,30 +4787,38 @@ test("Linux avatar overlay interactivity is bounded to avatar regions", () => {
     false,
   );
 
+  const appliedShapes = [];
   const overlayWindow = {
     isDestroyed: () => false,
     getContentBounds: () => ({ x: 5743, y: 936, width: 356, height: 320 }),
-    setShape() {},
+    setInputShape(shape) {
+      appliedShapes.push(shape);
+      return true;
+    },
   };
   const serializeShape = (shape) => JSON.parse(JSON.stringify(shape));
-  assert.deepEqual(serializeShape(controller.codexLinuxBuildAvatarInputShape(overlayWindow)), [
-    { x: 220, y: 190, width: 113, height: 122 },
-    { x: 57, y: 55, width: 276, height: 131 },
+  controller.inputShape = [
+    { left: 220, top: 190, width: 113, height: 122 },
+    { left: 57, top: 55, width: 276, height: 131 },
+  ];
+  assert.deepEqual(serializeShape(controller.codexLinuxInputShape(overlayWindow)), [
+    { left: 220, top: 190, width: 113, height: 122 },
+    { left: 57, top: 55, width: 276, height: 131 },
   ]);
   controller.pointerInteractive = true;
-  assert.deepEqual(serializeShape(controller.codexLinuxBuildAvatarInputShape(overlayWindow)), [
-    { x: 220, y: 190, width: 113, height: 122 },
-    { x: 57, y: 55, width: 276, height: 131 },
+  assert.deepEqual(serializeShape(controller.codexLinuxInputShape(overlayWindow)), [
+    { left: 220, top: 190, width: 113, height: 122 },
+    { left: 57, top: 55, width: 276, height: 131 },
   ]);
   controller.dragState = {};
-  assert.deepEqual(serializeShape(controller.codexLinuxBuildAvatarInputShape(overlayWindow)), [
-    { x: 0, y: 0, width: 356, height: 320 },
+  assert.deepEqual(serializeShape(controller.codexLinuxInputShape(overlayWindow)), [
+    { left: 0, top: 0, width: 356, height: 320 },
   ]);
   controller.dragState = null;
   assert.equal(controller.codexLinuxShouldUseWholeWindowInput(), false);
   controller.codexLinuxWholeWindowInput = true;
-  assert.deepEqual(serializeShape(controller.codexLinuxBuildAvatarInputShape(overlayWindow)), [
-    { x: 0, y: 0, width: 356, height: 320 },
+  assert.deepEqual(serializeShape(controller.codexLinuxInputShape(overlayWindow)), [
+    { left: 0, top: 0, width: 356, height: 320 },
   ]);
   assert.equal(
     controller.codexLinuxIsCursorInAvatarInteractiveRegion({
@@ -4801,52 +4827,25 @@ test("Linux avatar overlay interactivity is bounded to avatar regions", () => {
     true,
   );
   controller.codexLinuxWholeWindowInput = false;
-  context.process.env.WAYLAND_DISPLAY = "wayland-0";
-  assert.equal(controller.codexLinuxIsAvatarShapeBackend(), false);
-  assert.equal(controller.codexLinuxApplyAvatarInputShape(overlayWindow), false);
-  let setShapeCalls = 0;
-  ozonePlatform = "x11";
-  assert.equal(controller.codexLinuxIsAvatarShapeBackend(), true);
-  assert.equal(
-    controller.codexLinuxApplyAvatarInputShape({
-      ...overlayWindow,
-      setShape() {
-        setShapeCalls += 1;
-      },
-    }),
-    true,
-  );
-  assert.equal(setShapeCalls, 1);
-  ozonePlatform = "wayland";
-  assert.equal(controller.codexLinuxIsAvatarShapeBackend(), false);
-  ozonePlatform = "x11";
+  assert.equal(controller.applyInputShape(overlayWindow), true);
+  assert.deepEqual(serializeShape(appliedShapes), [[
+    { x: 220, y: 190, width: 113, height: 122 },
+    { x: 57, y: 55, width: 276, height: 131 },
+  ]]);
+  controller.codexLinuxWholeWindowInput = true;
   let failingBoundsCalls = 0;
-  assert.equal(
-    controller.codexLinuxApplyAvatarInputShape({
-      isDestroyed: () => false,
-      getContentBounds: () => {
-        failingBoundsCalls += 1;
-        throw new Error("drift");
-      },
-      setShape() {},
-    }),
-    false,
-  );
+  assert.deepEqual(serializeShape(controller.codexLinuxInputShape({
+    getContentBounds: () => {
+      failingBoundsCalls += 1;
+      throw new Error("drift");
+    },
+  })), [
+    { left: 220, top: 190, width: 113, height: 122 },
+    { left: 57, top: 55, width: 276, height: 131 },
+  ]);
   assert.equal(failingBoundsCalls, 1);
-  controller.codexLinuxAvatarInputShapeKey = null;
-  let failingSetShapeCalls = 0;
-  assert.equal(
-    controller.codexLinuxApplyAvatarInputShape({
-      isDestroyed: () => false,
-      getContentBounds: () => ({ x: 5743, y: 936, width: 356, height: 320 }),
-      setShape() {
-        failingSetShapeCalls += 1;
-        throw new Error("unsupported");
-      },
-    }),
-    false,
-  );
-  assert.equal(failingSetShapeCalls, 1);
+  controller.supportsInputShape = false;
+  assert.equal(controller.applyInputShape(overlayWindow), false);
 });
 
 test("patches the latest avatar overlay class without depending on adjacent methods", () => {
@@ -4864,7 +4863,7 @@ test("patches the latest avatar overlay class without depending on adjacent meth
   assert.match(patched, /this\.windowServerDragActive=!1[\s\S]*?process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)\}setElementSize/);
   assert.match(patched, /this\.applyLatestElementSizes\(o\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/);
   assert.match(patched, /this\.compositionHost\.updateMascotRect\(a\.mascot\)[\s\S]*?process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)\}showWindow/);
-  assert.match(patched, /if\(this\.window!==e\)return;let t=this\.presentationVisibility!=null;this\.codexLinuxStopAvatarPassthroughRecovery\(\)/);
+  assert.match(patched, /if\(this\.window!==e\)return;let t=this\.presentationVisibility!=null\|\|this\.startupPresentationVisibility!=null;this\.codexLinuxStopAvatarPassthroughRecovery\(\)/);
   assert.match(patched, /traySize:process\.platform===`linux`&&typeof this\.codexLinuxIsI3Session==`function`/);
 });
 

--- a/scripts/patches/impl/avatar-overlay.js
+++ b/scripts/patches/impl/avatar-overlay.js
@@ -80,22 +80,18 @@ function avatarCursorRegionPatch(electronVar) {
   return `codexLinuxIsCursorInAvatarInteractiveRegion(e){let t=this.layout;if(t==null)return!1;let __codexCursor=${electronVar}.screen.getCursorScreenPoint(),__codexBounds=e.getContentBounds(),__codexX=__codexCursor.x-__codexBounds.x,__codexY=__codexCursor.y-__codexBounds.y,__codexWindowHit=__codexX>=0&&__codexY>=0&&__codexX<=__codexBounds.width&&__codexY<=__codexBounds.height;if(!__codexWindowHit)return!1;if(this.codexLinuxShouldUseWholeWindowInput())return!0;let __codexHit=e=>e!=null&&__codexX>=e.left&&__codexX<=e.left+e.width&&__codexY>=e.top&&__codexY<=e.top+e.height;return __codexHit(t.mascot)||__codexHit(t.tray)}`;
 }
 
-function avatarInputShapePatch() {
-  return "codexLinuxShouldUseWholeWindowInput(){return this.codexLinuxWholeWindowInput===!0}codexLinuxBuildAvatarInputShape(e){let t=this.layout;if(t==null)return null;let r;try{r=e.getContentBounds()}catch{return null}if(r==null||!Number.isFinite(r.width)||!Number.isFinite(r.height))return null;if(this.dragState!=null||this.codexLinuxShouldUseWholeWindowInput())return[{x:0,y:0,width:r.width,height:r.height}];let i=e=>{if(e==null)return null;let t=Math.max(0,e.left),n=Math.max(0,e.top),i=Math.min(r.width,e.left+e.width)-t,a=Math.min(r.height,e.top+e.height)-n;return i<=0||a<=0?null:{x:t,y:n,width:i,height:a}};return[i(t.mascot),i(t.tray)].filter(Boolean)}";
-}
-
-function avatarApplyInputShapePatch() {
-  return "codexLinuxApplyAvatarInputShape(e){if(process.platform!==`linux`||e==null||e.isDestroyed()||typeof e.setShape!=`function`||typeof this.codexLinuxIsAvatarShapeBackend==`function`&&!this.codexLinuxIsAvatarShapeBackend())return!1;try{let t=this.codexLinuxBuildAvatarInputShape(e);if(t==null)return!1;let n=JSON.stringify(t);if(this.codexLinuxAvatarInputShapeKey===n)return!0;e.setShape(t),this.codexLinuxAvatarInputShapeKey=n;return!0}catch{this.codexLinuxAvatarInputShapeKey=null;return!1}}";
+function avatarInputShapeOverridePatch() {
+  return "codexLinuxShouldUseWholeWindowInput(){return this.codexLinuxWholeWindowInput===!0}codexLinuxInputShape(e){let t=this.inputShape;if(t==null||this.dragState==null&&!this.codexLinuxShouldUseWholeWindowInput())return t;let n;try{n=e.getContentBounds()}catch{return t}return n==null||!Number.isFinite(n.width)||!Number.isFinite(n.height)?t:[{height:n.height,left:0,top:0,width:n.width}]}";
 }
 
 function patchAvatarOverlayWindowOptions(source) {
   const windowOptionsPatch =
-    "appearance:`avatarOverlay`,alwaysOnTop:process.platform===`linux`,skipTaskbar:process.platform===`linux`,focusable:process.platform===`linux`?!0:!1";
+    "appearance:`avatarOverlay`,supportsWindowTiling:!1,alwaysOnTop:process.platform===`linux`,skipTaskbar:process.platform===`linux`,focusable:process.platform===`linux`?!0:!1";
   if (source.includes(windowOptionsPatch)) {
     return source;
   }
   return source.replace(
-    "appearance:`avatarOverlay`,focusable:!1",
+    "appearance:`avatarOverlay`,supportsWindowTiling:!1,focusable:!1",
     windowOptionsPatch,
   );
 }
@@ -118,13 +114,14 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
     "codexLinuxIsI3Session(){let e=[process.env.XDG_CURRENT_DESKTOP,process.env.DESKTOP_SESSION,process.env.I3SOCK].filter(Boolean).join(`:`).toLowerCase();return/(^|[:;/])i3([:;/.-]|$)/.test(e)}";
   const compositorHintsMethod =
     `codexLinuxApplyAvatarCompositorHints(e){if(process.platform!==\`linux\`||!this.codexLinuxIsI3Session()||this.codexLinuxAvatarCompositorHintsApplied||this.codexLinuxAvatarCompositorHintsApplying||e==null||e.isDestroyed()||!process.env.DISPLAY)return;let t;try{t=e.getBounds?.()??e.getContentBounds?.()}catch{}if(t==null||!Number.isFinite(t.x)||!Number.isFinite(t.y)||!Number.isFinite(t.width)||!Number.isFinite(t.height))return;let n=[];try{let r=e.getNativeWindowHandle?.();r!=null&&r.length>=4&&n.push(String(r.readUInt32LE(0)))}catch{}this.codexLinuxAvatarCompositorHintsApplying=!0;let r=e=>{let r=[...new Set(e)].filter(e=>/^[0-9]+$/.test(e)&&e!==\`0\`);if(r.length===0){this.codexLinuxAvatarCompositorHintsApplying=!1;return}let i=r.length,a=!1,o=()=>{i--,i===0&&(this.codexLinuxAvatarCompositorHintsApplying=!1,a&&(this.codexLinuxAvatarCompositorHintsApplied=!0))},s=e=>{try{${childProcessVar}.execFile(\`xwininfo\`,[\`-id\`,e],{timeout:1e3},(r,i)=>{if(r){o();return}let s=String(i??\`\`),c=s.match(/Absolute upper-left X:\\s+(-?\\d+)[\\s\\S]*Absolute upper-left Y:\\s+(-?\\d+)[\\s\\S]*Width:\\s+(\\d+)[\\s\\S]*Height:\\s+(\\d+)/);if(c==null||!/Override Redirect State:\\s+yes/.test(s)){o();return}let[,__codexAvatarX,__codexAvatarY,__codexAvatarWidth,__codexAvatarHeight]=c;if(Number(__codexAvatarX)!==t.x||Number(__codexAvatarY)!==t.y||Number(__codexAvatarWidth)!==t.width||Number(__codexAvatarHeight)!==t.height){o();return}try{${childProcessVar}.execFile(\`xprop\`,[\`-id\`,e,\`-f\`,\`_GTK_FRAME_EXTENTS\`,\`32c\`,\`-set\`,\`_GTK_FRAME_EXTENTS\`,\`0, 0, 0, 0\`],{timeout:1e3},e=>{e||(a=!0),o()})}catch{o()}})}catch{o()}};for(let t of r)s(t)};try{${childProcessVar}.execFile(\`xdotool\`,[\`search\`,\`--pid\`,String(process.pid)],{timeout:1e3},(e,t)=>{r([...n,...String(t??\`\`).trim().split(/\\s+/).filter(Boolean)])})}catch{r(n)}}`;
-  const shapeBackendMethod =
-    `codexLinuxIsAvatarShapeBackend(){if(process.platform!==\`linux\`)return!1;let e=\`\`;try{e=${electronVar}.app.commandLine.getSwitchValue(\`ozone-platform\`)}catch{}return e===\`x11\`||e===\`\`&&!process.env.WAYLAND_DISPLAY}`;
-
   const interactivityNeedle =
-    "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1;return}let t=!this.pointerInteractive;if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}";
+    "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1;return}if(this.applyInputShape(e))return;let t=!this.pointerInteractive;if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}";
+  const inputShapeNeedle =
+    "applyInputShape(e){if(!this.supportsInputShape||this.inputShape==null)return!1;this.mousePassthroughEnabled&&=(e.setIgnoreMouseEvents(!1),!1);let t=Bs(e,this.inputShape.map(({height:e,left:t,top:n,width:r})=>({height:e,width:r,x:t,y:n})));return t&&(this.mousePassthroughEnabled=!1),t}";
+  const inputShapeMethodPatch =
+    "applyInputShape(e){if(!this.supportsInputShape||this.inputShape==null)return!1;this.mousePassthroughEnabled&&=(e.setIgnoreMouseEvents(!1),!1);let t=Bs(e,this.codexLinuxInputShape(e).map(({height:e,left:t,top:n,width:r})=>({height:e,width:r,x:t,y:n})));return t&&(this.mousePassthroughEnabled=!1),t}";
   const interactivityMethodPatch =
-    "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1,this.codexLinuxStopAvatarPassthroughRecovery();return}if(this.codexLinuxIsAvatarShapeBackend()&&typeof e.setShape==`function`){this.codexLinuxStartAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}process.platform===`linux`&&(this.codexLinuxStartAvatarPassthroughRecovery(),this.codexLinuxSyncAvatarPointerInteractivity(e));let t=!this.pointerInteractive;this.dragState!=null&&(t=!1);if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}";
+    "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1,this.codexLinuxStopAvatarPassthroughRecovery();return}if(this.applyInputShape(e)){this.codexLinuxStopAvatarPassthroughRecovery();return}process.platform===`linux`&&(this.codexLinuxStartAvatarPassthroughRecovery(),this.codexLinuxSyncAvatarPointerInteractivity(e));let t=!this.pointerInteractive;this.dragState!=null&&(t=!1);if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}";
   const stopRecoveryMethod =
     "codexLinuxStopAvatarPassthroughRecovery(){this.codexLinuxAvatarPassthroughRecoveryTimer!=null&&(clearInterval(this.codexLinuxAvatarPassthroughRecoveryTimer),this.codexLinuxAvatarPassthroughRecoveryTimer=null)}";
   const startRecoveryMethod =
@@ -135,10 +132,8 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
     interactivityMethodPatch +
     i3SessionMethod +
     compositorHintsMethod +
-    shapeBackendMethod +
     stopRecoveryMethod +
-    avatarInputShapePatch() +
-    avatarApplyInputShapePatch() +
+    avatarInputShapeOverridePatch() +
     startRecoveryMethod +
     syncInteractivityMethod +
     avatarCursorRegionPatch(electronVar);
@@ -148,11 +143,27 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
       patchedSource,
       /applyPointerInteractivityPolicy\(\)\{/,
     );
-    if (interactivityMethod?.text === interactivityNeedle) {
+    const inputShapeMethod = findAvatarOverlayMethod(
+      patchedSource,
+      /applyInputShape\([A-Za-z_$][\w$]*\)\{/,
+    );
+    if (
+      interactivityMethod?.text === interactivityNeedle &&
+      inputShapeMethod?.text === inputShapeNeedle
+    ) {
       recordStrategy("avatar-interactivity", "upstream");
       patchedSource = replaceAvatarMethodText(
         patchedSource,
-        interactivityMethod,
+        inputShapeMethod,
+        inputShapeMethodPatch,
+      );
+      const currentInteractivityMethod = findAvatarOverlayMethod(
+        patchedSource,
+        /applyPointerInteractivityPolicy\(\)\{/,
+      );
+      patchedSource = replaceAvatarMethodText(
+        patchedSource,
+        currentInteractivityMethod,
         interactivityPatch,
       );
     } else if (
@@ -355,7 +366,7 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
     ? null
     : createWindowMethod.text.slice(closedHandlerOpenIndex, closedHandlerCloseIndex + 1);
   const closeCleanup =
-    "this.codexLinuxStopAvatarPassthroughRecovery(),this.codexLinuxAvatarInputShapeKey=null,this.codexLinuxAvatarCompositorHintsApplied=!1,this.codexLinuxAvatarCompositorHintsApplying=!1,";
+    "this.codexLinuxStopAvatarPassthroughRecovery(),this.codexLinuxAvatarCompositorHintsApplied=!1,this.codexLinuxAvatarCompositorHintsApplying=!1,";
   if (closedHandler?.includes(closeCleanup)) {
     recordStrategy("avatar-close-cleanup", "already-applied");
   } else if (

--- a/scripts/patches/impl/main-process/quit-lifecycle.js
+++ b/scripts/patches/impl/main-process/quit-lifecycle.js
@@ -44,7 +44,7 @@ function parseCurrentWillQuitDrainBody(body, eventVar, listenerElectronVar) {
     `^(?<contextDispose>${identifier})\\((?<contextArg>${identifier}),(?<contextTimeout>${identifier})\\)\\.then\\(\\(\\)=>\\{(?<disposables>${identifier})\\.dispose\\(\\),(?<electron>${identifier})\\.app\\.quit\\(\\)\\}\\)$`,
   ));
   const reducedMatch = outerMatch.groups.reduced.match(new RegExp(
-    `^(?<event>${identifier})\\.preventDefault\\(\\),(?<draining>${identifier})=!0,(?<hotkey>${identifier})\\.dispose\\(\\),(?<dictation>${identifier})\\.dispose\\(\\),Promise\\.allSettled\\(\\[(?<stop>${identifier})\\(\\),(?<trace>${identifier})\\(\\)\\]\\)\\.then\\((?<finalize>${identifier})\\)$`,
+    `^(?<event>${identifier})\\.preventDefault\\(\\),(?<draining>${identifier})=!0,(?<hotkey>${identifier})\\.dispose\\(\\),(?<dictation>${identifier})\\.dispose\\(\\),Promise\\.allSettled\\(\\[(?<globalState>${identifier})\\.flush\\(\\),(?<stop>${identifier})\\(\\),(?<trace>${identifier})\\(\\)\\]\\)\\.then\\((?<finalize>${identifier})\\)$`,
   ));
   const fullMatch = outerMatch.groups.full.match(new RegExp(
     `^(?<event>${identifier})\\.preventDefault\\(\\),(?<draining>${identifier})=!0,(?<hotkey>${identifier})\\.dispose\\(\\),(?<dictation>${identifier})\\.dispose\\(\\),Promise\\.allSettled\\(\\[(?<globalState>${identifier})\\.flush\\(\\),(?<settings>${identifier})\\.flush\\(\\),(?<stop>${identifier})\\(\\),(?<trace>${identifier})\\(\\)\\]\\)\\.then\\((?<finalize>${identifier})\\)$`,
@@ -65,6 +65,7 @@ function parseCurrentWillQuitDrainBody(body, eventVar, listenerElectronVar) {
     full.draining !== outer.draining ||
     reduced.hotkey !== full.hotkey ||
     reduced.dictation !== full.dictation ||
+    reduced.globalState !== full.globalState ||
     reduced.stop !== full.stop ||
     reduced.trace !== full.trace ||
     reduced.finalize !== outer.upstreamFinalize ||
@@ -167,7 +168,7 @@ function hasAppliedWillQuitCleanupPostcondition(currentSource, appliedFinalizerS
   }
 
   const reducedMatch = reducedBody.match(new RegExp(
-    `codexLinuxRunQuitCleanup\\(\\(\\)=>\\{(?<hotkey>${identifier})\\.dispose\\(\\),(?<dictation>${identifier})\\.dispose\\(\\);return Promise\\.allSettled\\(\\[(?<stop>${identifier})\\(\\),(?<trace>${identifier})\\(\\)\\]\\)\\}\\)`,
+    `codexLinuxRunQuitCleanup\\(\\(\\)=>\\{(?<hotkey>${identifier})\\.dispose\\(\\),(?<dictation>${identifier})\\.dispose\\(\\);return Promise\\.allSettled\\(\\[(?<globalState>${identifier})\\.flush\\(\\),(?<stop>${identifier})\\(\\),(?<trace>${identifier})\\(\\)\\]\\)\\}\\)`,
   ));
   const fullMatch = fullBody.match(new RegExp(
     `codexLinuxRunQuitCleanup\\(\\(\\)=>\\{(?<hotkey>${identifier})\\.dispose\\(\\),(?<dictation>${identifier})\\.dispose\\(\\);return Promise\\.allSettled\\(\\[(?<globalState>${identifier})\\.flush\\(\\),(?<settings>${identifier})\\.flush\\(\\),(?<stop>${identifier})\\(\\),(?<trace>${identifier})\\(\\)\\]\\)\\}\\)`,
@@ -179,6 +180,7 @@ function hasAppliedWillQuitCleanupPostcondition(currentSource, appliedFinalizerS
   return (
     reducedMatch.groups.hotkey === fullMatch.groups.hotkey &&
     reducedMatch.groups.dictation === fullMatch.groups.dictation &&
+    reducedMatch.groups.globalState === fullMatch.groups.globalState &&
     reducedMatch.groups.stop === fullMatch.groups.stop &&
     reducedMatch.groups.trace === fullMatch.groups.trace
   );
@@ -234,8 +236,8 @@ function applyLinuxWillQuitDrainTimeoutPatch(currentSource) {
     `let ${originalFinalizer},${linuxFinalizer};`,
   );
   patchedBody = patchedBody.replace(
-    `${reduced.hotkey}.dispose(),${reduced.dictation}.dispose(),Promise.allSettled([${reduced.stop}(),${reduced.trace}()]).then(${outer.upstreamFinalize})`,
-    `codexLinuxRunQuitCleanup(()=>{${reduced.hotkey}.dispose(),${reduced.dictation}.dispose();return Promise.allSettled([${reduced.stop}(),${reduced.trace}()])})`,
+    `${reduced.hotkey}.dispose(),${reduced.dictation}.dispose(),Promise.allSettled([${reduced.globalState}.flush(),${reduced.stop}(),${reduced.trace}()]).then(${outer.upstreamFinalize})`,
+    `codexLinuxRunQuitCleanup(()=>{${reduced.hotkey}.dispose(),${reduced.dictation}.dispose();return Promise.allSettled([${reduced.globalState}.flush(),${reduced.stop}(),${reduced.trace}()])})`,
   );
   patchedBody = patchedBody.replace(
     `${full.hotkey}.dispose(),${full.dictation}.dispose(),Promise.allSettled([${full.globalState}.flush(),${full.settings}.flush(),${full.stop}(),${full.trace}()]).then(${outer.upstreamFinalize})`,

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -9219,7 +9219,7 @@ const x={o:e=>e};let s=require(`node:url`),n=require(`electron`);n=x.o(n);let l=
 var pb=class{getNativeTrayMenuItems(){return[{label:this.systemQuitMenuItemLabel,click:()=>{n.app.quit()}}]}};
 function qB(r,o){if(o.type===`quit-app`){n.app.quit();return}return o}
 n.app.on(`before-quit`,o=>{let s=BI(),c=t.sr().some(e=>e.status===`ACTIVE`);if(e||i.canQuitWithoutPrompt()||r||!s&&!c){g=!0,a.markAppQuitting();return}let l=n.app.getName();if(n.dialog.showMessageBoxSync({type:`warning`,buttons:[`Quit`,`Cancel`],defaultId:0,cancelId:1,noLink:!0,title:`Quit ${l}?`,message:`Quit ${l}?`,detail:vB({hasInProgressLocalConversation:s,hasEnabledAutomations:c})})!==0){o.preventDefault();return}i.markQuitApproved(),g=!0,a.markAppQuitting()});
-l.app.on(`will-quit`,e=>{if(y=!0,v)return;let t=()=>{U5(h,N5).then(()=>{g.dispose(),l.app.quit()})};if(r.shouldSkipDrainBeforeQuit()){e.preventDefault(),v=!0,c.dispose(),u.dispose(),Promise.allSettled([p(),m()]).then(t);return}e.preventDefault(),v=!0,c.dispose(),u.dispose(),Promise.allSettled([d.flush(),f.flush(),p(),m()]).then(t)});
+l.app.on(`will-quit`,e=>{if(y=!0,v)return;let t=()=>{U5(h,N5).then(()=>{g.dispose(),l.app.quit()})};if(r.shouldSkipDrainBeforeQuit()){e.preventDefault(),v=!0,c.dispose(),u.dispose(),Promise.allSettled([d.flush(),p(),m()]).then(t);return}e.preventDefault(),v=!0,c.dispose(),u.dispose(),Promise.allSettled([d.flush(),f.flush(),p(),m()]).then(t)});
 JS
 )"
     make_fake_extracted_asar "$extracted" "$bundle_body"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3952,7 +3952,9 @@ make_update_nix_hash_fixture() {
     local hash_a="sha256-VVQNu/E7Wuyxfsy93Gorknr0t7H7wy9kxMOiBZYOo/o="
 
     mkdir -p "$fixture/scripts/ci" "$fixture/nix/native-modules" "$fixture/bin"
+    cp "$REPO_DIR/scripts/ci/download-upstream-dmg.sh" "$fixture/scripts/ci/download-upstream-dmg.sh"
     cp "$REPO_DIR/scripts/ci/update-nix-hashes.sh" "$fixture/scripts/ci/update-nix-hashes.sh"
+    chmod +x "$fixture/scripts/ci/download-upstream-dmg.sh"
     chmod +x "$fixture/scripts/ci/update-nix-hashes.sh"
 
     cat > "$fixture/flake.nix" <<EOF


### PR DESCRIPTION
<!-- upstream-dmg-sha256:f8a5a74acb38aab4a59ac0ad7fef3bb4bb4f280a7ed25f3cb7ef6145df5e8747 -->

## Summary
- repair Linux compatibility drift for the current upstream DMG
- remove obsolete compatibility paths replaced by the current DMG shape

## Validation
- exact current-DMG acceptance recorded by watchdog v2
- GitHub CI must pass, including Nix Package Builds
