### PR TITLE
Fix Nix PipeWire microphone support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,7 @@ jobs:
             .#codex-desktop-computer-use-ui
             .#codex-desktop-remote-mobile-control
             .#codex-desktop-computer-use-ui-remote-mobile-control
+            .#checks.x86_64-linux.nix-pipewire-alsa-wrapper
             .#checks.x86_64-linux.nix-gsettings-schema-wrapper
             .#checks.x86_64-linux.watchdog-linux-features
           )

--- a/flake.nix
+++ b/flake.nix
@@ -327,6 +327,7 @@
           mesa
           libgbm
           alsa-lib
+          pipewire
           libX11
           libXcomposite
           libXdamage
@@ -739,6 +740,7 @@ PY
 
             makeWrapper "$out/opt/codex-desktop/start.sh" "$out/bin/codex-desktop" \
               --prefix PATH : "${payloadLauncherPath}" \
+              --set-default ALSA_PLUGIN_DIR "${pkgs.pipewire}/lib/alsa-lib" \
               --run 'export XDG_DATA_DIRS="''${XDG_DATA_DIRS:-${xdgDefaultDataDirs}}"' \
               --prefix XDG_DATA_DIRS : "${gsettingsSchemaDataDirs}" \
               --prefix PATH : "/run/current-system/sw/bin" \
@@ -838,6 +840,36 @@ PY
           notification-actions-linux = codexNotificationActionsBinary;
           notification-actions-installer = pkgs.runCommand "codex-notification-actions-installer-check" { } ''
             grep -F 'CODEX_NOTIFICATION_ACTIONS_SOURCE=' ${installer}/bin/codex-desktop-installer >/dev/null
+            touch "$out"
+          '';
+          nix-pipewire-alsa-wrapper = pkgs.runCommand "codex-desktop-nix-pipewire-alsa-wrapper-check" { } ''
+            plugin="${pkgs.pipewire}/lib/alsa-lib/libasound_module_pcm_pipewire.so"
+            expected_plugin_dir="${pkgs.pipewire}/lib/alsa-lib"
+            test -f "$plugin"
+
+            run_wrapper() {
+              case "$1" in
+                unset) unset ALSA_PLUGIN_DIR ;;
+                custom) export ALSA_PLUGIN_DIR=/custom/lib/alsa-lib ;;
+                *) echo "unknown test case: $1" >&2; return 1 ;;
+              esac
+
+              actual_plugin_dir="$({
+                exec() {
+                  printf '%s\n' "$ALSA_PLUGIN_DIR"
+                }
+
+                source ${codexDesktop}/bin/codex-desktop
+              })"
+              if [ "$actual_plugin_dir" != "$2" ]; then
+                printf 'expected ALSA_PLUGIN_DIR <%s>, got <%s>\n' \\
+                  "$2" "$actual_plugin_dir" >&2
+                return 1
+              fi
+            }
+
+            run_wrapper unset "$expected_plugin_dir"
+            run_wrapper custom /custom/lib/alsa-lib
             touch "$out"
           '';
           nix-gsettings-schema-wrapper = pkgs.runCommand "codex-desktop-nix-gsettings-schema-wrapper-check" { } ''


### PR DESCRIPTION
## Summary

- include PipeWire's ALSA module in the Nix Electron runtime
- set `ALSA_PLUGIN_DIR` so ALSA can load `libasound_module_pcm_pipewire.so`
- add a deterministic Nix check for the plugin and wrapper environment

Nix-packaged Electron could load `libasound.so.2`, but ALSA could not locate
the dynamically loaded PipeWire PCM module. As a result, microphone startup
failed with `NotReadableError`/`TrackStartError`, while the UI misleadingly
reported that another application was using the microphone.

## Validation

- `nix flake check --no-build --no-update-lock-file`
- `nix build .#checks.x86_64-linux.nix-pipewire-alsa-wrapper --no-link`
- `nix run .#codex-desktop` — microphone dictation verified on Fedora with PipeWire

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] This change does not add compatibility handling for an older DMG shape.
- [x] I added a targeted check, ran the validation listed above, and confirmed the microphone works in the built application.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort.
