### PR TITLE
Retarget project Last updated sorting to Codex 26.803

### DIFF
--- a/linux-features/project-group-last-updated-sort/patch.js
+++ b/linux-features/project-group-last-updated-sort/patch.js
@@ -1,14 +1,14 @@
 "use strict";
 
 const currentGroupSorter =
-  "function Drs({groups:e,items:t,projectOrder:n}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return voa(e.map((e,t)=>({group:e,index:t,recencyAt:e.threadKeys.reduce((e,t)=>Math.max(e,r.get(t)??0),e.projectUpdatedAt??0)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e),n)}";
+  "function p5o({groups:e,items:t,projectOrder:n}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return G6i(e.map((e,t)=>({group:e,index:t,recencyAt:e.threadKeys.reduce((e,t)=>Math.max(e,r.get(t)??0),e.projectUpdatedAt??0)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e),n)}";
 const patchedGroupSorter =
-  "function Drs({groups:e,items:t,projectOrder:n,sortMode:codexLinuxProjectSortMode}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return((codexLinuxRecencySortedGroups)=>codexLinuxProjectSortMode===`updated_at`?codexLinuxRecencySortedGroups:voa(codexLinuxRecencySortedGroups,n))(e.map((e,t)=>({group:e,index:t,recencyAt:e.threadKeys.reduce((e,t)=>Math.max(e,r.get(t)??0),e.projectUpdatedAt??0)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e))}";
+  "function p5o({groups:e,items:t,projectOrder:n,sortMode:codexLinuxProjectSortMode}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return((codexLinuxRecencySortedGroups)=>codexLinuxProjectSortMode===`updated_at`?codexLinuxRecencySortedGroups:G6i(codexLinuxRecencySortedGroups,n))(e.map((e,t)=>({group:e,index:t,recencyAt:e.threadKeys.reduce((e,t)=>Math.max(e,r.get(t)??0),e.projectUpdatedAt??0)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e))}";
 
 const currentGroupSorterCall =
-  "A=Drs({groups:Ers({groups:O,items:f}),items:f,projectOrder:Cp(t,Nl.PROJECT_ORDER)})";
+  "N=p5o({groups:A,items:f,projectOrder:jm(t,_u.PROJECT_ORDER)})";
 const patchedGroupSorterCall =
-  "A=Drs({groups:Ers({groups:O,items:f}),items:f,projectOrder:Cp(t,Nl.PROJECT_ORDER),sortMode:t(UR).projectSortMode})";
+  "N=p5o({groups:A,items:f,projectOrder:jm(t,_u.PROJECT_ORDER),sortMode:M})";
 
 function countOccurrences(source, needle) {
   return source.split(needle).length - 1;

--- a/linux-features/project-group-last-updated-sort/test.js
+++ b/linux-features/project-group-last-updated-sort/test.js
@@ -18,13 +18,13 @@ const {
 } = require("./patch.js");
 
 const currentProjectSource = [
-  "function goa(e,t){let n=new Set(e.map(e=>e.projectId)),r=(t??[]).filter(e=>n.has(e)),i=new Set(r);return[...e.map(e=>e.projectId).filter(e=>!i.has(e)),...r]}",
-  "function voa(e,t){let n=goa(e,t),r=new Map(n.map((e,t)=>[e,t]));return[...e].sort((e,t)=>(r.get(e.projectId)??2**53-1)-(r.get(t.projectId)??2**53-1))}",
-  "function Drs({groups:e,items:t,projectOrder:n}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return voa(e.map((e,t)=>({group:e,index:t,recencyAt:e.threadKeys.reduce((e,t)=>Math.max(e,r.get(t)??0),e.projectUpdatedAt??0)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e),n)}",
+  "function U6i(e,t){let n=new Set(e.map(e=>e.projectId)),r=(t??[]).filter(e=>n.has(e)),i=new Set(r);return[...e.map(e=>e.projectId).filter(e=>!i.has(e)),...r]}",
+  "function G6i(e,t){let n=U6i(e,t),r=new Map(n.map((e,t)=>[e,t]));return[...e].sort((e,t)=>(r.get(e.projectId)??2**53-1)-(r.get(t.projectId)??2**53-1))}",
+  "function p5o({groups:e,items:t,projectOrder:n}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return G6i(e.map((e,t)=>({group:e,index:t,recencyAt:e.threadKeys.reduce((e,t)=>Math.max(e,r.get(t)??0),e.projectUpdatedAt??0)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e),n)}",
   "const prioritySortId=`sidebarElectron.sortMenu.priority`;",
   "const updatedSortId=`sidebarElectron.sortMenu.updated`;",
   "const manualSortId=`sidebarElectron.sortMenu.manual`;",
-  "A=Drs({groups:Ers({groups:O,items:f}),items:f,projectOrder:Cp(t,Nl.PROJECT_ORDER)});",
+  "let{chatSortMode:j,projectSortMode:M}=t(xH),N=p5o({groups:A,items:f,projectOrder:jm(t,_u.PROJECT_ORDER)});",
 ].join("");
 
 function captureWarns(fn) {
@@ -70,7 +70,7 @@ function withFeatureConfig(enabled, fn) {
 function evaluateGroupSorter(source) {
   const context = {};
   const sorterSource = source.slice(0, source.indexOf("const prioritySortId"));
-  vm.runInNewContext(`${sorterSource};globalThis.sortProjectGroups=Drs`, context);
+  vm.runInNewContext(`${sorterSource};globalThis.sortProjectGroups=p5o`, context);
   return context.sortProjectGroups;
 }
 
@@ -154,15 +154,15 @@ test("patch passes the selected project sort mode into the group sorter", () => 
   const patched = applyPatchTwice(currentProjectSource);
   assert.ok(
     patched.includes(
-      "projectOrder:Cp(t,Nl.PROJECT_ORDER),sortMode:t(UR).projectSortMode",
+      "projectOrder:jm(t,_u.PROJECT_ORDER),sortMode:M",
     ),
   );
 });
 
 test("drift leaves the asset byte-identical", () => {
   const source = currentProjectSource.replace(
-    "function Drs({groups:e,items:t,projectOrder:n})",
-    "function Drs({groups:e,items:t,projectOrder:n,unknown:o})",
+    "function p5o({groups:e,items:t,projectOrder:n})",
+    "function p5o({groups:e,items:t,projectOrder:n,unknown:o})",
   );
   const { value, warnings } = captureWarns(() =>
     applyProjectGroupLastUpdatedSortPatch(source),
@@ -175,7 +175,7 @@ test("drift leaves the asset byte-identical", () => {
 
 test("missing current call site leaves the asset byte-identical", () => {
   const source = currentProjectSource.replace(
-    "projectOrder:Cp(t,Nl.PROJECT_ORDER)",
+    "projectOrder:jm(t,_u.PROJECT_ORDER)",
     "projectOrder:unknownProjectOrder",
   );
   const { value, warnings } = captureWarns(() =>
@@ -208,7 +208,7 @@ test("descriptor targets and patches only the current project sidebar chunk", ()
     const assetsDir = path.join(tempDir, "webview", "assets");
     const assetPath = path.join(
       assetsDir,
-      "app-initial-CKNQDTeE.js",
+      "app-initial-Biw83Aiz.js",
     );
     fs.mkdirSync(assetsDir, { recursive: true });
     fs.writeFileSync(assetPath, currentProjectSource);


### PR DESCRIPTION
## Summary

- Retarget the `project-group-last-updated-sort` feature to the exact project-group sorter and call-site symbols in Codex `26.803.41515` (`app-initial-Biw83Aiz.js`).
- Refresh the current-DMG fixture while preserving Last updated recency behavior and upstream saved order for Manual and Priority modes.
- Restore upstream-DMG candidate acceptance when this optional feature is enabled.

This intentionally replaces the Codex 26.730 matcher shape rather than retaining a compatibility fallback. The source-of-truth changes are limited to the feature patch descriptor and its test fixture.

## User-visible behavior

Users with `project-group-last-updated-sort` enabled can rebuild from the current upstream DMG without candidate promotion being rejected for enabled-feature drift. Last updated continues to order project groups by their newest task, while Manual and Priority keep the upstream saved project order.

## Validation

- `node --test linux-features/project-group-last-updated-sort/test.js` — 8 passed.
- Real Codex 26.803 asset application — first pass changed the exact sorter and call site once; second pass was byte-identical.
- `./scripts/rebuild-candidate.sh ./Codex.dmg` from commit `4fd435a0` — Codex `26.803.41515` candidate verdict `accepted_with_warnings`, zero blockers, and `project-group-last-updated-sort` reported `applied`. The remaining Computer Use UI availability warning is an unrelated optional core patch.
- `git diff --check origin/main...HEAD` — passed.
- Broader suites were attempted: the core patch suite passed 413/414 tests, with the bundled-plugin staging test rejected by the sandbox trust check; the Linux feature suite passed 879/881 tests, with the real app-server integration exiting before socket creation and Thorium cleanup unable to write the sandboxed `~/.codex/hooks.json`.
- Native system package installation was not run; validation used the side-by-side transactional candidate.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
