### PR TITLE
fix(linux): reduce app-shell tab layout stalls

### DIFF
--- a/.agents/plans/2026-08-10-linux-app-shell-tab-layout-performance.md
+++ b/.agents/plans/2026-08-10-linux-app-shell-tab-layout-performance.md
@@ -1,0 +1,59 @@
+# Linux app-shell tab layout performance
+
+## Goal
+
+Reduce stalls when opening or switching to long/running conversations with
+Browser tabs, without suspending Browser Use or Computer Use workloads.
+
+## Evidence and scope
+
+- An isolated same-DMG baseline reproduced 2.0-6.8 second settle times, a 3.6
+  second long task, and up to 6,674 DOM elements across eight session switches.
+- A focused heavy-session CPU profile attributed about 423 ms to the app-shell
+  tab overflow callback and 361 ms to Framer Motion `measureScroll` work.
+- App-shell tabs entered from zero width on every tab-strip mount. Their label
+  ResizeObserver synchronously read `scrollWidth` during the same resize/layout
+  cascade.
+- Retained hidden Browser guest views are intentional for active Browser Use.
+  Destroying or suspending them is out of scope.
+- Reducing thread overscan and adding per-block CSS containment were measured
+  against the same workload and rejected because they did not materially help.
+
+## Implementation
+
+1. Add one optional all-Linux webview-asset patch for the semantic app-shell tab
+   contract in the current `app-initial-*.js` bundle.
+2. Disable only the tab's enter-from-zero-width animation when a tab strip is
+   mounted; preserve its exit animation, drag behavior, and tab controls.
+3. Defer and coalesce each label's overflow read to one animation-frame callback
+   so it no longer forces layout during React/ResizeObserver delivery.
+4. Keep the overflow fade state and retained Browser webviews intact.
+5. Match one complete contract, remain idempotent, and fail soft on upstream
+   drift, ambiguity, or a partial patch.
+
+## Validation
+
+- Lock the transform with fixture tests for the complete contract, idempotence,
+  semantic rejection, ambiguity, and drift.
+- Rebuild from the same upstream DMG and require an accepted patch report.
+- Profile a light-to-heavy switch in an isolated candidate and verify the two
+  targeted layout-read hotspots fall materially.
+- Check after two animation frames that overflowing tab labels retain their fade
+  and all retained Browser webviews remain connected.
+- Run focused and full patch tests, smoke tests, local PR CI, diff checks, and an
+  independent read-only review before publication.
+
+## Publication
+
+- Correct issue #1279 with the confirmed resize/layout root cause and sanitized
+  measurements.
+- Commit only implementation, descriptor, tests, and this plan.
+- Push a focused branch, open one draft PR, and inspect CI to terminal status.
+
+## Stop conditions
+
+- Stop if tab overflow state no longer converges after animation frames, tab
+  interactions regress, or Browser/Computer Use guest views disconnect.
+- Stop if the current bundle contract is not unique.
+- Do not claim an end-to-end settle-time improvement from noisy live-session
+  sweeps; report the directly profiled hotspot reduction instead.

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -192,6 +192,7 @@ const {
   applyLinuxI18nGatePatch,
   applyLinuxOpaqueWindowsDefaultPatch,
   applyLinuxSettingsSearchVisibilityPatch,
+  applyLinuxAppShellTabLayoutPerformancePatch,
   applyLinuxSidebarScrollPerformancePatch,
   applyLinuxSkillsListDedupePatch,
   applyLinuxThreadSidePanelNativeTooltipPatch,
@@ -199,6 +200,7 @@ const {
   applyLinuxWindowControlsSafeAreaPatch,
   applySubagentNicknameMetadataPatch,
   codexLinuxWatchBrowserWebviewAttachment,
+  matchesLinuxAppShellTabLayoutPerformanceContract,
   matchesLinuxSidebarScrollPerformanceContract,
 } = require("./patches/impl/webview/index.js");
 const {
@@ -1037,6 +1039,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-workspace-root-open-targets",
     "linux-settings-search-visibility",
     "linux-sidebar-scroll-performance",
+    "linux-app-shell-tab-layout-performance",
     "linux-i18n-gate",
     "automation-schedule-multi-time-rrule",
     "automation-update-eager-tool",
@@ -3615,6 +3618,127 @@ test("rejects an incomplete sidebar performance patch marker", () => {
   assert.equal(value, source);
   assert.deepEqual(warnings, [
     "WARN: Found incomplete Linux sidebar scroll performance patch — skipping",
+  ]);
+});
+
+function appShellTabMountAnimationFixture({
+  duplicate = false,
+  initialExpression = "p?PCr:!1",
+} = {}) {
+  const tab =
+    "function ECr(e){let [N,P]=useState(!1),z=(e,t)=>{P(t.scrollWidth>t.clientWidth)};return jsx(`span`,{\"data-app-shell-tab-close-button\":!0,className:`@max-[4rem]/app-shell-tab:invisible`})}function kCr(e){let p=!Zm()&&u?.dragState==null;let R=" +
+    initialExpression +
+    ",z=p?PCr:void 0,B;return (0,eM.jsxs)(rp.div,{inert:F,\"data-app-shell-tab-controller\":I,\"data-tab-id\":m,ref:L,initial:R,animate:FCr,exit:z,transition:wCr,onAnimationComplete:B,className:`@container/app-shell-tab contain-content`,style:ee,children:[se,ue]})}";
+  const presets =
+    "var PCr={maxWidth:`0px`,minWidth:`0px`},FCr={maxWidth:`160px`,minWidth:`90px`};";
+  const source = `${tab}${presets}`;
+  return duplicate ? `${source}${source.replaceAll("kCr", "kDr")}` : source;
+}
+
+test("skips app-shell tab enter animation while preserving exit animation", () => {
+  const source = appShellTabMountAnimationFixture();
+
+  const patched = applyPatchTwice(
+    applyLinuxAppShellTabLayoutPerformancePatch,
+    source,
+  );
+
+  assert.match(patched, /let p=!Zm\(\)&&u\?\.dragState==null;let R=!1,z=p\?PCr:void 0,B/);
+  assert.match(
+    patched,
+    /initial:R,animate:FCr,exit:z,transition:wCr,onAnimationComplete:B/,
+  );
+  assert.match(
+    patched,
+    /z=\(e,t\)=>\{codexLinuxScheduleAppShellTabOverflow\(t,P\)\}/,
+  );
+  assert.match(
+    patched,
+    /function codexLinuxScheduleAppShellTabOverflow\(e,t\)/,
+  );
+  assert.match(patched, /PCr=\{maxWidth:`0px`,minWidth:`0px`\}/);
+  assert.equal(matchesLinuxAppShellTabLayoutPerformanceContract(patched), true);
+});
+
+test("coalesces app-shell tab overflow reads and ignores disconnected labels", () => {
+  const patched = applyLinuxAppShellTabLayoutPerformancePatch(
+    appShellTabMountAnimationFixture(),
+  );
+  const helper = patched.slice(
+    patched.indexOf("const codexLinuxAppShellTabOverflowFrames="),
+    patched.indexOf("function ECr("),
+  );
+  const frames = [];
+  const schedule = new Function(
+    "requestAnimationFrame",
+    `${helper};return codexLinuxScheduleAppShellTabOverflow`,
+  )((callback) => {
+    frames.push(callback);
+    return frames.length;
+  });
+  const label = { clientWidth: 80, isConnected: true, scrollWidth: 120 };
+  const states = [];
+
+  schedule(label, (overflow) => states.push(overflow));
+  schedule(label, (overflow) => states.push(overflow));
+  assert.equal(frames.length, 1);
+  assert.deepEqual(states, []);
+
+  frames.shift()();
+  assert.deepEqual(states, [true]);
+
+  schedule(label, (overflow) => states.push(overflow));
+  label.isConnected = false;
+  frames.shift()();
+  assert.deepEqual(states, [true]);
+});
+
+test("matches only the app-shell width-animation contract", () => {
+  assert.equal(
+    matchesLinuxAppShellTabLayoutPerformanceContract(
+      appShellTabMountAnimationFixture(),
+    ),
+    true,
+  );
+  assert.equal(
+    matchesLinuxAppShellTabLayoutPerformanceContract(
+      "function generic(){let R=p?PCr:!1,z=p?PCr:void 0;return jsx(motion.div,{initial:R,animate:FCr,exit:z})}",
+    ),
+    false,
+  );
+  assert.equal(
+    matchesLinuxAppShellTabLayoutPerformanceContract(
+      appShellTabMountAnimationFixture({ duplicate: true }),
+    ),
+    false,
+  );
+});
+
+test("leaves drifted app-shell tab animation byte-identical", () => {
+  const source = appShellTabMountAnimationFixture({
+    initialExpression: "getInitialTabWidth(p)",
+  });
+
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxAppShellTabLayoutPerformancePatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not uniquely identify the app-shell tab layout contract — skipping Linux tab layout performance patch",
+  ]);
+});
+
+test("leaves ambiguous app-shell tab animation assets byte-identical", () => {
+  const source = appShellTabMountAnimationFixture({ duplicate: true });
+
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxAppShellTabLayoutPerformancePatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not uniquely identify the app-shell tab layout contract — skipping Linux tab layout performance patch",
   ]);
 });
 

--- a/scripts/patches/core/all-linux/webview/app-shell-tab-layout-performance/patch.js
+++ b/scripts/patches/core/all-linux/webview/app-shell-tab-layout-performance/patch.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const {
+  CI_POLICY_OPTIONAL,
+  webviewAssetPatch,
+} = require("../../../../descriptor.js");
+const {
+  applyLinuxAppShellTabLayoutPerformancePatch,
+  matchesLinuxAppShellTabLayoutPerformanceContract,
+} = require("../../../../impl/webview/index.js");
+
+module.exports = [
+  webviewAssetPatch({
+    id: "linux-app-shell-tab-layout-performance",
+    phase: "webview-asset",
+    order: 1046,
+    ciPolicy: CI_POLICY_OPTIONAL,
+    pattern: /^app-initial-[^.]+\.js$/,
+    assetMatch: matchesLinuxAppShellTabLayoutPerformanceContract,
+    missingDescription: "app-shell tab layout bundle",
+    skipDescription: "Linux app-shell tab layout performance patch",
+    apply: applyLinuxAppShellTabLayoutPerformancePatch,
+  }),
+];

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -33,6 +33,177 @@ const LINUX_SIDEBAR_SCROLL_STYLE =
   "{animationName:`none`,animationTimeline:`auto`,\"--bottom-fade\":`calc(var(--spacing) * 10)`}";
 const LINUX_SIDEBAR_SCROLL_DRIFT_WARNING =
   "WARN: Could not uniquely identify the main sidebar scroll container — skipping Linux sidebar scroll performance patch";
+const LINUX_APP_SHELL_TAB_LAYOUT_DRIFT_WARNING =
+  "WARN: Could not uniquely identify the app-shell tab layout contract — skipping Linux tab layout performance patch";
+const LINUX_APP_SHELL_TAB_OVERFLOW_HELPER =
+  "const codexLinuxAppShellTabOverflowFrames=new WeakMap;function codexLinuxScheduleAppShellTabOverflow(e,t){if(e?.isConnected&&!codexLinuxAppShellTabOverflowFrames.has(e)){let n=requestAnimationFrame(()=>{codexLinuxAppShellTabOverflowFrames.delete(e),e.isConnected&&t(e.scrollWidth>e.clientWidth)});codexLinuxAppShellTabOverflowFrames.set(e,n)}}";
+
+function enclosingFunction(currentSource, targetIndex) {
+  const functionPattern =
+    /function ([A-Za-z_$][\w$]*)\([^)]*\)\{/gu;
+  let enclosing = null;
+  for (const candidate of currentSource.matchAll(functionPattern)) {
+    if (candidate.index > targetIndex) {
+      break;
+    }
+    const openBrace = candidate.index + candidate[0].length - 1;
+    const closeBrace = findMatchingBrace(currentSource, openBrace);
+    if (closeBrace >= targetIndex) {
+      enclosing = {
+        end: closeBrace + 1,
+        name: candidate[1],
+        start: candidate.index,
+      };
+    }
+  }
+  return enclosing;
+}
+
+function linuxAppShellTabOverflowMeasurements(currentSource) {
+  const callbackPattern =
+    /([A-Za-z_$][\w$]*)=\(e,t\)=>\{(?:([A-Za-z_$][\w$]*)\(t\.scrollWidth>t\.clientWidth\)|codexLinuxScheduleAppShellTabOverflow\(t,([A-Za-z_$][\w$]*)\))\}/gu;
+  const candidates = [];
+  for (const callback of currentSource.matchAll(callbackPattern)) {
+    const owner = enclosingFunction(currentSource, callback.index);
+    if (owner == null) {
+      continue;
+    }
+    const ownerSource = currentSource.slice(owner.start, owner.end);
+    if (
+      !ownerSource.includes("data-app-shell-tab-close-button") ||
+      !ownerSource.includes("@max-[4rem]/app-shell-tab")
+    ) {
+      continue;
+    }
+    candidates.push({
+      callbackEnd: callback.index + callback[0].length,
+      callbackName: callback[1],
+      callbackStart: callback.index,
+      functionStart: owner.start,
+      patched: callback[3] != null,
+      setterName: callback[2] ?? callback[3],
+    });
+  }
+  return candidates;
+}
+
+function linuxAppShellTabMountAnimations(currentSource) {
+  const controllerPattern =
+    /"data-app-shell-tab-controller":[A-Za-z_$][\w$]*,[\s\S]{0,1000}?initial:([A-Za-z_$][\w$]*),animate:([A-Za-z_$][\w$]*),exit:([A-Za-z_$][\w$]*),transition:[A-Za-z_$][\w$]*,onAnimationComplete:/gu;
+  const candidates = [];
+
+  for (const controller of currentSource.matchAll(controllerPattern)) {
+    const initialName = controller[1];
+    const animateName = controller[2];
+    const exitName = controller[3];
+    const prefixStart = Math.max(0, controller.index - 6_000);
+    const prefix = currentSource.slice(prefixStart, controller.index);
+    const suffix = currentSource.slice(controller.index, controller.index + 6_000);
+    const vicinity = `${prefix}${suffix}`;
+    const initialPrefix = `let ${initialName}=`;
+    const exitPrefix = `,${exitName}=`;
+    const unpatchedPattern = new RegExp(
+      `${escapeRegExp(initialPrefix)}([A-Za-z_$][\\w$]*)\\?([A-Za-z_$][\\w$]*):!1${escapeRegExp(exitPrefix)}\\1\\?\\2:void 0,`,
+      "gu",
+    );
+    const patchedPattern = new RegExp(
+      `${escapeRegExp(initialPrefix)}!1${escapeRegExp(exitPrefix)}([A-Za-z_$][\\w$]*)\\?([A-Za-z_$][\\w$]*):void 0,`,
+      "gu",
+    );
+    const unpatchedMatches = [...prefix.matchAll(unpatchedPattern)];
+    const patchedMatches = [...prefix.matchAll(patchedPattern)];
+    const pair = unpatchedMatches.at(-1) ?? patchedMatches.at(-1);
+    if (pair == null) {
+      continue;
+    }
+
+    const patched = patchedMatches.at(-1) === pair;
+    const collapsedName = pair[2];
+    const collapsedPreset = `${collapsedName}={maxWidth:\`0px\`,minWidth:\`0px\`}`;
+    const expandedPreset = `${animateName}={maxWidth:\`160px\`,minWidth:\`90px\`}`;
+    if (
+      !vicinity.includes("@container/app-shell-tab") ||
+      !vicinity.includes(collapsedPreset) ||
+      !vicinity.includes(expandedPreset)
+    ) {
+      continue;
+    }
+
+    const declarationStart = prefixStart + pair.index;
+    const expressionStart = declarationStart + initialPrefix.length;
+    const expression = patched ? "!1" : `${pair[1]}?${pair[2]}:!1`;
+    candidates.push({
+      expressionEnd: expressionStart + expression.length,
+      expressionStart,
+      patched,
+    });
+  }
+
+  return candidates;
+}
+
+function matchesLinuxAppShellTabLayoutPerformanceContract(currentSource) {
+  const mountAnimations = linuxAppShellTabMountAnimations(currentSource);
+  const overflowMeasurements = linuxAppShellTabOverflowMeasurements(currentSource);
+  if (mountAnimations.length !== 1 || overflowMeasurements.length !== 1) {
+    return false;
+  }
+  const patched = mountAnimations[0].patched && overflowMeasurements[0].patched;
+  const unpatched = !mountAnimations[0].patched && !overflowMeasurements[0].patched;
+  const hasHelper = currentSource.includes(LINUX_APP_SHELL_TAB_OVERFLOW_HELPER);
+  return (patched && hasHelper) || (unpatched && !hasHelper);
+}
+
+function applyLinuxAppShellTabLayoutPerformancePatch(currentSource) {
+  const mountAnimations = linuxAppShellTabMountAnimations(currentSource);
+  const overflowMeasurements = linuxAppShellTabOverflowMeasurements(currentSource);
+  const hasHelper = currentSource.includes(LINUX_APP_SHELL_TAB_OVERFLOW_HELPER);
+  if (mountAnimations.length === 1 && overflowMeasurements.length === 1) {
+    const [mountAnimation] = mountAnimations;
+    const [overflowMeasurement] = overflowMeasurements;
+    if (mountAnimation.patched && overflowMeasurement.patched && hasHelper) {
+      return currentSource;
+    }
+    if (!mountAnimation.patched && !overflowMeasurement.patched && !hasHelper) {
+      const callbackPatch =
+        `${overflowMeasurement.callbackName}=(e,t)=>{` +
+        `codexLinuxScheduleAppShellTabOverflow(t,${overflowMeasurement.setterName})}`;
+      const edits = [
+        {
+          end: mountAnimation.expressionEnd,
+          start: mountAnimation.expressionStart,
+          text: "!1",
+        },
+        {
+          end: overflowMeasurement.callbackEnd,
+          start: overflowMeasurement.callbackStart,
+          text: callbackPatch,
+        },
+        {
+          end: overflowMeasurement.functionStart,
+          start: overflowMeasurement.functionStart,
+          text: LINUX_APP_SHELL_TAB_OVERFLOW_HELPER,
+        },
+      ].sort((left, right) => right.start - left.start);
+      let patchedSource = currentSource;
+      for (const edit of edits) {
+        patchedSource =
+          patchedSource.slice(0, edit.start) +
+          edit.text +
+          patchedSource.slice(edit.end);
+      }
+      return patchedSource;
+    }
+  }
+
+  if (
+    currentSource.includes("data-app-shell-tab-controller") &&
+    currentSource.includes("@container/app-shell-tab")
+  ) {
+    console.warn(LINUX_APP_SHELL_TAB_LAYOUT_DRIFT_WARNING);
+  }
+  return currentSource;
+}
 
 function linuxSidebarScrollContainers(currentSource) {
   const anchorPattern =
@@ -2587,6 +2758,7 @@ module.exports = {
   applyPersistentRateLimitFooterPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
+  applyLinuxAppShellTabLayoutPerformancePatch,
   applyLinuxThreadSidePanelNativeTooltipPatch,
   applyLinuxTooltipWindowControlsCollisionPatch,
   applyLinuxWindowControlsSafeAreaPatch,
@@ -2597,6 +2769,7 @@ module.exports = {
   applyLocalEnvironmentActionModalDraftPatch,
   applySubagentNicknameMetadataPatch,
   codexLinuxWatchBrowserWebviewAttachment,
+  matchesLinuxAppShellTabLayoutPerformanceContract,
   matchesLinuxSidebarScrollPerformanceContract,
   patchBrowserPagePreloadBundle,
 };


### PR DESCRIPTION
## Summary

Fixes #1279.

Session switches with long conversations and retained Browser / Computer Use tabs can trigger an app-shell tab resize cascade on Linux. Renderer profiling identified two avoidable costs in that cascade:

- every existing tab replays its enter-from-zero-width animation when the tab strip remounts;
- its ResizeObserver callback synchronously reads `scrollWidth` / `clientWidth` while layout is still changing.

This PR adds one optional semantic webview patch that:

- disables only the tab's mount-time enter animation while preserving animate, exit, drag, close, and controls;
- defers and coalesces overflow measurement to one animation frame per label element;
- leaves retained Browser / Computer Use guest views mounted and connected;
- remains idempotent and fails soft if the latest upstream bundle contract drifts or becomes ambiguous.

Source-of-truth changes are limited to the webview patch implementation and descriptor, focused regression tests, and the implementation plan.

## Performance evidence

| Profiled renderer work | Before | After |
| --- | ---: | ---: |
| App-shell overflow callback self time | ~423 ms | ~14 ms |
| Framer Motion `measureScroll` self time | ~361 ms | below the final top-self-time cutoff |

The overflow callback reduction is about 97%. The intermediate mount-only profile reduced `measureScroll` to about 40 ms before the combined patch removed it from the final profile's hot-self list.

The live end-to-end settle-time sweep was noisy because session content continued changing, so this PR intentionally does not claim a wall-time percentage. Long-conversation rendering remains visible in the trace and is outside this focused patch.

## Validation

- `node --test --test-name-pattern='app-shell tab' scripts/patch-linux-window-ui.test.js`
- Transform applied successfully to the current installed `app-initial-*.js` contract; the second application was byte-identical
- Same-DMG isolated candidate accepted with no required patch or integrity failures
- Heavy-session CPU profile repeated after the patch
- Overflow UI checked after two animation frames: 2/2 overflowing labels retained fade indicators
- Browser retention checked: 3/3 guest views remained connected, including 2 hidden views
- `./scripts/ci-local.sh pr`: passed
  - container test phase: 1,580 passed, 0 failed, 2 skipped
  - script smoke suite: passed
  - Debian, RPM, and pacman package matrices: passed
- `git diff --check`
- Independent read-only review found no confirmed defect

The direct host-only patch suite reports 419/424 passing; the same five environment-sensitive tests already fail on the unmodified host setup (cursor bridge timing, native desktop enumeration, bundled-plugin path trust, and two CLI stderr assertions). Those paths pass in the repository's isolated CI container.

## Compatibility and risk

- Targets only the current upstream DMG semantic contract.
- Optional/fail-soft behavior leaves unknown or partial future contracts unchanged.
- Does not change Browser / Computer Use lifetime policy.
- Does not add dependencies or modify generated app artifacts.
- Remaining risk is limited to upstream minified-bundle drift, which is surfaced as an optional patch skip.

## Checklist

- [ ] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] This is not an upstream-drift compatibility fix; the semantic patch intentionally targets only the latest `CODEX.DMG`.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required local and GitHub CI checks pass.
- [ ] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
