### PR TITLE
Add opt-in ChatGPT conversation deletion for Linux

### DIFF
--- a/linux-features/conversation-delete/README.md
+++ b/linux-features/conversation-delete/README.md
@@ -1,0 +1,40 @@
+# Conversation Delete
+
+Optional Linux feature that adds **Delete chat** to ChatGPT conversations in
+Codex Desktop's sidebar.
+
+Feature is disabled by default because deletion is permanent. Enable it in
+`linux-features/features.json`:
+
+```json
+{
+  "enabled": ["conversation-delete"]
+}
+```
+
+Action asks for confirmation, then uses upstream's authenticated ChatGPT
+request client. It sends:
+
+```text
+DELETE /backend-api/conversation/id/<conversation_id>
+```
+
+Request has no body. Existing upstream client sends session authentication,
+handles `204 No Content`, removes conversation from sidebar cache, suppresses
+stale refetched list entries during backend propagation, and returns to home
+when deleting active chat.
+
+## Scope
+
+Feature targets ChatGPT server conversations shown in ChatGPT mode. It does not
+add deletion for local Codex threads or archived-chat bulk actions.
+
+## Test
+
+```bash
+node --test linux-features/conversation-delete/test.js
+```
+
+Known risk: endpoint and minified sidebar markers are private upstream
+contracts. Current-DMG drift leaves asset unchanged and emits warning; rebuild
+with feature enabled after upstream refresh.

--- a/linux-features/conversation-delete/feature.json
+++ b/linux-features/conversation-delete/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "conversation-delete",
+  "title": "Conversation Delete",
+  "description": "Adds a confirmed permanent-delete action to ChatGPT conversations in the sidebar.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/conversation-delete/patch.js
+++ b/linux-features/conversation-delete/patch.js
@@ -16,6 +16,7 @@ const SIDEBAR_MENU_REPLACEMENT = `{id:\`archive-chatgpt-conversation\`,message:O
 const SIDEBAR_COMPONENT_NEEDLE = "function VBc(e){let t=(0,w5.c)(83),";
 const CACHE_EVICTION_NEEDLE = "function KDa(";
 const DELETE_API_NEEDLE = "safeDelete(`/conversation/id/{conversation_id}`,";
+const NEW_CHAT_HANDLER_NEEDLE = "function y0(e,t){";
 const LIST_FILTER_NEEDLE = "return{...l,items:l.items?.filter(uBr)??[]}";
 const BATCH_FILTER_NEEDLE =
 	"async getBatch(e,t){return(await this.request.getConversationsBatch(e,t)).filter(uBr)}";
@@ -28,9 +29,8 @@ const PINNED_FILTER_REPLACEMENT =
 	`${DELETED_IDS}.has(e.item?.id))}`;
 const PROJECT_LIST_FILTER_NEEDLE =
 	"async listProjectConversations({cursor:e=null,limit:t=5,ownedOnly:n=!0,projectId:r}){let i=await this.request.listProjectConversations({cursor:e,limit:t,ownedOnly:n,projectId:r});return{cursor:i.cursor,items:i.items?.filter(uBr)??[]}}";
-const PROJECT_LIST_FILTER_REPLACEMENT =
-	`async listProjectConversations({cursor:e=null,limit:t=5,ownedOnly:n=!0,projectId:r}){let i=await this.request.listProjectConversations({cursor:e,limit:t,ownedOnly:n,projectId:r});return{cursor:i.cursor,items:i.items?.filter(e=>!${DELETED_IDS}.has(e?.id)&&uBr(e))??[]}}`;
-const RUNTIME_SOURCE = `const ${DELETED_IDS}=new Set;function ${RUNTIME_MARKER}(e,t,n,r,i,o,s){if(t==null||r)return;if(typeof window==="undefined"||typeof window.confirm!=="function"||!window.confirm(o.formatMessage(OW.deleteConfirm,{title:n})))return;e.get(zN).delete(t.id).then(()=>{${DELETED_IDS}.add(t.id),KDa(e.queryClient,t.id),i&&typeof s==="function"&&s(${JSON.stringify(NEW_THREAD_ROUTE)})}).catch(()=>{e.get(yv).danger(o.formatMessage(OW.deleteError))})}`;
+const PROJECT_LIST_FILTER_REPLACEMENT = `async listProjectConversations({cursor:e=null,limit:t=5,ownedOnly:n=!0,projectId:r}){let i=await this.request.listProjectConversations({cursor:e,limit:t,ownedOnly:n,projectId:r});return{cursor:i.cursor,items:i.items?.filter(e=>!${DELETED_IDS}.has(e?.id)&&uBr(e))??[]}}`;
+const RUNTIME_SOURCE = `const ${DELETED_IDS}=new Set;function ${RUNTIME_MARKER}(e,t,n,r,i,o,s){if(t==null||r)return;if(typeof window==="undefined"||typeof window.confirm!=="function"||!window.confirm(o.formatMessage(OW.deleteConfirm,{title:n})))return;e.get(zN).delete(t.id).then(()=>{${DELETED_IDS}.add(t.id),i&&(typeof y0==="function"?y0(e):typeof s==="function"&&s(${JSON.stringify(NEW_THREAD_ROUTE)})),KDa(e.queryClient,t.id)}).catch(()=>{e.get(yv).danger(o.formatMessage(OW.deleteError))})}`;
 
 function warn(message) {
 	console.warn(`WARN: ${message} - skipping conversation delete feature patch`);
@@ -56,10 +56,14 @@ function applyConversationDeletePatch(source) {
 			["ChatGPT sidebar conversation row", SIDEBAR_COMPONENT_NEEDLE],
 			["ChatGPT conversation cache helper", CACHE_EVICTION_NEEDLE],
 			["ChatGPT conversation delete API client", DELETE_API_NEEDLE],
+			["ChatGPT new-chat state handler", NEW_CHAT_HANDLER_NEEDLE],
 			["ChatGPT conversation list response filter", LIST_FILTER_NEEDLE],
 			["ChatGPT conversation batch response filter", BATCH_FILTER_NEEDLE],
 			["ChatGPT pinned conversation response filter", PINNED_FILTER_NEEDLE],
-			["ChatGPT project conversation response filter", PROJECT_LIST_FILTER_NEEDLE],
+			[
+				"ChatGPT project conversation response filter",
+				PROJECT_LIST_FILTER_NEEDLE,
+			],
 			["ChatGPT sidebar archive menu item", SIDEBAR_MENU_NEEDLE],
 		];
 		const missing = markers.filter(

--- a/linux-features/conversation-delete/patch.js
+++ b/linux-features/conversation-delete/patch.js
@@ -1,0 +1,118 @@
+const CHATGPT_SIDEBAR_ASSET_PATTERN = /^app-initial-[^.]+\.js$/;
+const RUNTIME_MARKER = "codexLinuxDeleteChatGptConversation";
+const DELETED_IDS = "codexLinuxDeletedChatGptConversationIds";
+const DELETE_MENU_ID = "delete-chatgpt-conversation";
+
+const ARCHIVE_MESSAGE =
+	"archive:{id:`chatgptConversations.sidebar.archive`,defaultMessage:`Archive chat`,description:`Action label to archive a ChatGPT conversation in the sidebar`}";
+const DELETE_MESSAGES =
+	"delete:{id:`codexLinuxConversationDelete.delete`,defaultMessage:`Delete chat`,description:`Action label to permanently delete a ChatGPT conversation in the sidebar`},deleteConfirm:{id:`codexLinuxConversationDelete.confirm`,defaultMessage:`Delete “{title}”? This can't be undone.`,description:`Confirmation message shown before permanently deleting a ChatGPT conversation`},deleteError:{id:`codexLinuxConversationDelete.error`,defaultMessage:`Failed to delete conversation`,description:`Error shown when permanently deleting a ChatGPT conversation fails`},";
+const LOCALIZATION_NEEDLE = `${ARCHIVE_MESSAGE},archiveError:`;
+const LOCALIZATION_REPLACEMENT = `${ARCHIVE_MESSAGE},${DELETE_MESSAGES}archiveError:`;
+const SIDEBAR_MENU_NEEDLE =
+	"{id:`archive-chatgpt-conversation`,message:OW.archive,onSelect:ae}]}";
+const SIDEBAR_MENU_REPLACEMENT = `{id:\`archive-chatgpt-conversation\`,message:OW.archive,onSelect:ae},{id:\`${DELETE_MENU_ID}\`,message:OW.delete,onSelect:()=>${RUNTIME_MARKER}(E,n,v,w,o,p,D,O)}]}`;
+const SIDEBAR_COMPONENT_NEEDLE = "function VBc(e){let t=(0,w5.c)(83),";
+const CACHE_EVICTION_NEEDLE = "function KDa(";
+const DELETE_API_NEEDLE = "safeDelete(`/conversation/id/{conversation_id}`,";
+const LIST_FILTER_NEEDLE = "return{...l,items:l.items?.filter(uBr)??[]}";
+const BATCH_FILTER_NEEDLE =
+	"async getBatch(e,t){return(await this.request.getConversationsBatch(e,t)).filter(uBr)}";
+const PINNED_FILTER_NEEDLE =
+	"async listPinnedConversationItems(){return(await this.request.listPinnedItems({itemType:`conversation`})).filter(lBr)}";
+const LIST_FILTER_REPLACEMENT = `return{...l,items:l.items?.filter(e=>!${DELETED_IDS}.has(e?.id)&&uBr(e))??[]}`;
+const BATCH_FILTER_REPLACEMENT = `async getBatch(e,t){return(await this.request.getConversationsBatch(e,t)).filter(uBr).filter(e=>!${DELETED_IDS}.has(e?.id))}`;
+const PINNED_FILTER_REPLACEMENT =
+	"async listPinnedConversationItems(){return(await this.request.listPinnedItems({itemType:`conversation`})).filter(lBr).filter(e=>!" +
+	`${DELETED_IDS}.has(e.item?.id))}`;
+const RUNTIME_SOURCE = `const ${DELETED_IDS}=new Set;function ${RUNTIME_MARKER}(e,t,n,r,i,a,o,s){if(t==null||r)return;if(typeof window==="undefined"||typeof window.confirm!=="function"||!window.confirm(o.formatMessage(OW.deleteConfirm,{title:n})))return;e.get(zN).delete(t.id).then(()=>{${DELETED_IDS}.add(t.id),KDa(e.queryClient,t.id),i&&typeof s==="function"&&s(a)}).catch(()=>{e.get(yv).danger(o.formatMessage(OW.deleteError))})}`;
+
+function warn(message) {
+	console.warn(`WARN: ${message} - skipping conversation delete feature patch`);
+}
+
+function countOccurrences(source, needle) {
+	return source.split(needle).length - 1;
+}
+
+function applyConversationDeletePatch(source) {
+	try {
+		if (typeof source !== "string") {
+			warn("Asset source is not a string");
+			return source;
+		}
+
+		if (source.includes(RUNTIME_MARKER)) {
+			return source;
+		}
+
+		const markers = [
+			["ChatGPT sidebar localization markers", LOCALIZATION_NEEDLE],
+			["ChatGPT sidebar conversation row", SIDEBAR_COMPONENT_NEEDLE],
+			["ChatGPT conversation cache helper", CACHE_EVICTION_NEEDLE],
+			["ChatGPT conversation delete API client", DELETE_API_NEEDLE],
+			["ChatGPT conversation list response filter", LIST_FILTER_NEEDLE],
+			["ChatGPT conversation batch response filter", BATCH_FILTER_NEEDLE],
+			["ChatGPT pinned conversation response filter", PINNED_FILTER_NEEDLE],
+			["ChatGPT sidebar archive menu item", SIDEBAR_MENU_NEEDLE],
+		];
+		const missing = markers.filter(
+			([, needle]) => countOccurrences(source, needle) !== 1,
+		);
+		if (missing.length > 0) {
+			warn(
+				`Could not find unique current ${missing.map(([label]) => label).join(", ")}`,
+			);
+			return source;
+		}
+
+		let patched = source.replace(LOCALIZATION_NEEDLE, LOCALIZATION_REPLACEMENT);
+		patched = patched.replace(LIST_FILTER_NEEDLE, LIST_FILTER_REPLACEMENT);
+		patched = patched.replace(BATCH_FILTER_NEEDLE, BATCH_FILTER_REPLACEMENT);
+		patched = patched.replace(PINNED_FILTER_NEEDLE, PINNED_FILTER_REPLACEMENT);
+		patched = patched.replace(
+			SIDEBAR_COMPONENT_NEEDLE,
+			`${RUNTIME_SOURCE}${SIDEBAR_COMPONENT_NEEDLE}`,
+		);
+		patched = patched.replace(SIDEBAR_MENU_NEEDLE, SIDEBAR_MENU_REPLACEMENT);
+
+		if (
+			!patched.includes(RUNTIME_MARKER) ||
+			!patched.includes(`${DELETED_IDS}.add(t.id)`) ||
+			!patched.includes(LIST_FILTER_REPLACEMENT) ||
+			!patched.includes(`id:\`${DELETE_MENU_ID}\``) ||
+			!patched.includes("message:OW.delete")
+		) {
+			warn("Could not verify delete menu injection");
+			return source;
+		}
+
+		return patched;
+	} catch (error) {
+		warn(
+			`Unexpected error: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return source;
+	}
+}
+
+const descriptors = [
+	{
+		id: "chatgpt-sidebar-delete",
+		phase: "webview-asset",
+		order: 20_910,
+		ciPolicy: "optional",
+		pattern: CHATGPT_SIDEBAR_ASSET_PATTERN,
+		missingDescription: "ChatGPT sidebar webview bundle",
+		skipDescription: "ChatGPT sidebar conversation delete feature patch",
+		apply: applyConversationDeletePatch,
+	},
+];
+
+module.exports = {
+	CHATGPT_SIDEBAR_ASSET_PATTERN,
+	DELETE_MENU_ID,
+	RUNTIME_MARKER,
+	applyConversationDeletePatch,
+	descriptors,
+};

--- a/linux-features/conversation-delete/patch.js
+++ b/linux-features/conversation-delete/patch.js
@@ -1,6 +1,7 @@
 const CHATGPT_SIDEBAR_ASSET_PATTERN = /^app-initial-[^.]+\.js$/;
 const RUNTIME_MARKER = "codexLinuxDeleteChatGptConversation";
 const DELETED_IDS = "codexLinuxDeletedChatGptConversationIds";
+const NEW_THREAD_ROUTE = "/new-thread";
 const DELETE_MENU_ID = "delete-chatgpt-conversation";
 
 const ARCHIVE_MESSAGE =
@@ -11,7 +12,7 @@ const LOCALIZATION_NEEDLE = `${ARCHIVE_MESSAGE},archiveError:`;
 const LOCALIZATION_REPLACEMENT = `${ARCHIVE_MESSAGE},${DELETE_MESSAGES}archiveError:`;
 const SIDEBAR_MENU_NEEDLE =
 	"{id:`archive-chatgpt-conversation`,message:OW.archive,onSelect:ae}]}";
-const SIDEBAR_MENU_REPLACEMENT = `{id:\`archive-chatgpt-conversation\`,message:OW.archive,onSelect:ae},{id:\`${DELETE_MENU_ID}\`,message:OW.delete,onSelect:()=>${RUNTIME_MARKER}(E,n,v,w,o,p,D,O)}]}`;
+const SIDEBAR_MENU_REPLACEMENT = `{id:\`archive-chatgpt-conversation\`,message:OW.archive,onSelect:ae},{id:\`${DELETE_MENU_ID}\`,message:OW.delete,onSelect:()=>${RUNTIME_MARKER}(E,n,v,w,o,D,O)}]}`;
 const SIDEBAR_COMPONENT_NEEDLE = "function VBc(e){let t=(0,w5.c)(83),";
 const CACHE_EVICTION_NEEDLE = "function KDa(";
 const DELETE_API_NEEDLE = "safeDelete(`/conversation/id/{conversation_id}`,";
@@ -25,7 +26,11 @@ const BATCH_FILTER_REPLACEMENT = `async getBatch(e,t){return(await this.request.
 const PINNED_FILTER_REPLACEMENT =
 	"async listPinnedConversationItems(){return(await this.request.listPinnedItems({itemType:`conversation`})).filter(lBr).filter(e=>!" +
 	`${DELETED_IDS}.has(e.item?.id))}`;
-const RUNTIME_SOURCE = `const ${DELETED_IDS}=new Set;function ${RUNTIME_MARKER}(e,t,n,r,i,a,o,s){if(t==null||r)return;if(typeof window==="undefined"||typeof window.confirm!=="function"||!window.confirm(o.formatMessage(OW.deleteConfirm,{title:n})))return;e.get(zN).delete(t.id).then(()=>{${DELETED_IDS}.add(t.id),KDa(e.queryClient,t.id),i&&typeof s==="function"&&s(a)}).catch(()=>{e.get(yv).danger(o.formatMessage(OW.deleteError))})}`;
+const PROJECT_LIST_FILTER_NEEDLE =
+	"async listProjectConversations({cursor:e=null,limit:t=5,ownedOnly:n=!0,projectId:r}){let i=await this.request.listProjectConversations({cursor:e,limit:t,ownedOnly:n,projectId:r});return{cursor:i.cursor,items:i.items?.filter(uBr)??[]}}";
+const PROJECT_LIST_FILTER_REPLACEMENT =
+	`async listProjectConversations({cursor:e=null,limit:t=5,ownedOnly:n=!0,projectId:r}){let i=await this.request.listProjectConversations({cursor:e,limit:t,ownedOnly:n,projectId:r});return{cursor:i.cursor,items:i.items?.filter(e=>!${DELETED_IDS}.has(e?.id)&&uBr(e))??[]}}`;
+const RUNTIME_SOURCE = `const ${DELETED_IDS}=new Set;function ${RUNTIME_MARKER}(e,t,n,r,i,o,s){if(t==null||r)return;if(typeof window==="undefined"||typeof window.confirm!=="function"||!window.confirm(o.formatMessage(OW.deleteConfirm,{title:n})))return;e.get(zN).delete(t.id).then(()=>{${DELETED_IDS}.add(t.id),KDa(e.queryClient,t.id),i&&typeof s==="function"&&s(${JSON.stringify(NEW_THREAD_ROUTE)})}).catch(()=>{e.get(yv).danger(o.formatMessage(OW.deleteError))})}`;
 
 function warn(message) {
 	console.warn(`WARN: ${message} - skipping conversation delete feature patch`);
@@ -54,6 +59,7 @@ function applyConversationDeletePatch(source) {
 			["ChatGPT conversation list response filter", LIST_FILTER_NEEDLE],
 			["ChatGPT conversation batch response filter", BATCH_FILTER_NEEDLE],
 			["ChatGPT pinned conversation response filter", PINNED_FILTER_NEEDLE],
+			["ChatGPT project conversation response filter", PROJECT_LIST_FILTER_NEEDLE],
 			["ChatGPT sidebar archive menu item", SIDEBAR_MENU_NEEDLE],
 		];
 		const missing = markers.filter(
@@ -70,6 +76,10 @@ function applyConversationDeletePatch(source) {
 		patched = patched.replace(LIST_FILTER_NEEDLE, LIST_FILTER_REPLACEMENT);
 		patched = patched.replace(BATCH_FILTER_NEEDLE, BATCH_FILTER_REPLACEMENT);
 		patched = patched.replace(PINNED_FILTER_NEEDLE, PINNED_FILTER_REPLACEMENT);
+		patched = patched.replace(
+			PROJECT_LIST_FILTER_NEEDLE,
+			PROJECT_LIST_FILTER_REPLACEMENT,
+		);
 		patched = patched.replace(
 			SIDEBAR_COMPONENT_NEEDLE,
 			`${RUNTIME_SOURCE}${SIDEBAR_COMPONENT_NEEDLE}`,
@@ -112,6 +122,7 @@ const descriptors = [
 module.exports = {
 	CHATGPT_SIDEBAR_ASSET_PATTERN,
 	DELETE_MENU_ID,
+	NEW_THREAD_ROUTE,
 	RUNTIME_MARKER,
 	applyConversationDeletePatch,
 	descriptors,

--- a/linux-features/conversation-delete/patch.js
+++ b/linux-features/conversation-delete/patch.js
@@ -1,7 +1,7 @@
 const CHATGPT_SIDEBAR_ASSET_PATTERN = /^app-initial-[^.]+\.js$/;
 const RUNTIME_MARKER = "codexLinuxDeleteChatGptConversation";
 const DELETED_IDS = "codexLinuxDeletedChatGptConversationIds";
-const NEW_THREAD_ROUTE = "/new-thread";
+const NEW_THREAD_ROUTE = "/";
 const DELETE_MENU_ID = "delete-chatgpt-conversation";
 
 const ARCHIVE_MESSAGE =

--- a/linux-features/conversation-delete/patch.js
+++ b/linux-features/conversation-delete/patch.js
@@ -12,6 +12,12 @@ const LOCALIZATION_NEEDLE = `${ARCHIVE_MESSAGE},archiveError:`;
 const LOCALIZATION_REPLACEMENT = `${ARCHIVE_MESSAGE},${DELETE_MESSAGES}archiveError:`;
 const SIDEBAR_MENU_NEEDLE =
 	"{id:`archive-chatgpt-conversation`,message:OW.archive,onSelect:ae}]}";
+const MENU_CACHE_GUARD_NEEDLE =
+	"t[27]!==n||t[28]!==ae||t[29]!==re||t[30]!==w||t[31]!==k||t[32]!==L||t[33]!==E?(oe=async()=>{";
+const MENU_CACHE_GUARD_REPLACEMENT =
+	"t[27]!==n||t[28]!==ae||t[29]!==re||t[30]!==w||t[31]!==k||t[32]!==L||t[33]!==E||t[83]!==o?(oe=async()=>{";
+const MENU_CACHE_ASSIGNMENT_NEEDLE = "t[33]=E,t[34]=oe):oe=t[34]";
+const MENU_CACHE_ASSIGNMENT_REPLACEMENT = "t[33]=E,t[83]=o,t[34]=oe):oe=t[34]";
 const SIDEBAR_MENU_REPLACEMENT = `{id:\`archive-chatgpt-conversation\`,message:OW.archive,onSelect:ae},{id:\`${DELETE_MENU_ID}\`,message:OW.delete,onSelect:()=>${RUNTIME_MARKER}(E,n,v,w,o,D,O)}]}`;
 const SIDEBAR_COMPONENT_NEEDLE = "function VBc(e){let t=(0,w5.c)(83),";
 const CACHE_EVICTION_NEEDLE = "function KDa(";
@@ -57,6 +63,8 @@ function applyConversationDeletePatch(source) {
 			["ChatGPT conversation cache helper", CACHE_EVICTION_NEEDLE],
 			["ChatGPT conversation delete API client", DELETE_API_NEEDLE],
 			["ChatGPT new-chat state handler", NEW_CHAT_HANDLER_NEEDLE],
+			["ChatGPT sidebar menu cache guard", MENU_CACHE_GUARD_NEEDLE],
+			["ChatGPT sidebar menu cache assignment", MENU_CACHE_ASSIGNMENT_NEEDLE],
 			["ChatGPT conversation list response filter", LIST_FILTER_NEEDLE],
 			["ChatGPT conversation batch response filter", BATCH_FILTER_NEEDLE],
 			["ChatGPT pinned conversation response filter", PINNED_FILTER_NEEDLE],
@@ -85,8 +93,16 @@ function applyConversationDeletePatch(source) {
 			PROJECT_LIST_FILTER_REPLACEMENT,
 		);
 		patched = patched.replace(
+			MENU_CACHE_GUARD_NEEDLE,
+			MENU_CACHE_GUARD_REPLACEMENT,
+		);
+		patched = patched.replace(
+			MENU_CACHE_ASSIGNMENT_NEEDLE,
+			MENU_CACHE_ASSIGNMENT_REPLACEMENT,
+		);
+		patched = patched.replace(
 			SIDEBAR_COMPONENT_NEEDLE,
-			`${RUNTIME_SOURCE}${SIDEBAR_COMPONENT_NEEDLE}`,
+			`${RUNTIME_SOURCE}${SIDEBAR_COMPONENT_NEEDLE.replace("(83)", "(84)")}`,
 		);
 		patched = patched.replace(SIDEBAR_MENU_NEEDLE, SIDEBAR_MENU_REPLACEMENT);
 
@@ -94,6 +110,9 @@ function applyConversationDeletePatch(source) {
 			!patched.includes(RUNTIME_MARKER) ||
 			!patched.includes(`${DELETED_IDS}.add(t.id)`) ||
 			!patched.includes(LIST_FILTER_REPLACEMENT) ||
+			!patched.includes(MENU_CACHE_GUARD_REPLACEMENT) ||
+			!patched.includes(MENU_CACHE_ASSIGNMENT_REPLACEMENT) ||
+			!patched.includes("function VBc(e){let t=(0,w5.c)(84),") ||
 			!patched.includes(`id:\`${DELETE_MENU_ID}\``) ||
 			!patched.includes("message:OW.delete")
 		) {

--- a/linux-features/conversation-delete/test.js
+++ b/linux-features/conversation-delete/test.js
@@ -12,6 +12,7 @@ const {
 } = require("../../scripts/lib/linux-features.js");
 const {
 	CHATGPT_SIDEBAR_ASSET_PATTERN,
+	DELETE_MENU_ID,
 	NEW_THREAD_ROUTE,
 	RUNTIME_MARKER,
 	applyConversationDeletePatch,
@@ -22,7 +23,7 @@ const SIDEBAR_FIXTURE = [
 	"var OW={newChat:{id:`chatgptConversations.newChat`,defaultMessage:`New chat`,description:`Fallback title`},archive:{id:`chatgptConversations.sidebar.archive`,defaultMessage:`Archive chat`,description:`Action label to archive a ChatGPT conversation in the sidebar`},archiveError:{id:`chatgptConversations.sidebar.archiveError`,defaultMessage:`Failed to archive conversation`,description:`Archive error`}};",
 	"var uBr=e=>true,lBr=e=>true;var yBr=class{async list({}){let l=await this.request.listConversations();return{...l,items:l.items?.filter(uBr)??[]}}async getBatch(e,t){return(await this.request.getConversationsBatch(e,t)).filter(uBr)}async listPinnedConversationItems(){return(await this.request.listPinnedItems({itemType:`conversation`})).filter(lBr)}async listProjectConversations({cursor:e=null,limit:t=5,ownedOnly:n=!0,projectId:r}){let i=await this.request.listProjectConversations({cursor:e,limit:t,ownedOnly:n,projectId:r});return{cursor:i.cursor,items:i.items?.filter(uBr)??[]}}};",
 	"/* function y0(e,t){ */;/* function KDa( */;/* safeDelete(`/conversation/id/{conversation_id}`, */",
-	"function VBc(e){let t=(0,w5.c)(83),{conversation:n,isActive:o,isArchivePending:w,route:p,title:v}=e,E=Fo(Q),D=Vd(),O=AC();let oe=async()=>{if(n==null||w)return[];let e=await FRc(E,{conversationId:n.id,projectId:PW(n)});return[{id:`rename-chatgpt-conversation`,message:OW.rename,onSelect:re},...e,{id:`archive-chatgpt-conversation`,message:OW.archive,onSelect:ae}]};return oe}",
+	"var archiveAction=()=>{},renameAction=()=>{};function VBc(e){let t=(0,w5.c)(83),{conversation:n,isActive:o,isArchivePending:w,route:p,title:v}=e,E=Fo(Q),D=Vd(),O=AC(),ae=archiveAction,re=renameAction,k=false,L=OW.archive;let oe;t[27]!==n||t[28]!==ae||t[29]!==re||t[30]!==w||t[31]!==k||t[32]!==L||t[33]!==E?(oe=async()=>{return[{id:`archive-chatgpt-conversation`,message:OW.archive,onSelect:ae}]},t[27]=n,t[28]=ae,t[29]=re,t[30]=w,t[31]=k,t[32]=L,t[33]=E,t[34]=oe):oe=t[34];return oe}",
 ].join("");
 
 function captureWarnings(fn) {
@@ -238,13 +239,102 @@ test("active deletion uses upstream new-chat state handler", async () => {
 		`${patched};globalThis.deleteChat= ${RUNTIME_MARKER};`,
 		context,
 	);
-	await context.deleteChat(scope, { id: "conversation-123" }, "Example chat", false, true, {
-		formatMessage: (message) => message.defaultMessage,
-	}, () => {
-		throw new Error("fallback navigator should not run");
-	});
+	await context.deleteChat(
+		scope,
+		{ id: "conversation-123" },
+		"Example chat",
+		false,
+		true,
+		{
+			formatMessage: (message) => message.defaultMessage,
+		},
+		() => {
+			throw new Error("fallback navigator should not run");
+		},
+	);
 
 	assert.deepEqual(started, [scope]);
+});
+
+test("compiled menu cache refreshes delete callback when active state changes", async () => {
+	const patched = applyConversationDeletePatch(SIDEBAR_FIXTURE);
+	const cache = [];
+	const deleteToken = {};
+	const toastToken = {};
+	const deleted = [];
+	const navigated = [];
+	const scope = {
+		queryClient: {},
+		get(token) {
+			if (token === deleteToken) {
+				return {
+					delete(id) {
+						deleted.push(id);
+						return Promise.resolve();
+					},
+				};
+			}
+			assert.equal(token, toastToken);
+			return { danger: () => assert.fail("unexpected error toast") };
+		},
+	};
+	const intl = {
+		formatMessage(message, values) {
+			return message.defaultMessage.replace("{title}", values?.title ?? "");
+		},
+	};
+	const context = {
+		w5: {
+			c(size) {
+				assert.equal(size, 84);
+				return cache;
+			},
+		},
+		Q: {},
+		OW: {
+			archive: "Archive chat",
+			deleteConfirm: {
+				defaultMessage: "Delete {title}?",
+			},
+			deleteError: { defaultMessage: "Delete failed" },
+		},
+		Fo: () => scope,
+		Vd: () => intl,
+		AC: () => (route) => navigated.push(route),
+		archiveAction: () => {},
+		renameAction: () => {},
+		KDa() {},
+		yv: toastToken,
+		zN: deleteToken,
+		window: { confirm: () => true },
+	};
+
+	vm.runInNewContext(`${patched};globalThis.renderSidebar=VBc;`, context);
+
+	const conversation = { id: "conversation-123" };
+	const firstMenu = await context.renderSidebar({
+		conversation,
+		isActive: false,
+		isArchivePending: false,
+		route: "/chat/conversation-123",
+		title: "Example chat",
+	})();
+	await firstMenu.find((item) => item.id === DELETE_MENU_ID).onSelect();
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.deepEqual(deleted, ["conversation-123"]);
+	assert.deepEqual(navigated, []);
+
+	const secondMenu = await context.renderSidebar({
+		conversation,
+		isActive: true,
+		isArchivePending: false,
+		route: "/chat/conversation-123",
+		title: "Example chat",
+	})();
+	await secondMenu.find((item) => item.id === DELETE_MENU_ID).onSelect();
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.deepEqual(deleted, ["conversation-123", "conversation-123"]);
+	assert.deepEqual(navigated, [NEW_THREAD_ROUTE]);
 });
 
 test("project conversation refetch filters deleted tombstone", async () => {
@@ -272,9 +362,16 @@ test("project conversation refetch filters deleted tombstone", async () => {
 		`${patched};globalThis.deleteChat= ${RUNTIME_MARKER};`,
 		context,
 	);
-	await context.deleteChat(scope, { id: "conversation-123" }, "Example chat", false, false, {
-		formatMessage: (message) => message.defaultMessage,
-	});
+	await context.deleteChat(
+		scope,
+		{ id: "conversation-123" },
+		"Example chat",
+		false,
+		false,
+		{
+			formatMessage: (message) => message.defaultMessage,
+		},
+	);
 
 	const client = new context.yBr();
 	client.request = {
@@ -283,7 +380,9 @@ test("project conversation refetch filters deleted tombstone", async () => {
 			items: [{ id: "conversation-123" }, { id: "conversation-456" }],
 		}),
 	};
-	const listed = await client.listProjectConversations({ projectId: "project-123" });
+	const listed = await client.listProjectConversations({
+		projectId: "project-123",
+	});
 	assert.equal(listed.cursor, null);
 	assert.deepEqual(listed.items, [{ id: "conversation-456" }]);
 });

--- a/linux-features/conversation-delete/test.js
+++ b/linux-features/conversation-delete/test.js
@@ -12,6 +12,7 @@ const {
 } = require("../../scripts/lib/linux-features.js");
 const {
 	CHATGPT_SIDEBAR_ASSET_PATTERN,
+	NEW_THREAD_ROUTE,
 	RUNTIME_MARKER,
 	applyConversationDeletePatch,
 	descriptors,
@@ -19,7 +20,7 @@ const {
 
 const SIDEBAR_FIXTURE = [
 	"var OW={newChat:{id:`chatgptConversations.newChat`,defaultMessage:`New chat`,description:`Fallback title`},archive:{id:`chatgptConversations.sidebar.archive`,defaultMessage:`Archive chat`,description:`Action label to archive a ChatGPT conversation in the sidebar`},archiveError:{id:`chatgptConversations.sidebar.archiveError`,defaultMessage:`Failed to archive conversation`,description:`Archive error`}};",
-	"var uBr=e=>true,lBr=e=>true;var yBr=class{async list({}){let l=await this.request.listConversations();return{...l,items:l.items?.filter(uBr)??[]}}async getBatch(e,t){return(await this.request.getConversationsBatch(e,t)).filter(uBr)}async listPinnedConversationItems(){return(await this.request.listPinnedItems({itemType:`conversation`})).filter(lBr)}};",
+	"var uBr=e=>true,lBr=e=>true;var yBr=class{async list({}){let l=await this.request.listConversations();return{...l,items:l.items?.filter(uBr)??[]}}async getBatch(e,t){return(await this.request.getConversationsBatch(e,t)).filter(uBr)}async listPinnedConversationItems(){return(await this.request.listPinnedItems({itemType:`conversation`})).filter(lBr)}async listProjectConversations({cursor:e=null,limit:t=5,ownedOnly:n=!0,projectId:r}){let i=await this.request.listProjectConversations({cursor:e,limit:t,ownedOnly:n,projectId:r});return{cursor:i.cursor,items:i.items?.filter(uBr)??[]}}};",
 	"/* function KDa( */;/* safeDelete(`/conversation/id/{conversation_id}`, */",
 	"function VBc(e){let t=(0,w5.c)(83),{conversation:n,isActive:o,isArchivePending:w,route:p,title:v}=e,E=Fo(Q),D=Vd(),O=AC();let oe=async()=>{if(n==null||w)return[];let e=await FRc(E,{conversationId:n.id,projectId:PW(n)});return[{id:`rename-chatgpt-conversation`,message:OW.rename,onSelect:re},...e,{id:`archive-chatgpt-conversation`,message:OW.archive,onSelect:ae}]};return oe}",
 ].join("");
@@ -101,6 +102,7 @@ test("patch adds confirmed delete action and is idempotent", () => {
 	assert.match(patched, /e\.get\(zN\)\.delete\(t\.id\)/);
 	assert.match(patched, /window\.confirm/);
 	assert.match(patched, /KDa\(e\.queryClient,t\.id\)/);
+	assert.match(patched, new RegExp(`s\\("${NEW_THREAD_ROUTE}"\\)`));
 	assert.match(
 		patched,
 		/codexLinuxDeletedChatGptConversationIds\.add\(t\.id\)/,
@@ -185,7 +187,6 @@ test("runtime calls upstream delete without body and updates active navigation",
 		"Example chat",
 		false,
 		true,
-		"/chat/conversation-123",
 		{
 			formatMessage(message, values) {
 				return message.defaultMessage.replace("{title}", values.title);
@@ -196,7 +197,7 @@ test("runtime calls upstream delete without body and updates active navigation",
 
 	assert.deepEqual(calls, [["conversation-123"]]);
 	assert.deepEqual(removed, [[scope.queryClient, "conversation-123"]]);
-	assert.deepEqual(navigated, ["/chat/conversation-123"]);
+	assert.deepEqual(navigated, [NEW_THREAD_ROUTE]);
 
 	const client = new context.yBr();
 	client.request = {
@@ -205,6 +206,47 @@ test("runtime calls upstream delete without body and updates active navigation",
 		}),
 	};
 	const listed = await client.list({});
+	assert.deepEqual(listed.items, [{ id: "conversation-456" }]);
+});
+
+test("project conversation refetch filters deleted tombstone", async () => {
+	const patched = applyConversationDeletePatch(SIDEBAR_FIXTURE);
+	const deleteToken = {};
+	const context = {
+		KDa() {},
+		OW: {
+			deleteConfirm: { defaultMessage: "Delete {title}?" },
+			deleteError: { defaultMessage: "Delete failed" },
+		},
+		yv: {},
+		zN: deleteToken,
+		window: { confirm: () => true },
+	};
+	const scope = {
+		queryClient: {},
+		get(token) {
+			assert.equal(token, deleteToken);
+			return { delete: () => Promise.resolve() };
+		},
+	};
+
+	vm.runInNewContext(
+		`${patched};globalThis.deleteChat= ${RUNTIME_MARKER};`,
+		context,
+	);
+	await context.deleteChat(scope, { id: "conversation-123" }, "Example chat", false, false, {
+		formatMessage: (message) => message.defaultMessage,
+	});
+
+	const client = new context.yBr();
+	client.request = {
+		listProjectConversations: async () => ({
+			cursor: null,
+			items: [{ id: "conversation-123" }, { id: "conversation-456" }],
+		}),
+	};
+	const listed = await client.listProjectConversations({ projectId: "project-123" });
+	assert.equal(listed.cursor, null);
 	assert.deepEqual(listed.items, [{ id: "conversation-456" }]);
 });
 
@@ -247,7 +289,6 @@ test("cancelled confirmation does not call delete", async () => {
 		"Example chat",
 		false,
 		false,
-		"/",
 		{
 			formatMessage: (message) => message.defaultMessage,
 		},

--- a/linux-features/conversation-delete/test.js
+++ b/linux-features/conversation-delete/test.js
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const {
+	loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const {
+	CHATGPT_SIDEBAR_ASSET_PATTERN,
+	RUNTIME_MARKER,
+	applyConversationDeletePatch,
+	descriptors,
+} = require("./patch.js");
+
+const SIDEBAR_FIXTURE = [
+	"var OW={newChat:{id:`chatgptConversations.newChat`,defaultMessage:`New chat`,description:`Fallback title`},archive:{id:`chatgptConversations.sidebar.archive`,defaultMessage:`Archive chat`,description:`Action label to archive a ChatGPT conversation in the sidebar`},archiveError:{id:`chatgptConversations.sidebar.archiveError`,defaultMessage:`Failed to archive conversation`,description:`Archive error`}};",
+	"var uBr=e=>true,lBr=e=>true;var yBr=class{async list({}){let l=await this.request.listConversations();return{...l,items:l.items?.filter(uBr)??[]}}async getBatch(e,t){return(await this.request.getConversationsBatch(e,t)).filter(uBr)}async listPinnedConversationItems(){return(await this.request.listPinnedItems({itemType:`conversation`})).filter(lBr)}};",
+	"/* function KDa( */;/* safeDelete(`/conversation/id/{conversation_id}`, */",
+	"function VBc(e){let t=(0,w5.c)(83),{conversation:n,isActive:o,isArchivePending:w,route:p,title:v}=e,E=Fo(Q),D=Vd(),O=AC();let oe=async()=>{if(n==null||w)return[];let e=await FRc(E,{conversationId:n.id,projectId:PW(n)});return[{id:`rename-chatgpt-conversation`,message:OW.rename,onSelect:re},...e,{id:`archive-chatgpt-conversation`,message:OW.archive,onSelect:ae}]};return oe}",
+].join("");
+
+function captureWarnings(fn) {
+	const originalWarn = console.warn;
+	const warnings = [];
+	console.warn = (message) => warnings.push(message);
+	try {
+		return { value: fn(), warnings };
+	} finally {
+		console.warn = originalWarn;
+	}
+}
+
+function withFeatureConfig(enabled, fn) {
+	const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "conversation-delete-"),
+	);
+	process.env.CODEX_LINUX_FEATURES_CONFIG = path.join(tempDir, "features.json");
+	try {
+		fs.writeFileSync(
+			process.env.CODEX_LINUX_FEATURES_CONFIG,
+			JSON.stringify({ enabled }),
+		);
+		return fn();
+	} finally {
+		if (originalConfig == null) {
+			delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+		} else {
+			process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+		}
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+test("feature is disabled until selected", () => {
+	const featuresRoot = path.resolve(__dirname, "..");
+	withFeatureConfig([], () => {
+		assert.equal(
+			loadLinuxFeaturePatchDescriptors({ featuresRoot }).some(
+				(descriptor) =>
+					descriptor.id ===
+					"feature:conversation-delete:chatgpt-sidebar-delete",
+			),
+			false,
+		);
+	});
+	withFeatureConfig(["conversation-delete"], () => {
+		assert.equal(
+			loadLinuxFeaturePatchDescriptors({ featuresRoot }).some(
+				(descriptor) =>
+					descriptor.id ===
+					"feature:conversation-delete:chatgpt-sidebar-delete",
+			),
+			true,
+		);
+	});
+});
+
+test("descriptor targets current ChatGPT sidebar asset family", () => {
+	assert.match("app-initial-Biw83Aiz.js", CHATGPT_SIDEBAR_ASSET_PATTERN);
+	assert.doesNotMatch("app-main-Biw83Aiz.js", CHATGPT_SIDEBAR_ASSET_PATTERN);
+	assert.doesNotMatch(
+		"chatgpt-conversation-page-BG0Dyleu.js",
+		CHATGPT_SIDEBAR_ASSET_PATTERN,
+	);
+	assert.equal(descriptors.length, 1);
+});
+
+test("patch adds confirmed delete action and is idempotent", () => {
+	const patched = applyConversationDeletePatch(SIDEBAR_FIXTURE);
+
+	assert.notEqual(patched, SIDEBAR_FIXTURE);
+	assert.match(patched, new RegExp(RUNTIME_MARKER));
+	assert.match(patched, /codexLinuxConversationDelete\.delete/);
+	assert.match(patched, /id:`delete-chatgpt-conversation`/);
+	assert.match(patched, /e\.get\(zN\)\.delete\(t\.id\)/);
+	assert.match(patched, /window\.confirm/);
+	assert.match(patched, /KDa\(e\.queryClient,t\.id\)/);
+	assert.match(
+		patched,
+		/codexLinuxDeletedChatGptConversationIds\.add\(t\.id\)/,
+	);
+	assert.match(
+		patched,
+		/codexLinuxDeletedChatGptConversationIds\.has\(e\?\.id\)/,
+	);
+	assert.match(patched, /O=AC\(\)/);
+	assert.equal(applyConversationDeletePatch(patched), patched);
+});
+
+test("drift leaves source unchanged and warns", () => {
+	const source = SIDEBAR_FIXTURE.replace(
+		"function VBc",
+		"function ChangedSidebarRow",
+	);
+	const { value, warnings } = captureWarnings(() =>
+		applyConversationDeletePatch(source),
+	);
+
+	assert.equal(value, source);
+	assert.equal(warnings.length, 1);
+	assert.match(warnings[0], /ChatGPT sidebar conversation row/);
+});
+
+test("runtime calls upstream delete without body and updates active navigation", async () => {
+	const patched = applyConversationDeletePatch(SIDEBAR_FIXTURE);
+	const deleteToken = {};
+	const toastToken = {};
+	const calls = [];
+	const removed = [];
+	const navigated = [];
+	const context = {
+		KDa: (...args) => removed.push(args),
+		OW: {
+			deleteConfirm: {
+				id: "confirm",
+				defaultMessage: "Delete {title}?",
+			},
+			deleteError: {
+				id: "error",
+				defaultMessage: "Delete failed",
+			},
+		},
+		yv: toastToken,
+		zN: deleteToken,
+		window: {
+			confirm: (message) => {
+				assert.equal(message, "Delete “Example chat”? This can't be undone.");
+				return true;
+			},
+		},
+	};
+	const scope = {
+		queryClient: {},
+		get(token) {
+			assert.equal(token === deleteToken || token === toastToken, true);
+			if (token === deleteToken) {
+				return {
+					delete(...args) {
+						calls.push(args);
+						return Promise.resolve();
+					},
+				};
+			}
+			return {
+				danger() {
+					throw new Error("unexpected error toast");
+				},
+			};
+		},
+	};
+
+	vm.runInNewContext(
+		`${patched};globalThis.deleteChat= ${RUNTIME_MARKER};`,
+		context,
+	);
+	await context.deleteChat(
+		scope,
+		{ id: "conversation-123" },
+		"Example chat",
+		false,
+		true,
+		"/chat/conversation-123",
+		{
+			formatMessage(message, values) {
+				return message.defaultMessage.replace("{title}", values.title);
+			},
+		},
+		(route) => navigated.push(route),
+	);
+
+	assert.deepEqual(calls, [["conversation-123"]]);
+	assert.deepEqual(removed, [[scope.queryClient, "conversation-123"]]);
+	assert.deepEqual(navigated, ["/chat/conversation-123"]);
+
+	const client = new context.yBr();
+	client.request = {
+		listConversations: async () => ({
+			items: [{ id: "conversation-123" }, { id: "conversation-456" }],
+		}),
+	};
+	const listed = await client.list({});
+	assert.deepEqual(listed.items, [{ id: "conversation-456" }]);
+});
+
+test("cancelled confirmation does not call delete", async () => {
+	const patched = applyConversationDeletePatch(SIDEBAR_FIXTURE);
+	const deleteToken = {};
+	let calls = 0;
+	const context = {
+		KDa() {
+			throw new Error("cache should not change");
+		},
+		OW: {
+			deleteConfirm: { defaultMessage: "Delete {title}?" },
+			deleteError: { defaultMessage: "Delete failed" },
+		},
+		yv: {},
+		zN: deleteToken,
+		window: { confirm: () => false },
+	};
+	const scope = {
+		queryClient: {},
+		get(token) {
+			assert.equal(token, deleteToken);
+			return {
+				delete() {
+					calls += 1;
+					return Promise.resolve();
+				},
+			};
+		},
+	};
+
+	vm.runInNewContext(
+		`${patched};globalThis.deleteChat= ${RUNTIME_MARKER};`,
+		context,
+	);
+	await context.deleteChat(
+		scope,
+		{ id: "conversation-123" },
+		"Example chat",
+		false,
+		false,
+		"/",
+		{
+			formatMessage: (message) => message.defaultMessage,
+		},
+	);
+
+	assert.equal(calls, 0);
+});

--- a/linux-features/conversation-delete/test.js
+++ b/linux-features/conversation-delete/test.js
@@ -21,7 +21,7 @@ const {
 const SIDEBAR_FIXTURE = [
 	"var OW={newChat:{id:`chatgptConversations.newChat`,defaultMessage:`New chat`,description:`Fallback title`},archive:{id:`chatgptConversations.sidebar.archive`,defaultMessage:`Archive chat`,description:`Action label to archive a ChatGPT conversation in the sidebar`},archiveError:{id:`chatgptConversations.sidebar.archiveError`,defaultMessage:`Failed to archive conversation`,description:`Archive error`}};",
 	"var uBr=e=>true,lBr=e=>true;var yBr=class{async list({}){let l=await this.request.listConversations();return{...l,items:l.items?.filter(uBr)??[]}}async getBatch(e,t){return(await this.request.getConversationsBatch(e,t)).filter(uBr)}async listPinnedConversationItems(){return(await this.request.listPinnedItems({itemType:`conversation`})).filter(lBr)}async listProjectConversations({cursor:e=null,limit:t=5,ownedOnly:n=!0,projectId:r}){let i=await this.request.listProjectConversations({cursor:e,limit:t,ownedOnly:n,projectId:r});return{cursor:i.cursor,items:i.items?.filter(uBr)??[]}}};",
-	"/* function KDa( */;/* safeDelete(`/conversation/id/{conversation_id}`, */",
+	"/* function y0(e,t){ */;/* function KDa( */;/* safeDelete(`/conversation/id/{conversation_id}`, */",
 	"function VBc(e){let t=(0,w5.c)(83),{conversation:n,isActive:o,isArchivePending:w,route:p,title:v}=e,E=Fo(Q),D=Vd(),O=AC();let oe=async()=>{if(n==null||w)return[];let e=await FRc(E,{conversationId:n.id,projectId:PW(n)});return[{id:`rename-chatgpt-conversation`,message:OW.rename,onSelect:re},...e,{id:`archive-chatgpt-conversation`,message:OW.archive,onSelect:ae}]};return oe}",
 ].join("");
 
@@ -207,6 +207,44 @@ test("runtime calls upstream delete without body and updates active navigation",
 	};
 	const listed = await client.list({});
 	assert.deepEqual(listed.items, [{ id: "conversation-456" }]);
+});
+
+test("active deletion uses upstream new-chat state handler", async () => {
+	const patched = applyConversationDeletePatch(SIDEBAR_FIXTURE);
+	const deleteToken = {};
+	const started = [];
+	const context = {
+		KDa() {},
+		y0(scope) {
+			started.push(scope);
+		},
+		OW: {
+			deleteConfirm: { defaultMessage: "Delete {title}?" },
+			deleteError: { defaultMessage: "Delete failed" },
+		},
+		yv: {},
+		zN: deleteToken,
+		window: { confirm: () => true },
+	};
+	const scope = {
+		queryClient: {},
+		get(token) {
+			assert.equal(token, deleteToken);
+			return { delete: () => Promise.resolve() };
+		},
+	};
+
+	vm.runInNewContext(
+		`${patched};globalThis.deleteChat= ${RUNTIME_MARKER};`,
+		context,
+	);
+	await context.deleteChat(scope, { id: "conversation-123" }, "Example chat", false, true, {
+		formatMessage: (message) => message.defaultMessage,
+	}, () => {
+		throw new Error("fallback navigator should not run");
+	});
+
+	assert.deepEqual(started, [scope]);
 });
 
 test("project conversation refetch filters deleted tombstone", async () => {


### PR DESCRIPTION
**IMPORTANT: Please keep only one pull request open at a time. The default maximum is two active pull requests from the same contributor, and even that should be reserved for exceptional circumstances. Maintainers may configure a different per-contributor limit for explicit exceptions. Do not open several pull requests at once; finish or close existing work before submitting more. An automated bot will close pull requests that exceed the effective limit.**

<!-- Complete this template before requesting review or merge. -->

## Summary

Adds opt-in `conversation-delete` Linux feature.

- Adds confirmed **Delete chat** action beside Archive.
- Uses upstream authenticated delete API with no request body.
- Removes deleted conversations from sidebar caches.
- Suppresses stale refetched entries during backend propagation.
- Disabled by default.
- Resolves sidebar conversation deletion request.

Known risk: relies on private upstream endpoint and minified bundle markers.

## Validation

- `node --test linux-features/conversation-delete/test.js` — 6 passed.
- `node --test linux-features/*/test.js` — 887 passed, 1 skipped, 0 failed.
- `node --test scripts/patch-linux-window-ui.test.js` — 414 passed.
- Patched latest upstream bundle successfully.
- `/usr/bin/node --check` passed on patched bundle.
- `git diff --check` passed.
- Required CI checks not run locally.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [ ] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [ ] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
