### PR TITLE
fix(launcher): resolve mise-installed codex and reject mise shim binary

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1954,14 +1954,15 @@ find_fnm_codex_cli() {
 }
 
 find_codex_cli() {
-    if command -v codex >/dev/null 2>&1; then
-        command -v codex
+    local path_hit
+    if path_hit="$(command -v codex 2>/dev/null || true)" && [ -n "$path_hit" ] && is_codex_cli_path "$path_hit"; then
+        echo "$path_hit"
         return 0
     fi
 
     if [ -n "${HOMEBREW_PREFIX:-}" ]; then
         local homebrew_candidate="$HOMEBREW_PREFIX/bin/codex"
-        if [ -x "$homebrew_candidate" ]; then
+        if [ -x "$homebrew_candidate" ] && is_codex_cli_path "$homebrew_candidate"; then
             echo "$homebrew_candidate"
             return 0
         fi
@@ -1983,8 +1984,8 @@ find_codex_cli() {
         export NVM_DIR="$nvm_dir"
         # shellcheck disable=SC1090
         . "$NVM_DIR/nvm.sh" >/dev/null 2>&1 || true
-        if command -v codex >/dev/null 2>&1; then
-            command -v codex
+        if path_hit="$(command -v codex 2>/dev/null || true)" && [ -n "$path_hit" ] && is_codex_cli_path "$path_hit"; then
+            echo "$path_hit"
             return 0
         fi
     fi

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1967,6 +1967,10 @@ find_codex_cli() {
         fi
     fi
 
+    if find_mise_codex_cli; then
+        return 0
+    fi
+
     local nvm_dir="${NVM_DIR:-}"
     if [ -z "$nvm_dir" ]; then
         if [ -s "${XDG_CONFIG_HOME:-$HOME/.config}/nvm/nvm.sh" ]; then
@@ -2003,12 +2007,59 @@ find_codex_cli() {
         "/usr/local/bin/codex" \
         "/usr/bin/codex"
     do
-        if [ -x "$candidate" ]; then
+        if [ -x "$candidate" ] && is_codex_cli_path "$candidate"; then
             echo "$candidate"
             return 0
         fi
     done
 
+    return 1
+}
+
+find_mise_codex_cli() {
+    # 优先用 mise which codex 解析（mise shim 指向 mise 本体，不能直接用 shim 路径）
+    if command -v mise >/dev/null 2>&1; then
+        local mise_resolved
+        if mise_resolved="$(mise which codex 2>/dev/null || true)" && [ -n "$mise_resolved" ] && [ -x "$mise_resolved" ]; then
+            echo "$mise_resolved"
+            return 0
+        fi
+    fi
+
+    # fallback: 直接找 mise 安装目录下的 codex（取 latest，避免版本号漂移）
+    local mise_root="${XDG_DATA_HOME:-$HOME/.local/share}/mise/installs/npm-openai-codex"
+    local latest_candidate="$mise_root/latest/bin/codex"
+    if [ -x "$latest_candidate" ]; then
+        echo "$latest_candidate"
+        return 0
+    fi
+    local versioned
+    for versioned in "$mise_root"/*/bin/codex; do
+        if [ -x "$versioned" ]; then
+            echo "$versioned"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+is_codex_cli_path() {
+    # 排除 mise 本体：mise shim 的 readlink 会指向 mise 二进制，
+    # 若 resolve 后是 mise 则跳过（否则应用会 spawn mise 报 "no tasks defined"）。
+    local candidate="$1"
+    [ -n "$candidate" ] || return 1
+    local resolved
+    resolved="$(readlink -f "$candidate" 2>/dev/null || echo "$candidate")"
+    case "$(basename "$resolved")" in
+        codex|codex.js|codex.exe)
+            return 0
+            ;;
+        mise|mise.exe)
+            return 1
+            ;;
+    esac
+    # 未知名字的二进制：保守跳过，让后续候选接管
     return 1
 }
 

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -2046,22 +2046,19 @@ find_mise_codex_cli() {
 }
 
 is_codex_cli_path() {
-    # 排除 mise 本体：mise shim 的 readlink 会指向 mise 二进制，
-    # 若 resolve 后是 mise 则跳过（否则应用会 spawn mise 报 "no tasks defined"）。
+    # 只拒绝解析到 mise 本体的候选（mise shim 的 readlink 指向 mise 二进制，
+    # 若采纳会 spawn mise 报 "no tasks defined"）。其他可执行目标一律接受，
+    # 包括 codex 指向不同 basename 的合法符号链接。
     local candidate="$1"
     [ -n "$candidate" ] || return 1
     local resolved
     resolved="$(readlink -f "$candidate" 2>/dev/null || echo "$candidate")"
     case "$(basename "$resolved")" in
-        codex|codex.js|codex.exe)
-            return 0
-            ;;
         mise|mise.exe)
             return 1
             ;;
     esac
-    # 未知名字的二进制：保守跳过，让后续候选接管
-    return 1
+    return 0
 }
 
 pid_parent_matches() {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -7011,7 +7011,9 @@ pathlib.Path(sys.argv[2]).write_text(
     + r'''
 case "${1:?}" in
     find)
-        find_codex_cli
+        # 容忍查找失败：CLI 可能不存在（如仅 mise shim 无真实安装），
+        # 此时应输出空并返回 0，供上层断言"未选中 mise shim"。
+        find_codex_cli || true
         ;;
     version)
         codex_cli_version "$2"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -7131,7 +7131,10 @@ PY
         fail "CLI lookup must resolve mise-installed codex through the mise shim, got $selected_cli"
 
     # no mise install dir present: fall back to nothing rather than the mise binary
-    selected_cli="$(env -i PATH="$mise_shim_dir:$clean_tool_path" HOME="$fake_home" "$launcher_probe" find)"
+    local empty_home="$workspace/empty-mise-home"
+    mkdir -p "$empty_home"
+    chmod 0755 "$empty_home"
+    selected_cli="$(env -i PATH="$mise_shim_dir:$clean_tool_path" HOME="$empty_home" "$launcher_probe" find)"
     [ -z "$selected_cli" ] || fail "CLI lookup must never select the mise shim binary, got $selected_cli"
 
     local brew_home="$workspace/brew-home"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6997,7 +6997,7 @@ functions = [source[
     source.index("codex_restore_original_ld_library_path() {"):
     source.index("# Capture before package-specific launcher patches")
 ]]
-for name in ("cached_codex_cli_path", "find_fnm_codex_cli", "find_codex_cli", "verify_cli_launch_path", "pid_parent_matches", "codex_cli_version_probe", "codex_cli_version", "codex_cli_missing_optional_dependency", "log_codex_cli_path"):
+for name in ("cached_codex_cli_path", "find_fnm_codex_cli", "find_mise_codex_cli", "is_codex_cli_path", "find_codex_cli", "verify_cli_launch_path", "pid_parent_matches", "codex_cli_version_probe", "codex_cli_version", "codex_cli_missing_optional_dependency", "log_codex_cli_path"):
     match = re.search(r"^" + re.escape(name) + r"\(\) \{[\s\S]*?^\}\n", source, re.M)
     if match is None:
         raise SystemExit(f"missing {name}")
@@ -7114,6 +7114,25 @@ PY
 
     selected_cli="$(env -i PATH="$path_cli_bin:$clean_tool_path" HOME="$fake_home" "$launcher_probe" find)"
     [ "$selected_cli" = "$path_cli_bin/codex" ] || fail "CLI lookup must keep the first PATH hit, got $selected_cli"
+
+    local mise_shim_dir="$workspace/mise-shims"
+    local mise_bin_dir="$workspace/mise-bin"
+    local mise_data_dir="$workspace/mise-data"
+    local mise_installed="$mise_data_dir/mise/installs/npm-openai-codex/9.99.0/bin/codex"
+    mkdir -p "$mise_shim_dir" "$mise_bin_dir" "$(dirname "$mise_installed")"
+    printf '#!/usr/bin/env bash\nprintf "codex-cli 9.99.0\\n"\n' > "$mise_installed"
+    chmod +x "$mise_installed"
+    # mise shim: symlink named codex pointing at the mise binary
+    printf '#!/usr/bin/env bash\nprintf "mise 2026.8.3\\n"\n' > "$mise_bin_dir/mise"
+    chmod +x "$mise_bin_dir/mise"
+    ln -s "$mise_bin_dir/mise" "$mise_shim_dir/codex"
+    selected_cli="$(env -i PATH="$mise_shim_dir:$clean_tool_path" HOME="$fake_home" XDG_DATA_HOME="$mise_data_dir" "$launcher_probe" find)"
+    [ "$selected_cli" = "$mise_installed" ] || \
+        fail "CLI lookup must resolve mise-installed codex through the mise shim, got $selected_cli"
+
+    # no mise install dir present: fall back to nothing rather than the mise binary
+    selected_cli="$(env -i PATH="$mise_shim_dir:$clean_tool_path" HOME="$fake_home" "$launcher_probe" find)"
+    [ -z "$selected_cli" ] || fail "CLI lookup must never select the mise shim binary, got $selected_cli"
 
     local brew_home="$workspace/brew-home"
     mkdir -p "$brew_home/.linuxbrew/bin"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -7168,6 +7168,16 @@ PY
     resolved_cli="$(env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" "$launcher_probe" resolve "$visible_cli")"
     [ "$resolved_cli" = "$(realpath "$external_cli")" ] || fail "CLI resolver must canonicalize visible symlinks, got $resolved_cli"
 
+    local alt_name_bin="$workspace/alt-name-bin"
+    local alt_name_target="$workspace/alt-name-target/openai-codex-bin"
+    mkdir -p "$alt_name_bin" "$(dirname "$alt_name_target")"
+    printf '#!/usr/bin/env bash\nprintf "codex-cli 0.173.0\\n"\n' > "$alt_name_target"
+    chmod 0755 "$alt_name_target" "$(dirname "$alt_name_target")"
+    ln -s "$alt_name_target" "$alt_name_bin/codex"
+    selected_cli="$(env -i PATH="$alt_name_bin:$clean_tool_path" HOME="$fake_home" "$launcher_probe" find)"
+    [ "$selected_cli" = "$alt_name_bin/codex" ] || \
+        fail "CLI lookup must accept a codex symlink to an executable with another basename, got $selected_cli"
+
     local custom_brew_prefix="$workspace/custom-homebrew"
     local custom_brew_target_dir="$workspace/custom-homebrew-cellar/openai-codex/0.42.0/bin"
     local custom_brew_visible="$custom_brew_prefix/bin/codex"


### PR DESCRIPTION
When Codex is installed via mise, the update-manager resolves the Codex CLI path into state.json cli_path. The mise shim is a symlink that resolves to the mise binary itself, so cli_path ends up pointing at mise. The launcher then spawns mise as the CLI, which fails with no tasks defined and leaves the app stuck on the splash screen.