### PR TITLE
feat(thorium): register Thorium in the current browser registry

### DIFF
--- a/linux-features/thorium-chrome-plugin/README.md
+++ b/linux-features/thorium-chrome-plugin/README.md
@@ -18,9 +18,16 @@ core Linux port does not regularly test. Enable it by adding the feature id to
 When enabled, the feature:
 
 - adds Thorium native-messaging manifest locations for the generated launcher
-- patches the staged Chrome plugin scripts to detect Thorium installs, profiles,
-  running processes, default-browser desktop IDs, and launch commands
+- registers Thorium in the staged Chrome plugin's browser registry
+  (`scripts/extension-ids.json`), which is where upstream reads install
+  commands, process names, profile directories, and native-messaging manifest
+  locations from
 - adds Thorium to the Electron-side Chrome extension settings/status helper
+
+Thorium inherits the Chrome extension identity, because it loads the same
+extension build. Upstream moved this contract into the registry in
+26.803.41515; before that the same coverage needed seven separate patches
+against Chrome-only constants in individual plugin scripts.
 
 Run the focused tests with:
 

--- a/linux-features/thorium-chrome-plugin/patch-chrome-plugin.js
+++ b/linux-features/thorium-chrome-plugin/patch-chrome-plugin.js
@@ -4,69 +4,133 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
+const THORIUM_BROWSER_FAMILY = "thorium";
+
+// 26.803.41515 replaced the per-script Chrome-only Linux constants with a
+// browser registry in extension-ids.json. Adding Thorium there covers manifest
+// locations, the browser inventory, running-process detection, profile
+// resolution, and window command selection in one entry, which is what the
+// seven source patches this replaces did by hand.
+const THORIUM_BROWSER_ENTRY = {
+  browserFamily: THORIUM_BROWSER_FAMILY,
+  displayName: "Thorium",
+  shortDisplayName: "Thorium",
+  extensionManagementUrl: "thorium://extensions",
+  linux: {
+    commands: ["thorium-browser-avx2", "thorium-browser", "thorium"],
+    configHomeEnvironmentVariables: ["XDG_CONFIG_HOME"],
+    nativeMessagingManifestDirectories: [".config/thorium/NativeMessagingHosts"],
+    processNames: ["thorium", "thorium-browser", "thorium-browser-avx2"],
+    userDataDirectorySegments: [".config", "thorium"],
+  },
+  macos: {
+    applicationNames: ["Thorium.app"],
+    bundleId: "org.chromium.Thorium",
+    nativeMessagingManifestDirectories: [
+      "Library/Application Support/Thorium/NativeMessagingHosts",
+    ],
+    processNames: ["Thorium", "Thorium Helper"],
+    userDataDirectorySegments: ["Library", "Application Support", "Thorium"],
+  },
+  windows: {
+    commandNames: ["thorium.exe", "thorium"],
+    installPathSegments: ["Thorium", "Application", "thorium.exe"],
+    processNames: ["thorium.exe"],
+    userDataDirectorySegments: ["Thorium", "User Data"],
+  },
+};
+
 function warn(message) {
   process.stderr.write(`WARN: ${message}\n`);
 }
 
-function sourceIncludesAny(source, texts) {
-  return (Array.isArray(texts) ? texts : [texts]).some(
-    (text) => typeof text === "string" && text.length > 0 && source.includes(text),
+function detectIndent(source) {
+  const match = source.match(/\n([ \t]+)"/u);
+  return match == null ? 2 : match[1].length;
+}
+
+function readRegistry(registryPath) {
+  let source;
+  try {
+    source = fs.readFileSync(registryPath, "utf8");
+  } catch (error) {
+    warn(
+      `Could not read ${path.basename(registryPath)}: ${error.message}; leaving Thorium unregistered`,
+    );
+    return null;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(source);
+  } catch (error) {
+    warn(
+      `Could not parse ${path.basename(registryPath)}: ${error.message}; leaving Thorium unregistered`,
+    );
+    return null;
+  }
+
+  if (!Array.isArray(parsed?.browserDiagnostics)) {
+    warn(
+      `${path.basename(registryPath)} missing browserDiagnostics registry; leaving Thorium unregistered`,
+    );
+    return null;
+  }
+
+  return { source, parsed };
+}
+
+function thoriumEntryFor(registry) {
+  const donor = registry.browserDiagnostics.find(
+    (browser) => browser?.browserFamily === "chrome",
   );
+  if (donor == null) {
+    return null;
+  }
+
+  // Thorium is a Chromium fork and loads the same extension build, so it
+  // inherits the Chrome extension identity rather than declaring its own.
+  return {
+    ...THORIUM_BROWSER_ENTRY,
+    ...(donor.extensionIds == null ? {} : { extensionIds: [...donor.extensionIds] }),
+    ...(donor.storeUrl == null ? {} : { storeUrl: donor.storeUrl }),
+  };
 }
 
-function patchFile(filePath, patches) {
-  let source;
-  try {
-    source = fs.readFileSync(filePath, "utf8");
-  } catch (error) {
-    warn(`Could not read ${filePath}: ${error.message}`);
-    return;
+function registerThorium(pluginDir) {
+  const registryPath = path.join(pluginDir, "scripts", "extension-ids.json");
+  const registry = readRegistry(registryPath);
+  if (registry == null) {
+    return false;
   }
 
-  let changed = false;
-  for (const { label, oldText, newText, alreadyText = newText } of patches) {
-    if (source.includes(newText) || sourceIncludesAny(source, alreadyText)) {
-      console.log(`${path.basename(filePath)} already patched: ${label}`);
-      continue;
-    }
-    if (!source.includes(oldText)) {
-      warn(`${path.basename(filePath)} missing patch target for ${label}`);
-      continue;
-    }
-    source = source.replace(oldText, newText);
-    changed = true;
-    console.log(`Patched ${path.basename(filePath)}: ${label}`);
+  const { source, parsed } = registry;
+  if (
+    parsed.browserDiagnostics.some(
+      (browser) => browser?.browserFamily === THORIUM_BROWSER_FAMILY,
+    )
+  ) {
+    console.log("extension-ids.json already patched: Thorium browser registry");
+    return true;
   }
 
-  if (changed) {
-    fs.writeFileSync(filePath, source, "utf8");
-  }
-}
-
-function patchFileFirstMatch(filePath, { label, oldTexts, newText, alreadyText = newText }) {
-  let source;
-  try {
-    source = fs.readFileSync(filePath, "utf8");
-  } catch (error) {
-    warn(`Could not read ${filePath}: ${error.message}`);
-    return;
+  const entry = thoriumEntryFor(parsed);
+  if (entry == null) {
+    warn(
+      "extension-ids.json missing the Chrome registry entry Thorium inherits from; leaving Thorium unregistered",
+    );
+    return false;
   }
 
-  if ((typeof newText === "string" && source.includes(newText)) || sourceIncludesAny(source, alreadyText)) {
-    console.log(`${path.basename(filePath)} already patched: ${label}`);
-    return;
-  }
-
-  const match = oldTexts
-    .map((candidate) => typeof candidate === "string" ? { oldText: candidate, newText } : candidate)
-    .find((candidate) => source.includes(candidate.oldText));
-  if (!match) {
-    warn(`${path.basename(filePath)} missing patch target for ${label}`);
-    return;
-  }
-
-  fs.writeFileSync(filePath, source.replace(match.oldText, match.newText ?? newText), "utf8");
-  console.log(`Patched ${path.basename(filePath)}: ${label}`);
+  parsed.browserDiagnostics.push(entry);
+  const trailingNewline = source.endsWith("\n") ? "\n" : "";
+  fs.writeFileSync(
+    registryPath,
+    `${JSON.stringify(parsed, null, detectIndent(source))}${trailingNewline}`,
+    "utf8",
+  );
+  console.log("Patched extension-ids.json: Thorium browser registry");
+  return true;
 }
 
 const pluginDir = process.argv[2];
@@ -74,275 +138,4 @@ if (!pluginDir) {
   throw new Error("Usage: patch-chrome-plugin.js /path/to/chrome/plugin");
 }
 
-const scriptsDir = path.resolve(pluginDir, "scripts");
-
-const nativeHostManifestFallback = `  if (process.platform === "linux") {
-    const manifestPaths = [
-      path.join(
-        os.homedir(),
-        ".config",
-        "google-chrome",
-        "NativeMessagingHosts",
-        \`\${expectedHostName}.json\`,
-      ),
-      path.join(
-        os.homedir(),
-        ".config",
-        "google-chrome-beta",
-        "NativeMessagingHosts",
-        \`\${expectedHostName}.json\`,
-      ),
-      path.join(
-        os.homedir(),
-        ".config",
-        "google-chrome-unstable",
-        "NativeMessagingHosts",
-        \`\${expectedHostName}.json\`,
-      ),
-      path.join(
-        os.homedir(),
-        ".config",
-        "BraveSoftware",
-        "Brave-Browser",
-        "NativeMessagingHosts",
-        \`\${expectedHostName}.json\`,
-      ),
-      path.join(
-        os.homedir(),
-        ".config",
-        "chromium",
-        "NativeMessagingHosts",
-        \`\${expectedHostName}.json\`,
-      ),
-      path.join(
-        os.homedir(),
-        ".config",
-        "thorium",
-        "NativeMessagingHosts",
-        \`\${expectedHostName}.json\`,
-      ),
-    ];
-
-    return {
-      manifestPath:
-        manifestPaths.find((candidate) => fs.existsSync(candidate)) ||
-        manifestPaths[0],
-      registryKey: null,
-      registryManifestPath: null,
-      registryKeyExists: null,
-    };
-  }`;
-
-const nativeHostManifestFallbackWithoutThorium = nativeHostManifestFallback.replace(
-  `      path.join(
-        os.homedir(),
-        ".config",
-        "thorium",
-        "NativeMessagingHosts",
-        \`\${expectedHostName}.json\`,
-      ),
-`,
-  "",
-);
-
-const extensionAwareUserDataFallback = `  const linuxChromeUserDataDirectory = path.join(os.homedir(), ".config", "google-chrome");
-  const linuxChromeBetaUserDataDirectory = path.join(os.homedir(), ".config", "google-chrome-beta");
-  const linuxChromeUnstableUserDataDirectory = path.join(os.homedir(), ".config", "google-chrome-unstable");
-  const linuxChromiumUserDataDirectory = path.join(os.homedir(), ".config", "chromium");
-  const linuxThoriumUserDataDirectory = path.join(os.homedir(), ".config", "thorium");
-  const linuxBraveUserDataDirectory = path.join(
-    os.homedir(),
-    ".config",
-    "BraveSoftware",
-    "Brave-Browser",
-  );
-  const linuxUserDataCandidates = [
-    linuxBraveUserDataDirectory,
-    linuxChromeUserDataDirectory,
-    linuxChromeBetaUserDataDirectory,
-    linuxChromeUnstableUserDataDirectory,
-    linuxChromiumUserDataDirectory,
-    linuxThoriumUserDataDirectory,
-  ].filter((candidate) => fs.existsSync(candidate));
-  const linuxCandidateWithInstalledExtension = linuxUserDataCandidates.find(
-    (candidate) => {
-      try {
-        const extensionId = loadRemoteChromeExtensionId();
-        return findLatestChromeProfile(candidate) != null &&
-          fs.existsSync(
-            path.join(
-              candidate,
-              resolveChromeProfileDirectory(candidate),
-              "Extensions",
-              extensionId,
-            ),
-          );
-      } catch {
-        return false;
-      }
-    },
-  );
-  if (linuxCandidateWithInstalledExtension) {
-    return linuxCandidateWithInstalledExtension;
-  }
-
-  if (linuxUserDataCandidates.length > 0) return linuxUserDataCandidates[0];
-
-  return linuxChromeUserDataDirectory;`;
-
-const extensionAwareUserDataFallbackWithoutThorium = extensionAwareUserDataFallback
-  .replace('  const linuxThoriumUserDataDirectory = path.join(os.homedir(), ".config", "thorium");\n', "")
-  .replace("    linuxThoriumUserDataDirectory,\n", "");
-
-const defaultBrowserUserDataFallback = `  const linuxChromeUserDataDirectory = path.join(os.homedir(), ".config", "google-chrome");
-  const linuxChromeBetaUserDataDirectory = path.join(os.homedir(), ".config", "google-chrome-beta");
-  const linuxChromeUnstableUserDataDirectory = path.join(os.homedir(), ".config", "google-chrome-unstable");
-  const linuxChromiumUserDataDirectory = path.join(os.homedir(), ".config", "chromium");
-  const linuxThoriumUserDataDirectory = path.join(os.homedir(), ".config", "thorium");
-  const linuxBraveUserDataDirectory = path.join(
-    os.homedir(),
-    ".config",
-    "BraveSoftware",
-    "Brave-Browser",
-  );
-  const defaultBrowser = runCommand(["xdg-settings", "get", "default-web-browser"]);
-  if (
-    defaultBrowser === "brave-browser.desktop" &&
-    fs.existsSync(linuxBraveUserDataDirectory)
-  ) {
-    return linuxBraveUserDataDirectory;
-  }
-  if (
-    defaultBrowser === "google-chrome-beta.desktop" &&
-    fs.existsSync(linuxChromeBetaUserDataDirectory)
-  ) {
-    return linuxChromeBetaUserDataDirectory;
-  }
-  if (
-    defaultBrowser === "google-chrome-unstable.desktop" &&
-    fs.existsSync(linuxChromeUnstableUserDataDirectory)
-  ) {
-    return linuxChromeUnstableUserDataDirectory;
-  }
-  if (
-    ["chromium.desktop", "chromium-browser.desktop"].includes(defaultBrowser) &&
-    fs.existsSync(linuxChromiumUserDataDirectory)
-  ) {
-    return linuxChromiumUserDataDirectory;
-  }
-  if (
-    ["thorium-browser.desktop", "thorium-browser-avx2.desktop"].includes(defaultBrowser) &&
-    fs.existsSync(linuxThoriumUserDataDirectory)
-  ) {
-    return linuxThoriumUserDataDirectory;
-  }
-
-  if (fs.existsSync(linuxBraveUserDataDirectory)) return linuxBraveUserDataDirectory;
-  if (fs.existsSync(linuxChromeUserDataDirectory)) return linuxChromeUserDataDirectory;
-  if (fs.existsSync(linuxChromeBetaUserDataDirectory)) return linuxChromeBetaUserDataDirectory;
-  if (fs.existsSync(linuxChromeUnstableUserDataDirectory)) return linuxChromeUnstableUserDataDirectory;
-  if (fs.existsSync(linuxChromiumUserDataDirectory)) return linuxChromiumUserDataDirectory;
-  if (fs.existsSync(linuxThoriumUserDataDirectory)) return linuxThoriumUserDataDirectory;
-
-  return linuxChromeUserDataDirectory;`;
-
-const defaultBrowserUserDataFallbackWithoutThorium = defaultBrowserUserDataFallback
-  .replace('  const linuxThoriumUserDataDirectory = path.join(os.homedir(), ".config", "thorium");\n', "")
-  .replace(`  if (
-    ["thorium-browser.desktop", "thorium-browser-avx2.desktop"].includes(defaultBrowser) &&
-    fs.existsSync(linuxThoriumUserDataDirectory)
-  ) {
-    return linuxThoriumUserDataDirectory;
-  }
-`, "")
-  .replace("  if (fs.existsSync(linuxThoriumUserDataDirectory)) return linuxThoriumUserDataDirectory;\n", "");
-
-patchFileFirstMatch(path.join(scriptsDir, "installManifest.mjs"), {
-  label: "Thorium native host manifest location",
-  oldTexts: [
-    'linux:[".config/google-chrome/NativeMessagingHosts",".config/google-chrome-beta/NativeMessagingHosts",".config/google-chrome-unstable/NativeMessagingHosts",".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",".config/chromium/NativeMessagingHosts"]',
-  ],
-  newText:
-    'linux:[".config/google-chrome/NativeMessagingHosts",".config/google-chrome-beta/NativeMessagingHosts",".config/google-chrome-unstable/NativeMessagingHosts",".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",".config/chromium/NativeMessagingHosts",".config/thorium/NativeMessagingHosts"]',
-});
-
-patchFile(path.join(scriptsDir, "check-native-host-manifest.js"), [
-  {
-    label: "Thorium native host manifest fallback",
-    oldText: nativeHostManifestFallbackWithoutThorium,
-    newText: nativeHostManifestFallback,
-    alreadyText: '"thorium",\n        "NativeMessagingHosts"',
-  },
-]);
-
-patchFile(path.join(scriptsDir, "installed-browsers.js"), [
-  {
-    label: "Thorium browser inventory",
-    oldText: `  {
-    name: "Chromium",
-    bundleIds: ["org.chromium.Chromium"],
-    appNames: ["Chromium.app"],
-    commands: ["chromium", "chromium-browser"],
-    windowsExecutable: "chrome.exe",
-  },
-];`,
-    newText: `  {
-    name: "Chromium",
-    bundleIds: ["org.chromium.Chromium"],
-    appNames: ["Chromium.app"],
-    commands: ["chromium", "chromium-browser"],
-    windowsExecutable: "chrome.exe",
-  },
-  {
-    name: "Thorium",
-    bundleIds: ["org.chromium.Thorium"],
-    appNames: ["Thorium.app"],
-    commands: ["thorium-browser-avx2", "thorium-browser", "thorium"],
-    windowsExecutable: "chrome.exe",
-  },
-];`,
-    alreadyText: '"Thorium"',
-  },
-]);
-
-patchFileFirstMatch(path.join(scriptsDir, "chrome-is-running.js"), {
-  label: "Thorium running-process detection",
-  oldTexts: [
-    `  linux: new Set(["chrome", "google-chrome", "google-chrome-beta", "google-chrome-unstable", "brave", "brave-browser", "chromium", "chromium-browser"]),`,
-  ],
-  newText: `  linux: new Set(["chrome", "google-chrome", "google-chrome-beta", "google-chrome-unstable", "brave", "brave-browser", "chromium", "chromium-browser", "thorium", "thorium-browser", "thorium-browser-avx2"]),`,
-  alreadyText: "thorium-browser-avx2",
-});
-
-patchFileFirstMatch(path.join(scriptsDir, "check-extension-installed.js"), {
-  label: "Thorium extension-aware browser profile fallback",
-  oldTexts: [extensionAwareUserDataFallbackWithoutThorium],
-  newText: extensionAwareUserDataFallback,
-  alreadyText: "linuxThoriumUserDataDirectory",
-});
-
-patchFileFirstMatch(path.join(scriptsDir, "open-chrome-window.js"), {
-  label: "Thorium default-browser profile fallback",
-  oldTexts: [defaultBrowserUserDataFallbackWithoutThorium],
-  newText: defaultBrowserUserDataFallback,
-  alreadyText: "linuxThoriumUserDataDirectory",
-});
-
-patchFile(path.join(scriptsDir, "open-chrome-window.js"), [
-  {
-    label: "Thorium browser window command",
-    oldText: `  } else if (linuxUserDataDirectory.includes(path.join(".config", "chromium"))) {
-    linuxCommand = commandPath("chromium") || commandPath("chromium-browser") || "chromium";
-  }
-
-  return {`,
-    newText: `  } else if (linuxUserDataDirectory.includes(path.join(".config", "chromium"))) {
-    linuxCommand = commandPath("chromium") || commandPath("chromium-browser") || "chromium";
-  } else if (linuxUserDataDirectory.includes(path.join(".config", "thorium"))) {
-    linuxCommand = commandPath("thorium-browser-avx2") || commandPath("thorium-browser") || commandPath("thorium") || "thorium-browser";
-  }
-
-  return {`,
-    alreadyText: 'commandPath("thorium-browser-avx2")',
-  },
-]);
+registerThorium(pluginDir);

--- a/linux-features/thorium-chrome-plugin/test.js
+++ b/linux-features/thorium-chrome-plugin/test.js
@@ -32,81 +32,57 @@ function writeFakeChromePlugin(pluginDir) {
   const scriptsDir = path.join(pluginDir, "scripts");
   fs.mkdirSync(scriptsDir, { recursive: true });
   fs.writeFileSync(
-    path.join(scriptsDir, "installManifest.mjs"),
-    'var n={extensionId:"hehggadaopoacecdllhhajmbjkdcmajg",extensionHostName:"com.openai.codexextension"};var p=o=>{let t=`${o.extensionHostName}.json`,r={darwin:["Library/Application Support/Google/Chrome/NativeMessagingHosts"],linux:[".config/google-chrome/NativeMessagingHosts"],win32:["AppData/Local/OpenAI/extension"]}[m.platform()];return r.map(s=>l.resolve(m.homedir(),s,t))};\n',
+    path.join(scriptsDir, "extension-ids.json"),
+    `${JSON.stringify(
+      {
+        extensionHostName: "com.openai.codexextension",
+        extensionIds: ["hehggadaopoacecdllhhajmbjkdcmajg"],
+        browserDiagnostics: [
+          {
+            browserFamily: "chrome",
+            displayName: "Google Chrome",
+            shortDisplayName: "Chrome",
+            extensionIds: [
+              "hehggadaopoacecdllhhajmbjkdcmajg",
+              "odlomjlbamekndcpllcnffbgeohgkmjh",
+            ],
+            extensionManagementUrl: "chrome://extensions",
+            storeUrl:
+              "https://chromewebstore.google.com/detail/chatgpt/hehggadaopoacecdllhhajmbjkdcmajg",
+            linux: {
+              commands: ["google-chrome", "google-chrome-stable"],
+              configHomeEnvironmentVariables: ["CHROME_CONFIG_HOME", "XDG_CONFIG_HOME"],
+              nativeMessagingManifestDirectories: [
+                ".config/google-chrome/NativeMessagingHosts",
+              ],
+              processNames: ["chrome"],
+              userDataDirectorySegments: [".config", "google-chrome"],
+            },
+            macos: {
+              applicationNames: ["Google Chrome.app"],
+              bundleId: "com.google.Chrome",
+              nativeMessagingManifestDirectories: [
+                "Library/Application Support/Google/Chrome/NativeMessagingHosts",
+              ],
+              processNames: ["Google Chrome"],
+              userDataDirectorySegments: ["Library", "Application Support", "Google", "Chrome"],
+            },
+            windows: {
+              commandNames: ["chrome.exe"],
+              installPathSegments: ["Google", "Chrome", "Application", "chrome.exe"],
+              processNames: ["chrome.exe"],
+              userDataDirectorySegments: ["Google", "Chrome", "User Data"],
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
   );
   fs.writeFileSync(
     path.join(scriptsDir, "browser-client.mjs"),
-    'import{resolve as GF}from"path";import{homedir as VF,platform as WF}from"os";var Tc=GF(VF(),WF()==="win32"?"AppData\\\\Local\\\\Google\\\\Chrome\\\\User Data":"Library/Application Support/Google/Chrome");var IS=async(t,e)=>{let r=Gf(Tc,t,"Local Extension Settings",e);if(!XF(r))return null;let n=await JF(Gf(QF(),"codex"));await ZF(r,n,{recursive:!0}),await kS(Gf(n,"LOCK"));let o=new KF(n,{createIfMissing:!1,keyEncoding:"utf8",valueEncoding:"utf8"});try{await o.open();let i=await o.get("extensionInstanceId");if(!i)return null;let s=JSON.parse(i);return typeof s!="string"?null:s}finally{await o.close(),await kS(n,{force:!0,recursive:!0})}};var AS=async t=>t,rO=async(t,e)=>(await nO(t)).find(o=>o.instanceId===e)||null,nO=async t=>{let e=await oO();return await Promise.all(e.map(async r=>({...r,instanceId:await IS(r.id,t).catch(n=>(ee(n),null))})))},oO=async()=>{let t=tO(Tc,"Local State"),e=JSON.parse(await eO(t,"utf8"));return e.profile.profiles_order.map((r,n)=>{let o=e.profile.info_cache[r];return o?{id:r,name:o.name,isLastUsed:e.profile.last_used===r,orderingIndex:n,avatarUrl:o.avatar_icon}:null}).filter(r=>!!r)};\n',
-  );
-  fs.writeFileSync(
-    path.join(scriptsDir, "check-native-host-manifest.js"),
-    `function getNativeHostManifestLocation() {
-  if (process.platform === "win32") {
-    const registryKey = \`\${WINDOWS_NATIVE_HOST_REGISTRY_KEY_PREFIX}\\\\\${expectedHostName}\`;
-    const registryManifestPath = readWindowsRegistryDefaultValue(registryKey);
-
-    return {
-      manifestPath: registryManifestPath || getDefaultWindowsManifestPath(),
-      registryKey,
-      registryManifestPath,
-      registryKeyExists: registryManifestPath != null,
-    };
-  }
-
-  throw new Error(
-    \`Unsupported platform for native host manifest check: \${process.platform}. This script supports macOS and Windows.\`,
-  );
-}
-`,
-  );
-  fs.writeFileSync(
-    path.join(scriptsDir, "installed-browsers.js"),
-    `const KNOWN_BROWSERS = [
-  {
-    name: "Google Chrome",
-    bundleIds: ["com.google.Chrome"],
-    appNames: ["Google Chrome.app"],
-    commands: ["google-chrome", "chrome"],
-    windowsExecutable: "chrome.exe",
-  },
-];
-`,
-  );
-  fs.writeFileSync(
-    path.join(scriptsDir, "chrome-is-running.js"),
-    `const CHROME_PROCESS_NAMES_BY_PLATFORM = {
-  darwin: new Set(["Google Chrome", "Google Chrome Helper"]),
-  win32: new Set(["chrome.exe"]),
-};
-`,
-  );
-  fs.writeFileSync(
-    path.join(scriptsDir, "check-extension-installed.js"),
-    `function resolveChromeUserDataDirectory() {
-  return path.join(os.homedir(), ".config", "google-chrome");
-}
-`,
-  );
-  fs.writeFileSync(
-    path.join(scriptsDir, "open-chrome-window.js"),
-    `function resolveChromeUserDataDirectory() {
-  return path.join(os.homedir(), ".config", "google-chrome");
-}
-
-function getOpenChromeCommand(profileDirectory) {
-  const chromeArgs = [
-    \`--profile-directory=\${profileDirectory}\`,
-    "--new-window",
-    ABOUT_BLANK_URL,
-  ];
-
-  return {
-    command: "google-chrome",
-    args: chromeArgs,
-  };
-}
-`,
+    'const browserPreference = {};\nfunction preferredWindowIdFor() {}\nfunction getForUrl() {}\n',
   );
 }
 
@@ -146,19 +122,14 @@ test("Thorium settings patch extends the core Linux Chrome status helper", () =>
   assert.match(patched, /Google Chrome, Brave, Chromium, or Thorium is not installed/);
 });
 
-test("Thorium staging targets only the current core Chrome plugin shape", () => {
+test("Thorium staging targets the current browser registry, not legacy script shapes", () => {
   const source = fs.readFileSync(path.join(__dirname, "patch-chrome-plugin.js"), "utf8");
 
-  assert.doesNotMatch(
-    source,
-    /linux:\["\.config\/google-chrome\/NativeMessagingHosts","\.config\/BraveSoftware\/Brave-Browser\/NativeMessagingHosts","\.config\/chromium\/NativeMessagingHosts"\]/,
-  );
-  assert.doesNotMatch(
-    source,
-    /linux: new Set\(\["chrome", "google-chrome", "brave", "brave-browser", "chromium", "chromium-browser"\]\)/,
-  );
-  assert.match(source, /google-chrome-beta\/NativeMessagingHosts/);
-  assert.match(source, /"google-chrome-beta", "google-chrome-unstable"/);
+  assert.match(source, /browserDiagnostics/);
+  assert.match(source, /extension-ids\.json/);
+  assert.doesNotMatch(source, /KNOWN_BROWSERS/);
+  assert.doesNotMatch(source, /CHROME_PROCESS_NAMES_BY_PLATFORM/);
+  assert.doesNotMatch(source, /linuxThoriumUserDataDirectory/);
 });
 
 test("Thorium stage hook upgrades a core Linux-patched Chrome plugin", () => {
@@ -199,12 +170,32 @@ test("Thorium stage hook upgrades a core Linux-patched Chrome plugin", () => {
     assert.doesNotMatch(stageResult.stderr, /missing patch target/);
 
     const scriptsDir = path.join(chromePlugin, "scripts");
-    assert.match(fs.readFileSync(path.join(scriptsDir, "installManifest.mjs"), "utf8"), /thorium\/NativeMessagingHosts/);
-    assert.match(fs.readFileSync(path.join(scriptsDir, "check-native-host-manifest.js"), "utf8"), /"thorium"/);
-    assert.match(fs.readFileSync(path.join(scriptsDir, "installed-browsers.js"), "utf8"), /Thorium/);
-    assert.match(fs.readFileSync(path.join(scriptsDir, "chrome-is-running.js"), "utf8"), /thorium-browser-avx2/);
-    assert.match(fs.readFileSync(path.join(scriptsDir, "check-extension-installed.js"), "utf8"), /linuxThoriumUserDataDirectory/);
-    assert.match(fs.readFileSync(path.join(scriptsDir, "open-chrome-window.js"), "utf8"), /commandPath\("thorium-browser-avx2"\)/);
+    const registry = JSON.parse(
+      fs.readFileSync(path.join(scriptsDir, "extension-ids.json"), "utf8"),
+    );
+    const thorium = registry.browserDiagnostics.find(
+      (browser) => browser.browserFamily === "thorium",
+    );
+    assert.ok(thorium, "expected a thorium entry in browserDiagnostics");
+    assert.deepEqual(thorium.linux.commands, [
+      "thorium-browser-avx2",
+      "thorium-browser",
+      "thorium",
+    ]);
+    assert.deepEqual(thorium.linux.processNames, [
+      "thorium",
+      "thorium-browser",
+      "thorium-browser-avx2",
+    ]);
+    assert.deepEqual(thorium.linux.nativeMessagingManifestDirectories, [
+      ".config/thorium/NativeMessagingHosts",
+    ]);
+    assert.deepEqual(thorium.linux.userDataDirectorySegments, [".config", "thorium"]);
+    assert.deepEqual(
+      thorium.extensionIds,
+      registry.browserDiagnostics.find((browser) => browser.browserFamily === "chrome")
+        .extensionIds,
+    );
     assert.equal(
       fs.readFileSync(path.join(installDir, ".codex-linux", "chrome-native-host-manifest-paths"), "utf8").trim(),
       ".config/thorium/NativeMessagingHosts",
@@ -214,7 +205,7 @@ test("Thorium stage hook upgrades a core Linux-patched Chrome plugin", () => {
   }
 });
 
-test("Thorium patcher accepts current browser preference routing without browser-client warnings", () => {
+test("Thorium patcher leaves browser-client routing untouched", () => {
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-thorium-current-plugin-"));
   try {
     const chromePlugin = path.join(workspace, "chrome");


### PR DESCRIPTION
Feature-owned prerequisite for #1252, as requested in review there.

## What changed

`thorium-chrome-plugin` extends the bundled Chrome plugin to recognise Thorium. It did that with seven patches against Chrome-only constants spread over the plugin's scripts. ChatGPT.dmg 26.803.41515 replaced those constants with a browser registry in `scripts/extension-ids.json`, read as `browser.linux.*`, so all seven targets drifted at once:

```
WARN: installManifest.mjs missing patch target for Thorium native host manifest location
WARN: check-native-host-manifest.js missing patch target for Thorium native host manifest fallback
WARN: installed-browsers.js missing patch target for Thorium browser inventory
WARN: chrome-is-running.js missing patch target for Thorium running-process detection
WARN: check-extension-installed.js missing patch target for Thorium extension-aware browser profile fallback
WARN: open-chrome-window.js missing patch target for Thorium default-browser profile fallback
WARN: open-chrome-window.js missing patch target for Thorium browser window command
```

That is reproducible on current `main`: run `scripts/lib/patch-chrome-plugin.js` and then the feature's patcher against the plugin extracted from the current DMG, and six of the seven miss, with the seventh unable to find `installManifest.mjs` at all. The feature's own tests stayed green because their fixtures still described the pre-26.803 script shapes.

Registering one Thorium entry in `browserDiagnostics` replaces all seven, because that registry is now where upstream reads each of them from:

| Old patch target | Registry field |
| --- | --- |
| native host manifest location + fallback | `linux.nativeMessagingManifestDirectories` |
| browser inventory | the entry itself (`displayName`, `linux.commands`) |
| running-process detection | `linux.processNames` |
| extension-aware profile fallback | `linux.userDataDirectorySegments` |
| default-browser profile fallback | `linux.userDataDirectorySegments` |
| browser window command | `linux.commands` |

Thorium inherits Chrome's `extensionIds` and `storeUrl` from the registry's own Chrome entry rather than hardcoding them, because it is a Chromium fork loading the same extension build. `macos` and `windows` blocks are populated too, since `installed-browsers.js` maps them unconditionally when it builds its list.

The settings/status patch (`patch.js`) and the stage hook's manifest-path handling are unchanged — only the plugin patcher moves.

## Why it is a separate PR

Requested in the #1252 review: the current-registry Thorium migration lands first as a feature-owned change, then that cleanup rebases on top. The two are otherwise coupled, because #1252 removes the core patches whose output the old Thorium needles keyed on.

Worth stating plainly: this is a fix, not just a rebase enabler. On `main` today the feature is inert against the current DMG — enabling it changes nothing about how Thorium is detected.

## Upstream DMG

| | |
| --- | --- |
| App version | `26.803.41515` |
| SHA-256 | `f8a5a74acb38aab4a59ac0ad7fef3bb4bb4f280a7ed25f3cb7ef6145df5e8747` |
| Last-Modified | `Fri, 07 Aug 2026 01:24:28 GMT` |

## Source-of-truth files edited

- `linux-features/thorium-chrome-plugin/patch-chrome-plugin.js`
- `linux-features/thorium-chrome-plugin/test.js`
- `linux-features/thorium-chrome-plugin/README.md`

## How it was tested

- Patcher run against the chrome plugin extracted from the current DMG: registers Thorium with the expected `linux` fields, and a second run reports it already patched.
- `node --test linux-features/thorium-chrome-plugin/test.js` — 6/6 pass. Fixtures moved to the current registry shape; the staging test asserts the registry entry and the inherited extension identity instead of seven per-script edits.
- Every `*.test.js` under `scripts/`, `tests/`, and `linux-features/` passes.
- `bash tests/scripts_smoke.sh` passes with only `test_launcher_warm_start_recovery` skipped, which fails identically on unmodified `main` in this headless environment.
- `git diff --check` clean.

Not run, and why: `cargo check` / `cargo test -p codex-update-manager` — no Rust code is touched. Package builds — no packaging code is touched.

## Risks and follow-ups

- The feature stays disabled by default; `features.example.json` is untouched.
- The registry entry is the whole contract now, so a wrong field is a silent behaviour change rather than a warning. The Linux values are carried over verbatim from the patches they replace; the macOS and Windows blocks are new and follow the shape of the sibling Chromium-fork entry, since nothing on those platforms consumes them for Thorium today.
- Verified on x86_64 Ubuntu, source install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
