### PR TITLE
Recognize DankMaterialShell polkit agent

### DIFF
--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -45,6 +45,7 @@ const POLKIT_AUTH_AGENT_PROCESS_TOKENS: &[&str] = &[
     "polkit-dde-agent",
     "polkit-gnome-authentication-agent",
     "polkit-kde-authentication-agent",
+    "quickshell/dms",
     "soteria",
     "ukui-polkit",
     "xfce-polkit",
@@ -4813,6 +4814,12 @@ mod tests {
         assert!(process_text_matches_polkit_auth_agent("cosmic-osd"));
         assert!(process_text_matches_polkit_auth_agent(
             "gnome-shell --wayland"
+        ));
+        assert!(process_text_matches_polkit_auth_agent(
+            "qs -p /usr/share/quickshell/dms"
+        ));
+        assert!(!process_text_matches_polkit_auth_agent(
+            "qs -p /usr/share/quickshell/other-shell"
         ));
         assert!(!process_text_matches_polkit_auth_agent(
             "/usr/lib/polkit-1/polkitd --no-debug"


### PR DESCRIPTION
## Summary

- Recognize the DankMaterialShell QuickShell process as a graphical polkit authentication agent.
- Cover the DMS process path and an unrelated QuickShell path in the updater matching test.

## User-visible behavior

niri sessions using the DMS built-in polkit agent no longer fall back to the manual sudo install path.

## Validation

- `cargo test -p codex-update-manager polkit_agent_process_matching_ignores_daemon_and_matches_agents`
- `cargo test -p codex-update-manager`
- `git diff --check`
