### PR TITLE
Fix Linux tray startup and watchdog metadata

### DIFF
--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -280,5 +280,6 @@ jobs:
               repo: context.repo,
               decision,
               currentHttpIdentityKey: httpIdentity(currentMetadata)?.key ?? null,
+              scanAll: true,
             });
             core.info(`Upstream DMG issue reconciliation: ${JSON.stringify(result)}`);

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -17,6 +17,9 @@ on:
       - scripts/lib/candidate-install.sh
       - scripts/lib/bundled-plugins.sh
       - scripts/lib/browser-client-node-repl-runtime.test.js
+      - scripts/lib/build-info.js
+      - scripts/lib/build-info.sh
+      - scripts/lib/build-info.test.js
       - scripts/lib/patch-browser-client-iab-socket-scope.js
       - scripts/lib/patch-validation.js
       - scripts/lib/upstream-dmg-acceptance.js
@@ -41,6 +44,9 @@ on:
       - scripts/lib/candidate-install.sh
       - scripts/lib/bundled-plugins.sh
       - scripts/lib/browser-client-node-repl-runtime.test.js
+      - scripts/lib/build-info.js
+      - scripts/lib/build-info.sh
+      - scripts/lib/build-info.test.js
       - scripts/lib/patch-browser-client-iab-socket-scope.js
       - scripts/lib/patch-validation.js
       - scripts/lib/upstream-dmg-acceptance.js

--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,11 @@ write_transaction_dmg_metadata() {
     "${CODEX_ACCEPTANCE_NODE:-node}" - "$output_path" "$dmg_path" "$cached_metadata" "$DMG_URL" <<'NODE'
 const fs = require("node:fs");
 const [outputPath, dmgPath, metadataPath, url] = process.argv.slice(2);
-const metadata = { url, path: dmgPath };
+let metadata = {};
+if (fs.existsSync(outputPath)) {
+  metadata = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+}
+Object.assign(metadata, { url, path: dmgPath });
 if (metadataPath && fs.existsSync(metadataPath)) {
   for (const line of fs.readFileSync(metadataPath, "utf8").split(/\r?\n/)) {
     const separator = line.indexOf("=");
@@ -134,6 +138,7 @@ transactional_install() {
         CODEX_INSTALL_DIR="$candidate_dir" \
         CODEX_PATCH_REPORT_JSON="$core_report" \
         CODEX_REBUILD_REPORT_JSON="$rebuild_report" \
+        CODEX_UPSTREAM_DMG_METADATA_JSON="$metadata_path" \
         "$BASH" "$SCRIPT_DIR/install.sh" "${original_args[@]}"; then
         build_status="success"
     fi
@@ -331,6 +336,7 @@ main() {
 
     local app_dir
     app_dir=$(extract_dmg "$dmg_path")
+    record_upstream_app_version "$app_dir"
 
     detect_electron_version "$app_dir"
     if [ "$INSPECT_ONLY" -eq 1 ]; then

--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -45,7 +45,7 @@ const currentRuntimeSource = [
 ].join("");
 
 const currentTraySource =
-  "let codexLinuxTray=null,codexLinuxRegisterTray=e=>(codexLinuxTray=e,e);async function Ywe(e){let t=await Xwe(e.buildFlavor,e.appBrand,e.repoRoot),n=codexLinuxRegisterTray(new l.Tray(t.defaultIcon));if(!W9)return n.destroy(),null;return n}";
+  "let codexLinuxTray=null,codexLinuxRegisterTray=e=>(codexLinuxTray=e,e);async function Ywe(e){let t=await Xwe(e.buildFlavor,e.appBrand,e.repoRoot),n=codexLinuxRegisterTray(new l.Tray(...(process.platform===`linux`?[t.defaultIcon]:[t.defaultIcon,process.platform===`win32`&&l.app.isPackaged?dEe(e.buildFlavor):void 0])));if(!W9)return n.destroy(),null;return n}";
 
 const currentMainSource = currentAppInfoSource + currentRuntimeSource + currentTraySource;
 
@@ -186,7 +186,7 @@ test("main patch enables official previews and synchronizes Linux window and tra
   assert.match(patched, /codexLinuxDockIconImage\.isEmpty\(\)/);
   assert.match(
     patched,
-    /codexLinuxRegisterTray\(new l\.Tray\(process\.platform===`linux`&&globalThis\.codexLinuxDockIconImage/,
+    /codexLinuxRegisterTray\(new l\.Tray\(\.\.\.\(process\.platform===`linux`\?\[globalThis\.codexLinuxDockIconImage/,
   );
   assert.match(
     patched,
@@ -206,7 +206,7 @@ test("main patch rejects drift at every current-DMG insertion point byte-identic
     "F=()=>{if(!v)return",
     "if(v){F();let e=()=>",
     "onWindowRegistered:e=>{I?.registerWindow(e),C?.(e)}",
-    "codexLinuxRegisterTray(new l.Tray(t.defaultIcon))",
+    "codexLinuxRegisterTray(new l.Tray(...(process.platform===`linux`?[t.defaultIcon]:[t.defaultIcon,process.platform===`win32`&&l.app.isPackaged?dEe(e.buildFlavor):void 0])))",
   ];
 
   for (const insertionPoint of insertionPoints) {
@@ -234,7 +234,7 @@ test("main patch rejects drift at every patched insertion point byte-identically
     "F=()=>{if(!v&&process.platform!==`linux`)return",
     "if(v||process.platform===`linux`){F();let e=()=>",
     "onWindowRegistered:e=>{I?.registerWindow(e),C?.(e),process.platform===`linux`&&setImmediate(F)}",
-    "n=codexLinuxRegisterTray(new l.Tray(process.platform===`linux`&&globalThis.codexLinuxDockIconImage&&!globalThis.codexLinuxDockIconImage.isEmpty()?globalThis.codexLinuxDockIconImage:t.defaultIcon));if(!W9)return",
+    "n=codexLinuxRegisterTray(new l.Tray(...(process.platform===`linux`?[globalThis.codexLinuxDockIconImage&&!globalThis.codexLinuxDockIconImage.isEmpty()?globalThis.codexLinuxDockIconImage:t.defaultIcon]:[t.defaultIcon,process.platform===`win32`&&l.app.isPackaged?dEe(e.buildFlavor):void 0])));if(!W9)return",
   ];
 
   for (const insertionPoint of insertionPoints) {

--- a/linux-features/ui-tweaks/patches/dock-icon.js
+++ b/linux-features/ui-tweaks/patches/dock-icon.js
@@ -28,9 +28,9 @@ const currentWindowRegistration =
 const patchedWindowRegistration =
   "onWindowRegistered:e=>{I?.registerWindow(e),C?.(e),process.platform===`linux`&&setImmediate(F)}";
 const currentTrayRegistration =
-  "n=codexLinuxRegisterTray(new l.Tray(t.defaultIcon));if(!W9)return";
+  "n=codexLinuxRegisterTray(new l.Tray(...(process.platform===`linux`?[t.defaultIcon]:[t.defaultIcon,process.platform===`win32`&&l.app.isPackaged?dEe(e.buildFlavor):void 0])));if(!W9)return";
 const patchedTrayRegistration =
-  "n=codexLinuxRegisterTray(new l.Tray(process.platform===`linux`&&globalThis.codexLinuxDockIconImage&&!globalThis.codexLinuxDockIconImage.isEmpty()?globalThis.codexLinuxDockIconImage:t.defaultIcon));if(!W9)return";
+  "n=codexLinuxRegisterTray(new l.Tray(...(process.platform===`linux`?[globalThis.codexLinuxDockIconImage&&!globalThis.codexLinuxDockIconImage.isEmpty()?globalThis.codexLinuxDockIconImage:t.defaultIcon]:[t.defaultIcon,process.platform===`win32`&&l.app.isPackaged?dEe(e.buildFlavor):void 0])));if(!W9)return";
 
 const currentMainContracts = [
   currentPreviewGate,

--- a/scripts/ci/upstream-dmg-issue.js
+++ b/scripts/ci/upstream-dmg-issue.js
@@ -201,6 +201,43 @@ async function consolidateMatchingIssues(github, repo, issues, fingerprint) {
   };
 }
 
+async function normalizeMatchingIssue({
+  github,
+  repo,
+  issue,
+  title,
+  body,
+  decision,
+  manageLabels,
+  assignee,
+}) {
+  const wasOpen = issue.state === "open";
+  const alreadyReported = issue.body?.includes(runMarker(decision.run.id));
+  if (manageLabels) {
+    await github.rest.issues.addLabels({
+      ...repo,
+      issue_number: issue.number,
+      labels: ISSUE_LABELS,
+    });
+  }
+  await github.rest.issues.update({
+    ...repo,
+    issue_number: issue.number,
+    title,
+    body,
+    state: "open",
+  });
+  await ensureAssignee(github, repo, issue, assignee);
+  if (!alreadyReported) {
+    await github.rest.issues.createComment({
+      ...repo,
+      issue_number: issue.number,
+      body: `Acceptance failed again. ${decision.run.url ?? "See the latest workflow artifacts."}`,
+    });
+  }
+  return wasOpen ? "updated" : "reopened";
+}
+
 async function reconcileUpstreamDmgIssue({
   github,
   repo,
@@ -283,32 +320,18 @@ async function reconcileUpstreamDmgIssue({
         duplicateIssueNumbers,
       };
     }
-    const wasOpen = matching.state === "open";
-    const alreadyReported = matching.body?.includes(runMarker(decision.run.id));
-    if (manageLabels) {
-      await github.rest.issues.addLabels({
-        ...repo,
-        issue_number: matching.number,
-        labels: ISSUE_LABELS,
-      });
-    }
-    await github.rest.issues.update({
-      ...repo,
-      issue_number: matching.number,
+    const action = await normalizeMatchingIssue({
+      github,
+      repo,
+      issue: matching,
       title,
       body,
-      state: "open",
+      decision,
+      manageLabels,
+      assignee,
     });
-    await ensureAssignee(github, repo, matching, assignee);
-    if (!alreadyReported) {
-      await github.rest.issues.createComment({
-        ...repo,
-        issue_number: matching.number,
-        body: `Acceptance failed again. ${decision.run.url ?? "See the latest workflow artifacts."}`,
-      });
-    }
     return {
-      action: wasOpen ? "updated" : "reopened",
+      action,
       issueNumber: matching.number,
       issueUrl: issueUrl(repo, matching),
       duplicateIssueNumbers,
@@ -320,9 +343,24 @@ async function reconcileUpstreamDmgIssue({
   if (assignee) createArgs.assignees = [assignee];
   const created = await github.rest.issues.create(createArgs);
   const refreshedIssues = await listTrackingIssues(github, repo, { scanAll, testId });
+  if (!refreshedIssues.some((issue) => issue.number === created.data.number)) {
+    refreshedIssues.push(created.data);
+  }
   const consolidated = await consolidateMatchingIssues(github, repo, refreshedIssues, fingerprint);
   const primary = consolidated.primary ?? created.data;
   if (primary.number !== created.data.number) {
+    if (!hasLabel(primary, MANUAL_ONLY_LABEL)) {
+      await normalizeMatchingIssue({
+        github,
+        repo,
+        issue: primary,
+        title,
+        body,
+        decision,
+        manageLabels,
+        assignee,
+      });
+    }
     return {
       action: hasLabel(primary, MANUAL_ONLY_LABEL) ? "manual-only" : "reused-after-create-race",
       issueNumber: primary.number,

--- a/scripts/ci/upstream-dmg-issue.js
+++ b/scripts/ci/upstream-dmg-issue.js
@@ -10,6 +10,7 @@ const LEGACY_LABELS = labelPolicy.migrations
   .map(({ from }) => from);
 const FINGERPRINT_PATTERN = /<!-- upstream-dmg-fingerprint:([a-f0-9]{64}) -->/i;
 const TEST_REHEARSAL_PATTERN = /<!-- upstream-dmg-test-rehearsal:([a-z0-9][a-z0-9._-]{0,63}) -->/i;
+const TRUSTED_AUTHOR_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
 function labelDefinition(name) {
   const definition = labelPolicy.labels.find((candidate) => candidate.name === name);
@@ -49,6 +50,11 @@ function runMarker(runId) {
 
 function issueFingerprint(issue) {
   return issue.body?.match(FINGERPRINT_PATTERN)?.[1]?.toLowerCase() ?? null;
+}
+
+function hasTrustedAutomationAuthor(issue) {
+  return issue.user?.login === "github-actions[bot]" ||
+    TRUSTED_AUTHOR_ASSOCIATIONS.has(issue.author_association);
 }
 
 function issueTitle(decision) {
@@ -116,11 +122,12 @@ async function listTrackingIssues(github, repo, { scanAll = false, testId = null
     }
     for (const issue of issues) issuesByNumber.set(issue.number, issue);
   }
-  // The label is public repository metadata and may also be useful on a
-  // maintainer-created issue. Only the hidden fingerprint marker proves that
-  // this automation owns an issue and may mutate its lifecycle.
+  // Fingerprint markers are public and can be copied into an arbitrary issue.
+  // Only maintainers and this workflow's bot may create lifecycle-managed
+  // trackers; labels and markers alone are not sufficient ownership proof.
   return [...issuesByNumber.values()].filter((issue) => (
     issue.pull_request == null &&
+    hasTrustedAutomationAuthor(issue) &&
     issueFingerprint(issue) !== null &&
     (testId ? issueTestId(issue) === testId : issueTestId(issue) === null)
   ));

--- a/scripts/ci/upstream-dmg-issue.js
+++ b/scripts/ci/upstream-dmg-issue.js
@@ -9,6 +9,7 @@ const LEGACY_LABELS = labelPolicy.migrations
   .filter(({ to }) => to === LABEL)
   .map(({ from }) => from);
 const FINGERPRINT_PATTERN = /<!-- upstream-dmg-fingerprint:([a-f0-9]{64}) -->/i;
+const TEST_REHEARSAL_PATTERN = /<!-- upstream-dmg-test-rehearsal:([a-z0-9][a-z0-9._-]{0,63}) -->/i;
 
 function labelDefinition(name) {
   const definition = labelPolicy.labels.find((candidate) => candidate.name === name);
@@ -30,6 +31,18 @@ function fingerprintMarker(fingerprint) {
   return `<!-- upstream-dmg-fingerprint:${fingerprint} -->`;
 }
 
+function testRehearsalMarker(testId) {
+  return `<!-- upstream-dmg-test-rehearsal:${testId} -->`;
+}
+
+function decisionTestId(decision) {
+  return decision.testRehearsal?.id ?? null;
+}
+
+function issueTestId(issue) {
+  return issue.body?.match(TEST_REHEARSAL_PATTERN)?.[1] ?? null;
+}
+
 function runMarker(runId) {
   return `<!-- upstream-dmg-run:${runId ?? "local"} -->`;
 }
@@ -40,14 +53,31 @@ function issueFingerprint(issue) {
 
 function issueTitle(decision) {
   const version = decision.dmg.appVersion ?? "unknown version";
-  return `Upstream DMG drift: ${version} (${decision.dmg.sha256.slice(0, 12)})`;
+  const prefix = decisionTestId(decision) ? `[TEST ${decisionTestId(decision)}] ` : "";
+  return `${prefix}Upstream DMG drift: ${version} (${decision.dmg.sha256.slice(0, 12)})`;
+}
+
+function blockerLine(item) {
+  const check = item.check ?? "unknown check";
+  const name = item.name ? ` / \`${item.name}\`` : "";
+  const status = item.status ? ` (\`${item.status}\`)` : "";
+  return `- **${check}**${name}${status}: ${item.reason}`;
 }
 
 function issueBody(decision) {
   const runUrl = decision.run.url;
   const lines = [
     fingerprintMarker(decision.dmg.sha256),
+    ...(decisionTestId(decision) ? [testRehearsalMarker(decisionTestId(decision))] : []),
     runMarker(decision.run.id),
+    ...(decisionTestId(decision) ? [
+      "> [!CAUTION]",
+      "> TEST REHEARSAL ONLY. This issue does not report a real upstream regression and must not be used for a production repair.",
+      "",
+    ] : []),
+    "> [!IMPORTANT]",
+    "> Automated repair is already in progress. Please do not open a pull request for this DMG unless the maintainer asks.",
+    "",
     "The latest upstream DMG was rejected by the shared local/CI acceptance profile.",
     "",
     "## Candidate",
@@ -58,7 +88,7 @@ function issueBody(decision) {
     "",
     "## Blocking checks",
     "",
-    ...decision.blockers.map((item) => `- **${item.check}**: ${item.reason}`),
+    ...decision.blockers.map(blockerLine),
     "",
     "## Maintainer checklist",
     "",
@@ -69,10 +99,12 @@ function issueBody(decision) {
   return `${lines.join("\n")}\n`;
 }
 
-async function listTrackingIssues(github, repo) {
+async function listTrackingIssues(github, repo, { scanAll = false, testId = null } = {}) {
   const issuesByNumber = new Map();
-  for (const label of [LABEL, ...LEGACY_LABELS]) {
-    const params = { ...repo, state: "all", labels: label, per_page: 100 };
+  const queries = scanAll
+    ? [{ ...repo, state: "all", per_page: 100 }]
+    : [LABEL, ...LEGACY_LABELS].map((label) => ({ ...repo, state: "all", labels: label, per_page: 100 }));
+  for (const params of queries) {
     let issues;
     try {
       issues = github.paginate
@@ -87,9 +119,26 @@ async function listTrackingIssues(github, repo) {
   // The label is public repository metadata and may also be useful on a
   // maintainer-created issue. Only the hidden fingerprint marker proves that
   // this automation owns an issue and may mutate its lifecycle.
-  return [...issuesByNumber.values()].filter(
-    (issue) => issue.pull_request == null && issueFingerprint(issue) !== null,
-  );
+  return [...issuesByNumber.values()].filter((issue) => (
+    issue.pull_request == null &&
+    issueFingerprint(issue) !== null &&
+    (testId ? issueTestId(issue) === testId : issueTestId(issue) === null)
+  ));
+}
+
+function issueUrl(repo, issue) {
+  return issue.html_url ?? `https://github.com/${repo.owner}/${repo.repo}/issues/${issue.number}`;
+}
+
+async function ensureAssignee(github, repo, issue, assignee) {
+  if (!assignee) return;
+  const alreadyAssigned = (issue.assignees || []).some((candidate) => candidate?.login === assignee);
+  if (alreadyAssigned) return;
+  await github.rest.issues.addAssignees({
+    ...repo,
+    issue_number: issue.number,
+    assignees: [assignee],
+  });
 }
 
 async function ensureLabels(github, repo) {
@@ -118,7 +167,42 @@ async function closeIssue(github, repo, issue, message, stateReason) {
   });
 }
 
-async function reconcileUpstreamDmgIssue({ github, repo, decision, currentHttpIdentityKey }) {
+async function consolidateMatchingIssues(github, repo, issues, fingerprint) {
+  const matching = issues
+    .filter((issue) => issueFingerprint(issue) === fingerprint)
+    .sort((left, right) => left.number - right.number);
+  if (matching.length === 0) return { primary: null, duplicateIssueNumbers: [] };
+
+  const primary = matching.find((issue) => hasLabel(issue, MANUAL_ONLY_LABEL)) ?? matching[0];
+  const duplicates = matching.filter((issue) => (
+    issue.number !== primary.number &&
+    issue.state === "open" &&
+    !hasLabel(issue, MANUAL_ONLY_LABEL)
+  ));
+  for (const issue of duplicates) {
+    await closeIssue(
+      github,
+      repo,
+      issue,
+      `Duplicate upstream DMG report; tracking continues in #${primary.number}.`,
+      "not_planned",
+    );
+  }
+  return {
+    primary,
+    duplicateIssueNumbers: duplicates.map((issue) => issue.number),
+  };
+}
+
+async function reconcileUpstreamDmgIssue({
+  github,
+  repo,
+  decision,
+  currentHttpIdentityKey,
+  assignee = null,
+  manageLabels = true,
+  scanAll = false,
+}) {
   if (decision.verdict === "inconclusive") {
     return { action: "ignored-inconclusive" };
   }
@@ -133,12 +217,16 @@ async function reconcileUpstreamDmgIssue({ github, repo, decision, currentHttpId
     return { action: "ignored-stale-candidate" };
   }
 
-  const issues = await listTrackingIssues(github, repo);
+  const testId = decisionTestId(decision);
+  const issues = await listTrackingIssues(github, repo, { scanAll, testId });
 
   if (decision.verdict === "accepted" || decision.verdict === "accepted_with_warnings") {
     const openIssues = issues.filter(
       (issue) => issue.state === "open" && !hasLabel(issue, MANUAL_ONLY_LABEL),
     );
+    const manualOnlyIssueNumbers = issues
+      .filter((issue) => issue.state === "open" && hasLabel(issue, MANUAL_ONLY_LABEL))
+      .map((issue) => issue.number);
     for (const issue of openIssues) {
       await closeIssue(
         github,
@@ -148,12 +236,20 @@ async function reconcileUpstreamDmgIssue({ github, repo, decision, currentHttpId
         "completed",
       );
     }
-    return { action: "closed-resolved", count: openIssues.length };
+    return {
+      action: "closed-resolved",
+      count: openIssues.length,
+      closedIssueNumbers: openIssues.map((issue) => issue.number),
+      manualOnlyIssueNumbers,
+    };
   }
 
-  await ensureLabels(github, repo);
+  if (manageLabels) await ensureLabels(github, repo);
   const fingerprint = decision.dmg.sha256.toLowerCase();
-  const matching = issues.find((issue) => issueFingerprint(issue) === fingerprint);
+  const {
+    primary: matching,
+    duplicateIssueNumbers,
+  } = await consolidateMatchingIssues(github, repo, issues, fingerprint);
   const obsolete = issues.filter((issue) => (
     issue.state === "open" &&
     issueFingerprint(issue) !== fingerprint &&
@@ -173,15 +269,22 @@ async function reconcileUpstreamDmgIssue({ github, repo, decision, currentHttpId
   const body = issueBody(decision);
   if (matching) {
     if (hasLabel(matching, MANUAL_ONLY_LABEL)) {
-      return { action: "manual-only", issueNumber: matching.number };
+      return {
+        action: "manual-only",
+        issueNumber: matching.number,
+        issueUrl: issueUrl(repo, matching),
+        duplicateIssueNumbers,
+      };
     }
     const wasOpen = matching.state === "open";
     const alreadyReported = matching.body?.includes(runMarker(decision.run.id));
-    await github.rest.issues.addLabels({
-      ...repo,
-      issue_number: matching.number,
-      labels: ISSUE_LABELS,
-    });
+    if (manageLabels) {
+      await github.rest.issues.addLabels({
+        ...repo,
+        issue_number: matching.number,
+        labels: ISSUE_LABELS,
+      });
+    }
     await github.rest.issues.update({
       ...repo,
       issue_number: matching.number,
@@ -189,6 +292,7 @@ async function reconcileUpstreamDmgIssue({ github, repo, decision, currentHttpId
       body,
       state: "open",
     });
+    await ensureAssignee(github, repo, matching, assignee);
     if (!alreadyReported) {
       await github.rest.issues.createComment({
         ...repo,
@@ -196,18 +300,45 @@ async function reconcileUpstreamDmgIssue({ github, repo, decision, currentHttpId
         body: `Acceptance failed again. ${decision.run.url ?? "See the latest workflow artifacts."}`,
       });
     }
-    return { action: wasOpen ? "updated" : "reopened", issueNumber: matching.number };
+    return {
+      action: wasOpen ? "updated" : "reopened",
+      issueNumber: matching.number,
+      issueUrl: issueUrl(repo, matching),
+      duplicateIssueNumbers,
+    };
   }
 
-  const created = await github.rest.issues.create({ ...repo, title, body, labels: ISSUE_LABELS });
-  return { action: "created", issueNumber: created.data.number };
+  const createArgs = { ...repo, title, body };
+  if (manageLabels) createArgs.labels = ISSUE_LABELS;
+  if (assignee) createArgs.assignees = [assignee];
+  const created = await github.rest.issues.create(createArgs);
+  const refreshedIssues = await listTrackingIssues(github, repo, { scanAll, testId });
+  const consolidated = await consolidateMatchingIssues(github, repo, refreshedIssues, fingerprint);
+  const primary = consolidated.primary ?? created.data;
+  if (primary.number !== created.data.number) {
+    return {
+      action: hasLabel(primary, MANUAL_ONLY_LABEL) ? "manual-only" : "reused-after-create-race",
+      issueNumber: primary.number,
+      issueUrl: issueUrl(repo, primary),
+      duplicateIssueNumbers: consolidated.duplicateIssueNumbers,
+    };
+  }
+  return {
+    action: "created",
+    issueNumber: created.data.number,
+    issueUrl: issueUrl(repo, created.data),
+    duplicateIssueNumbers: consolidated.duplicateIssueNumbers,
+  };
 }
 
 module.exports = {
   LABEL,
+  blockerLine,
   fingerprintMarker,
   issueBody,
   issueFingerprint,
+  issueTestId,
   reconcileUpstreamDmgIssue,
   runMarker,
+  testRehearsalMarker,
 };

--- a/scripts/ci/upstream-dmg-issue.test.js
+++ b/scripts/ci/upstream-dmg-issue.test.js
@@ -25,7 +25,11 @@ function decision(verdict, sha, runId = "100") {
 function fakeGithub(initialIssues = [], { createCollisionIssue = null } = {}) {
   const calls = [];
   let nextNumber = 50;
-  const issues = initialIssues.map((issue) => ({ ...issue }));
+  const issues = initialIssues.map((issue) => ({
+    author_association: "OWNER",
+    user: { login: "maintainer" },
+    ...issue,
+  }));
   const rest = { issues: {} };
   rest.issues.listForRepo = async () => ({ data: issues });
   rest.issues.getLabel = async () => ({ data: {} });
@@ -41,10 +45,20 @@ function fakeGithub(initialIssues = [], { createCollisionIssue = null } = {}) {
   };
   rest.issues.create = async (args) => {
     calls.push(["create", args]);
-    const issue = { ...args, number: nextNumber++, state: "open" };
+    const issue = {
+      ...args,
+      number: nextNumber++,
+      state: "open",
+      author_association: "NONE",
+      user: { login: "github-actions[bot]" },
+    };
     issues.push(issue);
     if (createCollisionIssue != null) {
-      issues.push({ ...createCollisionIssue });
+      issues.push({
+        author_association: "OWNER",
+        user: { login: "maintainer" },
+        ...createCollisionIssue,
+      });
       createCollisionIssue = null;
     }
     return { data: issue };
@@ -58,6 +72,30 @@ test("scheduled reconciliation scans unlabeled watchdog issues", () => {
     "utf8",
   );
   assert.match(workflow, /currentHttpIdentityKey:[\s\S]*?scanAll: true,/);
+});
+
+test("scan-all ignores a copied fingerprint marker from an untrusted issue author", async () => {
+  const sha = "a".repeat(64);
+  const outsider = {
+    number: 33,
+    state: "open",
+    body: fingerprintMarker(sha),
+    author_association: "CONTRIBUTOR",
+    user: { login: "external-contributor" },
+  };
+  const fixture = fakeGithub([outsider]);
+
+  const result = await reconcileUpstreamDmgIssue({
+    github: fixture.github,
+    repo: { owner: "o", repo: "r" },
+    decision: decision("rejected", sha),
+    currentHttpIdentityKey: "current",
+    scanAll: true,
+  });
+
+  assert.equal(result.action, "created");
+  assert.equal(fixture.calls.filter(([name]) => name === "create").length, 1);
+  assert.equal(fixture.calls.some(([, args]) => args.issue_number === 33), false);
 });
 
 test("creates one issue for a rejected current fingerprint", async () => {

--- a/scripts/ci/upstream-dmg-issue.test.js
+++ b/scripts/ci/upstream-dmg-issue.test.js
@@ -1,9 +1,16 @@
 "use strict";
 
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const test = require("node:test");
 
-const { fingerprintMarker, reconcileUpstreamDmgIssue } = require("./upstream-dmg-issue.js");
+const {
+  fingerprintMarker,
+  issueBody,
+  reconcileUpstreamDmgIssue,
+  testRehearsalMarker,
+} = require("./upstream-dmg-issue.js");
 
 function decision(verdict, sha, runId = "100") {
   return {
@@ -15,7 +22,7 @@ function decision(verdict, sha, runId = "100") {
   };
 }
 
-function fakeGithub(initialIssues = []) {
+function fakeGithub(initialIssues = [], { createCollisionIssue = null } = {}) {
   const calls = [];
   let nextNumber = 50;
   const issues = initialIssues.map((issue) => ({ ...issue }));
@@ -24,6 +31,7 @@ function fakeGithub(initialIssues = []) {
   rest.issues.getLabel = async () => ({ data: {} });
   rest.issues.createLabel = async (args) => { calls.push(["createLabel", args]); return { data: {} }; };
   rest.issues.addLabels = async (args) => { calls.push(["addLabels", args]); return { data: {} }; };
+  rest.issues.addAssignees = async (args) => { calls.push(["addAssignees", args]); return { data: {} }; };
   rest.issues.createComment = async (args) => { calls.push(["comment", args]); return { data: {} }; };
   rest.issues.update = async (args) => {
     calls.push(["update", args]);
@@ -35,10 +43,22 @@ function fakeGithub(initialIssues = []) {
     calls.push(["create", args]);
     const issue = { ...args, number: nextNumber++, state: "open" };
     issues.push(issue);
+    if (createCollisionIssue != null) {
+      issues.push({ ...createCollisionIssue });
+      createCollisionIssue = null;
+    }
     return { data: issue };
   };
   return { github: { rest }, calls, issues };
 }
+
+test("scheduled reconciliation scans unlabeled watchdog issues", () => {
+  const workflow = fs.readFileSync(
+    path.resolve(__dirname, "../../.github/workflows/upstream-build-app.yml"),
+    "utf8",
+  );
+  assert.match(workflow, /currentHttpIdentityKey:[\s\S]*?scanAll: true,/);
+});
 
 test("creates one issue for a rejected current fingerprint", async () => {
   const fixture = fakeGithub();
@@ -53,6 +73,90 @@ test("creates one issue for a rejected current fingerprint", async () => {
     "area: upstream dmg",
     "status: ready for work",
   ]);
+});
+
+test("watchdog issue mode assigns the current user without mutating labels", async () => {
+  const fixture = fakeGithub();
+  const sha = "0".repeat(64);
+  const result = await reconcileUpstreamDmgIssue({
+    github: fixture.github,
+    repo: { owner: "o", repo: "r" },
+    decision: decision("rejected", sha),
+    currentHttpIdentityKey: "current",
+    assignee: "maintainer",
+    manageLabels: false,
+    scanAll: true,
+  });
+
+  assert.equal(result.action, "created");
+  const create = fixture.calls.find(([name]) => name === "create")[1];
+  assert.deepEqual(create.assignees, ["maintainer"]);
+  assert.equal("labels" in create, false);
+  assert.match(create.body, /Automated repair is already in progress/);
+  assert.match(create.body, /Please do not open a pull request/);
+});
+
+test("issue body includes the precise blocker name and status", () => {
+  const current = decision("rejected", "a".repeat(64));
+  current.blockers = [{
+    check: "feature:ui-tweaks",
+    name: "model-picker-model-list",
+    status: "skipped-optional",
+    reason: "current bundle was not found",
+  }];
+
+  const body = issueBody(current);
+
+  assert.match(body, /feature:ui-tweaks/);
+  assert.match(body, /model-picker-model-list/);
+  assert.match(body, /skipped-optional/);
+  assert.match(body, /current bundle was not found/);
+});
+
+test("test rehearsal issue is unmistakably marked and isolated from production issues", async () => {
+  const sha = "a".repeat(64);
+  const production = { number: 31, state: "open", body: fingerprintMarker("b".repeat(64)) };
+  const fixture = fakeGithub([production]);
+  const current = decision("rejected", sha);
+  current.testRehearsal = { id: "issue-drill-1", merge_policy: "skip" };
+
+  const result = await reconcileUpstreamDmgIssue({
+    github: fixture.github,
+    repo: { owner: "o", repo: "r" },
+    decision: current,
+    currentHttpIdentityKey: "current",
+    manageLabels: false,
+    scanAll: true,
+  });
+
+  assert.equal(result.action, "created");
+  const create = fixture.calls.find(([name]) => name === "create")[1];
+  assert.match(create.title, /^\[TEST issue-drill-1\]/);
+  assert.match(create.body, /TEST REHEARSAL ONLY/);
+  assert.match(create.body, /upstream-dmg-test-rehearsal:issue-drill-1/);
+  assert.equal(fixture.calls.some(([, args]) => args.issue_number === 31), false);
+});
+
+test("production reconciliation ignores test rehearsal issues", async () => {
+  const testIssue = {
+    number: 32,
+    state: "open",
+    body: `${fingerprintMarker("c".repeat(64))}\n${testRehearsalMarker("issue-drill-2")}`,
+  };
+  const fixture = fakeGithub([testIssue]);
+
+  const result = await reconcileUpstreamDmgIssue({
+    github: fixture.github,
+    repo: { owner: "o", repo: "r" },
+    decision: decision("accepted", "d".repeat(64)),
+    currentHttpIdentityKey: "current",
+    manageLabels: false,
+    scanAll: true,
+  });
+
+  assert.equal(result.action, "closed-resolved");
+  assert.equal(result.count, 0);
+  assert.equal(fixture.calls.length, 0);
 });
 
 test("closes old fingerprints before creating the new issue", async () => {
@@ -75,6 +179,69 @@ test("reopens the matching closed issue instead of duplicating it", async () => 
   assert.equal(fixture.calls.filter(([name]) => name === "create").length, 0);
 });
 
+test("closes duplicate matching fingerprint issues and keeps the oldest canonical issue", async () => {
+  const sha = "d".repeat(64);
+  const fixture = fakeGithub([
+    { number: 7, state: "open", body: fingerprintMarker(sha) },
+    { number: 8, state: "open", body: fingerprintMarker(sha) },
+  ]);
+  const result = await reconcileUpstreamDmgIssue({
+    github: fixture.github,
+    repo: { owner: "o", repo: "r" },
+    decision: decision("rejected", sha),
+    currentHttpIdentityKey: "current",
+    scanAll: true,
+  });
+
+  assert.equal(result.action, "updated");
+  assert.equal(result.issueNumber, 7);
+  assert.deepEqual(result.duplicateIssueNumbers, [8]);
+  assert.ok(fixture.calls.some(([name, args]) => (
+    name === "update" && args.issue_number === 8 && args.state === "closed"
+  )));
+  assert.equal(fixture.calls.filter(([name]) => name === "create").length, 0);
+});
+
+test("rechecks after create and closes a colliding watchdog issue", async () => {
+  const sha = "c".repeat(64);
+  const fixture = fakeGithub([], {
+    createCollisionIssue: { number: 51, state: "open", body: fingerprintMarker(sha) },
+  });
+  const result = await reconcileUpstreamDmgIssue({
+    github: fixture.github,
+    repo: { owner: "o", repo: "r" },
+    decision: decision("rejected", sha),
+    currentHttpIdentityKey: "current",
+    scanAll: true,
+  });
+
+  assert.equal(result.action, "created");
+  assert.equal(result.issueNumber, 50);
+  assert.deepEqual(result.duplicateIssueNumbers, [51]);
+  assert.ok(fixture.calls.some(([name, args]) => (
+    name === "update" && args.issue_number === 51 && args.state === "closed"
+  )));
+});
+
+test("watchdog mode finds an unlabelled closed marker and reuses it", async () => {
+  const sha = "d".repeat(64);
+  const fixture = fakeGithub([{ number: 8, state: "closed", body: fingerprintMarker(sha) }]);
+  const result = await reconcileUpstreamDmgIssue({
+    github: fixture.github,
+    repo: { owner: "o", repo: "r" },
+    decision: decision("rejected", sha),
+    currentHttpIdentityKey: "current",
+    assignee: "maintainer",
+    manageLabels: false,
+    scanAll: true,
+  });
+
+  assert.equal(result.action, "reopened");
+  assert.equal(fixture.calls.filter(([name]) => name === "create").length, 0);
+  assert.ok(fixture.calls.some(([name]) => name === "addAssignees"));
+  assert.equal(fixture.calls.some(([name]) => name === "addLabels"), false);
+});
+
 test("accepted candidates close old drift issues without creating a new one", async () => {
   const fixture = fakeGithub([{ number: 9, state: "open", body: fingerprintMarker("e".repeat(64)) }]);
   const result = await reconcileUpstreamDmgIssue({
@@ -82,6 +249,27 @@ test("accepted candidates close old drift issues without creating a new one", as
   });
   assert.equal(result.action, "closed-resolved");
   assert.equal(fixture.calls.filter(([name]) => name === "create").length, 0);
+});
+
+test("accepted candidates report manual-only issues without mutating them", async () => {
+  const sha = "7".repeat(64);
+  const fixture = fakeGithub([{
+    number: 15,
+    state: "open",
+    body: fingerprintMarker(sha),
+    labels: [{ name: "workflow: manual only" }],
+  }]);
+
+  const result = await reconcileUpstreamDmgIssue({
+    github: fixture.github,
+    repo: { owner: "o", repo: "r" },
+    decision: decision("accepted", sha),
+    currentHttpIdentityKey: "current",
+    scanAll: true,
+  });
+
+  assert.deepEqual(result.manualOnlyIssueNumbers, [15]);
+  assert.equal(fixture.calls.some(([, args]) => args.issue_number === 15), false);
 });
 
 test("does not add a duplicate comment for the same workflow run", async () => {

--- a/scripts/ci/upstream-dmg-issue.test.js
+++ b/scripts/ci/upstream-dmg-issue.test.js
@@ -261,6 +261,48 @@ test("rechecks after create and closes a colliding watchdog issue", async () => 
   )));
 });
 
+test("normalizes an older canonical issue after losing a create race", async () => {
+  const sha = "b".repeat(64);
+  const fixture = fakeGithub([], {
+    createCollisionIssue: {
+      number: 49,
+      state: "open",
+      body: fingerprintMarker(sha),
+      labels: [],
+      assignees: [],
+    },
+  });
+  const result = await reconcileUpstreamDmgIssue({
+    github: fixture.github,
+    repo: { owner: "o", repo: "r" },
+    decision: decision("rejected", sha, "race-run"),
+    currentHttpIdentityKey: "current",
+    assignee: "maintainer",
+    scanAll: true,
+  });
+
+  assert.equal(result.action, "reused-after-create-race");
+  assert.equal(result.issueNumber, 49);
+  assert.deepEqual(result.duplicateIssueNumbers, [50]);
+  assert.ok(fixture.calls.some(([name, args]) => (
+    name === "update" && args.issue_number === 50 && args.state === "closed"
+  )));
+  assert.ok(fixture.calls.some(([name, args]) => (
+    name === "addLabels" && args.issue_number === 49
+  )));
+  assert.ok(fixture.calls.some(([name, args]) => (
+    name === "addAssignees" && args.issue_number === 49
+  )));
+  const canonicalUpdate = fixture.calls.find(([name, args]) => (
+    name === "update" && args.issue_number === 49
+  ));
+  assert.equal(canonicalUpdate[1].state, "open");
+  assert.match(canonicalUpdate[1].body, /<!-- upstream-dmg-run:race-run -->/);
+  assert.ok(fixture.calls.some(([name, args]) => (
+    name === "comment" && args.issue_number === 49
+  )));
+});
+
 test("watchdog mode finds an unlabelled closed marker and reuses it", async () => {
   const sha = "d".repeat(64);
   const fixture = fakeGithub([{ number: 8, state: "closed", body: fingerprintMarker(sha) }]);

--- a/scripts/lib/build-info.js
+++ b/scripts/lib/build-info.js
@@ -278,8 +278,16 @@ function recordAppVersionMetadata(metadataPath, appDir) {
     ? JSON.parse(fs.readFileSync(metadataPath, "utf8"))
     : {};
   metadata.appVersion = appVersion;
-  fs.mkdirSync(path.dirname(metadataPath), { recursive: true });
-  fs.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+  const metadataDir = path.dirname(metadataPath);
+  fs.mkdirSync(metadataDir, { recursive: true });
+  const stagingDir = fs.mkdtempSync(path.join(metadataDir, ".upstream-dmg-metadata-"));
+  const stagingPath = path.join(stagingDir, path.basename(metadataPath));
+  try {
+    fs.writeFileSync(stagingPath, `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+    fs.renameSync(stagingPath, metadataPath);
+  } finally {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  }
   return appVersion;
 }
 

--- a/scripts/lib/build-info.js
+++ b/scripts/lib/build-info.js
@@ -269,6 +269,20 @@ function appBundleVersion(appDir) {
   return version.length > 0 ? version : null;
 }
 
+function recordAppVersionMetadata(metadataPath, appDir) {
+  const appVersion = appBundleVersion(appDir);
+  if (appVersion == null) {
+    return null;
+  }
+  const metadata = fs.existsSync(metadataPath)
+    ? JSON.parse(fs.readFileSync(metadataPath, "utf8"))
+    : {};
+  metadata.appVersion = appVersion;
+  fs.mkdirSync(path.dirname(metadataPath), { recursive: true });
+  fs.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+  return appVersion;
+}
+
 function linuxTargetInfo(target) {
   return {
     summary: linuxTargetSummary(target),
@@ -356,6 +370,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  appBundleVersion,
   buildInfo,
   githubCommitUrl,
   isoTimestamp,
@@ -363,5 +378,6 @@ module.exports = {
   sanitizeGitRemoteUrl,
   sourceInfo,
   sourceInfoFromGit,
+  recordAppVersionMetadata,
   writeBuildInfo,
 };

--- a/scripts/lib/build-info.sh
+++ b/scripts/lib/build-info.sh
@@ -4,6 +4,18 @@
 # Sourced by install.sh. Do not run directly.
 # shellcheck shell=bash
 
+record_upstream_app_version() {
+    local app_dir="$1"
+    local metadata_path="${CODEX_UPSTREAM_DMG_METADATA_JSON:-}"
+    [ -n "$metadata_path" ] || return 0
+
+    "${CODEX_ACCEPTANCE_NODE:-node}" -e \
+        'require(process.argv[1]).recordAppVersionMetadata(process.argv[2], process.argv[3])' \
+        "$SCRIPT_DIR/scripts/lib/build-info.js" \
+        "$metadata_path" \
+        "$app_dir"
+}
+
 write_build_info() {
     local dmg_path="$1"
     local app_dir="$2"

--- a/scripts/lib/build-info.test.js
+++ b/scripts/lib/build-info.test.js
@@ -1,0 +1,66 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  appBundleVersion,
+  recordAppVersionMetadata,
+} = require("./build-info.js");
+
+function writeInfoPlist(appDir, version) {
+  const contentsDir = path.join(appDir, "Contents");
+  fs.mkdirSync(contentsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(contentsDir, "Info.plist"),
+    [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+      '<plist version="1.0"><dict>',
+      "<key>CFBundleShortVersionString</key>",
+      `<string>${version}</string>`,
+      "</dict></plist>",
+    ].join("\n"),
+  );
+}
+
+test("records the extracted app version without discarding downloaded DMG metadata", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-build-info-"));
+  try {
+    const appDir = path.join(tempDir, "Codex.app");
+    const metadataPath = path.join(tempDir, "reports", "upstream-dmg-metadata.json");
+    writeInfoPlist(appDir, "26.803.41515");
+    fs.mkdirSync(path.dirname(metadataPath), { recursive: true });
+    fs.writeFileSync(metadataPath, `${JSON.stringify({ etag: "current", path: "/tmp/Codex.dmg" })}\n`);
+
+    assert.equal(appBundleVersion(appDir), "26.803.41515");
+    assert.equal(recordAppVersionMetadata(metadataPath, appDir), "26.803.41515");
+    assert.deepEqual(JSON.parse(fs.readFileSync(metadataPath, "utf8")), {
+      etag: "current",
+      path: "/tmp/Codex.dmg",
+      appVersion: "26.803.41515",
+    });
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("leaves metadata untouched when the extracted app has no readable version", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-build-info-missing-"));
+  try {
+    const appDir = path.join(tempDir, "Codex.app");
+    const metadataPath = path.join(tempDir, "upstream-dmg-metadata.json");
+    const original = '{"etag":"current"}\n';
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(metadataPath, original);
+
+    assert.equal(appBundleVersion(appDir), null);
+    assert.equal(recordAppVersionMetadata(metadataPath, appDir), null);
+    assert.equal(fs.readFileSync(metadataPath, "utf8"), original);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/lib/build-info.test.js
+++ b/scripts/lib/build-info.test.js
@@ -64,3 +64,23 @@ test("leaves metadata untouched when the extracted app has no readable version",
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+test("leaves malformed metadata untouched instead of publishing a partial replacement", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-build-info-malformed-"));
+  try {
+    const appDir = path.join(tempDir, "Codex.app");
+    const metadataPath = path.join(tempDir, "upstream-dmg-metadata.json");
+    const original = '{"etag":';
+    writeInfoPlist(appDir, "26.803.41515");
+    fs.writeFileSync(metadataPath, original);
+
+    assert.throws(() => recordAppVersionMetadata(metadataPath, appDir), SyntaxError);
+    assert.equal(fs.readFileSync(metadataPath, "utf8"), original);
+    assert.deepEqual(
+      fs.readdirSync(tempDir).filter((entry) => entry.startsWith(".upstream-dmg-metadata-")),
+      [],
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2685,7 +2685,7 @@ test("retains the current native Linux tray when quit-state helpers already exis
   assert.match(patched, /let codexLinuxTray=null,codexLinuxRegisterTray=e=>/);
   assert.match(
     patched,
-    /r=codexLinuxRegisterTray\(new c\.Tray\(t\.defaultIcon,process\.platform===`win32`&&c\.app\.isPackaged\?dEe\(e\.buildFlavor\):void 0\)\)/,
+    /r=codexLinuxRegisterTray\(new c\.Tray\(\.\.\.\(process\.platform===`linux`\?\[t\.defaultIcon\]:\[t\.defaultIcon,process\.platform===`win32`&&c\.app\.isPackaged\?dEe\(e\.buildFlavor\):void 0\]\)\)\)/,
   );
   assert.doesNotMatch(patched, /typeof codexLinuxRegisterTray===`function`/);
 });
@@ -2693,13 +2693,36 @@ test("retains the current native Linux tray when quit-state helpers already exis
 test("wraps the complete exact-DMG nested-ternary Tray constructor in a parseable bundle", () => {
   const source = `${currentMainBundlePrefix}${exactDmgNestedTernaryTrayBundleFixture()}`;
   const patched = patchMainBundleSource(source, null);
+  const retainedConstructor =
+    "r=codexLinuxRegisterTray(new c.Tray(...(process.platform===`linux`?[t.defaultIcon]:[t.defaultIcon,process.platform===`win32`&&c.app.isPackaged?dEe(e.buildFlavor):void 0])))";
 
-  assert.match(
-    patched,
-    /r=codexLinuxRegisterTray\(new c\.Tray\(t\.defaultIcon,process\.platform===`win32`&&c\.app\.isPackaged\?dEe\(e\.buildFlavor\):void 0\)\)/,
-  );
+  assert.ok(patched.includes(retainedConstructor));
   assert.doesNotThrow(() => new Function(patched));
   assert.equal(patchMainBundleSource(patched, null), patched);
+
+  const trayArguments = (platform) => {
+    const context = {
+      c: {
+        app: { isPackaged: true },
+        Tray: class {
+          constructor(...args) {
+            this.args = args;
+          }
+        },
+      },
+      codexLinuxRegisterTray: (tray) => tray,
+      dEe: () => "windows-guid",
+      e: { buildFlavor: "prod" },
+      process: { platform },
+      result: null,
+      t: { defaultIcon: "icon" },
+    };
+    vm.runInNewContext(`${retainedConstructor};result=r.args`, context);
+    return [...context.result];
+  };
+
+  assert.deepEqual(trayArguments("linux"), ["icon"]);
+  assert.deepEqual(trayArguments("win32"), ["icon", "windows-guid"]);
 });
 
 test("bypasses the upstream before-quit confirmation after a Linux explicit quit", () => {

--- a/scripts/patches/impl/main-process/tray.js
+++ b/scripts/patches/impl/main-process/tray.js
@@ -35,6 +35,48 @@ function findMatchingParenthesis(source, openIndex) {
   return -1;
 }
 
+function findTopLevelArgumentSeparator(source) {
+  let parentheses = 0;
+  let brackets = 0;
+  let braces = 0;
+  let quote = null;
+  let escaped = false;
+
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    if (quote != null) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+    } else if (char === "(") {
+      parentheses += 1;
+    } else if (char === ")") {
+      parentheses -= 1;
+    } else if (char === "[") {
+      brackets += 1;
+    } else if (char === "]") {
+      brackets -= 1;
+    } else if (char === "{") {
+      braces += 1;
+    } else if (char === "}") {
+      braces -= 1;
+    } else if (char === "," && parentheses === 0 && brackets === 0 && braces === 0) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
 function findTrayConstructor(source) {
   const retainedPattern =
     /([A-Za-z_$][\w$]*)=codexLinuxRegisterTray\(new ([A-Za-z_$][\w$]*)\.Tray\(/g;
@@ -150,8 +192,12 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
     startIndex: constructorStartIndex,
     trayVar,
   } = constructorMatch;
+  const argumentSeparator = findTopLevelArgumentSeparator(constructorArgs);
+  const trayConstructor = argumentSeparator === -1
+    ? `new ${electronVar}.Tray(${constructorArgs})`
+    : `new ${electronVar}.Tray(...(process.platform===\`linux\`?[${constructorArgs.slice(0, argumentSeparator)}]:[${constructorArgs}]))`;
   const retainedConstructor =
-    `${trayVar}=codexLinuxRegisterTray(new ${electronVar}.Tray(${constructorArgs}))`;
+    `${trayVar}=codexLinuxRegisterTray(${trayConstructor})`;
   if (!retained) {
     patchedSource =
       patchedSource.slice(0, constructorStartIndex) +


### PR DESCRIPTION
## Summary
- call Electron `Tray` with one argument on Linux while preserving the Windows GUID path, restoring StatusNotifier tray registration on the current upstream DMG
- keep the opt-in Dock icon patch compatible with the normalized tray constructor
- integrate the local watchdog metadata fixes, including extracted app-version propagation and scan-all reconciliation
- make metadata publication atomic, deduplicate watchdog races, and trust only maintainer-owned automation issues

## Tests/checks run
- current-DMG inspection against `Codex.dmg` (tray and all required upstream patches applied)
- `TMPDIR=/tmp node --test scripts/patch-linux-window-ui.test.js scripts/lib/build-info.test.js scripts/ci/upstream-dmg-issue.test.js linux-features/ui-tweaks/dock-icon.test.js`
- `node --test linux-features/directory-only-working-tree-watch/test.js` (118/118)
- `bash -n install.sh scripts/lib/build-info.sh`
- `git diff --check`
- `CI_SKIP_PULL=1 ./scripts/ci-local.sh pr` (one suite-only directory-watch timing failure; the complete feature suite and isolated failing case pass)

## Notes
- both runtime and watchdog paths received independent post-commit reviews with no remaining findings
