### PR TITLE
fix(linux): reduce sidebar scroll layout invalidation

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -192,12 +192,14 @@ const {
   applyLinuxI18nGatePatch,
   applyLinuxOpaqueWindowsDefaultPatch,
   applyLinuxSettingsSearchVisibilityPatch,
+  applyLinuxSidebarScrollPerformancePatch,
   applyLinuxSkillsListDedupePatch,
   applyLinuxThreadSidePanelNativeTooltipPatch,
   applyLinuxTooltipWindowControlsCollisionPatch,
   applyLinuxWindowControlsSafeAreaPatch,
   applySubagentNicknameMetadataPatch,
   codexLinuxWatchBrowserWebviewAttachment,
+  matchesLinuxSidebarScrollPerformanceContract,
 } = require("./patches/impl/webview/index.js");
 const {
   findCodexRequestWebviewAsset,
@@ -1034,6 +1036,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-projectless-xdg-documents-dir",
     "linux-workspace-root-open-targets",
     "linux-settings-search-visibility",
+    "linux-sidebar-scroll-performance",
     "linux-i18n-gate",
     "automation-schedule-multi-time-rrule",
     "automation-update-eager-tool",
@@ -1141,6 +1144,14 @@ test("default core patch descriptors are grouped and unique", () => {
     descriptors.find((descriptor) => descriptor.id === "linux-terminal-user-path")?.ciPolicy,
     "optional",
   );
+  const sidebarScrollPerformance = descriptors.find(
+    (descriptor) => descriptor.id === "linux-sidebar-scroll-performance",
+  );
+  assert.equal(sidebarScrollPerformance?.ciPolicy, "optional");
+  assert.equal(sidebarScrollPerformance?.pattern.test("app-initial-Biw83Aiz.js"), true);
+  assert.equal(sidebarScrollPerformance?.pattern.test("app-DuLjgNkx.css"), false);
+  assert.equal(sidebarScrollPerformance?.assetMatch(sidebarScrollFixture()), true);
+  assert.equal(sidebarScrollPerformance?.assetMatch("function unrelated(){}"), false);
   assert.equal(
     descriptors.find((descriptor) => descriptor.id === "linux-computer-use-avatar-cursor")?.ciPolicy,
     "optional",
@@ -3515,6 +3526,96 @@ test("keeps tooltip collision padding after middleware alias drift", () => {
 
   assert.match(patched, /o\(\{mainAxis:ne,crossAxis:t\}\),l\(\{padding:\{top:44,right:8,bottom:8,left:8\}\}\),u\(\{padding:\{top:44,right:8,bottom:8,left:8\}\}\),d\(\{padding:\{top:44,right:8,bottom:8,left:8\},apply/);
   assert.doesNotMatch(patched, /[,(]\{padding:8\}/);
+});
+
+function sidebarScrollFixture({ handler = null, duplicate = false } = {}) {
+  const scrollHandler = handler ??
+    "e=>{let t=D.current;(t==null||e.timeStamp-t>=CKc)&&(Fh(),D.current=e.timeStamp);let{scrollTop:n}=e.currentTarget;C||(u?.(n>0),r(n))}";
+  const container =
+    "(0,SKc.jsxs)(`div`,{...cm.sidebarScroll,className:$(`vertical-scroll-fade-mask relative isolate flex min-h-0 flex-1 flex-col overflow-y-auto [contain:layout_paint]`,_Kc.headerFadeMask),ref:p,onScroll:" +
+    scrollHandler +
+    ",children:[h,m]})";
+  const source = `function yKc(e){return ${container}}`;
+  return duplicate ? `${source}${source}` : source;
+}
+
+test("disables only the main sidebar scroll-driven fade timeline", () => {
+  const source = `${sidebarScrollFixture()}function unrelated(){return\`vertical-scroll-fade-mask\`}`;
+
+  const patched = applyPatchTwice(applyLinuxSidebarScrollPerformancePatch, source);
+
+  assert.equal(
+    (patched.match(/animationName:`none`,animationTimeline:`auto`/g) ?? []).length,
+    1,
+  );
+  assert.match(
+    patched,
+    /"--bottom-fade":`calc\(var\(--spacing\) \* 10\)`/,
+  );
+  assert.match(
+    patched,
+    /onScroll:e=>\{let t=D\.current;.*let\{scrollTop:n\}=e\.currentTarget;C\|\|\(u\?\.\(n>0\),r\(n\)\)\}/,
+  );
+  assert.match(patched, /function unrelated\(\)\{return`vertical-scroll-fade-mask`\}/);
+  assert.equal(matchesLinuxSidebarScrollPerformanceContract(patched), true);
+});
+
+test("matches the semantic main-sidebar contract rather than generic fade masks", () => {
+  assert.equal(matchesLinuxSidebarScrollPerformanceContract(sidebarScrollFixture()), true);
+  assert.equal(
+    matchesLinuxSidebarScrollPerformanceContract(
+      "function generic(){return jsx(`div`,{className:`vertical-scroll-fade-mask [contain:layout_paint]`,onScroll:e=>e.currentTarget.scrollTop})}",
+    ),
+    false,
+  );
+  assert.equal(
+    matchesLinuxSidebarScrollPerformanceContract(sidebarScrollFixture({ duplicate: true })),
+    false,
+  );
+});
+
+test("leaves the sidebar asset byte-identical when its scroll handler drifts", () => {
+  const source = sidebarScrollFixture({
+    handler: "e=>{r(e.currentTarget.dataset.scrollPosition)}",
+  });
+
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxSidebarScrollPerformancePatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not uniquely identify the main sidebar scroll container — skipping Linux sidebar scroll performance patch",
+  ]);
+});
+
+test("leaves ambiguous sidebar assets byte-identical", () => {
+  const source = sidebarScrollFixture({ duplicate: true });
+
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxSidebarScrollPerformancePatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not uniquely identify the main sidebar scroll container — skipping Linux sidebar scroll performance patch",
+  ]);
+});
+
+test("rejects an incomplete sidebar performance patch marker", () => {
+  const source = sidebarScrollFixture().replace(
+    "),ref:p,onScroll:",
+    "),style:{animationName:`none`},ref:p,onScroll:",
+  );
+
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxSidebarScrollPerformancePatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, [
+    "WARN: Found incomplete Linux sidebar scroll performance patch — skipping",
+  ]);
 });
 
 test("removes native title tooltip from the thread side panel toolbar action", () => {

--- a/scripts/patches/core/all-linux/webview/sidebar-scroll-performance/patch.js
+++ b/scripts/patches/core/all-linux/webview/sidebar-scroll-performance/patch.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const {
+  CI_POLICY_OPTIONAL,
+  webviewAssetPatch,
+} = require("../../../../descriptor.js");
+const {
+  applyLinuxSidebarScrollPerformancePatch,
+  matchesLinuxSidebarScrollPerformanceContract,
+} = require("../../../../impl/webview/index.js");
+
+module.exports = [
+  webviewAssetPatch({
+    id: "linux-sidebar-scroll-performance",
+    phase: "webview-asset",
+    order: 1045,
+    ciPolicy: CI_POLICY_OPTIONAL,
+    pattern: /^app-initial-[^.]+\.js$/,
+    assetMatch: matchesLinuxSidebarScrollPerformanceContract,
+    missingDescription: "main sidebar scroll bundle",
+    skipDescription: "Linux sidebar scroll performance patch",
+    apply: applyLinuxSidebarScrollPerformancePatch,
+  }),
+];

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -25,6 +25,99 @@ const LINUX_WINDOW_CONTROLS_SAFE_AREA_MARKER =
   "/*codexLinuxWindowControlsSafeAreaPatch*/";
 const LINUX_WINDOW_CONTROLS_SAFE_AREA_PATCH_ID =
   "linux-window-controls-safe-area";
+// Chromium on Linux invalidates the full sidebar subtree when the fade custom
+// properties are driven by animation-timeline: scroll(self y).
+// Keep the existing header mask and footer fade, but make this one container's
+// footer distance static so scrolling can stay on the compositor path.
+const LINUX_SIDEBAR_SCROLL_STYLE =
+  "{animationName:`none`,animationTimeline:`auto`,\"--bottom-fade\":`calc(var(--spacing) * 10)`}";
+const LINUX_SIDEBAR_SCROLL_DRIFT_WARNING =
+  "WARN: Could not uniquely identify the main sidebar scroll container — skipping Linux sidebar scroll performance patch";
+
+function linuxSidebarScrollContainers(currentSource) {
+  const anchorPattern =
+    /\{\.\.\.[A-Za-z_$][\w$]*\.sidebarScroll,className:/gu;
+  const containers = [];
+  for (const anchor of currentSource.matchAll(anchorPattern)) {
+    const tail = currentSource.slice(anchor.index, anchor.index + 4_000);
+    const propsMatch = tail.match(
+      /\)(?:,style:(\{[^{}]*\}))?,ref:[A-Za-z_$][\w$]*,onScroll:[A-Za-z_$][\w$]*=>\{/u,
+    );
+    if (propsMatch?.index == null) {
+      continue;
+    }
+
+    const classNameSource = tail.slice(0, propsMatch.index + 1);
+    if (
+      !classNameSource.includes("vertical-scroll-fade-mask") ||
+      !classNameSource.includes("[contain:layout_paint]") ||
+      !classNameSource.includes(".headerFadeMask")
+    ) {
+      continue;
+    }
+
+    const handlerOpenBrace =
+      anchor.index + propsMatch.index + propsMatch[0].lastIndexOf("{");
+    const handlerCloseBrace = findMatchingBrace(currentSource, handlerOpenBrace);
+    if (handlerCloseBrace === -1) {
+      continue;
+    }
+    const handlerSource = currentSource.slice(
+      handlerOpenBrace,
+      handlerCloseBrace + 1,
+    );
+    if (
+      !/let\{scrollTop:[A-Za-z_$][\w$]*\}=[A-Za-z_$][\w$]*\.currentTarget/u.test(
+        handlerSource,
+      )
+    ) {
+      continue;
+    }
+
+    const style = propsMatch[1] ?? null;
+    containers.push({
+      classNameEnd: anchor.index + propsMatch.index + 1,
+      style,
+      styleComplete: style == null || style === LINUX_SIDEBAR_SCROLL_STYLE,
+    });
+  }
+  return containers;
+}
+
+function matchesLinuxSidebarScrollPerformanceContract(currentSource) {
+  const containers = linuxSidebarScrollContainers(currentSource);
+  return containers.length === 1 && containers[0].styleComplete;
+}
+
+function applyLinuxSidebarScrollPerformancePatch(currentSource) {
+  const containers = linuxSidebarScrollContainers(currentSource);
+  if (containers.length === 1 && containers[0].styleComplete) {
+    const [container] = containers;
+    if (container.style === LINUX_SIDEBAR_SCROLL_STYLE) {
+      return currentSource;
+    }
+    return (
+      currentSource.slice(0, container.classNameEnd) +
+      `,style:${LINUX_SIDEBAR_SCROLL_STYLE}` +
+      currentSource.slice(container.classNameEnd)
+    );
+  }
+
+  if (containers.some((container) => !container.styleComplete)) {
+    console.warn(
+      "WARN: Found incomplete Linux sidebar scroll performance patch — skipping",
+    );
+    return currentSource;
+  }
+  if (
+    currentSource.includes(".sidebarScroll") &&
+    currentSource.includes("vertical-scroll-fade-mask") &&
+    currentSource.includes("[contain:layout_paint]")
+  ) {
+    console.warn(LINUX_SIDEBAR_SCROLL_DRIFT_WARNING);
+  }
+  return currentSource;
+}
 
 function applyLinuxSettingsSearchVisibilityPatch(currentSource) {
   if (currentSource.includes("function codexLinuxFilterSettingsSearchSection(")) {
@@ -2498,10 +2591,12 @@ module.exports = {
   applyLinuxTooltipWindowControlsCollisionPatch,
   applyLinuxWindowControlsSafeAreaPatch,
   applyLinuxSettingsSearchVisibilityPatch,
+  applyLinuxSidebarScrollPerformancePatch,
   applyLinuxFastModeModelGuardPatch,
   applyLinuxSkillsListDedupePatch,
   applyLocalEnvironmentActionModalDraftPatch,
   applySubagentNicknameMetadataPatch,
   codexLinuxWatchBrowserWebviewAttachment,
+  matchesLinuxSidebarScrollPerformanceContract,
   patchBrowserPagePreloadBundle,
 };


### PR DESCRIPTION
## Problem

Continuous scrolling in a large ChatGPT Desktop sidebar stutters badly on Linux. The main renderer was spending almost the entire scroll-event budget updating style/layout rather than running the React handler or painting conversation content.

Related to #1048.

## Root cause

The main sidebar scroll container uses `vertical-scroll-fade-mask`, whose `edge-fade` animation drives `--top-fade` and `--bottom-fade` from `animation-timeline: scroll(self y)`.

On Electron 42 / Chromium on Linux, advancing that scroll timeline causes `UpdateLayoutTree` to revisit essentially the entire sidebar subtree on each scroll delivery, despite the fade properties being declared non-inherited. The worst stack is the semantic sidebar `onScroll` site because the synchronous style update is charged to event dispatch; the React scroll-state update and tooltip dismissal were ruled out by separate A/B traces.

## Fix

Add one optional all-Linux core webview patch that:

- semantically identifies the unique main sidebar container using the `sidebarScroll`, fade-mask, containment, header-mask, ref, and `currentTarget.scrollTop` handler contract;
- disables only that container's scroll-driven animation/timeline;
- preserves the existing React `onScroll` handler and header mask;
- preserves the footer affordance as the same static 40px fade;
- applies once, is idempotent, and leaves bytes unchanged with an explicit warning on ambiguity, partial markers, or upstream drift.

No global animations, GPU features, tooltips, history rows, or integrations are disabled.

## Performance

The DevTools comparison is a same-renderer/same-fixture A/B: both passes used the same process, 5,038px scroll height, 707px viewport, 3,770 sidebar descendants, 4,206 document elements, normal scroll handler, four identical synthesized gestures, and the same 40px footer fade. Only `edge-fade / scroll(self y)` versus `none / auto` changed.

| Metric | Before | After |
|---|---:|---:|
| Renderer CPU average (`pidstat`, clean candidate run) | 75.70% | 30.38% |
| Renderer CPU peak | 107% | 111% |
| Minor faults / second | ~7,394 | 4,461.75 |
| Major faults | 0 | 0 |
| Scroll event average | 38.817 ms | 0.416 ms |
| Scroll event p50 | 39.047 ms | 0.328 ms |
| Scroll event p95 | 46.345 ms | 0.538 ms |
| `UpdateLayoutTree` average | 37.824 ms | 0.236 ms |
| `UpdateLayoutTree` p95 | 45.161 ms | 0.377 ms |
| `UpdateLayoutTree` max | 55.734 ms | 2.959 ms |
| Average invalidated elements | 3,244.87 | 2.97 |
| Maximum invalidated elements | 3,340 | 48 |
| Broad invalidations (>1,000 elements) | 137 | 0 |
| Long tasks (>=50 ms) | 56 | 2 |
| Presented-frame gap p50 | 49.218 ms | 8.298 ms |
| Presented-frame gap p95 | 105.599 ms | 10.224 ms |

The original field baseline was 28.66ms average scroll handling, 28.03ms average `UpdateLayoutTree`, ~2,342 invalidated elements/event, and 75.7% renderer CPU. The controlled A/B above used an intentionally expanded, fixed sidebar DOM and reproduced the same pathology.

The patched renderer accepted 918 scroll deliveries over 8.16s versus 141 over 8.44s before, consistent with no longer blocking input behind ~38ms style updates. Peak one-second process CPU remains noisy because the responsive renderer now services far more events/frames; average CPU fell by 59.9%. RSS remained bounded in the clean patched sample (about 555MB average). The preferred <30% CPU target was missed by 0.38 percentage points, while the frame and layout targets were exceeded by a wide margin.

## Testing

- `node --test --test-isolation=none --test-name-pattern='sidebar|default core patch descriptors' scripts/patch-linux-window-ui.test.js` — 6 passed
- Full `scripts/patch-linux-window-ui.test.js` — new tests pass; five known host-sensitive failures reproduced before this change
- `./scripts/ci-local.sh pr` in the supported Ubuntu 24.04 Docker profile — passed; 1,575 Node tests passed, 2 skipped, all Rust, script-smoke, and package checks passed
- `./scripts/rebuild-candidate.sh` — accepted ChatGPT Desktop 26.803.41515 / Electron 42.3.0 candidate; patch applied exactly once, no required or integrity failures
- `git diff --check` — passed
- Manual Wayland and X11 candidate smoke — conversation/project selection, expand/collapse, active highlight, sidebar scrolling/restoration, keyboard navigation, tooltip, context menu, and search passed
- Wayland and X11 traces both eliminated repeated broad invalidation

## Compatibility

The patch targets a stable semantic construct rather than generated offsets, hash names, or minified symbol names. The matcher requires the co-occurrence of the main-sidebar ownership, fade/containment classes, header mask, ref, and semantic `scrollTop` handler shape. Zero or multiple matches are non-mutating optional drift; partial marker states also fail closed. The patch report therefore exposes upstream changes without corrupting a future asset.

## Trace evidence

The original trace attributed about 97.8% of scroll processing to `UpdateLayoutTree`, with affected-element count and duration correlated at approximately r=0.976. In the controlled A/B, the baseline had 137 broad invalidations and the patch had zero; `UpdateLayoutTree` p95 fell from 45.161ms to 0.377ms. No private conversation text or trace artifact is attached.