### PR TITLE
Add disabled-by-default Chromium sandbox Linux Feature

### DIFF
--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -166,6 +166,11 @@ PACKAGE_VERSION=2026.03.24.220723+88f07cd3 make deb
 The packaging scripts only repackage what is already in `codex-app/`; they do
 not download or extract the DMG.
 
+An enabled Linux Feature may declare a format incompatible with its runtime
+requirements. AppImage construction checks that declaration against the
+generated app snapshot before creating an AppDir or output artifact; disabled
+features leave the default AppImage path unchanged.
+
 ## AppImage Local Self-Build
 
 ```bash

--- a/docs/launcher-performance.md
+++ b/docs/launcher-performance.md
@@ -90,6 +90,11 @@ Launching Electron itself in parallel with any of this remains rejected:
 the renderer needs a verified local origin, and the warm-start handoff
 markers depend on the current ordering.
 
+Ordinary warm-start IPC also remains ahead of full Electron argument and
+launcher-hook preparation. Only a feature that explicitly stages a strict
+`preHandoffLauncher` hook opts into that preparation and the deeper resident
+scan before handoff; disabled features and ordinary hooks add no hot-path cost.
+
 ### In-app startup latency
 
 Most of the visible loading-screen time is spent inside the upstream app:

--- a/docs/launcher-performance.md
+++ b/docs/launcher-performance.md
@@ -44,7 +44,9 @@ These are security-posture flags, not measurable rendering-performance
 factors. Removing them is a separate compatibility project: the Electron
 SUID/user-namespace sandbox behaves differently across distributions and
 container/AppImage environments, and the troubleshooting docs currently
-promise `--no-sandbox` behavior. Out of scope for performance work.
+promise `--no-sandbox` behavior. Out of scope for performance work. The
+disabled-by-default `linux-features/chromium-sandbox` integration owns the
+host-qualified opt-in path.
 
 ### Wayland `--disable-gpu-compositing` workaround
 

--- a/docs/linux-features-architecture.md
+++ b/docs/linux-features-architecture.md
@@ -165,6 +165,7 @@ Use `runtimeHooks` for launcher-visible hooks:
     "prelaunch": "prelaunch.sh",
     "electronArgs": "electron-args",
     "launcher": "launcher.sh",
+    "preHandoffLauncher": "strict-launcher.sh",
     "coldStart": "cold-start.sh",
     "afterExit": "after-exit.sh"
   }
@@ -181,18 +182,25 @@ The runtime hook types map to:
   line is appended as one Electron argument.
 - `launcher`: copied to `.codex-linux/launcher.d/`; executable hooks run after
   feature, user, and command-line Electron args are merged, but before final
-  Electron launch args are built. Hooks receive the current Electron args as
-  argv and may print `env KEY=VALUE` or `electron-arg VALUE` lines on stdout.
-  A hook may print `env-lock KEY` after setting a security-sensitive value to
-  reject later launcher-hook overrides. It may also print
+  Electron launch args are built on a cold start or Electron second-instance
+  fallback. Successful warm-start IPC remains ahead of this work. Hooks receive
+  the current Electron args as argv and may print `env KEY=VALUE` or
+  `electron-arg VALUE` lines on stdout. Process failures are warned and ignored,
+  preserving the established launcher-hook contract; unknown output is also
+  ignored.
+- `preHandoffLauncher`: copied to `.codex-linux/pre-handoff-launcher.d/`;
+  executable hooks explicitly opt into full Electron preparation before either
+  warm-start IPC or Electron second-instance handoff. Process failures and
+  `launch-error MESSAGE` output are fatal. A strict hook may print `env-lock KEY`
+  after setting a security-sensitive value to reject later strict-hook
+  overrides. It may also print
   `electron-default-arg-remove SWITCH` to suppress one exact generic launcher
   default, `electron-arg-deny PATTERN` to reject a matching final Electron
-  switch after all launcher hooks and core defaults, or `launch-error MESSAGE`
-  to reject the launch. Hooks run before resident-process IPC and Electron
-  second-instance handoff, so a feature rejection cannot be bypassed by warm
-  start. A launcher hook process failure is fatal; an enabled feature cannot
-  silently fall back to core behavior. Unknown output lines are ignored; stderr
-  is logged normally.
+  switch after ordinary launcher hooks and core defaults, or the ordinary
+  `env` and `electron-arg` outputs. The launcher performs its deeper resident
+  process scan under the launcher lock only when at least one executable strict
+  hook is staged, so markerless residents cannot bypass the opt-in check and
+  ordinary launches do not inherit the scan or preparation cost.
 - `coldStart`: copied to `.codex-linux/cold-start.d/`; executable hooks run in
   the background during cold start, after bundled plugin cache sync.
 - `afterExit`: copied to `.codex-linux/after-exit.d/`; executable hooks run
@@ -213,6 +221,34 @@ such as Codex skills: stage the source file with `resources` under
 `$CODEX_LINUX_FEATURES_DIR/<feature-id>/...` to `$CODEX_HOME/skills/...` in a
 `runtimeHooks.prelaunch` script. Do not write user-home files from `stage.sh`;
 install, package, and updater rebuilds may run outside the real user's session.
+
+## Build And Promotion Compatibility
+
+An enabled feature that cannot produce a usable artifact may declare the
+generic build compatibility contract:
+
+```json
+{
+  "buildCompatibility": {
+    "unsupportedFormats": ["appimage"],
+    "reason": "the packaged runtime cannot satisfy this feature"
+  }
+}
+```
+
+Supported format names are `deb`, `rpm`, `pacman`, and `appimage`. Builders that
+use this contract validate the generated app's `linuxFeatures.enabled` snapshot
+against the current config and refuse before staging or emitting the artifact.
+Disabled features do not affect the default build path.
+
+Features whose safety depends on host state outside the generated app may add
+`entrypoints.promotionHook`. The transactional installer discovers hooks from
+the exact candidate build snapshot and runs them under the promotion lock before
+creating a new journal or exchanging app directories. Hooks receive
+`CODEX_CANDIDATE_APP_DIR`, `CODEX_CURRENT_APP_DIR`, and
+`CODEX_LINUX_FEATURE_HOOK_PHASE=promotion`. Any failure refuses promotion and
+leaves the current app in place. Promotion hooks are compatibility checks only;
+they must not mutate the current app, candidate, or external host state.
 
 ## Declarative Native Package Staging
 

--- a/docs/linux-features-architecture.md
+++ b/docs/linux-features-architecture.md
@@ -183,7 +183,16 @@ The runtime hook types map to:
   feature, user, and command-line Electron args are merged, but before final
   Electron launch args are built. Hooks receive the current Electron args as
   argv and may print `env KEY=VALUE` or `electron-arg VALUE` lines on stdout.
-  Unknown output lines are ignored; stderr is logged normally.
+  A hook may print `env-lock KEY` after setting a security-sensitive value to
+  reject later launcher-hook overrides. It may also print
+  `electron-default-arg-remove SWITCH` to suppress one exact generic launcher
+  default, `electron-arg-deny PATTERN` to reject a matching final Electron
+  switch after all launcher hooks and core defaults, or `launch-error MESSAGE`
+  to reject the launch. Hooks run before resident-process IPC and Electron
+  second-instance handoff, so a feature rejection cannot be bypassed by warm
+  start. A launcher hook process failure is fatal; an enabled feature cannot
+  silently fall back to core behavior. Unknown output lines are ignored; stderr
+  is logged normally.
 - `coldStart`: copied to `.codex-linux/cold-start.d/`; executable hooks run in
   the background during cold start, after bundled plugin cache sync.
 - `afterExit`: copied to `.codex-linux/after-exit.d/`; executable hooks run

--- a/docs/linux-features-architecture.md
+++ b/docs/linux-features-architecture.md
@@ -203,7 +203,11 @@ Runtime hooks receive `CODEX_HOME`, `CODEX_LINUX_APP_DIR`,
 `CODEX_LINUX_APP_STATE_DIR`, `CODEX_LINUX_FEATURES_DIR`, and
 `CODEX_LINUX_LAUNCHER_LOG`. Executable hooks also receive
 `CODEX_LINUX_FEATURE_HOOK_PHASE`; `afterExit` additionally receives
-`CODEX_LINUX_ELECTRON_EXIT_STATUS`. Use this pattern for user-home artifacts
+`CODEX_LINUX_ELECTRON_EXIT_STATUS`. Launcher hooks additionally receive
+`CODEX_LINUX_RESIDENT_PROCESS_ACTIVE=1` when the launcher's normal identity
+checks found an active app primary, or `0` otherwise. This is presence only;
+it does not attest to that primary's launch arguments or feature modes. Use
+this pattern for user-home artifacts
 such as Codex skills: stage the source file with `resources` under
 `.codex-linux/features/<feature-id>/...`, then copy it from
 `$CODEX_LINUX_FEATURES_DIR/<feature-id>/...` to `$CODEX_HOME/skills/...` in a

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -282,6 +282,11 @@ is refused and the working app remains unchanged until Electron exits. Failed
 promotion candidates are disposable by default; opt in to diagnostic retention
 with `CODEX_KEEP_REJECTED_CANDIDATE=1`.
 
+If an enabled Linux Feature declares a pre-promotion compatibility hook, that
+hook also checks the exact generated candidate under the promotion lock before a
+new journal or directory exchange. External dependency drift therefore refuses
+the update without replacing the working app.
+
 Transactional user-local installs retain one previous-app directory for manual
 recovery. Each successful promotion replaces that retained backup with the
 version that was working immediately beforehand; older exact managed backup

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -125,6 +125,7 @@ FEATURE_ENV_DIR="$SCRIPT_DIR/.codex-linux/env.d"
 FEATURE_PRELAUNCH_HOOK_DIR="$SCRIPT_DIR/.codex-linux/prelaunch.d"
 FEATURE_ELECTRON_ARGS_DIR="$SCRIPT_DIR/.codex-linux/electron-args.d"
 FEATURE_LAUNCHER_HOOK_DIR="$SCRIPT_DIR/.codex-linux/launcher.d"
+FEATURE_PRE_HANDOFF_LAUNCHER_HOOK_DIR="$SCRIPT_DIR/.codex-linux/pre-handoff-launcher.d"
 FEATURE_AFTER_EXIT_HOOK_DIR="$SCRIPT_DIR/.codex-linux/after-exit.d"
 ELECTRON_DEFAULT_ARG_REMOVALS=()
 ELECTRON_ARG_DENY_PATTERNS=()
@@ -3968,7 +3969,7 @@ apply_feature_launcher_hook_env() {
         return 0
     fi
     if feature_launcher_hook_env_locked "$name"; then
-        notify_error "A Linux feature refused an override of locked launcher environment variable: $name"
+        echo "WARN: Ignoring Linux feature override of locked launcher environment variable: $name"
         return 1
     fi
     printf -v "$name" '%s' "$value"
@@ -4041,9 +4042,29 @@ apply_feature_launcher_hook_electron_arg() {
     scan_electron_rendering_arg "$arg"
 }
 
-run_feature_launcher_hooks() {
-    [ -n "${FEATURE_LAUNCHER_HOOK_DIR:-}" ] || return 0
-    [ -d "$FEATURE_LAUNCHER_HOOK_DIR" ] || return 0
+feature_hook_dir_has_executable() {
+    local hook_dir="$1"
+    local hook
+
+    [ -n "$hook_dir" ] || return 1
+    [ -d "$hook_dir" ] || return 1
+    for hook in "$hook_dir"/*; do
+        [ -f "$hook" ] && [ -x "$hook" ] && return 0
+    done
+    return 1
+}
+
+pre_handoff_launcher_hooks_active() {
+    feature_hook_dir_has_executable "${FEATURE_PRE_HANDOFF_LAUNCHER_HOOK_DIR:-}"
+}
+
+run_feature_launcher_hooks_from_dir() {
+    local hook_dir="$1"
+    local hook_phase="$2"
+    local fatal="$3"
+
+    [ -n "$hook_dir" ] || return 0
+    [ -d "$hook_dir" ] || return 0
 
     local hook
     local output
@@ -4051,14 +4072,14 @@ run_feature_launcher_hooks() {
     local line
     local payload
 
-    for hook in "$FEATURE_LAUNCHER_HOOK_DIR"/*; do
+    for hook in "$hook_dir"/*; do
         [ -f "$hook" ] || continue
         [ -x "$hook" ] || {
             echo "Skipping non-executable Linux feature launcher hook: $hook"
             continue
         }
 
-        echo "Running Linux feature launcher hook: $hook"
+        echo "Running Linux feature $hook_phase hook: $hook"
         if output="$(
             CODEX_HOME="$CODEX_HOME" \
             CODEX_LINUX_APP_DIR="$SCRIPT_DIR" \
@@ -4066,14 +4087,18 @@ run_feature_launcher_hooks() {
             CODEX_LINUX_FEATURES_DIR="$CODEX_LINUX_FEATURES_DIR" \
             CODEX_LINUX_LAUNCHER_LOG="$LOG_FILE" \
             CODEX_LINUX_RESIDENT_PROCESS_ACTIVE="$([ -n "${RUNNING_APP_PID:-}" ] && printf 1 || printf 0)" \
-            CODEX_LINUX_FEATURE_HOOK_PHASE=launcher \
+            CODEX_LINUX_FEATURE_HOOK_PHASE="$hook_phase" \
             codex_run_host_command "$hook" "${ELECTRON_ARGS[@]}"
         )"; then
             :
         else
             status=$?
-            notify_error "Linux feature launcher hook failed with status $status: $hook"
-            return 1
+            if [ "$fatal" = "1" ]; then
+                notify_error "Linux feature $hook_phase hook failed with status $status: $hook"
+                return 1
+            fi
+            echo "WARN: Linux feature launcher hook failed with status $status: $hook"
+            continue
         fi
 
         while IFS= read -r line || [ -n "$line" ]; do
@@ -4084,9 +4109,15 @@ run_feature_launcher_hooks() {
                     ;;
                 env\ *)
                     payload="${line#env }"
-                    apply_feature_launcher_hook_env "$payload" || return 1
+                    if ! apply_feature_launcher_hook_env "$payload" && [ "$fatal" = "1" ]; then
+                        return 1
+                    fi
                     ;;
                 env-lock\ *)
+                    if [ "$fatal" != "1" ]; then
+                        echo "Ignoring unsupported Linux feature launcher hook output from $hook: $line"
+                        continue
+                    fi
                     payload="${line#env-lock }"
                     if [[ "$payload" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
                         FEATURE_LOCKED_ENV_NAMES+=("$payload")
@@ -4099,6 +4130,10 @@ run_feature_launcher_hooks() {
                     apply_feature_launcher_hook_electron_arg "$payload"
                     ;;
                 electron-default-arg-remove\ *)
+                    if [ "$fatal" != "1" ]; then
+                        echo "Ignoring unsupported Linux feature launcher hook output from $hook: $line"
+                        continue
+                    fi
                     payload="${line#electron-default-arg-remove }"
                     if [[ "$payload" == --* ]] && [[ "$payload" != *[[:space:]]* ]]; then
                         ELECTRON_DEFAULT_ARG_REMOVALS+=("${payload%%=*}")
@@ -4107,6 +4142,10 @@ run_feature_launcher_hooks() {
                     fi
                     ;;
                 electron-arg-deny\ *)
+                    if [ "$fatal" != "1" ]; then
+                        echo "Ignoring unsupported Linux feature launcher hook output from $hook: $line"
+                        continue
+                    fi
                     payload="${line#electron-arg-deny }"
                     if [[ "$payload" == --* ]] && [[ "$payload" != *[[:space:]]* ]]; then
                         ELECTRON_ARG_DENY_PATTERNS+=("$payload")
@@ -4115,6 +4154,10 @@ run_feature_launcher_hooks() {
                     fi
                     ;;
                 launch-error\ *)
+                    if [ "$fatal" != "1" ]; then
+                        echo "Ignoring unsupported Linux feature launcher hook output from $hook: $line"
+                        continue
+                    fi
                     payload="${line#launch-error }"
                     notify_error "${payload:-A Linux feature refused this launch.}"
                     return 1
@@ -4125,6 +4168,15 @@ run_feature_launcher_hooks() {
             esac
         done <<< "$output"
     done
+}
+
+run_feature_launcher_hooks() {
+    run_feature_launcher_hooks_from_dir "${FEATURE_LAUNCHER_HOOK_DIR:-}" launcher 0
+}
+
+run_feature_pre_handoff_launcher_hooks() {
+    run_feature_launcher_hooks_from_dir \
+        "${FEATURE_PRE_HANDOFF_LAUNCHER_HOOK_DIR:-}" pre-handoff-launcher 1
 }
 
 validate_feature_electron_arg_denials() {
@@ -4534,6 +4586,15 @@ refresh_launch_state_quick() {
     RUNNING_APP_PID=""
     if pid="$(find_running_app_pid)"; then
         set_detected_running_app "$pid"
+        return 0
+    fi
+
+    # Strict pre-handoff hooks opt into the deeper process scan. The launcher
+    # lock prevents another cooperating cold start from crossing this check;
+    # a resident that exits afterward can only cause a safe false rejection.
+    # Ordinary launches keep their marker-based hot path and avoid /proc cost.
+    if pre_handoff_launcher_hooks_active && pid="$(discover_running_app_pid)"; then
+        set_detected_running_app "$pid"
     fi
 }
 
@@ -4574,6 +4635,9 @@ launch_electron() {
     if [ "${ELECTRON_LAUNCH_PREPARED:-0}" -ne 1 ]; then
         prepare_electron_launch "$@"
     fi
+    run_feature_launcher_hooks
+    build_electron_launch_args
+    validate_feature_electron_arg_denials || exit 1
 
     if [ "$WARM_START" -eq 1 ]; then
         release_launcher_lock
@@ -4620,7 +4684,7 @@ prepare_electron_launch() {
     ELECTRON_DEFAULT_ARG_REMOVALS=()
     ELECTRON_ARG_DENY_PATTERNS=()
     FEATURE_LOCKED_ENV_NAMES=()
-    run_feature_launcher_hooks || exit 1
+    run_feature_pre_handoff_launcher_hooks || exit 1
     build_electron_launch_args
     validate_feature_electron_arg_denials || exit 1
     ELECTRON_LAUNCH_PREPARED=1
@@ -4654,10 +4718,12 @@ trap 'handle_launcher_signal HUP 129' HUP
 recover_unhealthy_running_app
 prepare_launch_state_under_lock
 
-# Launcher hooks are prepared before either resident-process handoff. Optional
-# features can therefore fail a launch without an IPC or Electron
-# second-instance path reporting success first.
-prepare_electron_launch "${LAUNCHER_ARGS[@]}"
+# Only features that explicitly stage a strict pre-handoff launcher hook pay
+# full Electron-preparation cost before resident IPC and receive fatal hook
+# semantics. Ordinary warm starts preserve the established fast handoff.
+if pre_handoff_launcher_hooks_active; then
+    prepare_electron_launch "${LAUNCHER_ARGS[@]}"
+fi
 
 if send_warm_start_launch_action "${LAUNCHER_ARGS[@]}"; then
     echo "Sent launch args over warm-start IPC"

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -126,6 +126,9 @@ FEATURE_PRELAUNCH_HOOK_DIR="$SCRIPT_DIR/.codex-linux/prelaunch.d"
 FEATURE_ELECTRON_ARGS_DIR="$SCRIPT_DIR/.codex-linux/electron-args.d"
 FEATURE_LAUNCHER_HOOK_DIR="$SCRIPT_DIR/.codex-linux/launcher.d"
 FEATURE_AFTER_EXIT_HOOK_DIR="$SCRIPT_DIR/.codex-linux/after-exit.d"
+ELECTRON_DEFAULT_ARG_REMOVALS=()
+ELECTRON_ARG_DENY_PATTERNS=()
+FEATURE_LOCKED_ENV_NAMES=()
 MANAGED_NODE_BIN_DIR="$SCRIPT_DIR/resources/node-runtime/bin"
 APP_NOTIFICATION_ICON_NAME="$CODEX_LINUX_APP_ID"
 APP_NOTIFICATION_ICON_BUNDLE="$SCRIPT_DIR/.codex-linux/$APP_NOTIFICATION_ICON_NAME.png"
@@ -3964,9 +3967,21 @@ apply_feature_launcher_hook_env() {
         echo "Ignoring invalid Linux feature launcher hook env assignment: $assignment"
         return 0
     fi
-
+    if feature_launcher_hook_env_locked "$name"; then
+        notify_error "A Linux feature refused an override of locked launcher environment variable: $name"
+        return 1
+    fi
     printf -v "$name" '%s' "$value"
     export "$name"
+}
+
+feature_launcher_hook_env_locked() {
+    local wanted="$1"
+    local locked
+    for locked in "${FEATURE_LOCKED_ENV_NAMES[@]}"; do
+        [ "$locked" = "$wanted" ] && return 0
+    done
+    return 1
 }
 
 # Remove entries from ELECTRON_ARGS whose switch name (the part before '=')
@@ -4050,14 +4065,15 @@ run_feature_launcher_hooks() {
             CODEX_LINUX_APP_STATE_DIR="$APP_STATE_DIR" \
             CODEX_LINUX_FEATURES_DIR="$CODEX_LINUX_FEATURES_DIR" \
             CODEX_LINUX_LAUNCHER_LOG="$LOG_FILE" \
+            CODEX_LINUX_RESIDENT_PROCESS_ACTIVE="$([ -n "${RUNNING_APP_PID:-}" ] && printf 1 || printf 0)" \
             CODEX_LINUX_FEATURE_HOOK_PHASE=launcher \
             codex_run_host_command "$hook" "${ELECTRON_ARGS[@]}"
         )"; then
             :
         else
             status=$?
-            echo "WARN: Linux feature launcher hook failed with status $status: $hook"
-            continue
+            notify_error "Linux feature launcher hook failed with status $status: $hook"
+            return 1
         fi
 
         while IFS= read -r line || [ -n "$line" ]; do
@@ -4068,11 +4084,40 @@ run_feature_launcher_hooks() {
                     ;;
                 env\ *)
                     payload="${line#env }"
-                    apply_feature_launcher_hook_env "$payload"
+                    apply_feature_launcher_hook_env "$payload" || return 1
+                    ;;
+                env-lock\ *)
+                    payload="${line#env-lock }"
+                    if [[ "$payload" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+                        FEATURE_LOCKED_ENV_NAMES+=("$payload")
+                    else
+                        echo "Ignoring invalid launcher environment lock from $hook: $payload"
+                    fi
                     ;;
                 electron-arg\ *)
                     payload="${line#electron-arg }"
                     apply_feature_launcher_hook_electron_arg "$payload"
+                    ;;
+                electron-default-arg-remove\ *)
+                    payload="${line#electron-default-arg-remove }"
+                    if [[ "$payload" == --* ]] && [[ "$payload" != *[[:space:]]* ]]; then
+                        ELECTRON_DEFAULT_ARG_REMOVALS+=("${payload%%=*}")
+                    else
+                        echo "Ignoring invalid default Electron arg removal from $hook: $payload"
+                    fi
+                    ;;
+                electron-arg-deny\ *)
+                    payload="${line#electron-arg-deny }"
+                    if [[ "$payload" == --* ]] && [[ "$payload" != *[[:space:]]* ]]; then
+                        ELECTRON_ARG_DENY_PATTERNS+=("$payload")
+                    else
+                        echo "Ignoring invalid Electron arg deny pattern from $hook: $payload"
+                    fi
+                    ;;
+                launch-error\ *)
+                    payload="${line#launch-error }"
+                    notify_error "${payload:-A Linux feature refused this launch.}"
+                    return 1
                     ;;
                 *)
                     echo "Ignoring unsupported Linux feature launcher hook output from $hook: $line"
@@ -4080,6 +4125,30 @@ run_feature_launcher_hooks() {
             esac
         done <<< "$output"
     done
+}
+
+validate_feature_electron_arg_denials() {
+    local arg
+    local name
+    local pattern
+    for arg in "${ELECTRON_LAUNCH_ARGS[@]}" "${ELECTRON_ARGS[@]}"; do
+        name="${arg%%=*}"
+        for pattern in "${ELECTRON_ARG_DENY_PATTERNS[@]}"; do
+            if [[ "$name" == $pattern ]]; then
+                notify_error "A Linux feature refused conflicting Electron argument: $arg"
+                return 1
+            fi
+        done
+    done
+}
+
+electron_default_arg_removed() {
+    local wanted="$1"
+    local removed
+    for removed in "${ELECTRON_DEFAULT_ARG_REMOVALS[@]}"; do
+        [ "$removed" = "$wanted" ] && return 0
+    done
+    return 1
 }
 
 build_electron_launch_args() {
@@ -4107,12 +4176,10 @@ build_electron_launch_args() {
         ELECTRON_FORCED_SCALE_FACTOR=""
     fi
 
-    ELECTRON_LAUNCH_ARGS=(
-        --no-sandbox
-        --class="$CODEX_LINUX_APP_ID"
-        --app-id="$CODEX_LINUX_APP_ID"
-        --disable-gpu-sandbox
-    )
+    ELECTRON_LAUNCH_ARGS=()
+    electron_default_arg_removed --no-sandbox || ELECTRON_LAUNCH_ARGS+=(--no-sandbox)
+    ELECTRON_LAUNCH_ARGS+=(--class="$CODEX_LINUX_APP_ID" --app-id="$CODEX_LINUX_APP_ID")
+    electron_default_arg_removed --disable-gpu-sandbox || ELECTRON_LAUNCH_ARGS+=(--disable-gpu-sandbox)
 
     if should_disable_dev_shm_usage; then
         ELECTRON_LAUNCH_ARGS+=(--disable-dev-shm-usage)
@@ -4504,12 +4571,9 @@ launch_electron() {
     cd "$SCRIPT_DIR"
     log_phase "electron_launch"
 
-    ensure_user_electron_flags_file
-    load_feature_electron_args
-    load_user_electron_flags
-    set_electron_defaults "${FEATURE_ELECTRON_ARGS[@]}" "${USER_ELECTRON_FLAGS[@]}" "$@"
-    run_feature_launcher_hooks
-    build_electron_launch_args
+    if [ "${ELECTRON_LAUNCH_PREPARED:-0}" -ne 1 ]; then
+        prepare_electron_launch "$@"
+    fi
 
     if [ "$WARM_START" -eq 1 ]; then
         release_launcher_lock
@@ -4548,6 +4612,20 @@ launch_electron() {
     return "$status"
 }
 
+prepare_electron_launch() {
+    ensure_user_electron_flags_file
+    load_feature_electron_args
+    load_user_electron_flags
+    set_electron_defaults "${FEATURE_ELECTRON_ARGS[@]}" "${USER_ELECTRON_FLAGS[@]}" "$@"
+    ELECTRON_DEFAULT_ARG_REMOVALS=()
+    ELECTRON_ARG_DENY_PATTERNS=()
+    FEATURE_LOCKED_ENV_NAMES=()
+    run_feature_launcher_hooks || exit 1
+    build_electron_launch_args
+    validate_feature_electron_arg_denials || exit 1
+    ELECTRON_LAUNCH_PREPARED=1
+}
+
 hydrate_graphical_session_env
 configure_side_by_side_app_env
 export_feature_runtime_env
@@ -4575,6 +4653,11 @@ trap 'handle_launcher_signal HUP 129' HUP
 
 recover_unhealthy_running_app
 prepare_launch_state_under_lock
+
+# Launcher hooks are prepared before either resident-process handoff. Optional
+# features can therefore fail a launch without an IPC or Electron
+# second-instance path reporting success first.
+prepare_electron_launch "${LAUNCHER_ARGS[@]}"
 
 if send_warm_start_launch_action "${LAUNCHER_ARGS[@]}"; then
     echo "Sent launch args over warm-start IPC"

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -3442,8 +3442,16 @@ add_electron_enable_features() {
 electron_enable_features_arg() {
     local joined=""
     local feature
+    local existing
+    local -a features=("${ELECTRON_ENABLE_FEATURES[@]}" "$@")
+    local -a emitted=()
 
-    for feature in "${ELECTRON_ENABLE_FEATURES[@]}"; do
+    for feature in "${features[@]}"; do
+        [ -n "$feature" ] || continue
+        for existing in "${emitted[@]}"; do
+            [ "$existing" != "$feature" ] || continue 2
+        done
+        emitted+=("$feature")
         if [ -z "$joined" ]; then
             joined="$feature"
         else
@@ -4205,6 +4213,7 @@ electron_default_arg_removed() {
 
 build_electron_launch_args() {
     local enable_features_arg
+    local -a implicit_enable_features=()
 
     # Feature launcher hooks (runtimeHooks.launcher) run after
     # set_electron_defaults() has already chosen the Ozone platform and device
@@ -4275,10 +4284,13 @@ build_electron_launch_args() {
     fi
 
     if [ "$ELECTRON_OZONE_PLATFORM" = "wayland" ]; then
-        add_electron_enable_features "WaylandWindowDecorations"
+        # This is derived final-argv state, not a persistent input. Keeping it
+        # out of ELECTRON_ENABLE_FEATURES makes the builder idempotent when a
+        # strict pre-handoff check is followed by an ordinary launcher hook.
+        implicit_enable_features+=("WaylandWindowDecorations")
     fi
 
-    if enable_features_arg="$(electron_enable_features_arg)"; then
+    if enable_features_arg="$(electron_enable_features_arg "${implicit_enable_features[@]}")"; then
         ELECTRON_LAUNCH_ARGS+=("$enable_features_arg")
     fi
 
@@ -4589,12 +4601,17 @@ refresh_launch_state_quick() {
         return 0
     fi
 
-    # Strict pre-handoff hooks opt into the deeper process scan. The launcher
-    # lock prevents another cooperating cold start from crossing this check;
-    # a resident that exits afterward can only cause a safe false rejection.
-    # Ordinary launches keep their marker-based hot path and avoid /proc cost.
-    if pre_handoff_launcher_hooks_active && pid="$(discover_running_app_pid)"; then
-        set_detected_running_app "$pid"
+    # Strict pre-handoff hooks opt into the deeper same- and cross-install
+    # process scans. The launcher lock prevents another cooperating cold start
+    # from crossing this check; a resident that exits afterward can only cause
+    # a safe false rejection. Ordinary launches keep their marker-based hot
+    # path and avoid /proc cost.
+    if pre_handoff_launcher_hooks_active; then
+        if pid="$(discover_running_app_pid)"; then
+            set_detected_running_app "$pid"
+            return 0
+        fi
+        detect_cross_install_conflict
     fi
 }
 
@@ -4685,8 +4702,10 @@ prepare_electron_launch() {
     ELECTRON_ARG_DENY_PATTERNS=()
     FEATURE_LOCKED_ENV_NAMES=()
     run_feature_pre_handoff_launcher_hooks || exit 1
-    build_electron_launch_args
-    validate_feature_electron_arg_denials || exit 1
+    if pre_handoff_launcher_hooks_active; then
+        build_electron_launch_args
+        validate_feature_electron_arg_denials || exit 1
+    fi
     ELECTRON_LAUNCH_PREPARED=1
 }
 

--- a/linux-features/README.md
+++ b/linux-features/README.md
@@ -103,7 +103,12 @@ Declarative runtime hooks are staged under `codex-app/.codex-linux/`:
 - `runtimeHooks.electronArgs` appends one Electron argument per line
 - `runtimeHooks.launcher` runs before final Electron args are built; executable
   hooks receive current Electron args as argv and can print `env KEY=VALUE` or
-  `electron-arg VALUE` lines
+  `electron-arg VALUE` lines. Successful warm-start IPC stays ahead of these
+  hooks, and hook process failures remain fail-soft.
+- `runtimeHooks.preHandoffLauncher` is the explicit strict variant: it runs
+  before resident handoff, makes hook failures fatal, enables the strict
+  environment/default-argument/final-denial protocol, and opts into deeper
+  markerless-resident detection.
 - `runtimeHooks.coldStart` runs background hooks after bundled plugin cache sync
 - `runtimeHooks.afterExit` runs after Electron exits while preserving the
   original Electron exit status
@@ -139,6 +144,12 @@ the app after changing the feature config.
 `packageHooks` run after declarative native package resources are staged and
 receive `PACKAGE_FORMAT`,
 `PACKAGE_ROOT`, `PACKAGE_NAME`, `PACKAGE_VERSION`, and `APP_DIR`.
+
+`buildCompatibility.unsupportedFormats` can make an enabled feature refuse an
+incompatible `deb`, `rpm`, `pacman`, or `appimage` build before artifact
+staging or emission. `entrypoints.promotionHook` can revalidate external host
+dependencies against the exact generated candidate under the promotion lock;
+failure leaves the current working app untouched.
 
 Feature patching uses only `entrypoints.patchDescriptors`. Descriptor modules
 may export an array directly or `{ descriptors: [...] }`; `.patches`,

--- a/linux-features/chromium-sandbox/README.md
+++ b/linux-features/chromium-sandbox/README.md
@@ -31,9 +31,10 @@ absent and the generated Electron executable is owned by the launching user.
 This makes the caller-selected environment path authoritative without placing
 a machine-specific path in the build. The selected helper must be an absolute,
 non-symlink executable regular file, owned by root:root with mode 4755, and
-byte-identical to the preserved generated helper. Reinstall it after every
-Electron rebuild. Any explicit `--no-sandbox` or `--disable-*-sandbox` argument
-is rejected.
+byte-identical to the preserved generated helper. Its path must not contain CR
+or LF because launcher hooks use a line-oriented protocol. Reinstall it after
+every Electron rebuild. Any explicit `--no-sandbox` or
+`--disable-*-sandbox` argument is rejected.
 
 The native package builders reject this feature because installed Electron
 payloads are root-owned, so Chromium will not use the development-helper

--- a/linux-features/chromium-sandbox/README.md
+++ b/linux-features/chromium-sandbox/README.md
@@ -1,0 +1,50 @@
+# Chromium SUID Sandbox
+
+This disabled-by-default Linux Feature removes the launcher's compatibility
+`--no-sandbox` and `--disable-gpu-sandbox` defaults after validating a
+host-installed Chromium SUID helper. It supports user-managed generated apps;
+native `.deb`, RPM, and pacman packaging fails closed while this feature is
+enabled. It contains renderer-process containment policy only; it does not
+change Codex permissions, approvals, filesystem, or network authority.
+
+Enable `chromium-sandbox` in the gitignored `linux-features/features.json` and
+build the app. The feature staging hook relocates the generated helper to a
+provenance reference, leaving Electron's sibling `chrome-sandbox` path absent.
+Install that exact reference as the privileged helper:
+
+```bash
+sudo install -D -o root -g root -m 4755 \
+  codex-app/.codex-linux/features/chromium-sandbox/generated-chrome-sandbox \
+  /usr/local/lib/codex-desktop-linux/chrome-sandbox
+```
+
+Launch with the caller-selected absolute path:
+
+```bash
+CHROME_DEVEL_SANDBOX=/usr/local/lib/codex-desktop-linux/chrome-sandbox \
+  ./codex-app/start.sh
+```
+
+Chromium checks for a sibling `chrome-sandbox` before consulting
+`CHROME_DEVEL_SANDBOX`. The feature therefore fails unless that sibling stays
+absent and the generated Electron executable is owned by the launching user.
+This makes the caller-selected environment path authoritative without placing
+a machine-specific path in the build. The selected helper must be an absolute,
+non-symlink executable regular file, owned by root:root with mode 4755, and
+byte-identical to the preserved generated helper. Reinstall it after every
+Electron rebuild. Any explicit `--no-sandbox` or `--disable-*-sandbox` argument
+is rejected.
+
+The native package builders reject this feature because installed Electron
+payloads are root-owned, so Chromium will not use the development-helper
+environment fallback. Build the ordinary user-managed app for this
+host-qualified mode.
+
+Because the launcher has no authoritative, race-safe evidence of a resident
+primary's Chromium mode, this feature rejects every launch while a resident app
+process is active. Quit the running app before requesting a sandboxed launch.
+Compatibility-mode launches and warm starts are unchanged when this feature is
+disabled.
+
+Run `node --test linux-features/chromium-sandbox/test.js` to exercise staging,
+helper validation, argument rejection, and both resident handoff paths.

--- a/linux-features/chromium-sandbox/README.md
+++ b/linux-features/chromium-sandbox/README.md
@@ -3,9 +3,10 @@
 This disabled-by-default Linux Feature removes the launcher's compatibility
 `--no-sandbox` and `--disable-gpu-sandbox` defaults after validating a
 host-installed Chromium SUID helper. It supports user-managed generated apps;
-native `.deb`, RPM, and pacman packaging fails closed while this feature is
-enabled. It contains renderer-process containment policy only; it does not
-change Codex permissions, approvals, filesystem, or network authority.
+native `.deb`, RPM, and pacman packaging and AppImage construction fail closed
+while this feature is enabled. It contains renderer-process containment policy
+only; it does not change Codex permissions, approvals, filesystem, or network
+authority.
 
 Enable `chromium-sandbox` in the gitignored `linux-features/features.json` and
 build the app. The feature staging hook relocates the generated helper to a
@@ -38,9 +39,18 @@ every Electron rebuild. Any explicit `--no-sandbox` or
 
 The native package builders reject this feature because installed Electron
 payloads are root-owned, so Chromium will not use the development-helper
-environment fallback. Build the ordinary user-managed app for this
-host-qualified mode. The Nix feature selector does not expose this feature for
-the same root-owned-store constraint.
+environment fallback. AppImage builds reject it before creating the AppDir or
+artifact because the mounted Electron payload is also root-owned. Build the
+ordinary user-managed app for this host-qualified mode. The Nix feature selector
+does not expose this feature for the same root-owned-store constraint.
+
+Before replacing an existing user-managed app, the promotion gate rechecks the
+root-owned external helper against the exact candidate's preserved helper bytes.
+A missing, stale, or mismatched `CHROME_DEVEL_SANDBOX` refuses before a new
+promotion journal or directory exchange, leaving the working app untouched.
+This intentionally makes unattended rebuild promotion fail safely until the
+external helper has been updated for the candidate. A first install is allowed
+so the generated helper can be installed before the app's first launch.
 
 Because the launcher has no authoritative, race-safe evidence of a resident
 primary's Chromium mode, this feature rejects every launch while a resident app

--- a/linux-features/chromium-sandbox/README.md
+++ b/linux-features/chromium-sandbox/README.md
@@ -38,7 +38,8 @@ is rejected.
 The native package builders reject this feature because installed Electron
 payloads are root-owned, so Chromium will not use the development-helper
 environment fallback. Build the ordinary user-managed app for this
-host-qualified mode.
+host-qualified mode. The Nix feature selector does not expose this feature for
+the same root-owned-store constraint.
 
 Because the launcher has no authoritative, race-safe evidence of a resident
 primary's Chromium mode, this feature rejects every launch while a resident app

--- a/linux-features/chromium-sandbox/cleanup.sh
+++ b/linux-features/chromium-sandbox/cleanup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+: "${INSTALL_DIR:?INSTALL_DIR is required}"
+
+bundled_helper="$INSTALL_DIR/chrome-sandbox"
+feature_dir="$INSTALL_DIR/.codex-linux/features/chromium-sandbox"
+generated_helper="$feature_dir/generated-chrome-sandbox"
+
+if [ -L "$generated_helper" ] || { [ -e "$generated_helper" ] && [ ! -f "$generated_helper" ]; }; then
+    echo "ERROR: Chromium sandbox cleanup refused an invalid generated helper reference: $generated_helper" >&2
+    exit 1
+fi
+[ -f "$generated_helper" ] || exit 0
+
+if [ -L "$bundled_helper" ] || [ ! -e "$bundled_helper" ]; then
+    mv -fT -- "$generated_helper" "$bundled_helper"
+    chmod 0755 "$bundled_helper"
+else
+    rm -f -- "$generated_helper"
+fi
+
+rmdir "$feature_dir" 2>/dev/null || true

--- a/linux-features/chromium-sandbox/feature.json
+++ b/linux-features/chromium-sandbox/feature.json
@@ -5,7 +5,12 @@
   "defaultEnabled": false,
   "entrypoints": {
     "stageHook": "./stage.sh",
-    "cleanupHook": "./cleanup.sh"
+    "cleanupHook": "./cleanup.sh",
+    "promotionHook": "./promotion-hook.sh"
+  },
+  "buildCompatibility": {
+    "unsupportedFormats": ["appimage"],
+    "reason": "the AppImage-mounted Electron executable is root-owned and cannot honor CHROME_DEVEL_SANDBOX"
   },
   "packageHooks": [
     {
@@ -14,7 +19,7 @@
     }
   ],
   "runtimeHooks": {
-    "launcher": {
+    "preHandoffLauncher": {
       "source": "launcher-hook.sh",
       "name": "chromium-sandbox.sh",
       "mode": "0755"

--- a/linux-features/chromium-sandbox/feature.json
+++ b/linux-features/chromium-sandbox/feature.json
@@ -1,0 +1,23 @@
+{
+  "id": "chromium-sandbox",
+  "title": "Chromium SUID Sandbox",
+  "description": "Opt-in, host-qualified Chromium renderer sandbox for user-managed app builds.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "stageHook": "./stage.sh",
+    "cleanupHook": "./cleanup.sh"
+  },
+  "packageHooks": [
+    {
+      "path": "package-hook.sh",
+      "formats": ["deb", "rpm", "pacman"]
+    }
+  ],
+  "runtimeHooks": {
+    "launcher": {
+      "source": "launcher-hook.sh",
+      "name": "chromium-sandbox.sh",
+      "mode": "0755"
+    }
+  }
+}

--- a/linux-features/chromium-sandbox/launcher-hook.sh
+++ b/linux-features/chromium-sandbox/launcher-hook.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+fail_launch() {
+    printf 'launch-error Chromium sandbox: %s\n' "$1"
+    exit 0
+}
+
+helper="${CHROME_DEVEL_SANDBOX:-}"
+app_dir="${CODEX_LINUX_APP_DIR:-}"
+bundled_helper="$app_dir/chrome-sandbox"
+generated_helper="${CODEX_LINUX_FEATURES_DIR:-}/chromium-sandbox/generated-chrome-sandbox"
+electron="$app_dir/electron"
+metadata=""
+
+if [ "${CODEX_LINUX_RESIDENT_PROCESS_ACTIVE:-0}" = "1" ]; then
+    fail_launch "a resident app process is already running and its sandbox mode cannot be authoritatively verified; quit it and retry"
+fi
+
+case "$helper" in
+    /*) ;;
+    *) fail_launch "CHROME_DEVEL_SANDBOX must name an absolute helper path" ;;
+esac
+
+if [ -L "$helper" ] || [ ! -f "$helper" ] || [ ! -x "$helper" ]; then
+    fail_launch "helper must be a non-symlink executable regular file: $helper"
+fi
+if ! metadata="$(stat -Lc '%u:%g:%a' -- "$helper" 2>/dev/null)" || [ "$metadata" != "0:0:4755" ]; then
+    fail_launch "helper must be root:root mode 4755: $helper"
+fi
+if [ -L "$generated_helper" ] || [ ! -f "$generated_helper" ] || [ ! -x "$generated_helper" ]; then
+    fail_launch "generated helper reference is missing or invalid; rebuild with the chromium-sandbox feature enabled"
+fi
+if ! cmp -s -- "$helper" "$generated_helper"; then
+    fail_launch "helper does not match the generated Electron app helper"
+fi
+if [ -L "$electron" ] || [ ! -f "$electron" ] || [ ! -x "$electron" ] || [ ! -O "$electron" ]; then
+    fail_launch "Electron must be a non-symlink executable owned by the launching user so it can honor CHROME_DEVEL_SANDBOX: $electron"
+fi
+if [ -e "$bundled_helper" ] || [ -L "$bundled_helper" ]; then
+    fail_launch "the generated app chrome-sandbox path must remain absent so Chromium cannot supersede CHROME_DEVEL_SANDBOX; rebuild with the feature enabled"
+fi
+
+for arg in "$@"; do
+    case "${arg%%=*}" in
+        --no-sandbox|--disable-*-sandbox)
+            fail_launch "conflicting Electron argument is not allowed: $arg"
+            ;;
+    esac
+done
+
+printf 'env CHROME_DEVEL_SANDBOX=%s\n' "$helper"
+printf '%s\n' \
+    'env-lock CHROME_DEVEL_SANDBOX' \
+    'electron-default-arg-remove --no-sandbox' \
+    'electron-default-arg-remove --disable-gpu-sandbox' \
+    'electron-arg-deny --no-sandbox' \
+    'electron-arg-deny --disable-*-sandbox'

--- a/linux-features/chromium-sandbox/launcher-hook.sh
+++ b/linux-features/chromium-sandbox/launcher-hook.sh
@@ -21,6 +21,11 @@ case "$helper" in
     /*) ;;
     *) fail_launch "CHROME_DEVEL_SANDBOX must name an absolute helper path" ;;
 esac
+case "$helper" in
+    *$'\n'*|*$'\r'*)
+        fail_launch "CHROME_DEVEL_SANDBOX must not contain CR or LF"
+        ;;
+esac
 
 if [ -L "$helper" ] || [ ! -f "$helper" ] || [ ! -x "$helper" ]; then
     fail_launch "helper must be a non-symlink executable regular file: $helper"

--- a/linux-features/chromium-sandbox/package-hook.sh
+++ b/linux-features/chromium-sandbox/package-hook.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+echo "ERROR: chromium-sandbox supports user-managed app builds only; Chromium does not honor CHROME_DEVEL_SANDBOX for a root-owned packaged Electron executable" >&2
+exit 1

--- a/linux-features/chromium-sandbox/promotion-hook.sh
+++ b/linux-features/chromium-sandbox/promotion-hook.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+: "${CODEX_CANDIDATE_APP_DIR:?CODEX_CANDIDATE_APP_DIR is required}"
+: "${CODEX_CURRENT_APP_DIR:?CODEX_CURRENT_APP_DIR is required}"
+
+# A first install has no working app to invalidate. The user can promote it,
+# install the preserved helper, and then launch through the runtime gate.
+[ -e "$CODEX_CURRENT_APP_DIR" ] || exit 0
+
+fail_promotion() {
+    printf 'ERROR: chromium-sandbox promotion compatibility: %s\n' "$1" >&2
+    exit 1
+}
+
+helper="${CHROME_DEVEL_SANDBOX:-}"
+candidate="$CODEX_CANDIDATE_APP_DIR"
+generated_helper="$candidate/.codex-linux/features/chromium-sandbox/generated-chrome-sandbox"
+bundled_helper="$candidate/chrome-sandbox"
+electron="$candidate/electron"
+metadata=""
+
+case "$helper" in
+    /*) ;;
+    *) fail_promotion "CHROME_DEVEL_SANDBOX must name the absolute external helper qualified for this candidate" ;;
+esac
+case "$helper" in
+    *$'\n'*|*$'\r'*) fail_promotion "CHROME_DEVEL_SANDBOX must not contain CR or LF" ;;
+esac
+if [ -L "$helper" ] || [ ! -f "$helper" ] || [ ! -x "$helper" ]; then
+    fail_promotion "helper must be a non-symlink executable regular file: $helper"
+fi
+if ! metadata="$(stat -Lc '%u:%g:%a' -- "$helper" 2>/dev/null)" || [ "$metadata" != "0:0:4755" ]; then
+    fail_promotion "helper must be root:root mode 4755: $helper"
+fi
+if [ -L "$generated_helper" ] || [ ! -f "$generated_helper" ] || [ ! -x "$generated_helper" ]; then
+    fail_promotion "candidate generated helper reference is missing or invalid: $generated_helper"
+fi
+if ! cmp -s -- "$helper" "$generated_helper"; then
+    fail_promotion "external helper does not match the candidate Electron helper; the working app was not replaced"
+fi
+if [ -L "$electron" ] || [ ! -f "$electron" ] || [ ! -x "$electron" ] || [ ! -O "$electron" ]; then
+    fail_promotion "candidate Electron must be a non-symlink executable owned by the promoting user: $electron"
+fi
+if [ -e "$bundled_helper" ] || [ -L "$bundled_helper" ]; then
+    fail_promotion "candidate chrome-sandbox path must remain absent: $bundled_helper"
+fi

--- a/linux-features/chromium-sandbox/stage.sh
+++ b/linux-features/chromium-sandbox/stage.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+: "${INSTALL_DIR:?INSTALL_DIR is required}"
+
+bundled_helper="$INSTALL_DIR/chrome-sandbox"
+feature_dir="$INSTALL_DIR/.codex-linux/features/chromium-sandbox"
+generated_helper="$feature_dir/generated-chrome-sandbox"
+
+mkdir -p "$feature_dir"
+
+if [ ! -e "$bundled_helper" ] && [ ! -L "$bundled_helper" ]; then
+    if [ -L "$generated_helper" ] || [ ! -f "$generated_helper" ] || [ ! -x "$generated_helper" ]; then
+        echo "ERROR: Chromium sandbox feature could not find the generated Electron helper: $bundled_helper" >&2
+        exit 1
+    fi
+    exit 0
+fi
+
+if [ -L "$bundled_helper" ] || [ ! -f "$bundled_helper" ] || [ ! -x "$bundled_helper" ]; then
+    echo "ERROR: Chromium sandbox feature requires a non-symlink generated Electron helper: $bundled_helper" >&2
+    exit 1
+fi
+
+mv -fT -- "$bundled_helper" "$generated_helper"
+chmod 0755 "$generated_helper"
+
+if [ -e "$bundled_helper" ] || [ -L "$bundled_helper" ] ||
+   [ -L "$generated_helper" ] || [ ! -f "$generated_helper" ] || [ ! -x "$generated_helper" ]; then
+    echo "ERROR: Chromium sandbox feature could not preserve the generated helper while clearing Electron's sibling helper path" >&2
+    exit 1
+fi
+
+echo "Chromium sandbox feature preserved generated helper: $generated_helper" >&2

--- a/linux-features/chromium-sandbox/test.js
+++ b/linux-features/chromium-sandbox/test.js
@@ -266,7 +266,10 @@ test("actual launcher keeps ordinary warm starts fast and scopes strict preparat
     source.indexOf("refresh_launch_state_quick() {"),
     source.indexOf("prepare_launch_state_under_lock() {"),
   );
-  assert.match(quickRefresh,
-    /if pre_handoff_launcher_hooks_active && pid="\$\(discover_running_app_pid\)"/);
+  assert.match(quickRefresh, /if pre_handoff_launcher_hooks_active; then/);
+  assert.match(quickRefresh, /if pid="\$\(discover_running_app_pid\)"/);
+  assert.match(quickRefresh, /detect_cross_install_conflict/);
+  assert.ok(quickRefresh.indexOf("discover_running_app_pid")
+    < quickRefresh.indexOf("detect_cross_install_conflict"));
   assert.match(source, /launch-error\\ \*\)[\s\S]*notify_error[\s\S]*return 1/);
 });

--- a/linux-features/chromium-sandbox/test.js
+++ b/linux-features/chromium-sandbox/test.js
@@ -130,6 +130,29 @@ test("qualified cold launch removes only sandbox-disabling core defaults", () =>
   } finally { fs.rmSync(f.temp, { recursive: true, force: true }); }
 });
 
+test("validated helper path remains exact and line delimiters fail closed", () => {
+  const f = fixture();
+  try {
+    const safeHelper = path.join(f.temp, "installed helper=value");
+    fs.copyFileSync(f.generatedHelper, safeHelper);
+    fs.chmodSync(safeHelper, 0o755);
+    const safeResult = runHook(f, { helper: safeHelper });
+    assert.equal(safeResult.status, 0, safeResult.stderr);
+    assert.equal(safeResult.stdout.split("\n")[0],
+      `env CHROME_DEVEL_SANDBOX=${safeHelper}`);
+    assert.match(safeResult.stdout, /^env-lock CHROME_DEVEL_SANDBOX$/m);
+
+    for (const delimiter of ["\n", "\r"]) {
+      const unsafeHelper = path.join(f.temp, `installed${delimiter}helper`);
+      fs.copyFileSync(f.generatedHelper, unsafeHelper);
+      fs.chmodSync(unsafeHelper, 0o755);
+      const unsafeResult = runHook(f, { helper: unsafeHelper });
+      assert.match(unsafeResult.stdout, /must not contain CR or LF/);
+      assert.doesNotMatch(unsafeResult.stdout, /env-lock|electron-default-arg-remove/);
+    }
+  } finally { fs.rmSync(f.temp, { recursive: true, force: true }); }
+});
+
 test("resident process rejects both IPC warm start and second-instance fallback", () => {
   const f = fixture();
   try {

--- a/linux-features/chromium-sandbox/test.js
+++ b/linux-features/chromium-sandbox/test.js
@@ -8,12 +8,17 @@ const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 
-const { stageEnabledLinuxFeatureInstall } = require("../../scripts/lib/linux-features.js");
+const {
+  assertEnabledLinuxFeatureBuildCompatibility,
+  enabledLinuxFeaturePromotionHooks,
+  stageEnabledLinuxFeatureInstall,
+} = require("../../scripts/lib/linux-features.js");
 const root = path.resolve(__dirname, "../..");
 const hook = path.join(__dirname, "launcher-hook.sh");
 const stageHook = path.join(__dirname, "stage.sh");
 const cleanupHook = path.join(__dirname, "cleanup.sh");
 const packageHook = path.join(__dirname, "package-hook.sh");
+const promotionHook = path.join(__dirname, "promotion-hook.sh");
 
 function withConfig(enabled, callback) {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "chromium-sandbox-config-"));
@@ -76,7 +81,7 @@ test("feature is disabled by default and stages only when enabled", () => {
     try {
       const plan = stageEnabledLinuxFeatureInstall(app, options);
       assert.deepEqual(plan.runtimeHooks.map((entry) => entry.target), [
-        ".codex-linux/launcher.d/chromium-sandbox-chromium-sandbox.sh",
+        ".codex-linux/pre-handoff-launcher.d/chromium-sandbox-chromium-sandbox.sh",
       ]);
     } finally { fs.rmSync(app, { recursive: true, force: true }); }
   });
@@ -112,6 +117,59 @@ test("native package creation fails closed for the user-managed-only feature", (
   const result = spawnSync("bash", [packageHook], { encoding: "utf8" });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /supports user-managed app builds only/);
+});
+
+test("AppImage compatibility and promotion hooks are explicit enabled-feature contracts", () => {
+  withConfig([], (options) => {
+    const app = fs.mkdtempSync(path.join(os.tmpdir(), "chromium-sandbox-default-build-"));
+    try {
+      fs.mkdirSync(path.join(app, ".codex-linux"), { recursive: true });
+      fs.writeFileSync(path.join(app, ".codex-linux", "build-info.json"),
+        '{"linuxFeatures":{"enabled":[]}}\n');
+      assert.doesNotThrow(() => assertEnabledLinuxFeatureBuildCompatibility("appimage", app, options));
+      assert.deepEqual(enabledLinuxFeaturePromotionHooks(app, options), []);
+    } finally { fs.rmSync(app, { recursive: true, force: true }); }
+  });
+
+  withConfig(["chromium-sandbox"], (options) => {
+    const app = fs.mkdtempSync(path.join(os.tmpdir(), "chromium-sandbox-incompatible-build-"));
+    try {
+      fs.mkdirSync(path.join(app, ".codex-linux"), { recursive: true });
+      fs.writeFileSync(path.join(app, ".codex-linux", "build-info.json"),
+        '{"linuxFeatures":{"enabled":["chromium-sandbox"]}}\n');
+      assert.throws(
+        () => assertEnabledLinuxFeatureBuildCompatibility("appimage", app, options),
+        /chromium-sandbox.*incompatible with appimage/i,
+      );
+      assert.deepEqual(enabledLinuxFeaturePromotionHooks(app, options), [
+        { id: "chromium-sandbox", path: promotionHook },
+      ]);
+    } finally { fs.rmSync(app, { recursive: true, force: true }); }
+  });
+});
+
+test("promotion compatibility qualifies the external helper against candidate bytes", () => {
+  const f = fixture();
+  const current = path.join(f.temp, "current");
+  fs.mkdirSync(current);
+  const run = () => spawnSync("bash", [promotionHook], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${f.bin}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+      CODEX_CANDIDATE_APP_DIR: f.app,
+      CODEX_CURRENT_APP_DIR: current,
+      CHROME_DEVEL_SANDBOX: f.helper,
+      CODEX_TEST_STAT_METADATA: "0:0:4755",
+    },
+  });
+  try {
+    fs.writeFileSync(f.helper, "old helper\n");
+    assert.notEqual(run().status, 0);
+    assert.match(run().stderr, /does not match the candidate Electron helper/);
+    fs.copyFileSync(f.generatedHelper, f.helper);
+    assert.equal(run().status, 0, run().stderr);
+  } finally { fs.rmSync(f.temp, { recursive: true, force: true }); }
 });
 
 test("qualified cold launch removes only sandbox-disabling core defaults", () => {
@@ -195,14 +253,20 @@ test("helper and final conflicting-argument failures are actionable", () => {
   } finally { fs.rmSync(f.temp, { recursive: true, force: true }); }
 });
 
-test("actual launcher control flow executes launch preparation before either handoff", () => {
+test("actual launcher keeps ordinary warm starts fast and scopes strict preparation before handoff", () => {
   const source = fs.readFileSync(path.join(root, "launcher/start.sh.template"), "utf8");
   const runtime = source.slice(source.indexOf("recover_unhealthy_running_app\nprepare_launch_state_under_lock"));
-  const prepare = runtime.indexOf("prepare_electron_launch");
-  assert.ok(prepare >= 0);
-  assert.match(runtime, /prepare_electron_launch "\${LAUNCHER_ARGS\[@\]}"/);
-  assert.doesNotMatch(runtime, /prepare_electron_launch "\${LAUNCHER_ARGS\[@\]:1}"/);
-  assert.ok(prepare < runtime.indexOf("send_warm_start_launch_action"));
-  assert.ok(prepare < runtime.indexOf("using_second_instance_handoff"));
+  assert.match(runtime,
+    /if pre_handoff_launcher_hooks_active; then\s+prepare_electron_launch "\${LAUNCHER_ARGS\[@\]}"\s+fi/);
+  assert.ok(runtime.indexOf("prepare_electron_launch") < runtime.indexOf("send_warm_start_launch_action"));
+  assert.ok(runtime.indexOf("send_warm_start_launch_action") < runtime.lastIndexOf("launch_electron"));
+  const launchBody = source.slice(source.indexOf("launch_electron() {"), source.indexOf("prepare_electron_launch() {"));
+  assert.match(launchBody, /run_feature_launcher_hooks\s+build_electron_launch_args/);
+  const quickRefresh = source.slice(
+    source.indexOf("refresh_launch_state_quick() {"),
+    source.indexOf("prepare_launch_state_under_lock() {"),
+  );
+  assert.match(quickRefresh,
+    /if pre_handoff_launcher_hooks_active && pid="\$\(discover_running_app_pid\)"/);
   assert.match(source, /launch-error\\ \*\)[\s\S]*notify_error[\s\S]*return 1/);
 });

--- a/linux-features/chromium-sandbox/test.js
+++ b/linux-features/chromium-sandbox/test.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { stageEnabledLinuxFeatureInstall } = require("../../scripts/lib/linux-features.js");
+const root = path.resolve(__dirname, "../..");
+const hook = path.join(__dirname, "launcher-hook.sh");
+const stageHook = path.join(__dirname, "stage.sh");
+const cleanupHook = path.join(__dirname, "cleanup.sh");
+const packageHook = path.join(__dirname, "package-hook.sh");
+
+function withConfig(enabled, callback) {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "chromium-sandbox-config-"));
+  const configPath = path.join(temp, "features.json");
+  fs.writeFileSync(configPath, `${JSON.stringify({ enabled })}\n`);
+  try {
+    return callback({ featuresRoot: path.join(root, "linux-features"), featuresConfigPath: configPath });
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+function fixture() {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "chromium-sandbox-hook-"));
+  const app = path.join(temp, "app");
+  const bin = path.join(temp, "bin");
+  const helper = path.join(temp, "installed-helper");
+  const features = path.join(app, ".codex-linux", "features");
+  const generatedHelper = path.join(features, "chromium-sandbox", "generated-chrome-sandbox");
+  fs.mkdirSync(path.dirname(generatedHelper), { recursive: true });
+  fs.mkdirSync(bin);
+  fs.writeFileSync(generatedHelper, "matching helper\n", { mode: 0o755 });
+  fs.writeFileSync(path.join(app, "electron"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  fs.copyFileSync(generatedHelper, helper);
+  fs.chmodSync(helper, 0o755);
+  fs.writeFileSync(path.join(bin, "stat"),
+    "#!/bin/sh\nprintf '%s\\n' \"${CODEX_TEST_STAT_METADATA:-0:0:4755}\"\n",
+    { mode: 0o755 });
+  return { temp, app, bin, features, generatedHelper, helper };
+}
+
+function runHook(f, {
+  resident = "0",
+  helper = f.helper,
+  args = [],
+  metadata = "0:0:4755",
+} = {}) {
+  return spawnSync("bash", [hook, ...args], {
+    encoding: "utf8",
+    env: {
+      PATH: `${f.bin}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+      CODEX_LINUX_APP_DIR: f.app,
+      CODEX_LINUX_FEATURES_DIR: f.features,
+      CODEX_LINUX_RESIDENT_PROCESS_ACTIVE: resident,
+      CHROME_DEVEL_SANDBOX: helper,
+      CODEX_TEST_STAT_METADATA: metadata,
+    },
+  });
+}
+
+test("feature is disabled by default and stages only when enabled", () => {
+  withConfig([], (options) => {
+    const app = fs.mkdtempSync(path.join(os.tmpdir(), "chromium-sandbox-disabled-"));
+    try {
+      assert.deepEqual(stageEnabledLinuxFeatureInstall(app, options).runtimeHooks, []);
+    } finally { fs.rmSync(app, { recursive: true, force: true }); }
+  });
+  withConfig(["chromium-sandbox"], (options) => {
+    const app = fs.mkdtempSync(path.join(os.tmpdir(), "chromium-sandbox-enabled-"));
+    try {
+      const plan = stageEnabledLinuxFeatureInstall(app, options);
+      assert.deepEqual(plan.runtimeHooks.map((entry) => entry.target), [
+        ".codex-linux/launcher.d/chromium-sandbox-chromium-sandbox.sh",
+      ]);
+    } finally { fs.rmSync(app, { recursive: true, force: true }); }
+  });
+});
+
+test("stage hook preserves the generated helper and cleanup restores it", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "chromium-sandbox-stage-"));
+  const app = path.join(temp, "app");
+  const bundled = path.join(app, "chrome-sandbox");
+  const generated = path.join(app, ".codex-linux", "features", "chromium-sandbox", "generated-chrome-sandbox");
+  fs.mkdirSync(app);
+  fs.writeFileSync(bundled, "generated helper\n", { mode: 0o755 });
+  try {
+    const staged = spawnSync("bash", [stageHook], {
+      encoding: "utf8",
+      env: { ...process.env, INSTALL_DIR: app },
+    });
+    assert.equal(staged.status, 0, staged.stderr);
+    assert.equal(fs.existsSync(bundled), false);
+    assert.equal(fs.readFileSync(generated, "utf8"), "generated helper\n");
+
+    const cleaned = spawnSync("bash", [cleanupHook], {
+      encoding: "utf8",
+      env: { ...process.env, INSTALL_DIR: app },
+    });
+    assert.equal(cleaned.status, 0, cleaned.stderr);
+    assert.equal(fs.readFileSync(bundled, "utf8"), "generated helper\n");
+    assert.equal(fs.existsSync(generated), false);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("native package creation fails closed for the user-managed-only feature", () => {
+  const result = spawnSync("bash", [packageHook], { encoding: "utf8" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /supports user-managed app builds only/);
+});
+
+test("qualified cold launch removes only sandbox-disabling core defaults", () => {
+  const f = fixture();
+  try {
+    const result = runHook(f);
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.stdout.trim().split("\n"), [
+      `env CHROME_DEVEL_SANDBOX=${f.helper}`,
+      "env-lock CHROME_DEVEL_SANDBOX",
+      "electron-default-arg-remove --no-sandbox",
+      "electron-default-arg-remove --disable-gpu-sandbox",
+      "electron-arg-deny --no-sandbox",
+      "electron-arg-deny --disable-*-sandbox",
+    ]);
+  } finally { fs.rmSync(f.temp, { recursive: true, force: true }); }
+});
+
+test("resident process rejects both IPC warm start and second-instance fallback", () => {
+  const f = fixture();
+  try {
+    const result = runHook(f, { resident: "1" });
+    assert.equal(result.status, 0);
+    assert.match(result.stdout,
+      /launch-error Chromium sandbox: a resident app process is already running/);
+    assert.doesNotMatch(result.stdout, /electron-default-arg-remove/);
+  } finally { fs.rmSync(f.temp, { recursive: true, force: true }); }
+});
+
+test("helper and final conflicting-argument failures are actionable", () => {
+  const f = fixture();
+  try {
+    assert.match(runHook(f, { helper: "" }).stdout, /must name an absolute helper path/);
+    assert.match(runHook(f, { helper: "relative" }).stdout, /must name an absolute helper path/);
+    assert.match(runHook(f, { helper: path.join(f.temp, "missing") }).stdout,
+      /non-symlink executable regular file/);
+    const symlink = path.join(f.temp, "symlink");
+    fs.symlinkSync(f.helper, symlink);
+    assert.match(runHook(f, { helper: symlink }).stdout,
+      /non-symlink executable regular file/);
+    fs.chmodSync(f.helper, 0o644);
+    assert.match(runHook(f).stdout, /non-symlink executable regular file/);
+    fs.chmodSync(f.helper, 0o755);
+    assert.match(runHook(f, { metadata: "1000:1000:755" }).stdout,
+      /root:root mode 4755/);
+    const mismatch = path.join(f.temp, "mismatch");
+    fs.writeFileSync(mismatch, "wrong\n", { mode: 0o755 });
+    assert.match(runHook(f, { helper: mismatch }).stdout, /does not match/);
+    fs.writeFileSync(path.join(f.app, "chrome-sandbox"), "matching helper\n", { mode: 0o755 });
+    assert.match(runHook(f).stdout, /chrome-sandbox path must remain absent/);
+    fs.rmSync(path.join(f.app, "chrome-sandbox"));
+    fs.renameSync(f.generatedHelper, `${f.generatedHelper}.missing`);
+    assert.match(runHook(f).stdout, /generated helper reference is missing or invalid/);
+    fs.renameSync(`${f.generatedHelper}.missing`, f.generatedHelper);
+    for (const arg of ["--no-sandbox", "--disable-gpu-sandbox", "--disable-setuid-sandbox=true"]) {
+      assert.match(runHook(f, { args: [arg] }).stdout, /conflicting Electron argument/);
+    }
+  } finally { fs.rmSync(f.temp, { recursive: true, force: true }); }
+});
+
+test("actual launcher control flow executes launch preparation before either handoff", () => {
+  const source = fs.readFileSync(path.join(root, "launcher/start.sh.template"), "utf8");
+  const runtime = source.slice(source.indexOf("recover_unhealthy_running_app\nprepare_launch_state_under_lock"));
+  const prepare = runtime.indexOf("prepare_electron_launch");
+  assert.ok(prepare >= 0);
+  assert.match(runtime, /prepare_electron_launch "\${LAUNCHER_ARGS\[@\]}"/);
+  assert.doesNotMatch(runtime, /prepare_electron_launch "\${LAUNCHER_ARGS\[@\]:1}"/);
+  assert.ok(prepare < runtime.indexOf("send_warm_start_launch_action"));
+  assert.ok(prepare < runtime.indexOf("using_second_instance_handoff"));
+  assert.match(source, /launch-error\\ \*\)[\s\S]*notify_error[\s\S]*return 1/);
+});

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -188,6 +188,10 @@ prepare_appdir() {
 
 main() {
     ensure_app_layout
+    # Check the staged app snapshot before creating or replacing an AppDir or
+    # output artifact. Disabled features leave the ordinary AppImage path
+    # unchanged; enabled features may explicitly declare an incompatibility.
+    assert_linux_feature_build_compatibility appimage "$APP_DIR"
     ensure_file_exists "$APPRUN_TEMPLATE" "AppImage AppRun template"
     ensure_file_exists "$DESKTOP_TEMPLATE" "AppImage desktop template"
     ensure_file_exists "$APPIMAGE_RUNTIME_TEMPLATE" "AppImage runtime helper template"

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -47,6 +47,7 @@ main() {
     validate_max_build_threads
 
     ensure_app_layout
+    assert_linux_feature_build_compatibility deb "$APP_DIR"
     ensure_file_exists "$CONTROL_TEMPLATE" "control template"
     ensure_file_exists "$DESKTOP_TEMPLATE" "desktop template"
     ensure_file_exists "$ICON_SOURCE" "icon"

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -81,6 +81,7 @@ main() {
 	validate_max_build_threads
 
 	ensure_app_layout
+	assert_linux_feature_build_compatibility pacman "$APP_DIR"
 	ensure_file_exists "$PKGBUILD_TEMPLATE" "PKGBUILD template"
 	ensure_file_exists "$DESKTOP_TEMPLATE" "desktop template"
 	ensure_file_exists "$ICON_SOURCE" "icon"

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -66,6 +66,7 @@ main() {
     fi
 
     ensure_app_layout
+    assert_linux_feature_build_compatibility rpm "$APP_DIR"
     [ -f "$SPEC_TEMPLATE" ] || error "Missing spec template: $SPEC_TEMPLATE"
     [ -f "$DESKTOP_TEMPLATE" ] || error "Missing desktop template: $DESKTOP_TEMPLATE"
     [ -f "$ICON_SOURCE" ] || error "Missing icon: $ICON_SOURCE"

--- a/scripts/lib/candidate-install.sh
+++ b/scripts/lib/candidate-install.sh
@@ -124,6 +124,19 @@ promote_candidate_install() {
     recover_pending_candidate_promotion_locked "$final_dir"
     [ -d "$candidate_dir" ] || error "Candidate app was not created: $candidate_dir"
 
+    # Enabled features may depend on host state outside the generated app.
+    # Revalidate that state against the exact candidate while holding the
+    # promotion lock, before this transaction creates a journal or exchanges
+    # either app directory. A refusal leaves both directories untouched.
+    if declare -F run_linux_feature_promotion_hooks >/dev/null 2>&1; then
+        if ! run_linux_feature_promotion_hooks "$candidate_dir" "$final_dir"; then
+            warn "Accepted candidate failed Linux feature promotion compatibility; the current app was not changed"
+            flock -u "$promotion_lock_fd"
+            exec {promotion_lock_fd}>&-
+            return 1
+        fi
+    fi
+
     # The long build is allowed while the app runs. Only the short atomic
     # promotion window requires the installed executable to be stopped.
     INSTALL_DIR="$final_dir"

--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -21,12 +21,14 @@ const RUNTIME_HOOK_DIRS = {
   prelaunch: { dir: "prelaunch.d", executable: true },
   electronArgs: { dir: "electron-args.d", executable: false },
   launcher: { dir: "launcher.d", executable: true },
+  preHandoffLauncher: { dir: "pre-handoff-launcher.d", executable: true },
   coldStart: { dir: "cold-start.d", executable: true },
   afterExit: { dir: "after-exit.d", executable: true },
 };
 const STAGED_FEATURE_MANIFEST_RELATIVE_PATH = ".codex-linux/linux-features-staged.json";
 const BUILD_INFO_RELATIVE_PATH = ".codex-linux/build-info.json";
 const SUPPORTED_PACKAGE_FORMATS = new Set(["deb", "rpm", "pacman"]);
+const SUPPORTED_BUILD_FORMATS = new Set([...SUPPORTED_PACKAGE_FORMATS, "appimage"]);
 const PACKAGE_DEPENDENCY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9+._:@()=<>~\/-]*$/;
 const RPM_ELF_DEPENDENCY_SUFFIX = "%{codex_elf_suffix}";
 const PACKAGE_PATH_COMPONENT_PATTERN = /^(?!-)(?!\.\.?$)[A-Za-z0-9._+@:-]+$/;
@@ -607,6 +609,85 @@ function disabledLinuxFeatureCleanupHooks(options = {}) {
       path: resolveFeatureEntrypoint(feature, "cleanupHook"),
     }))
     .filter((hook) => hook.path != null);
+}
+
+function enabledLinuxFeaturePromotionHooks(appDir, options = {}) {
+  const selectedOptions = {
+    ...options,
+    enabledFeatureIds: enabledFeatureIdsFromBuildInfo(appDir),
+  };
+  return loadEnabledLinuxFeatures(selectedOptions)
+    .filter((feature) => feature.manifest.entrypoints?.promotionHook != null)
+    .map((feature) => ({
+      id: feature.id,
+      path: resolveFeatureRelativePath(
+        feature,
+        feature.manifest.entrypoints.promotionHook,
+        "promotionHook entrypoint",
+      ),
+    }));
+}
+
+function normalizeBuildFormat(value) {
+  if (typeof value !== "string" || !SUPPORTED_BUILD_FORMATS.has(value)) {
+    throw new Error(`Unsupported build format '${String(value)}'`);
+  }
+  return value;
+}
+
+function featureBuildCompatibility(feature) {
+  const compatibility = feature.manifest.buildCompatibility;
+  if (compatibility == null) {
+    return { unsupportedFormats: [], reason: "" };
+  }
+  if (typeof compatibility !== "object" || Array.isArray(compatibility)) {
+    throw new Error(`Linux feature '${feature.id}' buildCompatibility must be an object`);
+  }
+  const rawFormats = compatibility.unsupportedFormats ?? [];
+  if (!Array.isArray(rawFormats)) {
+    throw new Error(`Linux feature '${feature.id}' buildCompatibility.unsupportedFormats must be an array`);
+  }
+  const unsupportedFormats = [];
+  for (const rawFormat of rawFormats) {
+    const format = normalizeBuildFormat(rawFormat);
+    if (!unsupportedFormats.includes(format)) {
+      unsupportedFormats.push(format);
+    }
+  }
+  const reason = compatibility.reason == null ? "" : String(compatibility.reason).trim();
+  return { unsupportedFormats, reason };
+}
+
+function assertEnabledLinuxFeatureBuildCompatibility(buildFormat, appDir, options = {}) {
+  const format = normalizeBuildFormat(buildFormat);
+  const snapshotEnabled = enabledFeatureIdsFromBuildInfo(appDir);
+  const strictOptions = { ...options, strictConfig: true };
+  const configuredEnabled = enabledLinuxFeatureIds(strictOptions);
+  if (
+    snapshotEnabled.length !== configuredEnabled.length
+    || snapshotEnabled.some((id, index) => id !== configuredEnabled[index])
+  ) {
+    throw new Error(
+      [
+        `App Linux feature snapshot does not match the current feature config: ${path.resolve(appDir)}`,
+        `app snapshot: ${JSON.stringify(snapshotEnabled)}`,
+        `current config: ${JSON.stringify(configuredEnabled)}`,
+        "Rebuild the app with the current feature config before creating an artifact.",
+      ].join("\n"),
+    );
+  }
+  for (
+    const feature of loadEnabledLinuxFeatures(
+      { ...strictOptions, enabledFeatureIds: snapshotEnabled },
+    )
+  ) {
+    const compatibility = featureBuildCompatibility(feature);
+    if (!compatibility.unsupportedFormats.includes(format)) {
+      continue;
+    }
+    const suffix = compatibility.reason ? `: ${compatibility.reason}` : "";
+    throw new Error(`Linux feature '${feature.id}' is incompatible with ${format}${suffix}`);
+  }
 }
 
 function normalizeEntryList(value, label, feature) {
@@ -1347,6 +1428,27 @@ function main() {
     }
     return;
   }
+  if (command === "--assert-build-compatible") {
+    const buildFormat = process.argv[3] ?? "";
+    const appDir = process.argv[4] ?? process.env.APP_DIR;
+    if (!appDir) {
+      console.error("Usage: linux-features.js --assert-build-compatible <format> <app-dir>");
+      process.exit(1);
+    }
+    assertEnabledLinuxFeatureBuildCompatibility(buildFormat, appDir);
+    return;
+  }
+  if (command === "--promotion-hooks") {
+    const appDir = process.argv[3] ?? process.env.CODEX_CANDIDATE_APP_DIR;
+    if (!appDir) {
+      console.error("Usage: linux-features.js --promotion-hooks <candidate-app-dir>");
+      process.exit(1);
+    }
+    for (const hook of enabledLinuxFeaturePromotionHooks(appDir)) {
+      process.stdout.write(`${hook.id}\t${hook.path}\n`);
+    }
+    return;
+  }
   if (command === "--stage-package-resources") {
     const packageFormat = process.argv[3] ?? "";
     const packageRoot = process.argv[4] ?? process.env.PACKAGE_ROOT;
@@ -1436,7 +1538,7 @@ function main() {
     process.stdout.write(`${linuxFeaturesRoot()}\n`);
     return;
   }
-  console.error("Usage: linux-features.js --enabled | --features-json | --features-root | --stage-install <install-dir> | --staged-files-json <install-dir> | --stage-hooks | --cleanup-hooks | --package-hooks <format> <app-dir> | --stage-package-resources <format> <package-root> <app-dir> | --restore-package-resource-permissions <format> <package-root> <app-dir> | --package-dependencies <format> <app-dir> | --package-files <format> <app-dir>");
+  console.error("Usage: linux-features.js --enabled | --features-json | --features-root | --stage-install <install-dir> | --staged-files-json <install-dir> | --stage-hooks | --cleanup-hooks | --promotion-hooks <candidate-app-dir> | --assert-build-compatible <format> <app-dir> | --package-hooks <format> <app-dir> | --stage-package-resources <format> <package-root> <app-dir> | --restore-package-resource-permissions <format> <package-root> <app-dir> | --package-dependencies <format> <app-dir> | --package-files <format> <app-dir>");
   process.exit(1);
 }
 
@@ -1450,6 +1552,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  assertEnabledLinuxFeatureBuildCompatibility,
   disabledLinuxFeatureCleanupHooks,
   discoverLinuxFeatureManifests,
   enabledLinuxFeaturesConfig,
@@ -1460,6 +1563,7 @@ module.exports = {
   enabledLinuxFeaturePackageFiles,
   enabledLinuxFeaturePackageHooks,
   enabledLinuxFeaturePackagePlan,
+  enabledLinuxFeaturePromotionHooks,
   enabledLinuxFeatureStageHooks,
   featuresJsonSummary,
   loadEnabledLinuxFeatures,

--- a/scripts/lib/linux-features.sh
+++ b/scripts/lib/linux-features.sh
@@ -41,3 +41,38 @@ run_linux_feature_stage_hooks() {
         fi
     done < <(node "$feature_helper" --stage-hooks)
 }
+
+run_linux_feature_promotion_hooks() {
+    local candidate_dir="$1"
+    local current_dir="$2"
+    local feature_helper="$SCRIPT_DIR/scripts/lib/linux-features.js"
+    local feature_id
+    local hook_path
+    local hooks_output
+
+    [ -f "$feature_helper" ] || {
+        warn "Linux feature helper not found at $feature_helper"
+        return 1
+    }
+    if ! hooks_output="$(node "$feature_helper" --promotion-hooks "$candidate_dir")"; then
+        warn "Could not discover enabled Linux feature promotion hooks"
+        return 1
+    fi
+
+    while IFS=$'\t' read -r feature_id hook_path; do
+        [ -n "$feature_id" ] || continue
+        [ -f "$hook_path" ] || {
+            warn "Missing Linux feature promotion hook for $feature_id: $hook_path"
+            return 1
+        }
+        info "Running Linux feature promotion compatibility hook: $feature_id"
+        if ! CODEX_CANDIDATE_APP_DIR="$candidate_dir" \
+            CODEX_CURRENT_APP_DIR="$current_dir" \
+            CODEX_LINUX_FEATURE_HOOK_PHASE=promotion \
+            SCRIPT_DIR="$SCRIPT_DIR" \
+            bash "$hook_path"; then
+            warn "Linux feature promotion compatibility refused the candidate: $feature_id"
+            return 1
+        fi
+    done <<<"$hooks_output"
+}

--- a/scripts/lib/linux-features.test.js
+++ b/scripts/lib/linux-features.test.js
@@ -8,10 +8,12 @@ const path = require("node:path");
 const test = require("node:test");
 
 const {
+  assertEnabledLinuxFeatureBuildCompatibility,
   enabledFeatureIdsFromBuildInfo,
   enabledLinuxFeaturePackageDependencies,
   enabledLinuxFeaturePackageFiles,
   enabledLinuxFeaturePackagePlan,
+  enabledLinuxFeaturePromotionHooks,
   loadLinuxFeaturePatchDescriptors,
   restoreEnabledLinuxFeaturePackageResourcePermissions,
   stageEnabledLinuxFeaturePackageResources,
@@ -100,6 +102,50 @@ test("Linux feature asset matchers receive feature settings", (t) => {
 
   const [descriptor] = loadLinuxFeaturePatchDescriptors({ featuresRoot });
   assert.equal(descriptor.assetMatch("current-contract", "app-current.js", {}), true);
+});
+
+test("strict launcher, build compatibility, and promotion hooks are explicit opt-ins", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-strict-lifecycle-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const { featureDir, featuresRoot, id } = makePackageFeatureRoot(root, {
+    runtimeHooks: {
+      preHandoffLauncher: {
+        source: "strict-launcher.sh",
+        mode: "0755",
+      },
+    },
+    entrypoints: { promotionHook: "./promotion.sh" },
+    buildCompatibility: {
+      unsupportedFormats: ["appimage"],
+      reason: "fixture incompatibility",
+    },
+  });
+  fs.writeFileSync(path.join(featureDir, "strict-launcher.sh"), "#!/bin/sh\nexit 0\n");
+  fs.writeFileSync(path.join(featureDir, "promotion.sh"), "#!/bin/sh\nexit 0\n");
+
+  const appDir = path.join(root, "app");
+  const plan = stageEnabledLinuxFeatureInstall(appDir, { featuresRoot });
+  assert.deepEqual(plan.runtimeHooks.map((hook) => hook.target), [
+    `.codex-linux/pre-handoff-launcher.d/${id}-strict-launcher.sh`,
+  ]);
+  writeBuildInfoSnapshot(appDir, [id]);
+  assert.throws(
+    () => assertEnabledLinuxFeatureBuildCompatibility("appimage", appDir, { featuresRoot }),
+    /package-framework-fixture.*incompatible with appimage.*fixture incompatibility/i,
+  );
+  assert.doesNotThrow(
+    () => assertEnabledLinuxFeatureBuildCompatibility("deb", appDir, { featuresRoot }),
+  );
+  assert.deepEqual(enabledLinuxFeaturePromotionHooks(appDir, { featuresRoot }), [
+    { id, path: path.join(featureDir, "promotion.sh") },
+  ]);
+
+  fs.rmSync(path.join(featureDir, "promotion.sh"));
+  assert.throws(
+    () => enabledLinuxFeaturePromotionHooks(appDir, { featuresRoot }),
+    /promotionHook entrypoint not found/i,
+  );
 });
 
 test("Linux feature staging rejects duplicate resource targets", (t) => {

--- a/scripts/lib/linux-features.test.js
+++ b/scripts/lib/linux-features.test.js
@@ -117,7 +117,7 @@ test("strict launcher, build compatibility, and promotion hooks are explicit opt
     },
     entrypoints: { promotionHook: "./promotion.sh" },
     buildCompatibility: {
-      unsupportedFormats: ["appimage"],
+      unsupportedFormats: ["appimage", "deb", "rpm", "pacman"],
       reason: "fixture incompatibility",
     },
   });
@@ -134,9 +134,12 @@ test("strict launcher, build compatibility, and promotion hooks are explicit opt
     () => assertEnabledLinuxFeatureBuildCompatibility("appimage", appDir, { featuresRoot }),
     /package-framework-fixture.*incompatible with appimage.*fixture incompatibility/i,
   );
-  assert.doesNotThrow(
-    () => assertEnabledLinuxFeatureBuildCompatibility("deb", appDir, { featuresRoot }),
-  );
+  for (const format of ["deb", "rpm", "pacman"]) {
+    assert.throws(
+      () => assertEnabledLinuxFeatureBuildCompatibility(format, appDir, { featuresRoot }),
+      new RegExp(`package-framework-fixture.*incompatible with ${format}.*fixture incompatibility`, "i"),
+    );
+  }
   assert.deepEqual(enabledLinuxFeaturePromotionHooks(appDir, { featuresRoot }), [
     { id, path: path.join(featureDir, "promotion.sh") },
   ]);

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -68,6 +68,19 @@ linux_feature_enabled() {
     grep -Fxq "$feature_id" <<<"$enabled_output"
 }
 
+assert_linux_feature_build_compatibility() {
+    local build_format="$1"
+    local app_dir="${2:-$APP_DIR}"
+    local helper="$REPO_DIR/scripts/lib/linux-features.js"
+    local node_bin
+
+    [ -f "$helper" ] || error "Missing Linux features helper: $helper"
+    node_bin="$(package_node_binary)"
+    if ! "$node_bin" "$helper" --assert-build-compatible "$build_format" "$app_dir"; then
+        error "Enabled Linux features are not compatible with $build_format"
+    fi
+}
+
 stage_update_builder_linux_features_config() {
     local update_builder_root="$1"
     local helper="$REPO_DIR/scripts/lib/linux-features.js"

--- a/tests/launcher_warm_start_recovery.sh
+++ b/tests/launcher_warm_start_recovery.sh
@@ -17,6 +17,7 @@ SOCKET_PATH="$RUNTIME_DIR/$TEST_APP_ID/launch-action.sock"
 FIRST_LOG="$TMP_DIR/first-launch.log"
 SECOND_LOG="$TMP_DIR/second-launch.log"
 APP_LOG="$HOME_DIR/.cache/$TEST_APP_ID/launcher.log"
+CHROMIUM_SANDBOX_RESIDENT_REJECTION="${CODEX_TEST_CHROMIUM_SANDBOX_RESIDENT_REJECTION:-0}"
 LAUNCHER_PID=""
 SOCKET_PID=""
 HOOK_PID=""
@@ -65,7 +66,7 @@ wait_for() {
     local description="$1"
     shift
     local attempt
-    for attempt in $(seq 1 200); do
+    for attempt in $(seq 1 300); do
         "$@" && return 0
         sleep 0.05
     done
@@ -274,6 +275,46 @@ if [ "${CODEX_TEST_TERM_STATUS:-0}" = "1" ]; then
     wait_for "Electron signal forwarding" electron_is_down
     wait_for "webview cleanup after planned TERM" webview_is_down
     printf '%s\n' "launcher planned TERM status test passed"
+    exit 0
+fi
+
+if [ "$CHROMIUM_SANDBOX_RESIDENT_REJECTION" = "1" ]; then
+    # The resident was launched without the feature and therefore uses the
+    # compatibility sandbox-disable defaults. Stage the feature only for the
+    # requesting launch. Its resident rejection runs before helper validation,
+    # so this full-path CI regression needs no privileged SUID fixture.
+    cp "$REPO_DIR/linux-features/chromium-sandbox/launcher-hook.sh" \
+        "$APP_DIR/.codex-linux/launcher.d/chromium-sandbox-chromium-sandbox.sh"
+    chmod +x "$APP_DIR/.codex-linux/launcher.d/chromium-sandbox-chromium-sandbox.sh"
+
+    : > "$SECOND_LOG"
+    if "${COMMON_ENV[@]}" "$APP_DIR/start.sh" >> "$SECOND_LOG" 2>&1; then
+        fail "sandbox-requested IPC warm start silently succeeded"
+    fi
+    grep -q "sandbox mode cannot be authoritatively verified" "$APP_LOG" \
+        || fail "sandbox-requested IPC warm start did not return the feature diagnostic"
+    grep -q "Sent launch args over warm-start IPC" "$APP_LOG" \
+        && fail "sandbox-requested IPC warm start reached IPC before rejection"
+    kill -0 "$FIRST_ELECTRON_PID" 2>/dev/null \
+        || fail "sandbox-requested IPC rejection disturbed the healthy compatibility resident"
+
+    printf '%s\n' '{"codex-linux-warm-start-enabled":false}' \
+        > "$HOME_DIR/.config/$TEST_APP_ID/settings.json"
+    : > "$SECOND_LOG"
+    if "${COMMON_ENV[@]}" "$APP_DIR/start.sh" >> "$SECOND_LOG" 2>&1; then
+        fail "sandbox-requested Electron second-instance fallback silently succeeded"
+    fi
+    [ "$(grep -c "sandbox mode cannot be authoritatively verified" "$APP_LOG")" -ge 2 ] \
+        || fail "sandbox-requested second-instance fallback did not return the feature diagnostic"
+    grep -q "using Electron second-instance handoff" "$APP_LOG" \
+        && fail "sandbox request reached Electron second-instance handoff before rejection"
+    kill -0 "$FIRST_ELECTRON_PID" 2>/dev/null \
+        || fail "sandbox-requested second-instance rejection disturbed the healthy compatibility resident"
+
+    kill "$FIRST_ELECTRON_PID"
+    wait "$LAUNCHER_PID"
+    LAUNCHER_PID=""
+    printf '%s\n' "launcher Chromium sandbox compatibility-resident handoff rejection test passed"
     exit 0
 fi
 

--- a/tests/launcher_warm_start_recovery.sh
+++ b/tests/launcher_warm_start_recovery.sh
@@ -7,6 +7,7 @@ TMP_DIR="$(mktemp -d)"
 TEST_APP_ID="codex-test-$$"
 APP_DIR="$TMP_DIR/app"
 REMOUNT_APP_DIR="$TMP_DIR/remounted-app"
+FOREIGN_APP_DIR="$TMP_DIR/foreign-app"
 SECOND_APP_DIR="$APP_DIR"
 APPIMAGE_PATH="$TMP_DIR/codex-desktop.AppImage"
 APPIMAGE_RECOVERY="${CODEX_TEST_APPIMAGE_REMOUNT:-0}"
@@ -22,6 +23,7 @@ ORDINARY_HOOK_WARM_COMPAT="${CODEX_TEST_ORDINARY_HOOK_WARM_COMPAT:-0}"
 LAUNCHER_PID=""
 SOCKET_PID=""
 HOOK_PID=""
+FOREIGN_ELECTRON_PID=""
 
 if [ "$APPIMAGE_RECOVERY" = "1" ]; then
     SECOND_APP_DIR="$REMOUNT_APP_DIR"
@@ -36,13 +38,14 @@ cleanup() {
     [ -z "$LAUNCHER_PID" ] || kill "$LAUNCHER_PID" 2>/dev/null || true
     [ -z "$SOCKET_PID" ] || kill "$SOCKET_PID" 2>/dev/null || true
     [ -z "$HOOK_PID" ] || kill "$HOOK_PID" 2>/dev/null || true
+    [ -z "$FOREIGN_ELECTRON_PID" ] || kill "$FOREIGN_ELECTRON_PID" 2>/dev/null || true
     for cmdline in /proc/[0-9]*/cmdline; do
         [ -r "$cmdline" ] || continue
         pid="${cmdline#/proc/}"
         pid="${pid%/cmdline}"
         IFS= read -r -d '' arg0 < "$cmdline" 2>/dev/null || true
         case "${arg0:-}" in
-            "$APP_DIR/electron"|"$REMOUNT_APP_DIR/electron")
+            "$APP_DIR/electron"|"$REMOUNT_APP_DIR/electron"|"$FOREIGN_APP_DIR/electron")
                 kill "$pid" 2>/dev/null || true
                 ;;
         esac
@@ -309,6 +312,31 @@ HOOK
     kill "$FIRST_ELECTRON_PID"
     wait "$LAUNCHER_PID"
     LAUNCHER_PID=""
+    rm -f "$APP_DIR/.codex-linux/launcher.d/failing-ordinary-hook"
+
+    # Exercise the real cold-launch path. A launcher hook that replaces the
+    # wayland-gpu platform must be applied before the sole final argv build, so
+    # a stale WaylandWindowDecorations feature cannot survive the X11 override.
+    cat > "$APP_DIR/.codex-linux/launcher.d/platform-override-hook" <<'HOOK'
+#!/usr/bin/env bash
+printf '%s\n' 'electron-arg --ozone-platform=x11'
+HOOK
+    chmod +x "$APP_DIR/.codex-linux/launcher.d/platform-override-hook"
+    rm -f "$STATE_DIR/app.pid" "$STATE_DIR/webview.pid"
+    : > "$SECOND_LOG"
+    "${COMMON_ENV[@]}" CODEX_LINUX_RENDERING_MODE=wayland-gpu \
+        "$APP_DIR/start.sh" >> "$SECOND_LOG" 2>&1 &
+    LAUNCHER_PID=$!
+    wait_for "ordinary-hook cold Electron" pid_file_is_live
+    SECOND_ELECTRON_PID="$(read_live_app_pid)"
+    grep -zq -- '--ozone-platform=x11' "/proc/$SECOND_ELECTRON_PID/cmdline" \
+        || fail "ordinary launcher hook did not replace the cold-launch platform"
+    if grep -zq -- 'WaylandWindowDecorations' "/proc/$SECOND_ELECTRON_PID/cmdline"; then
+        fail "cold launch retained Wayland decorations from an earlier Electron argv build"
+    fi
+    kill "$SECOND_ELECTRON_PID"
+    wait "$LAUNCHER_PID"
+    LAUNCHER_PID=""
     printf '%s\n' "launcher ordinary-hook warm-start compatibility test passed"
     exit 0
 fi
@@ -376,6 +404,30 @@ if [ "$CHROMIUM_SANDBOX_RESIDENT_REJECTION" = "1" ]; then
     kill "$FIRST_ELECTRON_PID"
     wait "$LAUNCHER_PID"
     LAUNCHER_PID=""
+
+    # A different checkout with the same isolated test identity participates
+    # in the same Electron single-instance namespace. With every shared runtime
+    # marker absent, the strict scan must reject that foreign resident too.
+    mkdir -p "$FOREIGN_APP_DIR"
+    cp "$APP_DIR/electron" "$FOREIGN_APP_DIR/electron"
+    CODEX_LINUX_APP_ID="$TEST_APP_ID" \
+        "$FOREIGN_APP_DIR/electron" --app-id="$TEST_APP_ID" &
+    FOREIGN_ELECTRON_PID=$!
+    wait_for "foreign compatibility resident" kill -0 "$FOREIGN_ELECTRON_PID"
+    rm -f "$STATE_DIR/app.pid" "$STATE_DIR/webview.pid" "$SOCKET_PATH"
+    : > "$SECOND_LOG"
+    if timeout 5s "${COMMON_ENV[@]}" "$APP_DIR/start.sh" >> "$SECOND_LOG" 2>&1; then
+        fail "sandbox-requested foreign markerless-resident launch silently succeeded"
+    fi
+    grep -q "Another ChatGPT Desktop is already running" "$APP_LOG" \
+        || fail "foreign markerless resident was not rejected by the strict scan"
+    grep -q "using Electron second-instance handoff" "$SECOND_LOG" \
+        && fail "foreign markerless sandbox request reached Electron handoff before rejection"
+    kill -0 "$FOREIGN_ELECTRON_PID" 2>/dev/null \
+        || fail "foreign markerless-resident rejection disturbed the compatibility resident"
+    kill "$FOREIGN_ELECTRON_PID"
+    wait "$FOREIGN_ELECTRON_PID"
+    FOREIGN_ELECTRON_PID=""
     printf '%s\n' "launcher Chromium sandbox compatibility-resident handoff rejection test passed"
     exit 0
 fi

--- a/tests/launcher_warm_start_recovery.sh
+++ b/tests/launcher_warm_start_recovery.sh
@@ -18,6 +18,7 @@ FIRST_LOG="$TMP_DIR/first-launch.log"
 SECOND_LOG="$TMP_DIR/second-launch.log"
 APP_LOG="$HOME_DIR/.cache/$TEST_APP_ID/launcher.log"
 CHROMIUM_SANDBOX_RESIDENT_REJECTION="${CODEX_TEST_CHROMIUM_SANDBOX_RESIDENT_REJECTION:-0}"
+ORDINARY_HOOK_WARM_COMPAT="${CODEX_TEST_ORDINARY_HOOK_WARM_COMPAT:-0}"
 LAUNCHER_PID=""
 SOCKET_PID=""
 HOOK_PID=""
@@ -95,6 +96,31 @@ webview_is_down() {
         "http://127.0.0.1:$PORT/index.html" >/dev/null 2>&1
 }
 
+start_launch_action_socket() {
+    python3 - "$SOCKET_PATH" <<'PY' &
+import os
+import socket
+import sys
+
+path = sys.argv[1]
+os.makedirs(os.path.dirname(path), exist_ok=True)
+try:
+    os.unlink(path)
+except FileNotFoundError:
+    pass
+with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+    server.bind(path)
+    server.listen()
+    while True:
+        client, _ = server.accept()
+        with client:
+            client.recv(65536)
+            client.sendall(b"ok\n")
+PY
+    SOCKET_PID=$!
+    wait_for "launch-action socket" test -S "$SOCKET_PATH"
+}
+
 mkdir -p \
     "$APP_DIR/.codex-linux/cold-start.d" \
     "$APP_DIR/.codex-linux/env.d" \
@@ -102,6 +128,7 @@ mkdir -p \
     "$APP_DIR/.codex-linux/prelaunch.d" \
     "$APP_DIR/.codex-linux/electron-args.d" \
     "$APP_DIR/.codex-linux/launcher.d" \
+    "$APP_DIR/.codex-linux/pre-handoff-launcher.d" \
     "$APP_DIR/.codex-linux/after-exit.d" \
     "$APP_DIR/content/webview" \
     "$APP_DIR/resources/node-runtime/bin" \
@@ -183,28 +210,7 @@ if [ "$APPIMAGE_RECOVERY" = "1" ]; then
     touch "$APPIMAGE_PATH"
 fi
 
-python3 - "$SOCKET_PATH" <<'PY' &
-import os
-import socket
-import sys
-
-path = sys.argv[1]
-os.makedirs(os.path.dirname(path), exist_ok=True)
-try:
-    os.unlink(path)
-except FileNotFoundError:
-    pass
-with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
-    server.bind(path)
-    server.listen()
-    while True:
-        client, _ = server.accept()
-        with client:
-            client.recv(65536)
-            client.sendall(b"ok\n")
-PY
-SOCKET_PID=$!
-wait_for "launch-action socket" test -S "$SOCKET_PATH"
+start_launch_action_socket
 
 COMMON_ENV=(
     env -i
@@ -278,14 +284,47 @@ if [ "${CODEX_TEST_TERM_STATUS:-0}" = "1" ]; then
     exit 0
 fi
 
+if [ "$ORDINARY_HOOK_WARM_COMPAT" = "1" ]; then
+    kill "$SOCKET_PID"
+    wait "$SOCKET_PID" 2>/dev/null || true
+    SOCKET_PID=""
+    start_launch_action_socket
+    cat > "$APP_DIR/.codex-linux/launcher.d/failing-ordinary-hook" <<'HOOK'
+#!/usr/bin/env bash
+exit 23
+HOOK
+    chmod +x "$APP_DIR/.codex-linux/launcher.d/failing-ordinary-hook"
+
+    : > "$SECOND_LOG"
+    if ! "${COMMON_ENV[@]}" "$APP_DIR/start.sh" >> "$SECOND_LOG" 2>&1; then
+        fail "ordinary launcher-hook failure changed the successful warm-start contract"
+    fi
+    grep -q "Sent launch args over warm-start IPC" "$APP_LOG" \
+        || fail "ordinary warm start performed cold-launch preparation before IPC"
+    grep -q "Running Linux feature launcher hook: .*failing-ordinary-hook" "$APP_LOG" \
+        && fail "ordinary launcher hook ran before successful warm-start IPC"
+    kill -0 "$FIRST_ELECTRON_PID" 2>/dev/null \
+        || fail "ordinary warm start disturbed the healthy resident"
+
+    kill "$FIRST_ELECTRON_PID"
+    wait "$LAUNCHER_PID"
+    LAUNCHER_PID=""
+    printf '%s\n' "launcher ordinary-hook warm-start compatibility test passed"
+    exit 0
+fi
+
 if [ "$CHROMIUM_SANDBOX_RESIDENT_REJECTION" = "1" ]; then
+    kill "$SOCKET_PID"
+    wait "$SOCKET_PID" 2>/dev/null || true
+    SOCKET_PID=""
+    start_launch_action_socket
     # The resident was launched without the feature and therefore uses the
     # compatibility sandbox-disable defaults. Stage the feature only for the
     # requesting launch. Its resident rejection runs before helper validation,
     # so this full-path CI regression needs no privileged SUID fixture.
     cp "$REPO_DIR/linux-features/chromium-sandbox/launcher-hook.sh" \
-        "$APP_DIR/.codex-linux/launcher.d/chromium-sandbox-chromium-sandbox.sh"
-    chmod +x "$APP_DIR/.codex-linux/launcher.d/chromium-sandbox-chromium-sandbox.sh"
+        "$APP_DIR/.codex-linux/pre-handoff-launcher.d/chromium-sandbox-chromium-sandbox.sh"
+    chmod +x "$APP_DIR/.codex-linux/pre-handoff-launcher.d/chromium-sandbox-chromium-sandbox.sh"
 
     : > "$SECOND_LOG"
     if "${COMMON_ENV[@]}" "$APP_DIR/start.sh" >> "$SECOND_LOG" 2>&1; then
@@ -310,6 +349,29 @@ if [ "$CHROMIUM_SANDBOX_RESIDENT_REJECTION" = "1" ]; then
         && fail "sandbox request reached Electron second-instance handoff before rejection"
     kill -0 "$FIRST_ELECTRON_PID" 2>/dev/null \
         || fail "sandbox-requested second-instance rejection disturbed the healthy compatibility resident"
+
+    # Re-enable warm start, then remove every runtime marker while the
+    # compatibility-mode primary remains alive. The strict hook must still
+    # discover the resident under the launcher lock and reject before either
+    # launcher IPC or Electron's second-instance handoff.
+    printf '%s\n' '{"codex-linux-warm-start-enabled":true}' \
+        > "$HOME_DIR/.config/$TEST_APP_ID/settings.json"
+    rm -f "$STATE_DIR/app.pid" "$STATE_DIR/webview.pid" "$SOCKET_PATH"
+    [ ! -e "$STATE_DIR/app.pid" ] && [ ! -e "$STATE_DIR/webview.pid" ] \
+        && [ ! -e "$SOCKET_PATH" ] \
+        || fail "could not remove every runtime marker for the markerless-resident regression"
+    : > "$SECOND_LOG"
+    if "${COMMON_ENV[@]}" "$APP_DIR/start.sh" >> "$SECOND_LOG" 2>&1; then
+        fail "sandbox-requested markerless-resident launch silently succeeded"
+    fi
+    [ "$(grep -c "sandbox mode cannot be authoritatively verified" "$APP_LOG")" -ge 3 ] \
+        || fail "markerless resident was not rediscovered for strict pre-handoff rejection"
+    grep -q "Sent launch args over warm-start IPC" "$SECOND_LOG" \
+        && fail "markerless sandbox request reached launcher IPC before rejection"
+    grep -q "using Electron second-instance handoff" "$SECOND_LOG" \
+        && fail "markerless sandbox request reached Electron second-instance handoff before rejection"
+    kill -0 "$FIRST_ELECTRON_PID" 2>/dev/null \
+        || fail "markerless-resident rejection disturbed the healthy compatibility resident"
 
     kill "$FIRST_ELECTRON_PID"
     wait "$LAUNCHER_PID"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1457,6 +1457,8 @@ test_appimage_builder_smoke() {
     local target_triple
     local platform_version_suffix
     local arch
+    local feature_config="$workspace/features.json"
+    local incompatible_log="$workspace/incompatible-feature.log"
 
     case "$(uname -m)" in
         x86_64)
@@ -1549,6 +1551,32 @@ SCRIPT
     assert_not_contains "$capture_dir/AppDir/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh" "/usr/share/applications"
     [ "$(cat "$capture_dir/arch")" = "$arch" ] || fail "Expected appimagetool ARCH=$arch"
     [ "$(cat "$capture_dir/version")" = "2026.03.24.120000+appimage" ] || fail "Expected appimagetool VERSION override"
+
+    printf '%s\n' '{"enabled":["chromium-sandbox"]}' > "$feature_config"
+    printf '%s\n' '{"schemaVersion":1,"linuxFeatures":{"enabled":["chromium-sandbox"]}}' \
+        > "$app_dir/.codex-linux/build-info.json"
+    rm -rf "$capture_dir" "$appdir"
+    rm -f "$dist_dir/codex-desktop-2026.03.24.120000+appimage-incompatible-$arch.AppImage"
+    if PATH="$bin_dir:$PATH" \
+        CAPTURE_DIR="$capture_dir" \
+        APP_DIR_OVERRIDE="$app_dir" \
+        DIST_DIR_OVERRIDE="$dist_dir" \
+        APPIMAGE_APPDIR_OVERRIDE="$appdir" \
+        CODEX_LINUX_FEATURES_CONFIG="$feature_config" \
+        PACKAGE_VERSION="2026.03.24.120000+appimage-incompatible" \
+        bash "$REPO_DIR/scripts/build-appimage.sh" >"$incompatible_log" 2>&1; then
+        fail "AppImage build must reject an enabled feature declared incompatible before artifact emission"
+    fi
+    assert_contains "$incompatible_log" "chromium-sandbox"
+    assert_contains "$incompatible_log" "incompatible with appimage"
+    assert_file_not_exists "$dist_dir/codex-desktop-2026.03.24.120000+appimage-incompatible-$arch.AppImage"
+    assert_file_not_exists "$capture_dir/AppDir"
+
+    printf '%s\n' '{"enabled":[]}' > "$feature_config"
+    printf '%s\n' '{"schemaVersion":1,"linuxFeatures":{"enabled":[]}}' \
+        > "$app_dir/.codex-linux/build-info.json"
+    rm -rf "$capture_dir"
+    mkdir -p "$capture_dir"
 
     if [ "$arch" = "armhf" ]; then
         return 0
@@ -2748,6 +2776,87 @@ test_candidate_promotion_refuses_a_running_final_app() {
         promote_candidate_install "$workspace/candidate" "$workspace/final"
     )
     [ "$(cat "$workspace/final/version")" = "new" ] || fail "Promotion did not succeed after the app exited"
+}
+
+test_candidate_promotion_feature_compatibility_gate() {
+    info "Checking enabled-feature promotion compatibility before journal or exchange"
+    local workspace="$TMP_DIR/candidate-feature-compatibility"
+    local candidate="$workspace/candidate"
+    local final="$workspace/final"
+    local external_helper="$workspace/external-helper"
+    local feature_config="$workspace/features.json"
+    local stat_bin="$workspace/bin"
+    local refusal_log="$workspace/refusal.log"
+
+    mkdir -p \
+        "$candidate/.codex-linux/features/chromium-sandbox" \
+        "$final" \
+        "$stat_bin"
+    printf '%s\n' old > "$final/version"
+    printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" working-old' > "$final/start.sh"
+    chmod +x "$final/start.sh"
+    printf '%s\n' new > "$candidate/version"
+    printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" working-new' > "$candidate/start.sh"
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$candidate/electron"
+    chmod +x "$candidate/start.sh" "$candidate/electron"
+    printf '%s\n' new-helper \
+        > "$candidate/.codex-linux/features/chromium-sandbox/generated-chrome-sandbox"
+    chmod +x "$candidate/.codex-linux/features/chromium-sandbox/generated-chrome-sandbox"
+    printf '%s\n' old-helper > "$external_helper"
+    chmod +x "$external_helper"
+    printf '%s\n' '{"schemaVersion":1,"linuxFeatures":{"enabled":["chromium-sandbox"]}}' \
+        > "$candidate/.codex-linux/build-info.json"
+    printf '%s\n' '{"enabled":["chromium-sandbox"]}' > "$feature_config"
+    printf '%s\n' '#!/usr/bin/env bash' "printf '%s\\n' '0:0:4755'" > "$stat_bin/stat"
+    chmod +x "$stat_bin/stat"
+
+    if (
+        info() { :; }
+        warn() { echo "$*" >&2; }
+        error() { echo "$*" >&2; return 1; }
+        assert_install_target_not_running() { :; }
+        export SCRIPT_DIR="$REPO_DIR"
+        export INSTALL_DIR="$final"
+        export WORK_DIR="$workspace/work"
+        export ARCH="$(uname -m)"
+        export CODEX_LINUX_FEATURES_CONFIG="$feature_config"
+        export CHROME_DEVEL_SANDBOX="$external_helper"
+        export PATH="$stat_bin:$PATH"
+        # shellcheck source=scripts/lib/linux-features.sh
+        . "$REPO_DIR/scripts/lib/linux-features.sh"
+        # shellcheck source=scripts/lib/candidate-install.sh
+        . "$REPO_DIR/scripts/lib/candidate-install.sh"
+        promote_candidate_install "$candidate" "$final"
+    ) >"$refusal_log" 2>&1; then
+        fail "Promotion accepted a candidate whose external dependency matched only the working app"
+    fi
+    assert_contains "$refusal_log" "chromium-sandbox"
+    [ "$(cat "$final/version")" = "old" ] || fail "Compatibility refusal replaced the working app"
+    [ "$("$final/start.sh")" = "working-old" ] || fail "Compatibility refusal left the working app unlaunchable"
+    [ "$(cat "$candidate/version")" = "new" ] || fail "Compatibility refusal changed the candidate"
+    [ ! -e "$workspace/.final.promotion.json" ] || fail "Compatibility refusal created a promotion journal"
+    if find "$workspace" -maxdepth 1 -type d -name 'final.backup-*' -print -quit | grep -q .; then
+        fail "Compatibility refusal created a previous-app backup"
+    fi
+
+    cp "$candidate/.codex-linux/features/chromium-sandbox/generated-chrome-sandbox" "$external_helper"
+    (
+        info() { :; }
+        warn() { :; }
+        error() { echo "$*" >&2; exit 1; }
+        assert_install_target_not_running() { :; }
+        export SCRIPT_DIR="$REPO_DIR"
+        export INSTALL_DIR="$final"
+        export WORK_DIR="$workspace/work"
+        export ARCH="$(uname -m)"
+        export CODEX_LINUX_FEATURES_CONFIG="$feature_config"
+        export CHROME_DEVEL_SANDBOX="$external_helper"
+        export PATH="$stat_bin:$PATH"
+        . "$REPO_DIR/scripts/lib/linux-features.sh"
+        . "$REPO_DIR/scripts/lib/candidate-install.sh"
+        promote_candidate_install "$candidate" "$final"
+    )
+    [ "$(cat "$final/version")" = "new" ] || fail "Qualified feature candidate was not promoted"
 }
 
 test_candidate_backup_retention_is_bounded() {
@@ -5603,7 +5712,7 @@ webview_probe_body = source.split("webview_port_is_open() {", 1)[1].split("wait_
 wait_body = source.split("wait_for_webview_server() {", 1)[1].split("verify_webview_origin() {", 1)[0]
 send_body = source.split("send_warm_start_launch_action() {", 1)[1].split("webview_origin_is_reachable() {", 1)[0]
 prelaunch_hooks_body = source.split("run_feature_prelaunch_hooks() {", 1)[1].split("bundled_plugin_version() {", 1)[0]
-launcher_hooks_body = source.split("run_feature_launcher_hooks() {", 1)[1].split("build_electron_launch_args() {", 1)[0]
+launcher_hooks_body = source.split("run_feature_launcher_hooks_from_dir() {", 1)[1].split("build_electron_launch_args() {", 1)[0]
 cold_start_hooks_body = source.split("run_cold_start_hooks() {", 1)[1].split("run_cli_preflight() {", 1)[0]
 after_exit_hooks_body = source.split("run_feature_after_exit_hooks() {", 1)[1].split("run_cli_preflight() {", 1)[0]
 cli_probe_body = source.split("codex_cli_version_probe() {", 1)[1].split("codex_cli_version() {", 1)[0]
@@ -5856,7 +5965,7 @@ if 'codex_run_host_command notify-send' not in notify_body:
     raise SystemExit("desktop notifications must not inherit packaged LD_LIBRARY_PATH")
 if 'codex_run_host_command "$CODEX_UPDATE_MANAGER_PATH" "$@"' not in update_manager_body:
     raise SystemExit("update manager and its host children must not inherit packaged LD_LIBRARY_PATH")
-if 'CODEX_LINUX_FEATURE_HOOK_PHASE=launcher' not in launcher_hooks_body:
+if 'CODEX_LINUX_FEATURE_HOOK_PHASE="$hook_phase"' not in launcher_hooks_body:
     raise SystemExit("launcher hooks must receive their hook phase")
 if '"$hook" "${ELECTRON_ARGS[@]}"' not in launcher_hooks_body:
     raise SystemExit("launcher hooks must receive current Electron args as argv")
@@ -6014,6 +6123,7 @@ LOG_FILE="${LOG_FILE:-/tmp/codex-launcher-probe.log}"
 CODEX_LINUX_FEATURES_DIR="${CODEX_LINUX_FEATURES_DIR:-$SCRIPT_DIR/.codex-linux/features}"
 FEATURE_ELECTRON_ARGS_DIR="${FEATURE_ELECTRON_ARGS_DIR:-}"
 FEATURE_LAUNCHER_HOOK_DIR="${FEATURE_LAUNCHER_HOOK_DIR:-}"
+FEATURE_PRE_HANDOFF_LAUNCHER_HOOK_DIR="${FEATURE_PRE_HANDOFF_LAUNCHER_HOOK_DIR:-}"
 ELECTRON_DEFAULT_ARG_REMOVALS=()
 ELECTRON_ARG_DENY_PATTERNS=()
 FEATURE_LOCKED_ENV_NAMES=()
@@ -6048,6 +6158,7 @@ case "${1:-}" in
         load_feature_electron_args
         load_user_electron_flags
         set_electron_defaults "${FEATURE_ELECTRON_ARGS[@]}" "${USER_ELECTRON_FLAGS[@]}" "$@"
+        run_feature_pre_handoff_launcher_hooks
         run_feature_launcher_hooks
         build_electron_launch_args
         validate_feature_electron_arg_denials
@@ -6131,7 +6242,8 @@ EOF
     [[ "$output" != *"<--ozone-platform-hint=auto>"* ]] || fail "launcher must not add ozone hint when pass-through supplies an ozone platform: $output"
 
     local feature_launcher_hook_dir="$TMP_DIR/feature-launcher-hooks"
-    mkdir -p "$feature_launcher_hook_dir"
+    local pre_handoff_launcher_hook_dir="$TMP_DIR/pre-handoff-launcher-hooks"
+    mkdir -p "$feature_launcher_hook_dir" "$pre_handoff_launcher_hook_dir"
     cat > "$feature_launcher_hook_dir/generic-hook" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' 'env CODEX_TEST_LAUNCHER_HOOK_VALUE=from-hook'
@@ -6162,71 +6274,73 @@ EOF
     printf '%s\n' '#!/usr/bin/env bash' "printf '%s\\n' '0:0:4755'" \
         > "$chromium_stat_stub_dir/stat"
     cp "$REPO_DIR/linux-features/chromium-sandbox/launcher-hook.sh" \
-        "$feature_launcher_hook_dir/chromium-sandbox-hook"
+        "$pre_handoff_launcher_hook_dir/chromium-sandbox-hook"
     chmod +x "$chromium_generated_helper" "$chromium_external_helper" \
         "$chromium_app_dir/electron" "$chromium_stat_stub_dir/stat" \
-        "$feature_launcher_hook_dir/chromium-sandbox-hook"
+        "$pre_handoff_launcher_hook_dir/chromium-sandbox-hook"
     output="$(env -i PATH="$chromium_stat_stub_dir:$PATH" HOME="$HOME" \
         SCRIPT_DIR="$chromium_app_dir" CODEX_LINUX_FEATURES_DIR="$chromium_features_dir" \
-        FEATURE_LAUNCHER_HOOK_DIR="$feature_launcher_hook_dir" \
+        FEATURE_PRE_HANDOFF_LAUNCHER_HOOK_DIR="$pre_handoff_launcher_hook_dir" \
         CHROME_DEVEL_SANDBOX="$chromium_external_helper" \
         CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
     [[ "$output" == *"sandbox_helper=$chromium_external_helper launch="* ]] \
         || fail "launcher must preserve the exact helper pathname validated by the feature: $output"
     [[ "$output" != *"<--no-sandbox>"* && "$output" != *"<--disable-gpu-sandbox>"* ]] \
         || fail "qualified Chromium feature must remove sandbox-disabling defaults: $output"
-    rm -f "$feature_launcher_hook_dir/chromium-sandbox-hook"
+    rm -f "$pre_handoff_launcher_hook_dir/chromium-sandbox-hook"
 
     printf '%s\n' '#!/usr/bin/env bash' 'exit 23' > "$feature_launcher_hook_dir/failing-hook"
     chmod +x "$feature_launcher_hook_dir/failing-hook"
-    if env -i PATH="$PATH" HOME="$HOME" FEATURE_LAUNCHER_HOOK_DIR="$feature_launcher_hook_dir" \
+    if ! env -i PATH="$PATH" HOME="$HOME" FEATURE_LAUNCHER_HOOK_DIR="$feature_launcher_hook_dir" \
         CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe >/dev/null 2>&1; then
-        fail "an enabled launcher hook process failure must fail closed"
+        fail "an ordinary launcher hook process failure must remain fail-soft"
     fi
     rm -f "$feature_launcher_hook_dir/failing-hook"
 
     printf '%s\n' '#!/usr/bin/env bash' \
         "printf '%s\\n' 'electron-default-arg-remove --no-sandbox' 'electron-default-arg-remove --disable-gpu-sandbox'" \
-        > "$feature_launcher_hook_dir/default-removal-hook"
-    chmod +x "$feature_launcher_hook_dir/default-removal-hook"
-    output="$(env -i PATH="$PATH" HOME="$HOME" FEATURE_LAUNCHER_HOOK_DIR="$feature_launcher_hook_dir" \
+        > "$pre_handoff_launcher_hook_dir/default-removal-hook"
+    chmod +x "$pre_handoff_launcher_hook_dir/default-removal-hook"
+    output="$(env -i PATH="$PATH" HOME="$HOME" FEATURE_PRE_HANDOFF_LAUNCHER_HOOK_DIR="$pre_handoff_launcher_hook_dir" \
         CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
     [[ "$output" != *"<--no-sandbox>"* && "$output" != *"<--disable-gpu-sandbox>"* ]] \
         || fail "a launcher hook must be able to remove exact generic Electron defaults: $output"
-    rm -f "$feature_launcher_hook_dir/default-removal-hook"
+    rm -f "$pre_handoff_launcher_hook_dir/default-removal-hook"
 
     printf '%s\n' '#!/usr/bin/env bash' \
         "printf '%s\\n' 'env CODEX_TEST_LOCKED_VALUE=qualified' 'env-lock CODEX_TEST_LOCKED_VALUE'" \
-        > "$feature_launcher_hook_dir/a-lock-hook"
+        > "$pre_handoff_launcher_hook_dir/a-lock-hook"
     printf '%s\n' '#!/usr/bin/env bash' \
         "printf '%s\\n' 'env CODEX_TEST_LOCKED_VALUE=overridden'" \
-        > "$feature_launcher_hook_dir/z-override-hook"
-    chmod +x "$feature_launcher_hook_dir/a-lock-hook" "$feature_launcher_hook_dir/z-override-hook"
-    if env -i PATH="$PATH" HOME="$HOME" FEATURE_LAUNCHER_HOOK_DIR="$feature_launcher_hook_dir" \
+        > "$pre_handoff_launcher_hook_dir/z-override-hook"
+    chmod +x "$pre_handoff_launcher_hook_dir/a-lock-hook" "$pre_handoff_launcher_hook_dir/z-override-hook"
+    if env -i PATH="$PATH" HOME="$HOME" FEATURE_PRE_HANDOFF_LAUNCHER_HOOK_DIR="$pre_handoff_launcher_hook_dir" \
         CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe >/dev/null 2>&1; then
         fail "a later launcher hook must not override a locked environment value"
     fi
-    rm -f "$feature_launcher_hook_dir/a-lock-hook" "$feature_launcher_hook_dir/z-override-hook"
+    rm -f "$pre_handoff_launcher_hook_dir/a-lock-hook" "$pre_handoff_launcher_hook_dir/z-override-hook"
 
     printf '%s\n' '#!/usr/bin/env bash' "printf '%s\\n' 'electron-arg-deny --no-sandbox'" \
-        > "$feature_launcher_hook_dir/default-deny-hook"
-    chmod +x "$feature_launcher_hook_dir/default-deny-hook"
-    if env -i PATH="$PATH" HOME="$HOME" FEATURE_LAUNCHER_HOOK_DIR="$feature_launcher_hook_dir" \
+        > "$pre_handoff_launcher_hook_dir/default-deny-hook"
+    chmod +x "$pre_handoff_launcher_hook_dir/default-deny-hook"
+    if env -i PATH="$PATH" HOME="$HOME" FEATURE_PRE_HANDOFF_LAUNCHER_HOOK_DIR="$pre_handoff_launcher_hook_dir" \
         CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe >/dev/null 2>&1; then
         fail "a final Electron arg deny pattern must inspect generic core defaults"
     fi
-    rm -f "$feature_launcher_hook_dir/default-deny-hook"
+    rm -f "$pre_handoff_launcher_hook_dir/default-deny-hook"
 
     printf '%s\n' '#!/usr/bin/env bash' "printf '%s\\n' 'electron-arg-deny --disable-*-sandbox'" \
-        > "$feature_launcher_hook_dir/a-deny-hook"
+        > "$pre_handoff_launcher_hook_dir/a-deny-hook"
     printf '%s\n' '#!/usr/bin/env bash' "printf '%s\\n' 'electron-arg --disable-late-sandbox'" \
         > "$feature_launcher_hook_dir/z-late-hook"
-    chmod +x "$feature_launcher_hook_dir/a-deny-hook" "$feature_launcher_hook_dir/z-late-hook"
-    if env -i PATH="$PATH" HOME="$HOME" FEATURE_LAUNCHER_HOOK_DIR="$feature_launcher_hook_dir" \
+    chmod +x "$pre_handoff_launcher_hook_dir/a-deny-hook" "$feature_launcher_hook_dir/z-late-hook"
+    if env -i PATH="$PATH" HOME="$HOME" \
+        FEATURE_PRE_HANDOFF_LAUNCHER_HOOK_DIR="$pre_handoff_launcher_hook_dir" \
+        FEATURE_LAUNCHER_HOOK_DIR="$feature_launcher_hook_dir" \
         CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe >/dev/null 2>&1; then
         fail "a final Electron arg deny pattern must reject switches from later launcher hooks"
     fi
-    rm -f "$feature_launcher_hook_dir/a-deny-hook" "$feature_launcher_hook_dir/z-late-hook"
+    rm -f "$pre_handoff_launcher_hook_dir/a-deny-hook" "$feature_launcher_hook_dir/z-late-hook"
 
     local user_flags_dir="$TMP_DIR/user-electron-flags"
     local user_flags_file="$user_flags_dir/electron-flags.conf"
@@ -11265,6 +11379,8 @@ test_launcher_warm_start_recovery() {
     CODEX_TEST_KILL_DURING_PRELAUNCH=1 bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
     CODEX_TEST_CHROMIUM_SANDBOX_RESIDENT_REJECTION=1 \
         bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
+    CODEX_TEST_ORDINARY_HOOK_WARM_COMPAT=1 \
+        bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
     CODEX_TEST_DISABLE_PIDFD=1 CODEX_TEST_NORMAL_LOCK_ONLY=1 \
         bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
     CODEX_TEST_DISABLE_PIDFD=1 CODEX_TEST_KILL_DURING_PRELAUNCH=1 \
@@ -11438,6 +11554,7 @@ main() {
     test_update_manager_service_helper_respects_disabled_service
     test_rpm_builder_smoke
     test_pacman_builder_without_updater_transition_hook
+    test_candidate_promotion_feature_compatibility_gate
     test_appimage_builder_smoke
     test_missing_input_failure
     test_make_install_reports_missing_native_packages

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6019,7 +6019,7 @@ ELECTRON_ARG_DENY_PATTERNS=()
 FEATURE_LOCKED_ENV_NAMES=()
 
 print_state() {
-    printf 'mode=%s wslg=%s ozone_platform=%s ozone_hint=%s gpu=%s gpu_arg=%s comp=%s gl_added=%s renderer_accessibility=%s hook_value=%s hook_saw_arg=%s launch=' \
+    printf 'mode=%s wslg=%s ozone_platform=%s ozone_hint=%s gpu=%s gpu_arg=%s comp=%s gl_added=%s renderer_accessibility=%s hook_value=%s hook_saw_arg=%s sandbox_helper=%s launch=' \
         "$ELECTRON_RENDERING_MODE" \
         "$ELECTRON_WSLG_DETECTED" \
         "${ELECTRON_OZONE_PLATFORM:-}" \
@@ -6030,7 +6030,8 @@ print_state() {
         "$ELECTRON_GL_SWITCH_ADDED" \
         "$ELECTRON_RENDERER_ACCESSIBILITY_FORCED" \
         "${CODEX_TEST_LAUNCHER_HOOK_VALUE:-}" \
-        "${CODEX_TEST_LAUNCHER_HOOK_SAW_ARG:-}"
+        "${CODEX_TEST_LAUNCHER_HOOK_SAW_ARG:-}" \
+        "${CHROME_DEVEL_SANDBOX:-}"
     for arg in "${ELECTRON_LAUNCH_ARGS[@]}"; do
         printf '<%s>' "$arg"
     done
@@ -6147,6 +6148,34 @@ EOF
     [[ "$output" == *"hook_value=from-hook hook_saw_arg=1"* ]] || fail "launcher hook must contribute environment variables and receive current Electron args: $output"
     [[ "$output" == *"electron=<--existing-electron-arg><--test-feature-launcher-hook=1>"* ]] || fail "launcher hook must append Electron args after existing args: $output"
     [[ "$output" == *"<--enable-features=TestHookFeature>"* ]] || fail "launcher hook enable-features output must merge into launch args: $output"
+    rm -f "$feature_launcher_hook_dir/generic-hook"
+
+    local chromium_app_dir="$TMP_DIR/chromium sandbox=app"
+    local chromium_features_dir="$chromium_app_dir/.codex-linux/features"
+    local chromium_generated_helper="$chromium_features_dir/chromium-sandbox/generated-chrome-sandbox"
+    local chromium_external_helper="$TMP_DIR/chromium helper=value"
+    local chromium_stat_stub_dir="$TMP_DIR/chromium-stat-stub"
+    mkdir -p "$(dirname "$chromium_generated_helper")" "$chromium_stat_stub_dir"
+    printf '%s\n' 'matching helper' > "$chromium_generated_helper"
+    cp "$chromium_generated_helper" "$chromium_external_helper"
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$chromium_app_dir/electron"
+    printf '%s\n' '#!/usr/bin/env bash' "printf '%s\\n' '0:0:4755'" \
+        > "$chromium_stat_stub_dir/stat"
+    cp "$REPO_DIR/linux-features/chromium-sandbox/launcher-hook.sh" \
+        "$feature_launcher_hook_dir/chromium-sandbox-hook"
+    chmod +x "$chromium_generated_helper" "$chromium_external_helper" \
+        "$chromium_app_dir/electron" "$chromium_stat_stub_dir/stat" \
+        "$feature_launcher_hook_dir/chromium-sandbox-hook"
+    output="$(env -i PATH="$chromium_stat_stub_dir:$PATH" HOME="$HOME" \
+        SCRIPT_DIR="$chromium_app_dir" CODEX_LINUX_FEATURES_DIR="$chromium_features_dir" \
+        FEATURE_LAUNCHER_HOOK_DIR="$feature_launcher_hook_dir" \
+        CHROME_DEVEL_SANDBOX="$chromium_external_helper" \
+        CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
+    [[ "$output" == *"sandbox_helper=$chromium_external_helper launch="* ]] \
+        || fail "launcher must preserve the exact helper pathname validated by the feature: $output"
+    [[ "$output" != *"<--no-sandbox>"* && "$output" != *"<--disable-gpu-sandbox>"* ]] \
+        || fail "qualified Chromium feature must remove sandbox-disabling defaults: $output"
+    rm -f "$feature_launcher_hook_dir/chromium-sandbox-hook"
 
     printf '%s\n' '#!/usr/bin/env bash' 'exit 23' > "$feature_launcher_hook_dir/failing-hook"
     chmod +x "$feature_launcher_hook_dir/failing-hook"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1442,6 +1442,53 @@ SCRIPT
     assert_not_contains "$capture_dir/codex-desktop.install" "update-builder"
 }
 
+test_native_builder_feature_compatibility_gate() {
+    info "Checking native builders enforce enabled-feature compatibility before staging"
+    local workspace="$TMP_DIR/native-feature-compatibility"
+    local app_dir="$workspace/app"
+    local features_root="$workspace/linux-features"
+    local feature_config="$features_root/features.json"
+    local feature_dir="$features_root/native-incompatible"
+    local format
+    local output_log
+
+    make_fake_app "$app_dir"
+    mkdir -p "$feature_dir"
+    printf '%s\n' '# Native Incompatible' > "$feature_dir/README.md"
+    cat > "$feature_dir/feature.json" <<'JSON'
+{
+  "id": "native-incompatible",
+  "title": "Native Incompatible",
+  "description": "Native build compatibility regression fixture.",
+  "defaultEnabled": false,
+  "buildCompatibility": {
+    "unsupportedFormats": ["deb", "rpm", "pacman"],
+    "reason": "native fixture refusal"
+  }
+}
+JSON
+    printf '%s\n' '{"enabled":["native-incompatible"]}' > "$feature_config"
+    printf '%s\n' '{"schemaVersion":1,"linuxFeatures":{"enabled":["native-incompatible"]}}' \
+        > "$app_dir/.codex-linux/build-info.json"
+
+    for format in deb rpm pacman; do
+        output_log="$workspace/$format.log"
+        if APP_DIR_OVERRIDE="$app_dir" \
+            PKG_ROOT_OVERRIDE="$workspace/$format-root" \
+            DIST_DIR_OVERRIDE="$workspace/$format-dist" \
+            CODEX_LINUX_FEATURES_ROOT="$features_root" \
+            CODEX_LINUX_FEATURES_CONFIG="$feature_config" \
+            PACKAGE_WITH_UPDATER=0 \
+            bash "$REPO_DIR/scripts/build-$format.sh" > "$output_log" 2>&1; then
+            fail "$format builder accepted an enabled feature declared incompatible"
+        fi
+        assert_contains "$output_log" "native-incompatible"
+        assert_contains "$output_log" "incompatible with $format"
+        assert_file_not_exists "$workspace/$format-root"
+        assert_file_not_exists "$workspace/$format-dist"
+    done
+}
+
 test_appimage_builder_smoke() {
     info "Running AppImage packaging smoke test"
     local workspace="$TMP_DIR/appimage"
@@ -11554,6 +11601,7 @@ main() {
     test_update_manager_service_helper_respects_disabled_service
     test_rpm_builder_smoke
     test_pacman_builder_without_updater_transition_hook
+    test_native_builder_feature_compatibility_gate
     test_candidate_promotion_feature_compatibility_gate
     test_appimage_builder_smoke
     test_missing_input_failure

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5671,6 +5671,12 @@ if 'CODEX_ELECTRON_USER_DATA_DIR="$APP_STATE_DIR/electron-user-data"' not in mul
     raise SystemExit("multi-launch must force a per-instance Electron user-data dir")
 if 'send_warm_start_launch_action "${LAUNCHER_ARGS[@]}"' not in source:
     raise SystemExit("warm-start handoff must not receive launcher-only multi-launch flags")
+if 'prepare_electron_launch "${LAUNCHER_ARGS[@]}"' not in runtime_body:
+    raise SystemExit("launcher hooks must prepare the complete sanitized argv before resident handoff")
+if 'prepare_electron_launch "${LAUNCHER_ARGS[@]:1}"' in source:
+    raise SystemExit("pre-handoff launch preparation must not drop the first launcher argument")
+if runtime_body.index('prepare_electron_launch "${LAUNCHER_ARGS[@]}"') > runtime_body.index('send_warm_start_launch_action "${LAUNCHER_ARGS[@]}"'):
+    raise SystemExit("launcher hooks must reject before warm-start IPC")
 if "client.shutdown(socket.SHUT_WR)" not in send_body or "response = client.recv(32)" not in send_body:
     raise SystemExit("warm-start IPC client must read the Electron socket acknowledgement")
 if "running_app_is_active || return 1" not in send_body:
@@ -6008,6 +6014,9 @@ LOG_FILE="${LOG_FILE:-/tmp/codex-launcher-probe.log}"
 CODEX_LINUX_FEATURES_DIR="${CODEX_LINUX_FEATURES_DIR:-$SCRIPT_DIR/.codex-linux/features}"
 FEATURE_ELECTRON_ARGS_DIR="${FEATURE_ELECTRON_ARGS_DIR:-}"
 FEATURE_LAUNCHER_HOOK_DIR="${FEATURE_LAUNCHER_HOOK_DIR:-}"
+ELECTRON_DEFAULT_ARG_REMOVALS=()
+ELECTRON_ARG_DENY_PATTERNS=()
+FEATURE_LOCKED_ENV_NAMES=()
 
 print_state() {
     printf 'mode=%s wslg=%s ozone_platform=%s ozone_hint=%s gpu=%s gpu_arg=%s comp=%s gl_added=%s renderer_accessibility=%s hook_value=%s hook_saw_arg=%s launch=' \
@@ -6040,6 +6049,7 @@ case "${1:-}" in
         set_electron_defaults "${FEATURE_ELECTRON_ARGS[@]}" "${USER_ELECTRON_FLAGS[@]}" "$@"
         run_feature_launcher_hooks
         build_electron_launch_args
+        validate_feature_electron_arg_denials
         print_state
         ;;
     ensure-template)
@@ -6137,6 +6147,57 @@ EOF
     [[ "$output" == *"hook_value=from-hook hook_saw_arg=1"* ]] || fail "launcher hook must contribute environment variables and receive current Electron args: $output"
     [[ "$output" == *"electron=<--existing-electron-arg><--test-feature-launcher-hook=1>"* ]] || fail "launcher hook must append Electron args after existing args: $output"
     [[ "$output" == *"<--enable-features=TestHookFeature>"* ]] || fail "launcher hook enable-features output must merge into launch args: $output"
+
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 23' > "$feature_launcher_hook_dir/failing-hook"
+    chmod +x "$feature_launcher_hook_dir/failing-hook"
+    if env -i PATH="$PATH" HOME="$HOME" FEATURE_LAUNCHER_HOOK_DIR="$feature_launcher_hook_dir" \
+        CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe >/dev/null 2>&1; then
+        fail "an enabled launcher hook process failure must fail closed"
+    fi
+    rm -f "$feature_launcher_hook_dir/failing-hook"
+
+    printf '%s\n' '#!/usr/bin/env bash' \
+        "printf '%s\\n' 'electron-default-arg-remove --no-sandbox' 'electron-default-arg-remove --disable-gpu-sandbox'" \
+        > "$feature_launcher_hook_dir/default-removal-hook"
+    chmod +x "$feature_launcher_hook_dir/default-removal-hook"
+    output="$(env -i PATH="$PATH" HOME="$HOME" FEATURE_LAUNCHER_HOOK_DIR="$feature_launcher_hook_dir" \
+        CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
+    [[ "$output" != *"<--no-sandbox>"* && "$output" != *"<--disable-gpu-sandbox>"* ]] \
+        || fail "a launcher hook must be able to remove exact generic Electron defaults: $output"
+    rm -f "$feature_launcher_hook_dir/default-removal-hook"
+
+    printf '%s\n' '#!/usr/bin/env bash' \
+        "printf '%s\\n' 'env CODEX_TEST_LOCKED_VALUE=qualified' 'env-lock CODEX_TEST_LOCKED_VALUE'" \
+        > "$feature_launcher_hook_dir/a-lock-hook"
+    printf '%s\n' '#!/usr/bin/env bash' \
+        "printf '%s\\n' 'env CODEX_TEST_LOCKED_VALUE=overridden'" \
+        > "$feature_launcher_hook_dir/z-override-hook"
+    chmod +x "$feature_launcher_hook_dir/a-lock-hook" "$feature_launcher_hook_dir/z-override-hook"
+    if env -i PATH="$PATH" HOME="$HOME" FEATURE_LAUNCHER_HOOK_DIR="$feature_launcher_hook_dir" \
+        CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe >/dev/null 2>&1; then
+        fail "a later launcher hook must not override a locked environment value"
+    fi
+    rm -f "$feature_launcher_hook_dir/a-lock-hook" "$feature_launcher_hook_dir/z-override-hook"
+
+    printf '%s\n' '#!/usr/bin/env bash' "printf '%s\\n' 'electron-arg-deny --no-sandbox'" \
+        > "$feature_launcher_hook_dir/default-deny-hook"
+    chmod +x "$feature_launcher_hook_dir/default-deny-hook"
+    if env -i PATH="$PATH" HOME="$HOME" FEATURE_LAUNCHER_HOOK_DIR="$feature_launcher_hook_dir" \
+        CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe >/dev/null 2>&1; then
+        fail "a final Electron arg deny pattern must inspect generic core defaults"
+    fi
+    rm -f "$feature_launcher_hook_dir/default-deny-hook"
+
+    printf '%s\n' '#!/usr/bin/env bash' "printf '%s\\n' 'electron-arg-deny --disable-*-sandbox'" \
+        > "$feature_launcher_hook_dir/a-deny-hook"
+    printf '%s\n' '#!/usr/bin/env bash' "printf '%s\\n' 'electron-arg --disable-late-sandbox'" \
+        > "$feature_launcher_hook_dir/z-late-hook"
+    chmod +x "$feature_launcher_hook_dir/a-deny-hook" "$feature_launcher_hook_dir/z-late-hook"
+    if env -i PATH="$PATH" HOME="$HOME" FEATURE_LAUNCHER_HOOK_DIR="$feature_launcher_hook_dir" \
+        CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe >/dev/null 2>&1; then
+        fail "a final Electron arg deny pattern must reject switches from later launcher hooks"
+    fi
+    rm -f "$feature_launcher_hook_dir/a-deny-hook" "$feature_launcher_hook_dir/z-late-hook"
 
     local user_flags_dir="$TMP_DIR/user-electron-flags"
     local user_flags_file="$user_flags_dir/electron-flags.conf"
@@ -11173,6 +11234,8 @@ test_launcher_warm_start_recovery() {
     CODEX_TEST_APPIMAGE_REMOUNT=1 bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
     CODEX_TEST_DISABLE_WARM_START=1 bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
     CODEX_TEST_KILL_DURING_PRELAUNCH=1 bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
+    CODEX_TEST_CHROMIUM_SANDBOX_RESIDENT_REJECTION=1 \
+        bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
     CODEX_TEST_DISABLE_PIDFD=1 CODEX_TEST_NORMAL_LOCK_ONLY=1 \
         bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
     CODEX_TEST_DISABLE_PIDFD=1 CODEX_TEST_KILL_DURING_PRELAUNCH=1 \


### PR DESCRIPTION
## Summary

Adds a disabled-by-default `linux-features/chromium-sandbox` module for a
host-qualified Chromium SUID sandbox in user-managed generated apps. When the
feature is disabled, ordinary warm/cold launches and existing fail-soft launcher
hook behavior remain unchanged.

When enabled, the feature:

- preserves Electron's generated helper as a provenance reference, keeps the
  sibling `chrome-sandbox` path absent, and requires a caller-selected absolute
  non-symlink root:root mode-4755 executable that is byte-identical to the
  reference;
- removes the shared sandbox-disabling defaults and rejects conflicting final
  Electron switches;
- rejects launch before warm IPC or Electron second-instance handoff when a
  same-install or foreign-install resident is present, including markerless
  residents, because the repository has no authoritative resident-mode
  attestation;
- rejects AppImage construction and native `.deb`, RPM, and pacman packaging
  before staging an unusable application; and
- revalidates the external helper against the exact candidate under the
  promotion lock before creating a new journal or exchanging app directories,
  leaving the working app untouched on refusal.

Shared core changes are limited to generic opt-in feature lifecycle hooks,
build-format compatibility checks, promotion compatibility checks, exact
default-argument removal, final-argument denial, and environment locking.
Chromium-specific paths, metadata, and policy remain in the feature module. The
Nix selector does not expose this feature because store Electron binaries are
root-owned.

## Validation

- Complete local CI-equivalent matrix passed on candidate
  `8ab60ce541bb573d036b1ea52dc7bc14666e4bb8`: Rust, Node, script smoke,
  DEB/RPM/pacman, Ubuntu 22.04, Ubuntu 24.04, Debian 12, all 294 Nix checks,
  and a real cached-upstream rebuild and transactional promotion.
- Full Linux-feature suite: 927 passed, 0 failed; focused final independent
  verification: 48/48 framework, Chromium, and conversation-delete tests.
- Real ordinary warm/cold launcher behavior and same-install/foreign-install
  markerless-resident rejection passed.
- The implementation builder repaired material independent-review findings,
  reran the complete matrix, and obtained fresh full-diff acceptance. A final
  separate Gary-style adversarial review returned `ACCEPT_FOR_GARY` with no
  material unresolved local issue.

GitHub workflow status for the exact published head is reported by the PR's
checks; local validation is not represented as GitHub CI.
