### PR TITLE
fix(main-process): set Linux desktop name so notifications show ChatGPT instead of electron

### DIFF
--- a/scripts/patches/impl/main-process/notifications.js
+++ b/scripts/patches/impl/main-process/notifications.js
@@ -189,6 +189,10 @@ function codexLinuxCreateActionNotification(options, fallbackFactory, runtime) {
 function bridgeSource() {
   return [
     `var codexLinuxNotificationActionsPatch=${JSON.stringify(PATCH_MARKER)};`,
+    // Give Electron a Linux desktop identity so native notifications (and
+    // window app_id) resolve to the installed desktop file instead of falling
+    // back to the process name "electron" in Plasma/GNOME notification popups.
+    `try{require("electron").app.setDesktopName("codex-desktop")}catch(e){}`,
     codexLinuxNotificationActionsNativePath,
     codexLinuxNotificationActionLines,
     codexLinuxCreateActionNotification,

--- a/scripts/patches/impl/main-process/notifications.test.js
+++ b/scripts/patches/impl/main-process/notifications.test.js
@@ -19,6 +19,7 @@ test("Linux notification actions patch routes action payloads through the bridge
   const patched = applyLinuxNotificationActionsPatch(`before;${currentFactory};after`);
 
   assert.match(patched, new RegExp(PATCH_MARKER));
+  assert.match(patched, /require\("electron"\)\.app\.setDesktopName\("codex-desktop"\)/);
   assert.match(
     patched,
     /process\.platform===`linux`&&Array\.isArray\(e\.actions\)&&e\.actions\.length>0/,


### PR DESCRIPTION
## Summary

Native notifications from the app show "electron" as the source name in Plasma/GNOME instead of "ChatGPT".

Electron falls back to the process name (`electron`) for the notification's app identity because the app never sets a Linux desktop name. Notifications with action buttons already route through the wrapper's native bridge (which passes `app_name="ChatGPT"`), but plain notifications — such as turn-complete notifications — use Electron's native notification path and therefore display as "electron".

This PR calls `app.setDesktopName("codex-desktop")` in the injected notification-bridge bootstrap that already runs at main-bundle load. Electron then sets the `desktop-entry` hint on its native notifications, and Plasma/GNOME resolve it against the installed `codex-desktop.desktop` entry (`Name=ChatGPT` + icon) instead of showing the process name.

## Changes

- `scripts/patches/impl/main-process/notifications.js`: 4 new lines in `bridgeSource()` — a guarded `require("electron").app.setDesktopName("codex-desktop")` that runs when the main bundle loads.
- `scripts/patches/impl/main-process/notifications.test.js`: assertion that the patched bundle contains the `setDesktopName` call.

## Validation

- `node --test 'scripts/patches/impl/**/*.test.js'` — 49/49 pass (10 of them in the notifications suite).
- Applied to the current upstream main bundle: patch applies cleanly, output is syntactically valid (`node --check`), and the call is present in the built `app.asar`.
- End-to-end on Arch Linux (Plasma 6 / Wayland): task-complete notifications now show "ChatGPT" with the correct icon instead of "electron".

## Notes

- The bridge path was already correct (`app_name="ChatGPT"` hardcoded); this fixes the fallback path only.
- Related: #1278 (opt-in schema flatten for strict providers).
