### PR TITLE
HEROX-1259: Fix and disable the model picker tweak by default

### DIFF
--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -138,7 +138,8 @@ Power slider or opening a nested Model submenu. The compact GPT-5.6 Power
 slider also derives Sol's positions from the model's `supportedReasoningEfforts`
 after the app filters that list through the reasoning efforts enabled in
 settings. Enabled efforts such as Max therefore appear without maintaining a
-separate hard-coded effort list.
+separate hard-coded effort list. This tweak is disabled by default and must be
+enabled explicitly.
 
 Config keys:
 

--- a/linux-features/ui-tweaks/feature.json
+++ b/linux-features/ui-tweaks/feature.json
@@ -28,7 +28,7 @@
     },
     "modelPicker": {
       "showModelsByDefault": {
-        "enabled": true
+        "enabled": false
       }
     },
     "reasoning": {

--- a/linux-features/ui-tweaks/patches/model-picker-model-list.js
+++ b/linux-features/ui-tweaks/patches/model-picker-model-list.js
@@ -7,9 +7,7 @@ const SIMPLE_MENU_VIEW_PATTERN =
   /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(`composer-model-picker-menu-view-v1`,`simple`\)/;
 const ADVANCED_MENU_VIEW_PATTERN =
   /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(`composer-model-picker-menu-view-v2`,`advanced`\)/;
-const MODEL_TITLE_MARKER = "composer.intelligenceDropdown.model.title";
-const MODEL_ROW_MARKER = "composer.intelligenceDropdown.model.rowLabel";
-const EFFORT_TITLE_MARKER = "composer.intelligenceDropdown.effort.title";
+const CHAT_MODEL_PICKER_MARKER = "`chatgpt-model-picker`";
 const INLINE_MODEL_LIST_RUNTIME_MARKER = "codex-linux-inline-model-list";
 const DYNAMIC_POWER_EFFORTS_RUNTIME_MARKER =
   "codex-linux-dynamic-supported-reasoning-efforts";
@@ -32,44 +30,173 @@ function enabled(context) {
   return modelPickerConfig(context).enabled !== false;
 }
 
+function escapedPattern(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function chatMenuViewContract(source) {
+  const markerIndex = source.indexOf(CHAT_MODEL_PICKER_MARKER);
+  if (markerIndex < 0 || source.indexOf(CHAT_MODEL_PICKER_MARKER, markerIndex + 1) >= 0) {
+    return null;
+  }
+
+  const functionStart = source.lastIndexOf("function ", markerIndex);
+  const functionEnd = source.indexOf("function ", markerIndex + CHAT_MODEL_PICKER_MARKER.length);
+  if (functionStart < 0 || functionEnd < 0) {
+    return null;
+  }
+
+  const section = source.slice(functionStart, functionEnd);
+  const pattern = new RegExp(
+    "(\\[" +
+      JS_IDENT +
+      "," +
+      JS_IDENT +
+      "\\]=\\(0,(" +
+      JS_IDENT +
+      ")\\.useState\\)\\(``\\),\\[" +
+      JS_IDENT +
+      "," +
+      JS_IDENT +
+      "\\]=\\(0,\\2\\.useState\\)\\()`(simple|advanced)`(\\))",
+    "g",
+  );
+  const matches = [...section.matchAll(pattern)];
+  if (matches.length !== 1) {
+    return null;
+  }
+
+  const match = matches[0];
+  return {
+    end: functionStart + match.index + match[0].length,
+    replacement: `${match[1]}\`advanced\`${match[4]}`,
+    start: functionStart + match.index,
+    view: match[3],
+  };
+}
+
+function advancedViewContract(source) {
+  const simplePersistedCount = (source.match(new RegExp(SIMPLE_MENU_VIEW_PATTERN.source, "g")) ?? [])
+    .length;
+  const advancedPersistedCount = (
+    source.match(new RegExp(ADVANCED_MENU_VIEW_PATTERN.source, "g")) ?? []
+  ).length;
+  const chat = chatMenuViewContract(source);
+  if (simplePersistedCount + advancedPersistedCount !== 1 || chat == null) {
+    return "drifted";
+  }
+  if (simplePersistedCount === 1 && chat.view === "simple") {
+    return "current";
+  }
+  if (advancedPersistedCount === 1 && chat.view === "advanced") {
+    return "applied";
+  }
+  return "mixed";
+}
+
 function applyDefaultAdvancedViewPatch(source, context = {}) {
   try {
     if (typeof source !== "string") {
       warn("Asset source is not a string");
       return source;
     }
-    if (!enabled(context) || ADVANCED_MENU_VIEW_PATTERN.test(source)) {
+    if (!enabled(context)) {
       return source;
     }
-    if (!SIMPLE_MENU_VIEW_PATTERN.test(source)) {
+    const contract = advancedViewContract(source);
+    if (contract === "applied") {
+      return source;
+    }
+    if (contract !== "current") {
       if (context.warnOnMissingMarkers === true) {
-        warn("Could not find the persisted model picker view marker");
+        warn("Could not find the persisted model picker view marker and Chat state atomically");
       }
       return source;
     }
 
-    return source.replace(
+    const persistedPatched = source.replace(
       SIMPLE_MENU_VIEW_PATTERN,
       '$1=$2(`composer-model-picker-menu-view-v2`,`advanced`)',
     );
+    const chat = chatMenuViewContract(persistedPatched);
+    if (chat == null || chat.view !== "simple") {
+      if (context.warnOnMissingMarkers === true) {
+        warn("Could not find the persisted model picker view marker and Chat state atomically");
+      }
+      return source;
+    }
+    return persistedPatched.slice(0, chat.start) + chat.replacement + persistedPatched.slice(chat.end);
   } catch (error) {
     warn(`Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
     return source;
   }
 }
 
-function findInlineModelListVariable(source) {
-  const titleIndex = source.indexOf(MODEL_TITLE_MARKER);
-  const rowIndex = source.indexOf(MODEL_ROW_MARKER, titleIndex);
-  if (titleIndex < 0 || rowIndex < 0) {
+function inlineModelListContract(source) {
+  const modelSubmenuPattern = new RegExp(
+    `([,;])(${JS_IDENT});(${JS_IDENT})\\[(\\d+)\\]!==(${JS_IDENT})\\.model\\|\\|` +
+      `\\3\\[(\\d+)\\]!==(${JS_IDENT})\\?\\(\\2=\\7\\|\\|\\5\\.model==null\\?null:` +
+      `\\(0,(${JS_IDENT})\\.jsx\\)\\((${JS_IDENT}),\\{submenu:\\5\\.model\\}\\),` +
+      `\\3\\[\\4\\]=\\5\\.model,\\3\\[\\6\\]=\\7,\\3\\[(\\d+)\\]=\\2\\)` +
+      `:\\2=\\3\\[\\10\\]`,
+    "g",
+  );
+  const submenuMatches = [...source.matchAll(modelSubmenuPattern)];
+  if (submenuMatches.length !== 1) {
     return null;
   }
 
-  const section = source.slice(titleIndex, rowIndex);
-  const assignments = [
-    ...section.matchAll(/,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*);let/g),
-  ];
-  return assignments.at(-1)?.[1] ?? null;
+  const match = submenuMatches[0];
+  const submenuComponent = match[9];
+  const submenuMarker = `function ${submenuComponent}(`;
+  const submenuStart = source.indexOf(submenuMarker);
+  if (submenuStart < 0 || source.indexOf(submenuMarker, submenuStart + 1) >= 0) {
+    return null;
+  }
+  const submenuEnd = source.indexOf("function ", submenuStart + submenuMarker.length);
+  if (submenuEnd < 0) {
+    return null;
+  }
+
+  const submenuSection = source.slice(submenuStart, submenuEnd);
+  const jsxNamespace = match[8];
+  const titlePattern = new RegExp(
+    `\\(0,${escapedPattern(jsxNamespace)}\\.jsx\\)\\((${JS_IDENT})\\.Title,`,
+    "g",
+  );
+  const optionMapPattern = new RegExp(`\\.options\\.map\\((${JS_IDENT})\\)`, "g");
+  const titleMatches = [...submenuSection.matchAll(titlePattern)];
+  const optionMapMatches = [...submenuSection.matchAll(optionMapPattern)];
+  if (titleMatches.length !== 1 || optionMapMatches.length !== 1) {
+    return null;
+  }
+
+  const menuNamespace = titleMatches[0][1];
+  const optionRenderer = optionMapMatches[0][1];
+  const optionRendererPattern = new RegExp(
+    `function ${escapedPattern(optionRenderer)}\\((${JS_IDENT})\\)\\{return` +
+      `\\(0,${escapedPattern(jsxNamespace)}\\.jsx\\)` +
+      `\\(${escapedPattern(menuNamespace)}\\.Item,`,
+    "g",
+  );
+  if ([...source.matchAll(optionRendererPattern)].length !== 1) {
+    return null;
+  }
+
+  return {
+    cache: match[3],
+    config: match[5],
+    hide: match[7],
+    hideIndex: match[6],
+    jsxNamespace,
+    menuNamespace,
+    modelIndex: match[4],
+    optionRenderer,
+    original: match[0],
+    prefix: match[1],
+    result: match[2],
+    resultIndex: match[10],
+  };
 }
 
 function applyInlineModelListPatch(source, context = {}) {
@@ -82,31 +209,42 @@ function applyInlineModelListPatch(source, context = {}) {
       return source;
     }
 
-    const inlineModelListVariable = findInlineModelListVariable(source);
-    const effortIndex = source.indexOf(EFFORT_TITLE_MARKER);
-    if (inlineModelListVariable == null || effortIndex < 0) {
+    const contract = inlineModelListContract(source);
+    if (contract == null) {
       if (context.warnOnMissingMarkers === true) {
-        warn("Could not find the model list and advanced picker markers");
+        warn("Could not find the current advanced model submenu contract");
       }
       return source;
     }
 
-    const tail = source.slice(effortIndex);
-    const advancedChildrenPattern =
-      /(([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.jsxs\)\(\3\.Fragment,\{children:\[)([A-Za-z_$][\w$]*),/;
-    const match = tail.match(advancedChildrenPattern);
-    if (match == null) {
-      if (context.warnOnMissingMarkers === true) {
-        warn("Could not find the advanced picker child list");
-      }
-      return source;
-    }
-
-    const patchedTail = tail.replace(
-      advancedChildrenPattern,
-      `$1${inlineModelListVariable},/*${INLINE_MODEL_LIST_RUNTIME_MARKER}*/`,
-    );
-    return source.slice(0, effortIndex) + patchedTail;
+    const {
+      cache,
+      config,
+      hide,
+      hideIndex,
+      jsxNamespace,
+      menuNamespace,
+      modelIndex,
+      optionRenderer,
+      original,
+      prefix,
+      result,
+      resultIndex,
+    } = contract;
+    const inlineModelList =
+      `(0,${jsxNamespace}.jsxs)(${jsxNamespace}.Fragment,{children:[` +
+      `(0,${jsxNamespace}.jsx)(${menuNamespace}.Title,{children:${config}.model.label}),` +
+      `(0,${jsxNamespace}.jsx)(\`div\`,{className:` +
+      "`vertical-scroll-fade-mask flex max-h-[250px] flex-col overflow-y-auto`" +
+      `,children:${config}.model.options.map(${optionRenderer})})]})` +
+      `/*${INLINE_MODEL_LIST_RUNTIME_MARKER}*/`;
+    const replacement =
+      `${prefix}${result};${cache}[${modelIndex}]!==${config}.model||` +
+      `${cache}[${hideIndex}]!==${hide}?(${result}=${hide}||${config}.model==null?null:` +
+      `${inlineModelList},${cache}[${modelIndex}]=${config}.model,` +
+      `${cache}[${hideIndex}]=${hide},${cache}[${resultIndex}]=${result})` +
+      `:${result}=${cache}[${resultIndex}]`;
+    return source.replace(original, replacement);
   } catch (error) {
     warn(`Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
     return source;
@@ -207,6 +345,7 @@ const descriptors = [
     phase: "webview-asset",
     order: 20_794,
     ciPolicy: "optional",
+    enabled,
     pattern: MODEL_PICKER_STATE_ASSET_PATTERN,
     missingDescription: "composer model picker state bundle",
     skipDescription: "ui-tweaks model picker default advanced view patch",
@@ -218,6 +357,7 @@ const descriptors = [
     phase: "webview-asset",
     order: 20_796,
     ciPolicy: "optional",
+    enabled,
     pattern: MODEL_PICKER_INLINE_ASSET_PATTERN,
     missingDescription: "composer model picker menu bundle",
     skipDescription: "ui-tweaks model picker inline model list patch",
@@ -229,6 +369,7 @@ const descriptors = [
     phase: "webview-asset",
     order: 20_797,
     ciPolicy: "optional",
+    enabled,
     pattern: MODEL_PICKER_EFFORT_ASSET_PATTERN,
     missingDescription: "composer model picker menu bundle",
     skipDescription: "ui-tweaks dynamic supported reasoning efforts patch",
@@ -243,13 +384,10 @@ const descriptors = [
 module.exports = {
   ADVANCED_MENU_VIEW_PATTERN,
   DYNAMIC_POWER_EFFORTS_RUNTIME_MARKER,
-  EFFORT_TITLE_MARKER,
   INLINE_MODEL_LIST_RUNTIME_MARKER,
   MODEL_PICKER_EFFORT_ASSET_PATTERN,
   MODEL_PICKER_INLINE_ASSET_PATTERN,
   MODEL_PICKER_STATE_ASSET_PATTERN,
-  MODEL_ROW_MARKER,
-  MODEL_TITLE_MARKER,
   SIMPLE_MENU_VIEW_PATTERN,
   applyDefaultAdvancedViewPatch,
   applyDynamicSupportedReasoningEffortsPatch,
@@ -257,5 +395,4 @@ module.exports = {
   applyModelPickerModelListPatch,
   descriptors,
   findDynamicPowerSelectionsFunction,
-  findInlineModelListVariable,
 };

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -269,16 +269,23 @@ test("GPT-5.6 Power slider effort patch fails soft when upstream markers drift",
   assert.match(warnings[0], /Could not find the supported reasoning effort mapper/);
 });
 
-test("model picker tweak can be disabled through feature settings", () => {
+test("model picker tweak is disabled by default and can be explicitly enabled", () => {
   const stateSource = modelPickerStateBundleFixture();
   const menuSource = modelPickerMenuBundleFixture();
-  const context = {
+  const featureJson = JSON.parse(fs.readFileSync(path.join(__dirname, "feature.json"), "utf8"));
+  const defaultContext = {
     feature: {
+      manifest: featureJson,
+    },
+  };
+  const enabledContext = {
+    feature: {
+      manifest: featureJson,
       settings: {
         tweaks: {
           modelPicker: {
             showModelsByDefault: {
-              enabled: false,
+              enabled: true,
             },
           },
         },
@@ -286,11 +293,24 @@ test("model picker tweak can be disabled through feature settings", () => {
     },
   };
 
-  assert.equal(applyDefaultAdvancedViewPatch(stateSource, context), stateSource);
-  assert.equal(applyInlineModelListPatch(menuSource, context), menuSource);
+  assert.equal(featureJson.tweaks.modelPicker.showModelsByDefault.enabled, false);
+  assert.equal(applyDefaultAdvancedViewPatch(stateSource, defaultContext), stateSource);
+  assert.equal(applyInlineModelListPatch(menuSource, defaultContext), menuSource);
   assert.equal(
-    applyDynamicSupportedReasoningEffortsPatch(modelPickerPowerBundleFixture(), context),
+    applyDynamicSupportedReasoningEffortsPatch(modelPickerPowerBundleFixture(), defaultContext),
     modelPickerPowerBundleFixture(),
+  );
+  assert.match(
+    applyDefaultAdvancedViewPatch(stateSource, enabledContext),
+    ADVANCED_MENU_VIEW_PATTERN,
+  );
+  assert.match(
+    applyInlineModelListPatch(menuSource, enabledContext),
+    new RegExp(INLINE_MODEL_LIST_RUNTIME_MARKER),
+  );
+  assert.match(
+    applyDynamicSupportedReasoningEffortsPatch(modelPickerPowerBundleFixture(), enabledContext),
+    new RegExp(DYNAMIC_POWER_EFFORTS_RUNTIME_MARKER),
   );
 });
 

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -54,18 +54,30 @@ function modelPickerStateBundleFixture() {
     "function picker(){",
     "vz=wu(`composer-model-picker-menu-view-v1`,`simple`);",
     "}",
+    "function j_s(e){",
+    "let d=`chatgpt-model-picker`,[h,g]=(0,F_s.useState)(``),[_,v]=(0,F_s.useState)(`simple`);",
+    "return _}",
+    "function next(){}",
   ].join("");
 }
 
 function modelPickerMenuBundleFixture() {
   return [
-    "function menu(){",
-    "id:`composer.intelligenceDropdown.model.title`;",
-    "let ue=fragment,ie=ue;let fe;",
-    "id:`composer.intelligenceDropdown.model.rowLabel`;",
+    "function j_s(){",
     "id:`composer.intelligenceDropdown.effort.title`;",
-    "we=(0,c6.jsxs)(c6.Fragment,{children:[ye,effort]});",
-    "}",
+    "let re=[{id:`metadata`}],ie=re.find(e=>e.id),Ce=`label`,se=`text`;",
+    "we=(0,K1.jsxs)(K1.Fragment,{children:[Ce,se]});return we}",
+    "function Cgs(e){",
+    "let t=[],{advancedConfig:r,hideAdvancedSubmenus:i}=e,v=i!==void 0&&i,ce;",
+    "t[43]!==r.model||t[44]!==v?(ce=v||r.model==null?null:(0,H1.jsx)(wgs,{submenu:r.model}),t[43]=r.model,t[44]=v,t[45]=ce):ce=t[45];",
+    "return ce}",
+    "function wgs(e){",
+    "let n=e.submenu,o=n.title==null?null:(0,H1.jsx)(hH.Title,{children:n.title}),l=n.options.map(Tgs);return [o,l]}",
+    "function Tgs(e){return(0,H1.jsx)(hH.Item,{RightIcon:e.selected?fv:void 0,onSelect:t=>{t.preventDefault(),e.onSelect()},children:e.label},e.id)}",
+    "function XVs(){",
+    "id:`composer.intelligenceDropdown.model.title`;",
+    "let g=fragment,ie=g;let fe;",
+    "id:`composer.intelligenceDropdown.model.rowLabel`;}",
   ].join("");
 }
 
@@ -178,6 +190,14 @@ test("ui-tweaks is discoverable and disabled until listed in features.json", () 
         ["feature:ui-tweaks:home-suggested-prompts-content", "webview-asset", "optional"],
       ],
     );
+    const modelPickerDescriptors = descriptors.filter((descriptor) =>
+      descriptor.id.includes(":model-picker-"),
+    );
+    assert.equal(modelPickerDescriptors.length, 3);
+    assert.ok(
+      modelPickerDescriptors.every((descriptor) => typeof descriptor.enabled === "function"),
+    );
+    assert.ok(modelPickerDescriptors.every((descriptor) => descriptor.enabled({}) === false));
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
@@ -203,11 +223,83 @@ test("model picker opens advanced view and renders model choices inline", () => 
   const menuSource = modelPickerMenuBundleFixture();
   const patchedState = applyDefaultAdvancedViewPatch(stateSource);
   const patchedMenu = applyInlineModelListPatch(menuSource);
+  const H1 = {
+    Fragment: Symbol("Fragment"),
+    jsx: (type, props, key) => ({ key, props, type }),
+    jsxs: (type, props, key) => ({ key, props, type }),
+  };
+  const hH = { Item: Symbol("Item"), Title: Symbol("Title") };
+  const renderAdvancedModelList = Function(
+    "H1",
+    "hH",
+    "fv",
+    `${patchedMenu};return Cgs;`,
+  )(H1, hH, Symbol("Selected"));
+  const selected = [];
+  const modelOptions = [
+    {
+      id: "gpt-5.6-terra",
+      label: "5.6 Terra",
+      onSelect: () => selected.push("gpt-5.6-terra"),
+      selected: false,
+    },
+    {
+      id: "gpt-5.6-sol",
+      label: "5.6 Sol",
+      onSelect: () => selected.push("gpt-5.6-sol"),
+      selected: true,
+    },
+  ];
+  const rendered = renderAdvancedModelList({
+    advancedConfig: { model: { label: "Model", options: modelOptions } },
+    hideAdvancedSubmenus: false,
+  });
 
   assert.match(patchedState, ADVANCED_MENU_VIEW_PATTERN);
   assert.doesNotMatch(patchedState, SIMPLE_MENU_VIEW_PATTERN);
+  assert.match(patchedState, /useState\)\(`advanced`\)/);
+  assert.doesNotMatch(patchedState, /useState\)\(`simple`\)/);
   assert.match(patchedMenu, new RegExp(INLINE_MODEL_LIST_RUNTIME_MARKER));
-  assert.match(patchedMenu, /children:\[ie,\/\*codex-linux-inline-model-list\*\//);
+  assert.equal(
+    (patchedMenu.match(new RegExp(INLINE_MODEL_LIST_RUNTIME_MARKER, "g")) ?? []).length,
+    1,
+  );
+  assert.match(patchedMenu, /children:\[Ce,se\]/);
+  assert.doesNotMatch(patchedMenu, /children:\[ie,\/\*codex-linux-inline-model-list\*\//);
+  assert.equal(rendered.type, H1.Fragment);
+  assert.equal(rendered.props.children[0].type, hH.Title);
+  assert.equal(rendered.props.children[0].props.children, "Model");
+  assert.equal(rendered.props.children[1].type, "div");
+  assert.deepEqual(
+    rendered.props.children[1].props.children.map((item) => item.props.children),
+    ["5.6 Terra", "5.6 Sol"],
+  );
+  assert.ok(rendered.props.children[1].props.children.every((item) => item.type === hH.Item));
+  assert.ok(
+    rendered.props.children[1].props.children.every((item) => !modelOptions.includes(item)),
+  );
+  let prevented = false;
+  rendered.props.children[1].props.children[1].props.onSelect({
+    preventDefault: () => {
+      prevented = true;
+    },
+  });
+  assert.equal(prevented, true);
+  assert.deepEqual(selected, ["gpt-5.6-sol"]);
+  assert.equal(
+    renderAdvancedModelList({
+      advancedConfig: { model: { label: "Model", options: modelOptions } },
+      hideAdvancedSubmenus: true,
+    }),
+    null,
+  );
+  assert.equal(
+    renderAdvancedModelList({
+      advancedConfig: { model: null },
+      hideAdvancedSubmenus: false,
+    }),
+    null,
+  );
   assert.equal(applyDefaultAdvancedViewPatch(patchedState), patchedState);
   assert.equal(applyInlineModelListPatch(patchedMenu), patchedMenu);
 });
@@ -323,6 +415,30 @@ test("model picker drift warns and leaves the asset unchanged", () => {
   assert.equal(value, source);
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /^WARN: Could not find the persisted model picker view marker/);
+});
+
+test("model picker mixed, duplicate, and incomplete contracts fail closed", () => {
+  const mixedState = modelPickerStateBundleFixture().replace(
+    "`composer-model-picker-menu-view-v1`,`simple`",
+    "`composer-model-picker-menu-view-v2`,`advanced`",
+  );
+  const duplicateMenu = modelPickerMenuBundleFixture() + modelPickerMenuBundleFixture();
+  const incompleteMenu = modelPickerMenuBundleFixture().replace(
+    "n.options.map(Tgs)",
+    "n.options",
+  );
+
+  for (const [source, apply] of [
+    [mixedState, applyDefaultAdvancedViewPatch],
+    [duplicateMenu, applyInlineModelListPatch],
+    [incompleteMenu, applyInlineModelListPatch],
+  ]) {
+    const { value, warnings } = withCapturedWarns(() =>
+      apply(source, { warnOnMissingMarkers: true }),
+    );
+    assert.equal(value, source);
+    assert.equal(warnings.length, 1);
+  }
 });
 
 test("reasoning effort labels stay in English in the Simplified Chinese locale", () => {
@@ -486,6 +602,11 @@ test("feature settings override the tracked defaults through features.json", () 
                     style: "font-weight: 800 !important; color: red;",
                   },
                 },
+                modelPicker: {
+                  showModelsByDefault: {
+                    enabled: true,
+                  },
+                },
               },
             },
           },
@@ -495,10 +616,16 @@ test("feature settings override the tracked defaults through features.json", () 
       )}\n`,
     );
 
-    const [descriptor] = loadLinuxFeaturePatchDescriptors({ featuresRoot });
+    const descriptors = loadLinuxFeaturePatchDescriptors({ featuresRoot });
+    const [descriptor] = descriptors;
     const patched = descriptor.apply(projectBundleFixture(), {});
 
     assert.match(patched, /font-weight: 800 !important; color: red;/);
+    assert.ok(
+      descriptors
+        .filter((candidate) => candidate.id.includes(":model-picker-"))
+        .every((candidate) => candidate.enabled({}) === true),
+    );
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/scripts/ci/upstream-dmg-acceptance.test.js
+++ b/scripts/ci/upstream-dmg-acceptance.test.js
@@ -375,6 +375,10 @@ test("Nix hash refresh accepts a validated focused output override", () => {
     "remote-mobile-control",
     "ui-tweaks",
   ]);
+  assert.equal(
+    watchdogProfile.settings["ui-tweaks"].tweaks.modelPicker.showModelsByDefault.enabled,
+    true,
+  );
   assert.match(script, /NIX_VERIFY_OUTPUTS/);
   assert.match(script, /NIX_COMPARE_REF/);
   assert.match(workflow, /\.#checks\.x86_64-linux\.watchdog-linux-features/);

--- a/scripts/ci/watchdog-linux-features.json
+++ b/scripts/ci/watchdog-linux-features.json
@@ -14,5 +14,15 @@
     "remote-mobile-control",
     "ui-tweaks"
   ],
-  "settings": {}
+  "settings": {
+    "ui-tweaks": {
+      "tweaks": {
+        "modelPicker": {
+          "showModelsByDefault": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- retarget the inline model list patch to the current shared advanced picker renderer
- switch both persisted and Chat picker state to the advanced view atomically
- keep Show models by default disabled unless users explicitly opt in
- explicitly enable the tweak only in the upstream-DMG watchdog profile

Fixes #1259

## Tests

- `node --test linux-features/ui-tweaks/test.js` (58 passed)
- `node --test scripts/ci/upstream-dmg-acceptance.test.js` (19 passed)
- patched the raw 26.803.41515 renderer asset in memory and verified markers, semantics, and idempotence
- broad feature suite: 881/882 passed; the sole shared-app-server socket failure reproduces on `main`
- core patcher suite: 413/414 passed; the sole bundled-plugin trust failure reproduces on `main`
