### PR TITLE
feat(linux-features): add opt-in automation tool schema flatten for strict providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ workarounds.
 |---|---|---|---|
 | Record and Replay (alpha) | Opt-in alpha | `record-and-replay` | [Docs](linux-features/record-and-replay/README.md) |
 | Agent Workspaces | Opt-in | `agent-workspace` | [Docs](linux-features/agent-workspace/README.md) |
+| Automation tool schema flatten | Opt-in | `automation-schema-flatten` | [Docs](linux-features/automation-schema-flatten/README.md) |
 | API key model visibility | Opt-in | `api-key-model-visibility` | [Docs](linux-features/api-key-model-visibility/README.md) |
 | API key service tier | Opt-in | `api-key-service-tier` | [Docs](linux-features/api-key-service-tier/README.md) |
 | Linux AppShots | Opt-in | `appshots` | [Docs](linux-features/appshots/README.md) |

--- a/linux-features/automation-schema-flatten/README.md
+++ b/linux-features/automation-schema-flatten/README.md
@@ -1,0 +1,58 @@
+# Flatten automation_update schema for strict providers
+
+The Codex desktop app registers an `automation_update` tool (scheduled
+automations) whose emitted JSON Schema uses a root-level `oneOf` and has no
+top-level `"type": "object"` (`type` is `null`). OpenAI's own Responses
+endpoint tolerates this, but strict OpenAI-compatible providers that validate
+function schemas server-side (DeepSeek, Azure structured outputs) reject every
+request carrying the tool with:
+
+```text
+Invalid schema for function 'codex_app__automation_update':
+schema must be a JSON Schema of 'type: "object"', got 'type: null'
+```
+
+This feature rewrites the `automation_update` input schema in the shipped
+webview bundle before it reaches the model: it merges the properties of the
+root `oneOf` variants, emits a top-level `"type": "object"`, and keeps
+`additionalProperties` enabled so strict providers accept the tool. Tool calls
+are still validated app-side by the existing schema (`safeParse`), so this only
+relaxes the wire-level schema.
+
+## Enable
+
+```json
+{
+  "enabled": [
+    "automation-schema-flatten"
+  ]
+}
+```
+
+in the git-ignored `linux-features/features.json`, then rerun the install/build
+step so the patch is applied to the generated app.
+
+## How to test
+
+1. Build with the feature enabled and run the app.
+2. Configure a strict provider such as DeepSeek
+   (`wire_api = "responses"`, `deepseek-v4-flash`) in `~/.codex/config.toml`.
+3. Start a thread; requests that include `codex_app__automation_update` should
+   no longer return the 400 schema error above.
+
+Run the self-contained tests with:
+
+```bash
+node --test linux-features/automation-schema-flatten/test.js
+```
+
+## Known risks
+
+- The merged schema is more permissive than the original `oneOf`: the model may
+  see fields from multiple variants at once. Runtime argument validation is
+  unchanged, so invalid calls are still rejected by the app.
+- The patch targets the current upstream bundle's emitter line. If upstream
+  renames or restructures the `automation_update` tool emitter, the patch
+  warns and skips instead of failing the build.
+- This feature is not a substitute for an upstream fix; it only adapts the
+  wire-level schema on Linux builds.

--- a/linux-features/automation-schema-flatten/feature.json
+++ b/linux-features/automation-schema-flatten/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "automation-schema-flatten",
+  "title": "Flatten automation_update schema for strict providers",
+  "description": "Rewrites the codex_app automation_update tool schema into a top-level object schema so strict OpenAI-compatible providers (e.g. DeepSeek, Azure) accept it.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/automation-schema-flatten/patch.js
+++ b/linux-features/automation-schema-flatten/patch.js
@@ -1,0 +1,62 @@
+"use strict";
+
+/**
+ * Matches the codex_app tool emitter's special-case line:
+ *
+ *   return e.name===`automation_update`&&delete t.deferLoading,t
+ *
+ * The emitter is minified so identifiers are captured generically. The line
+ * always returns the tool object via the comma operator, which is what makes
+ * this single-line rewrite safe. The match ends right after the comma-tool
+ * expression so any trailing punctuation (typically `}` for the map callback,
+ * but possibly `;` or `]`) is preserved verbatim.
+ */
+const EMITTER_PATTERN =
+  /return\s+([A-Za-z_$][\w$]*)\.name===\s*`automation_update`\s*&&\s*delete\s+([A-Za-z_$][\w$]*)\.deferLoading\s*,\s*\2(?=[^\w$])/;
+
+function buildReplacement(obj, tool) {
+  // `tool` is the minified variable that holds the emitted tool object.
+  return (
+    `if(${obj}.name===\`automation_update\`){delete ${tool}.deferLoading;` +
+    `let s=${tool}.inputSchema;` +
+    `if(s&&typeof s===\`object\`&&!s.type&&Array.isArray(s.oneOf)){` +
+    `let p={},r=[];function merge(x){` +
+    `if(x&&x.properties)Object.assign(p,x.properties);` +
+    `if(Array.isArray(x.required))r.push(...x.required);` +
+    `if(Array.isArray(x.oneOf))x.oneOf.forEach(merge)` +
+    `}merge(s);` +
+    `let o={type:\`object\`,properties:p,additionalProperties:!0};` +
+    `if(r.length)o.required=[...new Set(r)];` +
+    `${tool}.inputSchema=o}` +
+    `}return ${tool}`
+  );
+}
+
+function applyAutomationSchemaFlattenPatch(source) {
+  const match = source.match(EMITTER_PATTERN);
+  if (match == null) {
+    console.warn(
+      "WARN: automation_update tool emitter not found — skipping automation schema flatten patch",
+    );
+    return source;
+  }
+  return source.replace(
+    EMITTER_PATTERN,
+    buildReplacement(match[1], match[2]),
+  );
+}
+
+module.exports = {
+  descriptors: [
+    {
+      id: "automation-schema-flatten-webview",
+      phase: "webview-asset",
+      order: 2000,
+      ciPolicy: "optional",
+      pattern: /^app-initial-.*\.js$/,
+      missingDescription: "codex_app webview bundle",
+      skipDescription: "automation schema flatten patch",
+      apply: applyAutomationSchemaFlattenPatch,
+    },
+  ],
+};

--- a/linux-features/automation-schema-flatten/test.js
+++ b/linux-features/automation-schema-flatten/test.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const { spawnSync } = require("node:child_process");
+const { descriptors } = require("./patch.js");
+const applyAutomationSchemaFlattenPatch = descriptors[0].apply;
+const {
+  enabledLinuxFeatureIds,
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const {
+  createPatchReport,
+} = require("../../scripts/lib/patch-report.js");
+const {
+  patchExtractedApp,
+} = require("../../scripts/patches/runner.js");
+
+// The real bundle emits the tool inside a map callback, so the line ends with
+// the callback's closing brace. The regex intentionally preserves the
+// trailing punctuation.
+const EMITTER_SNIPPET = "return e.name===`automation_update`&&delete t.deferLoading,t}";
+
+function withTempFeatureRoot(enabled, fn) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-automation-schema-flatten-"));
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  try {
+    delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+    fs.writeFileSync(path.join(root, "features.json"), JSON.stringify({ enabled }, null, 2));
+    fs.cpSync(
+      path.resolve(__dirname, "..", "automation-schema-flatten"),
+      path.join(root, "automation-schema-flatten"),
+      { recursive: true },
+    );
+    return fn(root);
+  } finally {
+    if (originalConfig == null) {
+      delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+    } else {
+      process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function syntaxCheck(source) {
+  const result = spawnSync(process.execPath, ["--check"], {
+    input: source,
+    encoding: "utf8",
+  });
+  return result.status === 0;
+}
+
+test("flattens the automation_update emitter into a valid object schema", () => {
+  // Mirror the real bundle: the emitter is the tail of a map callback that
+  // closes with `}` before the closing `)`.
+  const source = `[0].map(e=>{let t={};${EMITTER_SNIPPET})`;
+  const patched = applyAutomationSchemaFlattenPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /if\(e\.name===`automation_update`\)\{delete t\.deferLoading/);
+  assert.match(patched, /let o=\{type:`object`,properties:p,additionalProperties:!0\}/);
+  assert.match(patched, /t\.inputSchema=o\}/);
+  assert.ok(syntaxCheck(patched), "patched emitter must remain valid JavaScript");
+});
+
+test("merges oneOf variant properties and preserves required fields", () => {
+  const source = EMITTER_SNIPPET;
+  const patched = applyAutomationSchemaFlattenPatch(source);
+
+  assert.match(
+    patched,
+    /if\(s&&typeof s===\`object\`&&!s\.type&&Array\.isArray\(s\.oneOf\)\)\{let p=\{\},r=\[\];function merge\(x\)\{if\(x&&x\.properties\)Object\.assign\(p,x\.properties\)/,
+  );
+  assert.match(patched, /if\(r\.length\)o\.required=\[\.\.\.new Set\(r\)\]/);
+});
+
+test("is a no-op when the emitter marker is absent", () => {
+  const originalWarn = console.warn;
+  console.warn = () => {};
+  try {
+    const source = "const x = 1;";
+    assert.equal(applyAutomationSchemaFlattenPatch(source), source);
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test("feature stays disabled until listed in features.json", () => {
+  withTempFeatureRoot([], (root) => {
+    assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot: root }), []);
+    assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot: root }), []);
+  });
+});
+
+test("feature exposes a webview-asset patch when enabled", () => {
+  withTempFeatureRoot(["automation-schema-flatten"], (root) => {
+    assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot: root }), ["automation-schema-flatten"]);
+
+    const patches = loadLinuxFeaturePatchDescriptors({ featuresRoot: root })
+      .filter((patch) => patch.phase === "webview-asset");
+    assert.equal(patches.length, 1);
+    assert.equal(patches[0].name, "feature:automation-schema-flatten:automation-schema-flatten-webview");
+    assert.ok(patches[0].pattern.test("app-initial-test.js"));
+    assert.equal(patches[0].pattern.test("other-bundle.js"), false);
+    assert.equal(patches[0].apply(EMITTER_SNIPPET), applyAutomationSchemaFlattenPatch(EMITTER_SNIPPET));
+  });
+});
+
+test("feature participates in webview asset patching and patch reports", () => {
+  withTempFeatureRoot(["automation-schema-flatten"], (root) => {
+    const originalRoot = process.env.CODEX_LINUX_FEATURES_ROOT;
+    process.env.CODEX_LINUX_FEATURES_ROOT = root;
+    const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-automation-schema-flatten-app-"));
+    try {
+      const assetsDir = path.join(tempApp, "webview", "assets");
+      fs.mkdirSync(assetsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(assetsDir, "app-initial-test.js"),
+        `const x = 1;${EMITTER_SNIPPET}`,
+      );
+
+      const report = createPatchReport();
+      patchExtractedApp(tempApp, { report });
+
+      const patched = fs.readFileSync(path.join(assetsDir, "app-initial-test.js"), "utf8");
+      assert.match(patched, /if\(e\.name===`automation_update`\)/);
+      assert.ok(
+        report.patches.some((patch) =>
+          patch.name === "feature:automation-schema-flatten:automation-schema-flatten-webview" &&
+          patch.status === "applied"
+        ),
+      );
+    } finally {
+      if (originalRoot == null) {
+        delete process.env.CODEX_LINUX_FEATURES_ROOT;
+      } else {
+        process.env.CODEX_LINUX_FEATURES_ROOT = originalRoot;
+      }
+      fs.rmSync(tempApp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a disabled-by-default opt-in Linux feature, `automation-schema-flatten`, that normalizes the `codex_app__automation_update` tool schema at build time so strict OpenAI-compatible providers stop rejecting model requests.

The upstream app emits `automation_update` with a root-level `oneOf` JSON Schema and no top-level `"type": "object"` (`type` is `null`). OpenAI's own Responses endpoint tolerates this, but strict providers that validate function schemas server-side (DeepSeek, Azure structured outputs) return:

```text
Invalid schema for function 'codex_app__automation_update':
schema must be a JSON Schema of 'type: "object"', got 'type: null'
```

Background:

- [openai/codex#37786](https://github.com/openai/codex/issues/37786) — issue filed upstream for the same problem on the DeepSeek official integration
- [openai/codex#30132](https://github.com/openai/codex/issues/30132) — same failure class on Azure, closed as completed but does not cover strict custom providers
- [cc-switch#5447](https://github.com/farion1231/cc-switch/issues/5447) — proxy-side oneOf flattening workaround

## Changes

Only additive, no core code touched:

- `linux-features/automation-schema-flatten/feature.json` — manifest, `defaultEnabled: false`
- `linux-features/automation-schema-flatten/patch.js` — `webview-asset` patch descriptor targeting `app-initial-*.js`; rewrites the `automation_update` emitter line to merge the root `oneOf` variants' `properties` into a top-level `type: "object"` schema, preserving `required` and enabling `additionalProperties`
- `linux-features/automation-schema-flatten/README.md` — usage, testing, known risks
- `linux-features/automation-schema-flatten/test.js` — 6 self-contained tests (unit + framework integration + patch report)
- `README.md` — one row in the Opt-In Linux Features table

The patch is defensive: if upstream renames or restructures the emitter line, it warns and skips instead of failing the build.

## Validation

- `node --test linux-features/automation-schema-flatten/test.js` — 6/6 pass
- Applied to the current upstream bundle (26.803.41515): old emitter line replaced, normalizer present, full bundle passes `node --input-type=module --check`
- End-to-end on Arch Linux: app builds, launches, and DeepSeek (Responses API, `deepseek-v4-flash`) no longer returns the schema 400

## Risks

- The merged wire schema is more permissive than the original `oneOf`; runtime argument validation (`safeParse`) is unchanged and still rejects invalid calls app-side
- Not a substitute for an upstream fix; this only adapts the wire-level schema on Linux builds

## Test instructions

```bash
# in a checkout:
cp linux-features/features.example.json linux-features/features.json
# add "automation-schema-flatten" to "enabled", then:
node --test linux-features/automation-schema-flatten/test.js
./install.sh
```
