### PR TITLE
fix: bump rustls-webpki 0.103.10 → 0.103.13 (GHSA-82j2-j2ch-gfr8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,9 +2294,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- Bumps `rustls-webpki` from 0.103.10 to 0.103.13 in `Cargo.lock`
- Addresses GHSA-82j2-j2ch-gfr8 (rustls-webpki certificate-validation vulnerability)
- Bumps `codex-update-manager` patch version to 0.11.1 per CONTRIBUTING.md versioning rules
- The 0.103.11–0.103.13 patch series includes CRL-parsing fixes and additional certificate-validation hardening; this is not limited to malformed CRL handling

## Impact

`rustls-webpki` is a transitive dependency of `reqwest` (via the `rustls` feature) used by `codex-update-manager`. This is a shared/core dependency on the native-package update path, not behind an optional feature flag.

## Test plan

- [ ] `cargo check -p codex-update-manager` passes
- [ ] `cargo test -p codex-update-manager` passes
- [ ] CI passes on updated head