### PR TITLE
perf(linux): reduce chunked message decoder overhead

### DIFF
--- a/.agents/plans/2026-08-10-linux-chunked-message-decoder-performance.md
+++ b/.agents/plans/2026-08-10-linux-chunked-message-decoder-performance.md
@@ -1,0 +1,63 @@
+# Linux Chunked Message Decoder Performance Implementation Plan
+
+> **For Codex:** Execute this plan sequentially with test-driven development. Keep the generated webview patch optional, semantic, fail-soft, and idempotent.
+
+**Goal:** Reduce renderer main-thread work while reconstructing large chunked host messages without changing decoded object semantics or weakening protection for the special `__proto__` key.
+
+**Architecture:** Add one all-Linux webview asset descriptor for the primary `app-initial-*.js` bundle. Its semantic matcher will locate exactly one current chunk assembler contract using the chunk protocol marker, assembler diagnostics, and object-write shape. The transform will use ordinary property assignment for normal keys and retain `Object.defineProperty` for `__proto__`, which preserves the existing own-property descriptor and prototype behavior.
+
+**Evidence baseline (2026-08-10, ChatGPT 26.803.41515 / Electron 42.3.0):** A 34-session CPU profile identified chunk decoding as a recurring renderer hotspot (`j6e` 2.36s, `saveValue` 367ms in one baseline sweep). A controlled in-app benchmark decoded five 50,000-property transfers through the real `window.postMessage` listener. Across three sequential A/B samples, median wall time fell from 777.9ms to 728.5ms (-6.35%) and median `saveValue` self time fell from 163.2ms to 108.6ms (-33.45%). Concurrent samples were excluded because the two Electron instances contended for CPU. A previous synchronous text-measurement candidate was rejected after an exact-input sweep regressed end-to-end long-task time by about 9%.
+
+---
+
+## Task 1: Lock the semantic and safety contract with failing tests
+
+**Files:**
+- Modify: `scripts/patch-linux-window-ui.test.js`
+
+1. Import the new matcher and transform from `scripts/patches/impl/webview/index.js`.
+2. Add a compact current-bundle fixture containing the chunk marker, validation/assembler diagnostics, object/array/root behavior, and the original unconditional `Object.defineProperty` write.
+3. Add tests that require:
+   - exactly one semantic contract match;
+   - idempotent transformation;
+   - ordinary keys use direct assignment;
+   - `__proto__` still becomes an enumerable, configurable, writable own data property while the decoded object's prototype remains unchanged;
+   - ordinary keys such as `constructor` and `toString` preserve own-property descriptors;
+   - array and root writes are unchanged;
+   - generic, drifted, duplicated, and incomplete candidates remain byte-identical and warn precisely.
+4. Add the descriptor id to the canonical core descriptor list and assert its filename pattern/optional policy.
+5. Run the focused Node test by name and confirm it fails because the new exports/descriptor do not exist yet.
+
+## Task 2: Implement the minimal fail-soft webview transform
+
+**Files:**
+- Modify: `scripts/patches/impl/webview/index.js`
+- Create: `scripts/patches/core/all-linux/webview/chunked-message-decoder-performance/patch.js`
+
+1. Add semantic candidate discovery for the current chunk assembler using protocol and diagnostic anchors plus alias-tolerant write patterns.
+2. Recognize only one fully unpatched or fully patched candidate; reject ambiguous, drifted, and incomplete states.
+3. Replace the unconditional object-property write with a conditional that retains the exact `Object.defineProperty` call for `__proto__` and uses `object[key] = value` otherwise.
+4. Export the matcher and transform.
+5. Register an optional all-Linux `webview-asset` descriptor after the existing layout performance descriptors, targeting only `^app-initial-[^.]+\\.js$`.
+6. Run the focused tests and make them pass without loosening assertions.
+
+## Task 3: Verify generated-asset integration and runtime behavior
+
+**Files:**
+- No additional production files expected.
+
+1. Run the focused performance/safety tests, then the complete `scripts/patch-linux-window-ui.test.js` suite.
+2. Run repository lint/type/build checks required by the existing contribution workflow.
+3. Apply the descriptor to a fresh copy of the current generated asset and prove exactly one semantic match, one change, and idempotency; verify the original generated asset remains byte-identical.
+4. Build or regenerate the native app through the repository-supported path as practical, then rerun the controlled decoder benchmark on baseline and patched instances sequentially.
+5. Record exact before/after medians, retained Browser webview counts, test results, and any residual variance.
+
+## Task 4: Contribution handoff
+
+**Files:**
+- Modify only contribution documentation if the repository requires it.
+
+1. Review the complete diff for accidental generated artifacts or unrelated user files.
+2. Create a focused GitHub issue with reproduction, profiler evidence, scope, and acceptance criteria.
+3. Commit only owned files, push the feature branch, and open one PR linked to the issue with security semantics, validation evidence, and before/after results.
+4. Check CI and review feedback; address only actionable findings within this PR's scope.

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -187,6 +187,7 @@ const {
   applyLinuxBrowserUseWebviewRemountStorePatch,
   applyLinuxBrowserUseNonLocalNavigationPatch,
   applyLinuxChatSearchHydrationPatch,
+  applyLinuxChunkedMessageDecoderPerformancePatch,
   applyLinuxConfigWriteVersionConflictPatch,
   applyLinuxFastModeModelGuardPatch,
   applyLinuxI18nGatePatch,
@@ -201,6 +202,7 @@ const {
   applySubagentNicknameMetadataPatch,
   codexLinuxWatchBrowserWebviewAttachment,
   matchesLinuxAppShellTabLayoutPerformanceContract,
+  matchesLinuxChunkedMessageDecoderPerformanceContract,
   matchesLinuxSidebarScrollPerformanceContract,
 } = require("./patches/impl/webview/index.js");
 const {
@@ -1040,6 +1042,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-settings-search-visibility",
     "linux-sidebar-scroll-performance",
     "linux-app-shell-tab-layout-performance",
+    "linux-chunked-message-decoder-performance",
     "linux-i18n-gate",
     "automation-schedule-multi-time-rrule",
     "automation-update-eager-tool",
@@ -1155,6 +1158,26 @@ test("default core patch descriptors are grouped and unique", () => {
   assert.equal(sidebarScrollPerformance?.pattern.test("app-DuLjgNkx.css"), false);
   assert.equal(sidebarScrollPerformance?.assetMatch(sidebarScrollFixture()), true);
   assert.equal(sidebarScrollPerformance?.assetMatch("function unrelated(){}"), false);
+  const chunkedMessageDecoderPerformance = descriptors.find(
+    (descriptor) => descriptor.id === "linux-chunked-message-decoder-performance",
+  );
+  assert.equal(chunkedMessageDecoderPerformance?.ciPolicy, "optional");
+  assert.equal(
+    chunkedMessageDecoderPerformance?.pattern.test("app-initial-Biw83Aiz.js"),
+    true,
+  );
+  assert.equal(
+    chunkedMessageDecoderPerformance?.pattern.test("app-DuLjgNkx.css"),
+    false,
+  );
+  assert.equal(
+    chunkedMessageDecoderPerformance?.assetMatch(chunkedMessageDecoderFixture()),
+    true,
+  );
+  assert.equal(
+    chunkedMessageDecoderPerformance?.assetMatch("function unrelated(){}"),
+    false,
+  );
   assert.equal(
     descriptors.find((descriptor) => descriptor.id === "linux-computer-use-avatar-cursor")?.ciPolicy,
     "optional",
@@ -3739,6 +3762,150 @@ test("leaves ambiguous app-shell tab animation assets byte-identical", () => {
   assert.equal(value, source);
   assert.deepEqual(warnings, [
     "WARN: Could not uniquely identify the app-shell tab layout contract — skipping Linux tab layout performance patch",
+  ]);
+});
+
+function chunkedMessageDecoderFixture({ duplicate = false, write = null } = {}) {
+  const objectWrite = write ??
+    "Object.defineProperty(t.value,t.key,{configurable:!0,enumerable:!0,value:e,writable:!0}),t.key=null";
+  const source = [
+    "function validateChunk(e){return e?.marker===`codex-host-chunked-message-v1`}",
+    "var unset=Symbol(`unset`),Assembler=class{stack=[];root=unset;stringChunks=null;consume(e){for(let t of e)switch(t.type){case`container-end`:if(this.stack.pop()==null)throw Error(`Chunked message contained an unmatched container end`);break;case`value`:this.saveValue(t.value);break}}finish(){if(this.root===unset||this.stack.length>0||this.stringChunks!=null)throw Error(`Chunked message ended before its value was complete`);return this.root}setKey(e){let t=this.stack.at(-1);if(t?.type!==`object`||t.key!=null)throw Error(`Chunked message key was outside an object`);t.key=e}saveValue(e){let t=this.stack.at(-1);if(t==null){if(this.root!==unset)throw Error(`Chunked message contained multiple root values`);this.root=e;return}if(t.type===`array`){t.value.push(e);return}if(t.key==null)throw Error(`Chunked message object value had no key`);" + objectWrite + "}};",
+  ].join("");
+  return duplicate ? `${source}${source.replaceAll("Assembler", "SecondAssembler")}` : source;
+}
+
+test("uses fast ordinary writes in the chunked message decoder", () => {
+  const source = chunkedMessageDecoderFixture();
+
+  const patched = applyPatchTwice(
+    applyLinuxChunkedMessageDecoderPerformancePatch,
+    source,
+  );
+
+  assert.match(
+    patched,
+    /t\.key===`__proto__`\?Object\.defineProperty\(t\.value,t\.key,\{configurable:!0,enumerable:!0,value:e,writable:!0\}\):t\.value\[t\.key\]=e,t\.key=null/,
+  );
+  assert.equal(
+    matchesLinuxChunkedMessageDecoderPerformanceContract(patched),
+    true,
+  );
+});
+
+test("preserves chunked message object descriptors and prototype safety", () => {
+  const patched = applyLinuxChunkedMessageDecoderPerformancePatch(
+    chunkedMessageDecoderFixture(),
+  );
+  const context = {};
+  vm.runInNewContext(
+    `${patched};globalThis.ChunkAssembler=Assembler;`,
+    context,
+  );
+
+  const assembler = new context.ChunkAssembler();
+  const decoded = {};
+  for (const [key, value] of [
+    ["ordinary", 42],
+    ["constructor", "own-constructor"],
+    ["toString", "own-to-string"],
+  ]) {
+    assembler.stack = [{ type: "object", value: decoded, key }];
+    assembler.saveValue(value);
+    assert.deepEqual(Object.getOwnPropertyDescriptor(decoded, key), {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true,
+    });
+  }
+
+  const originalPrototype = Object.getPrototypeOf(decoded);
+  const protoValue = { polluted: true };
+  assembler.stack = [{ type: "object", value: decoded, key: "__proto__" }];
+  assembler.saveValue(protoValue);
+  assert.equal(Object.getPrototypeOf(decoded), originalPrototype);
+  assert.deepEqual(Object.getOwnPropertyDescriptor(decoded, "__proto__"), {
+    configurable: true,
+    enumerable: true,
+    value: protoValue,
+    writable: true,
+  });
+  assert.equal({}.polluted, undefined);
+
+  const arrayAssembler = new context.ChunkAssembler();
+  const decodedArray = [];
+  arrayAssembler.stack = [{ type: "array", value: decodedArray }];
+  arrayAssembler.saveValue("kept");
+  assert.deepEqual(decodedArray, ["kept"]);
+
+  const rootAssembler = new context.ChunkAssembler();
+  rootAssembler.saveValue("root");
+  assert.equal(rootAssembler.finish(), "root");
+});
+
+test("matches only one complete chunked message decoder contract", () => {
+  assert.equal(
+    matchesLinuxChunkedMessageDecoderPerformanceContract(
+      chunkedMessageDecoderFixture(),
+    ),
+    true,
+  );
+  assert.equal(
+    matchesLinuxChunkedMessageDecoderPerformanceContract(
+      "function generic(t,e){Object.defineProperty(t.value,t.key,{configurable:!0,enumerable:!0,value:e,writable:!0})}",
+    ),
+    false,
+  );
+  assert.equal(
+    matchesLinuxChunkedMessageDecoderPerformanceContract(
+      chunkedMessageDecoderFixture({ duplicate: true }),
+    ),
+    false,
+  );
+});
+
+test("leaves drifted chunked message decoders byte-identical", () => {
+  const source = chunkedMessageDecoderFixture({
+    write:
+      "Reflect.defineProperty(t.value,t.key,{configurable:!0,enumerable:!0,value:e,writable:!0}),t.key=null",
+  });
+
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxChunkedMessageDecoderPerformancePatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not uniquely identify the chunked message object-write contract — skipping Linux chunked message decoder performance patch",
+  ]);
+});
+
+test("leaves ambiguous chunked message decoder assets byte-identical", () => {
+  const source = chunkedMessageDecoderFixture({ duplicate: true });
+
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxChunkedMessageDecoderPerformancePatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not uniquely identify the chunked message object-write contract — skipping Linux chunked message decoder performance patch",
+  ]);
+});
+
+test("rejects an incomplete chunked message decoder fast-write patch", () => {
+  const source = chunkedMessageDecoderFixture({
+    write: "t.value[t.key]=e,t.key=null",
+  });
+
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxChunkedMessageDecoderPerformancePatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not uniquely identify the chunked message object-write contract — skipping Linux chunked message decoder performance patch",
   ]);
 });
 

--- a/scripts/patches/core/all-linux/webview/chunked-message-decoder-performance/patch.js
+++ b/scripts/patches/core/all-linux/webview/chunked-message-decoder-performance/patch.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const {
+  CI_POLICY_OPTIONAL,
+  webviewAssetPatch,
+} = require("../../../../descriptor.js");
+const {
+  applyLinuxChunkedMessageDecoderPerformancePatch,
+  matchesLinuxChunkedMessageDecoderPerformanceContract,
+} = require("../../../../impl/webview/index.js");
+
+module.exports = [
+  webviewAssetPatch({
+    id: "linux-chunked-message-decoder-performance",
+    phase: "webview-asset",
+    order: 1047,
+    ciPolicy: CI_POLICY_OPTIONAL,
+    pattern: /^app-initial-[^.]+\.js$/,
+    assetMatch: matchesLinuxChunkedMessageDecoderPerformanceContract,
+    missingDescription: "chunked message decoder bundle",
+    skipDescription: "Linux chunked message decoder performance patch",
+    apply: applyLinuxChunkedMessageDecoderPerformancePatch,
+  }),
+];

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -35,8 +35,85 @@ const LINUX_SIDEBAR_SCROLL_DRIFT_WARNING =
   "WARN: Could not uniquely identify the main sidebar scroll container — skipping Linux sidebar scroll performance patch";
 const LINUX_APP_SHELL_TAB_LAYOUT_DRIFT_WARNING =
   "WARN: Could not uniquely identify the app-shell tab layout contract — skipping Linux tab layout performance patch";
+const LINUX_CHUNKED_MESSAGE_DECODER_DRIFT_WARNING =
+  "WARN: Could not uniquely identify the chunked message object-write contract — skipping Linux chunked message decoder performance patch";
 const LINUX_APP_SHELL_TAB_OVERFLOW_HELPER =
   "const codexLinuxAppShellTabOverflowFrames=new WeakMap;function codexLinuxScheduleAppShellTabOverflow(e,t){if(e?.isConnected&&!codexLinuxAppShellTabOverflowFrames.has(e)){let n=requestAnimationFrame(()=>{codexLinuxAppShellTabOverflowFrames.delete(e),e.isConnected&&t(e.scrollWidth>e.clientWidth)});codexLinuxAppShellTabOverflowFrames.set(e,n)}}";
+
+function linuxChunkedMessageObjectWrites(currentSource) {
+  const unpatchedPattern =
+    /Object\.defineProperty\(([A-Za-z_$][\w$]*)\.value,\1\.key,\{configurable:!0,enumerable:!0,value:([A-Za-z_$][\w$]*),writable:!0\}\),\1\.key=null/gu;
+  const patchedPattern =
+    /([A-Za-z_$][\w$]*)\.key===`__proto__`\?Object\.defineProperty\(\1\.value,\1\.key,\{configurable:!0,enumerable:!0,value:([A-Za-z_$][\w$]*),writable:!0\}\):\1\.value\[\1\.key\]=\2,\1\.key=null/gu;
+  const candidates = [];
+
+  for (const [pattern, patched] of [
+    [unpatchedPattern, false],
+    [patchedPattern, true],
+  ]) {
+    for (const match of currentSource.matchAll(pattern)) {
+      const stackName = match[1];
+      const valueName = match[2];
+      const vicinity = currentSource.slice(
+        Math.max(0, match.index - 4_000),
+        match.index + match[0].length + 1_500,
+      );
+      if (
+        !vicinity.includes("codex-host-chunked-message-v1") ||
+        !vicinity.includes("Chunked message contained an unmatched container end") ||
+        !vicinity.includes("Chunked message ended before its value was complete") ||
+        !vicinity.includes("Chunked message contained multiple root values") ||
+        !vicinity.includes("Chunked message object value had no key") ||
+        !vicinity.includes(
+          `if(${stackName}.type===\`array\`){${stackName}.value.push(${valueName});return}`,
+        )
+      ) {
+        continue;
+      }
+      candidates.push({
+        end: match.index + match[0].length,
+        patched,
+        stackName,
+        start: match.index,
+        valueName,
+      });
+    }
+  }
+
+  return candidates;
+}
+
+function matchesLinuxChunkedMessageDecoderPerformanceContract(currentSource) {
+  return linuxChunkedMessageObjectWrites(currentSource).length === 1;
+}
+
+function applyLinuxChunkedMessageDecoderPerformancePatch(currentSource) {
+  const candidates = linuxChunkedMessageObjectWrites(currentSource);
+  if (candidates.length === 1) {
+    const [candidate] = candidates;
+    if (candidate.patched) {
+      return currentSource;
+    }
+    const { stackName, valueName } = candidate;
+    const replacement =
+      `${stackName}.key===\`__proto__\`?` +
+      `Object.defineProperty(${stackName}.value,${stackName}.key,{configurable:!0,enumerable:!0,value:${valueName},writable:!0}):` +
+      `${stackName}.value[${stackName}.key]=${valueName},${stackName}.key=null`;
+    return (
+      currentSource.slice(0, candidate.start) +
+      replacement +
+      currentSource.slice(candidate.end)
+    );
+  }
+
+  if (
+    currentSource.includes("codex-host-chunked-message-v1") &&
+    currentSource.includes("Chunked message object value had no key")
+  ) {
+    console.warn(LINUX_CHUNKED_MESSAGE_DECODER_DRIFT_WARNING);
+  }
+  return currentSource;
+}
 
 function enclosingFunction(currentSource, targetIndex) {
   const functionPattern =
@@ -2747,6 +2824,7 @@ module.exports = {
   applyAutomationUpdateEagerToolPatch,
   matchesAutomationUpdateEagerToolContract,
   applyLinuxChatSearchHydrationPatch,
+  applyLinuxChunkedMessageDecoderPerformancePatch,
   applyLinuxBrowserUseAvailabilityPatch,
   applyLinuxBrowserUseExternalAvailabilityPatch,
   patchLinuxBrowserUseExternalAvailabilityAssets,
@@ -2770,6 +2848,7 @@ module.exports = {
   applySubagentNicknameMetadataPatch,
   codexLinuxWatchBrowserWebviewAttachment,
   matchesLinuxAppShellTabLayoutPerformanceContract,
+  matchesLinuxChunkedMessageDecoderPerformanceContract,
   matchesLinuxSidebarScrollPerformanceContract,
   patchBrowserPagePreloadBundle,
 };


### PR DESCRIPTION
## Summary

Fixes #1284.

Large host messages are reconstructed in the renderer by the chunk assembler. Its object path currently calls `Object.defineProperty` for every decoded key, so content-heavy session hydration pays the safe `__proto__` write cost for ordinary properties too.

This PR adds one optional semantic webview patch that:

- uses ordinary assignment for normal decoded object keys;
- retains the existing `Object.defineProperty` path for `__proto__`;
- preserves root writes, array writes, property descriptors, and decoded-object prototypes;
- selects exactly one complete current assembler contract and leaves drifted, duplicated, or partially patched assets byte-identical;
- remains idempotent and fail-soft as upstream minified symbols change.

The patch does not unload retained Browser / Computer Use webviews and adds no dependency or generated app artifact.

## Performance evidence

Environment: ChatGPT 26.803.41515, Electron 42.3.0 / Chrome 148, Linux, 201-session sidebar, up to seven retained Browser webviews.

A 34-session CPU profile identified the chunk receive/assembly path as a recurring renderer hotspot. One baseline sweep recorded 2.36s of `j6e` self time and 367ms of `saveValue` self time.

A controlled benchmark through the real in-app `window.postMessage` chunk listener decoded five 50,000-property transfers per sample. Three sequential A/B samples produced:

| Metric | Before median | After median | Change |
| --- | ---: | ---: | ---: |
| Decoder wall time | 777.9 ms | 728.5 ms | -6.35% |
| `saveValue` self time | 163.2 ms | 108.6 ms | -33.45% |

Concurrent samples were excluded because two Electron instances contended for CPU. A separate text-measurement candidate was also excluded after an exact-input 34-session sweep regressed end-to-end long-task time, so it is not part of this PR.

## Validation

- TDD red/green cycle: the focused tests first failed because the transform and descriptor did not exist, then passed after the implementation
- `node scripts/patch-linux-window-ui.test.js` outside the restricted sandbox: 430 passed, 0 failed
- `bash tests/scripts_smoke.sh`: passed, including Debian/RPM/pacman/AppImage smoke matrices
- `node --check` on the implementation, descriptor, and test file
- `git diff --cached --check`
- Current `app-initial-Biw83Aiz.js` semantic acceptance:
  - exactly one match
  - one byte change
  - second application byte-identical
  - source SHA-256 remained `426cdc7d62c25d470ef82ff184fba0826026edab2653d75256d7f4458455eb61`
  - patched SHA-256 `a4d603fd40fda8472f596d934e2275b2f71841f9f69021c2927ec1a5cdba1796`, matching the profiled candidate
- Browser retention during session sweeps: up to 7/7 guest views remained connected

`make build-dev-app` was attempted in a side-by-side target. The execution environment hit its filesystem quota while unpacking the managed Node runtime, before the patcher ran (`patchReport: missing`), so that build is reported as inconclusive rather than passing. The generated-asset transform and the profiled candidate were verified independently as listed above.

## Compatibility and risk

- Targets only the latest primary `app-initial-*.js` semantic contract.
- `__proto__` remains an enumerable, configurable, writable own data property and cannot mutate the decoded object's prototype.
- Ordinary `constructor` and `toString` keys retain the same own data-property descriptors.
- Unknown, ambiguous, incomplete, or future upstream shapes are skipped with an optional drift warning.
- Remaining risk is upstream bundle drift, which does not block installation and does not modify an unknown asset.

## Checklist

- [ ] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] This is not an upstream-drift compatibility fix; the semantic patch intentionally targets only the latest `CODEX.DMG`.
- [ ] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass. (Local validation is complete; GitHub CI is pending.)
- [ ] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
