### PR TITLE
Fix Linux browser runtime hook cloning

### DIFF
--- a/scripts/lib/browser-client-node-repl-runtime.test.js
+++ b/scripts/lib/browser-client-node-repl-runtime.test.js
@@ -167,6 +167,64 @@ test("guards every Browser client nodeRepl env read", () => {
   }
 });
 
+test("keeps Browser notification hooks on the cloned nodeRepl runtime", async () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "browser-client-runtime-clone-"));
+  const clientPath = path.join(fixtureRoot, "browser-client.mjs");
+  const patcher = path.join(__dirname, "bundled-plugins.sh");
+  const client = [
+    "function bb(){let e=globalThis.nodeRepl;return e?.config==null?void 0:e}",
+    "async function cM(e){let t=e.createElicitation.bind(e),r={...e,platform:`linux`,setResponseMeta:e.setResponseMeta,get requestMeta(){return e.requestMeta},async createElicitation(o){return await t(o)}},n=await $K(e,r);return n!=null&&(r.gaas=n),r}",
+    "async function $K(){return null}",
+  ].join("");
+
+  try {
+    fs.writeFileSync(clientPath, client, "utf8");
+    const applyShim = () =>
+      spawnSync(
+        "bash",
+        [
+          "-c",
+          'source "$1"; patch_browser_use_node_repl_config_shim "$2"; patch_browser_use_node_repl_runtime_clone_shim "$2"',
+          "browser-client-runtime-clone",
+          patcher,
+          clientPath,
+        ],
+        { encoding: "utf8" },
+      );
+
+    const first = applyShim();
+    assert.equal(first.status, 0, first.stderr);
+    const patched = fs.readFileSync(clientPath, "utf8");
+    const previousNodeRepl = globalThis.nodeRepl;
+    const prototype = {};
+    const nodeRepl = Object.preventExtensions(
+      Object.assign(Object.create(prototype), {
+        createElicitation: async () => ({ action: "decline" }),
+        requestMeta: {},
+        setResponseMeta() {},
+      }),
+    );
+
+    try {
+      globalThis.nodeRepl = nodeRepl;
+      const initialize = new Function(`${patched};return {clone:cM,resolve:bb}`);
+      const runtime = initialize();
+      const resolved = runtime.resolve();
+      assert.equal(typeof resolved.addAfterSubmittedCodeHook, "function");
+      const cloned = await runtime.clone(resolved);
+      assert.equal(typeof cloned.addAfterSubmittedCodeHook, "function");
+    } finally {
+      globalThis.nodeRepl = previousNodeRepl;
+    }
+
+    const second = applyShim();
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(fs.readFileSync(clientPath, "utf8"), patched);
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
 test(
   "staged Browser and Chrome clients import through the real node_repl runtime",
   { skip: !runtimePath || !pluginsRoot },

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -1114,6 +1114,7 @@ stage_chrome_plugin_from_upstream() {
     patch_browser_use_node_repl_process_env_import "$target_plugin/scripts/browser-client.mjs"
     patch_browser_use_node_repl_env_guard "$target_plugin/scripts/browser-client.mjs"
     patch_browser_use_node_repl_config_shim "$target_plugin/scripts/browser-client.mjs"
+    patch_browser_use_node_repl_runtime_clone_shim "$target_plugin/scripts/browser-client.mjs"
     patch_browser_use_native_pipe_import_meta_bridge "$target_plugin/scripts/browser-client.mjs"
     patch_browser_use_site_status_allowlist_fallback "$target_plugin/scripts/browser-client.mjs"
     patch_browser_client_linux_socket_dir "$target_plugin/scripts/browser-client.mjs"
@@ -1506,6 +1507,57 @@ path.write_text(source[:match.start()] + replacement + source[match.end():], enc
 PY
 }
 
+patch_browser_use_node_repl_runtime_clone_shim() {
+    local client="$1"
+
+    if grep -q "codexLinuxBrowserUseRuntimeCloneShim" "$client"; then
+        return 0
+    fi
+
+    python3 - "$client" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text(encoding="utf-8")
+if "codexLinuxBrowserUseNodeReplMethodShim" not in source:
+    print(
+        "WARN: Browser Use nodeRepl method shim is unavailable — leaving the runtime clone unchanged",
+        file=sys.stderr,
+    )
+    raise SystemExit(0)
+
+pattern = re.compile(
+    r'(?P<declaration>'
+    r'let (?P<elicitation>[A-Za-z_$][\w$]*)='
+    r'(?P<source>[A-Za-z_$][\w$]*)\.createElicitation\.bind\((?P=source)\),'
+    r'(?P<runtime>[A-Za-z_$][\w$]*)=\{\.\.\.(?P=source),.{1,2048}?\}'
+    r')'
+    r',(?P<next>'
+    r'[A-Za-z_$][\w$]*=await [A-Za-z_$][\w$]*\((?P=source),(?P=runtime)\);return'
+    r')',
+    re.DOTALL,
+)
+match = pattern.search(source)
+if match is None:
+    print(
+        "WARN: Could not find Browser Use nodeRepl runtime clone — leaving browser-client.mjs unchanged",
+        file=sys.stderr,
+    )
+    raise SystemExit(0)
+
+runtime = match.group("runtime")
+replacement = (
+    match.group("declaration")
+    + ";/*codexLinuxBrowserUseRuntimeCloneShim*/"
+    + f"codexLinuxBrowserUseNodeReplMethodShim({runtime});let "
+    + match.group("next")
+)
+path.write_text(source[:match.start()] + replacement + source[match.end():], encoding="utf-8")
+PY
+}
+
 patch_browser_use_native_pipe_import_meta_bridge() {
     local client="$1"
 
@@ -1626,6 +1678,7 @@ stage_browser_plugin_from_upstream() {
     patch_browser_use_node_repl_process_env_import "$target_client"
     patch_browser_use_node_repl_env_guard "$target_client"
     patch_browser_use_node_repl_config_shim "$target_client"
+    patch_browser_use_node_repl_runtime_clone_shim "$target_client"
     patch_browser_use_native_pipe_import_meta_bridge "$target_client"
     patch_browser_use_site_status_allowlist_fallback "$target_client"
     patch_browser_use_file_url_policy "$target_client"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -163,7 +163,7 @@ JSON
 {"name":"browser","version":"0.1.0-alpha2","interface":{"category":"Engineering"}}
 JSON
     cat > "$resources_dir/plugins/openai-bundled/plugins/browser/scripts/browser-client.mjs" <<'JS'
-import{env as Ub}from"node:process";function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}function Me(){let e=globalThis.nodeRepl;return e?.config==null?void 0:e}function th(){let e=import.meta.__codexNativePipe;return e==null||typeof e.createConnection!="function"?null:e}var I2=new Set(["about:blank"]);function Gb(e){if(I2.has(e))return!0;let t;try{t=new URL(e)}catch{return!1}return t.protocol==="http:"||t.protocol==="https:"}class Uf{async fetchBlocked(e,t){let r=await bS(e.endpoint,{method:"GET"});if(!r.ok)throw new Error(ae(`${t} cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await r.json();return TF(n)}}var kE=t=>t==="win32"?"\\\\.\\pipe\\codex-browser-use":"/tmp/codex-browser-use";var Cb=kE(hV.platform()),EV=()=>_P()==="win32"?TV():CV(),CV=async()=>(await yP(Cb)).map(e=>wP.resolve(Cb,e)),TV=async()=>[];export function setupAtlasRuntime() {return Ub.XDG_CONFIG_HOME}
+import{env as Ub}from"node:process";function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}function Me(){let e=globalThis.nodeRepl;return e?.config==null?void 0:e}async function cM(e){let t=e.createElicitation.bind(e),r={...e,platform:`linux`,setResponseMeta:e.setResponseMeta,get requestMeta(){return e.requestMeta},async createElicitation(o){return await t(o)}},n=await $K(e,r);return n!=null&&(r.gaas=n),r}async function $K(){return null}function th(){let e=import.meta.__codexNativePipe;return e==null||typeof e.createConnection!="function"?null:e}var I2=new Set(["about:blank"]);function Gb(e){if(I2.has(e))return!0;let t;try{t=new URL(e)}catch{return!1}return t.protocol==="http:"||t.protocol==="https:"}class Uf{async fetchBlocked(e,t){let r=await bS(e.endpoint,{method:"GET"});if(!r.ok)throw new Error(ae(`${t} cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await r.json();return TF(n)}}var kE=t=>t==="win32"?"\\\\.\\pipe\\codex-browser-use":"/tmp/codex-browser-use";var Cb=kE(hV.platform()),EV=()=>_P()==="win32"?TV():CV(),CV=async()=>(await yP(Cb)).map(e=>wP.resolve(Cb,e)),TV=async()=>[];export function setupAtlasRuntime() {return Ub.XDG_CONFIG_HOME}
 JS
 }
 
@@ -7921,6 +7921,7 @@ test_browser_plugin_renamed_upstream_staging() {
     assert_not_contains "$browser_dir/scripts/browser-client.mjs" 'globalThis.nodeRepl?.env\[e\]'
     assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxBrowserUseDefineNodeReplMethod"
     assert_contains "$browser_dir/scripts/browser-client.mjs" "addAfterSubmittedCodeHook"
+    assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxBrowserUseRuntimeCloneShim"
     assert_contains "$browser_dir/scripts/browser-client.mjs" "nativePipe??import.meta.__codexNativePipe"
     assert_not_contains "$browser_dir/scripts/browser-client.mjs" "let e=import.meta.__codexNativePipe;return"
     assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
@@ -8581,6 +8582,8 @@ const browserPreference={};function preferredWindowIdFor(){}function getForUrl()
 var kE=t=>t==="win32"?"\\\\.\\pipe\\codex-browser-use":"/tmp/codex-browser-use";var Cb=kE(hV.platform()),EV=()=>_P()==="win32"?TV():CV(),CV=async()=>(await yP(Cb)).map(e=>wP.resolve(Cb,e)),TV=async()=>[];
 function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}
 function Me(){let e=globalThis.nodeRepl;return e?.config==null?void 0:e}
+async function cM(e){let t=e.createElicitation.bind(e),r={...e,platform:`linux`,setResponseMeta:e.setResponseMeta,get requestMeta(){return e.requestMeta},async createElicitation(o){return await t(o)}},n=await $K(e,r);return n!=null&&(r.gaas=n),r}
+async function $K(){return null}
 import{platform as yT}from"node:os";import{env as Ub}from"node:process";function eh(){return"privileged native pipe bridge is not available; browser-client is not trusted"}function th(){let e=globalThis.nodeRepl?.nativePipe;return e==null||typeof e.createConnection!="function"?null:e}var ml=class e{constructor(t){this.socket=t}static async create(t){let r=th();if(r!=null){let n=await r.createConnection(t);return new e(n)}throw new Error(eh())}};var chromeConfigHome=Ub.CHROME_CONFIG_HOME;
 async fetchBlocked(e,t){let r=await bS(e.endpoint,{method:"GET"});if(!r.ok)throw new Error(ae(`${t} cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await r.json();return TF(n)}
 JS
@@ -8775,6 +8778,7 @@ test_chrome_plugin_staging() {
     assert_contains "$chrome_dir/scripts/browser-client.mjs" 'Object.defineProperty(prototype, "config"'
     assert_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxBrowserUseDefineNodeReplMethod"
     assert_contains "$chrome_dir/scripts/browser-client.mjs" "addAfterSubmittedCodeHook"
+    assert_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxBrowserUseRuntimeCloneShim"
     assert_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxBrowserUseConfigShim();let e=globalThis.nodeRepl"
     assert_contains "$chrome_dir/scripts/browser-client.mjs" "nativePipe??import.meta.__codexNativePipe"
     assert_not_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxNativePipeFallback"


### PR DESCRIPTION
## Summary

- preserve Linux node_repl notification hooks when the current Browser Use client clones the runtime object
- apply the clone shim while staging both Browser and Chrome bundled plugins
- cover the current 26.803 minified shape in runtime and staging tests

## Root cause

The Linux compatibility methods are installed on the non-extensible node_repl object through its prototype. The current upstream Browser Use client creates a runtime with an object spread, which drops those inherited methods before registering the after-submitted-code hook.

## Validation

- real packaged node_repl import of patched Browser and Chrome 26.803.41515 clients
- node --test scripts/lib/browser-client-node-repl-runtime.test.js
- bash tests/scripts_smoke.sh
- bash syntax checks and git diff --check

The broad patcher suite still has one pre-existing local failure in the private bundled-plugin staging-root test; it reproduces unchanged on origin/main.