### PR TITLE
fix(updater): read sparkleManager from this.sparkleManager in getAppUpdateViewState

### DIFF
--- a/scripts/lib/linux-update-bridge-patch.js
+++ b/scripts/lib/linux-update-bridge-patch.js
@@ -121,6 +121,24 @@ function applyLinuxAppUpdaterMenuPatch(currentSource) {
   return currentSource.replace(menuRegex, "$1=$2.$3.shouldIncludeSparkle($4,process.platform,process.env)||process.platform===`linux`");
 }
 
+function applyLinuxAppUpdateViewStatePatch(currentSource) {
+  // 上游 bug: Zoe 类构造时把 sparkleManager 存入 this.sparkleManager，
+  // 但 getAppUpdateViewState() 读取 this.options.sparkleManager。
+  // macOS 上基类 options 恰好也有 sparkleManager，Linux 上没有，导致
+  // "this.options.sparkleManager.getDownloadProgressPercent is not a function"。
+  // 修复：改为读取 this.sparkleManager（构造时真正存储的字段）。
+  const viewStateRegex =
+    /getAppUpdateViewState\(\)\{return\{downloadProgressPercent:this\.options\.sparkleManager\.getDownloadProgressPercent\(\),downloadedUpdateAppBrand:this\.options\.sparkleManager\.getDownloadedUpdateAppBrand\(\),installProgressPercent:this\.options\.sparkleManager\.getInstallProgressPercent\(\),isUpdateReady:this\.options\.sparkleManager\.getIsUpdateReady\(\),lifecycleState:this\.options\.sparkleManager\.getUpdateLifecycleState\(\),relaunchNotice:this\.options\.sparkleManager\.getRelaunchNotice\(\)\}\}/;
+  const match = currentSource.match(viewStateRegex);
+  if (match == null) {
+    return currentSource;
+  }
+  const original = match[0];
+  const replacement =
+    "getAppUpdateViewState(){let e=this.sparkleManager??this.options?.sparkleManager;return{downloadProgressPercent:e?.getDownloadProgressPercent?.()??null,downloadedUpdateAppBrand:e?.getDownloadedUpdateAppBrand?.()??null,installProgressPercent:e?.getInstallProgressPercent?.()??null,isUpdateReady:e?.getIsUpdateReady?.()??!1,lifecycleState:e?.getUpdateLifecycleState?.()??`idle`,relaunchNotice:e?.getRelaunchNotice?.()??null}}";
+  return currentSource.replace(original, replacement);
+}
+
 function patchLinuxAppUpdaterBridge(extractedDir) {
   const buildDir = path.join(extractedDir, ".vite", "build");
   if (!fs.existsSync(buildDir)) {
@@ -135,7 +153,8 @@ function patchLinuxAppUpdaterBridge(extractedDir) {
     const source = fs.readFileSync(filePath, "utf8");
     const shouldPatchMenu = source.includes("shouldIncludeSparkle");
     const shouldPatchBridge = source.includes("exports.runMainAppStartup");
-    if (!shouldPatchMenu && !shouldPatchBridge) {
+    const shouldPatchViewState = source.includes("getAppUpdateViewState");
+    if (!shouldPatchMenu && !shouldPatchBridge && !shouldPatchViewState) {
       continue;
     }
     matched += 1;
@@ -145,6 +164,9 @@ function patchLinuxAppUpdaterBridge(extractedDir) {
     }
     if (shouldPatchBridge) {
       patched = applyLinuxAppUpdaterBridgePatch(patched);
+    }
+    if (shouldPatchViewState) {
+      patched = applyLinuxAppUpdateViewStatePatch(patched);
     }
     if (patched !== source) {
       fs.writeFileSync(filePath, patched, "utf8");
@@ -158,5 +180,6 @@ function patchLinuxAppUpdaterBridge(extractedDir) {
 module.exports = {
   applyLinuxAppUpdaterBridgePatch,
   applyLinuxAppUpdaterMenuPatch,
+  applyLinuxAppUpdateViewStatePatch,
   patchLinuxAppUpdaterBridge,
 };

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -155,6 +155,7 @@ const {
 const {
   applyLinuxAppUpdaterBridgePatch,
   applyLinuxAppUpdaterMenuPatch,
+  applyLinuxAppUpdateViewStatePatch,
   patchLinuxAppUpdaterBridge,
 } = require("./lib/linux-update-bridge-patch.js");
 const {
@@ -7849,6 +7850,52 @@ test("implements the current Sparkle AppView, menu, and RPC contract on Linux", 
   );
   assert.match(patched, /setSparkleQueryParams:\(\)=>\{\}/);
   assert.match(patched, /latchInAppUpdatesEnabledForLaunch:async\(\)=>\{\}/);
+});
+
+test("fixes the upstream getAppUpdateViewState options.sparkleManager bug", () => {
+  // 上游 Zoe 类构造时把 sparkleManager 存入 this.sparkleManager，
+  // 但 getAppUpdateViewState() 读取 this.options.sparkleManager，
+  // macOS 上基类 options 恰好有该字段，Linux 上没有 → 运行时报错。
+  const broken =
+    "class Zoe{windowManager;origin;sparkleManager;constructor(e,t,n){this.windowManager=e,this.origin=t,this.sparkleManager=n}getAppUpdateViewState(){return{downloadProgressPercent:this.options.sparkleManager.getDownloadProgressPercent(),downloadedUpdateAppBrand:this.options.sparkleManager.getDownloadedUpdateAppBrand(),installProgressPercent:this.options.sparkleManager.getInstallProgressPercent(),isUpdateReady:this.options.sparkleManager.getIsUpdateReady(),lifecycleState:this.options.sparkleManager.getUpdateLifecycleState(),relaunchNotice:this.options.sparkleManager.getRelaunchNotice()}}}";
+  const patched = applyLinuxAppUpdateViewStatePatch(broken);
+
+  assert.notEqual(patched, broken, "getAppUpdateViewState should be patched");
+  assert.match(patched, /let e=this\.sparkleManager\?\?this\.options\?\.sparkleManager/);
+  assert.doesNotMatch(
+    patched,
+    /downloadProgressPercent:this\.options\.sparkleManager/,
+    "old options.sparkleManager direct access must be gone",
+  );
+
+  // 行为验证：sparkleManager 存在时返回其状态；不存在时返回安全默认值
+  const makeEval = () => {
+    const factory = new Function(
+      "instance",
+      `${patched};return new Zoe(instance.windowManager, instance.origin, instance.sparkleManager).getAppUpdateViewState()`,
+    );
+    return factory;
+  };
+  const withManager = makeEval()({
+    windowManager: {},
+    origin: "test",
+    sparkleManager: {
+      getDownloadProgressPercent: () => 42,
+      getDownloadedUpdateAppBrand: () => "brand",
+      getInstallProgressPercent: () => 10,
+      getIsUpdateReady: () => true,
+      getUpdateLifecycleState: () => "ready",
+      getRelaunchNotice: () => "notice",
+    },
+  });
+  assert.equal(withManager.downloadProgressPercent, 42);
+  assert.equal(withManager.downloadedUpdateAppBrand, "brand");
+  assert.equal(withManager.isUpdateReady, true);
+
+  const withoutManager = makeEval()({ windowManager: {}, origin: "test", sparkleManager: undefined });
+  assert.equal(withoutManager.downloadProgressPercent, null);
+  assert.equal(withoutManager.isUpdateReady, false);
+  assert.equal(withoutManager.lifecycleState, "idle");
 });
 
 test("keeps every exact-DMG Sparkle manager caller callable on the Linux replacement", async () => {


### PR DESCRIPTION
## Problem

The upstream Zoe class (app-update state service) stores the sparkleManager in `this.sparkleManager` (a constructor argument), but `getAppUpdateViewState()` reads `this.options.sparkleManager`. On macOS the base class options happens to carry the field, so the bug is hidden; on Linux it is `undefined` and the app crashes with `this.options.sparkleManager.getDownloadProgressPercent is not a function`, leaving the app stuck on the splash screen.

## Fix

- `applyLinuxAppUpdateViewStatePatch`: rewrite `getAppUpdateViewState` to read `this.sparkleManager` (the field actually stored in the constructor) with null-safe fallbacks
- scan bundles containing `getAppUpdateViewState` in addition to the existing menu/bridge markers
- regression test: with a manager the state is returned; without one the method returns safe defaults instead of throwing

## Testing

- `node --test scripts/patch-linux-window-ui.test.js`: 415 pass
- Real app.asar extraction + patch applied, then launched: `getDownloadProgressPercent is not a function` no longer appears, app reaches main UI