### PR TITLE
fix(chrome): expose managed Node to sidepanel app-server

### DIFF
--- a/computer-use-linux/src/chrome_runtime.rs
+++ b/computer-use-linux/src/chrome_runtime.rs
@@ -6,12 +6,14 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::{
     collections::{HashMap, VecDeque},
-    env, fs,
+    env,
+    ffi::OsString,
+    fs,
     fs::{File, OpenOptions},
     io::{self, BufRead, BufReader, Read, Write},
     net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener},
     os::unix::{
-        ffi::OsStrExt,
+        ffi::{OsStrExt, OsStringExt},
         fs::{FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt},
         process::CommandExt,
     },
@@ -1611,22 +1613,38 @@ fn start_app_server(
     ))
 }
 
-fn app_server_child_path(node_path: &Path) -> RuntimeResult<std::ffi::OsString> {
+fn app_server_child_path(node_path: &Path) -> RuntimeResult<OsString> {
     let node_dir = node_path
         .parent()
         .filter(|path| !path.as_os_str().is_empty())
         .ok_or_else(|| RuntimeError::internal("Validated Node path has no parent directory"))?;
-    let ambient_path = env::var_os("PATH");
-    let paths = std::iter::once(node_dir.to_path_buf()).chain(
-        ambient_path
-            .as_deref()
-            .map(env::split_paths)
-            .into_iter()
-            .flatten(),
-    );
+    let search_path = env::var_os("PATH").unwrap_or_else(default_executable_search_path);
+    let paths = std::iter::once(node_dir.to_path_buf()).chain(env::split_paths(&search_path));
     env::join_paths(paths).map_err(|error| {
         RuntimeError::internal(format!("Failed to construct app-server PATH: {error}"))
     })
+}
+
+fn default_executable_search_path() -> OsString {
+    let length = unsafe { libc::confstr(libc::_CS_PATH, std::ptr::null_mut(), 0) };
+    if length == 0 {
+        return OsString::from("/bin:/usr/bin");
+    }
+    let mut buffer = vec![0_u8; length];
+    let written = unsafe {
+        libc::confstr(
+            libc::_CS_PATH,
+            buffer.as_mut_ptr().cast::<libc::c_char>(),
+            buffer.len(),
+        )
+    };
+    if written == 0 {
+        return OsString::from("/bin:/usr/bin");
+    }
+    if buffer.last() == Some(&0) {
+        buffer.pop();
+    }
+    OsString::from_vec(buffer)
 }
 
 fn stop_managed_process(process: &mut ManagedProcess) {
@@ -2983,6 +3001,14 @@ mod tests {
     }
 
     #[test]
+    fn app_server_child_path_rejects_an_unjoinable_node_parent() {
+        let error = app_server_child_path(Path::new("/tmp/managed:node/node")).unwrap_err();
+        assert!(error
+            .message
+            .starts_with("Failed to construct app-server PATH:"));
+    }
+
+    #[test]
     fn executable_validation_rejects_a_group_writable_parent() {
         let root = test_root("group-writable-parent");
         let unsafe_parent = root.join("shared");
@@ -3339,11 +3365,14 @@ while True:
 import os
 import signal
 import socket
+import subprocess
 import sys
 import time
 
 with open(os.environ["CODEX_TEST_PATH_RECORD"], "w", encoding="utf-8") as record:
     record.write(os.environ.get("PATH", "<missing>"))
+if os.environ.get("CODEX_TEST_REQUIRE_DEFAULT_COMMAND") == "1":
+    subprocess.run(["sh", "-c", "true"], check=True)
 listen = sys.argv[sys.argv.index("--listen") + 1]
 socket_path = listen.removeprefix("unix://")
 server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -3365,12 +3394,19 @@ while True:
         const CASE: &str = "CODEX_TEST_NPM_SHEBANG_CASE";
         const ROOT: &str = "CODEX_TEST_NPM_SHEBANG_ROOT";
         const PYTHON: &str = "CODEX_TEST_NPM_SHEBANG_PYTHON";
+        const RUNTIME_ROOT: &str = "CODEX_TEST_NPM_SHEBANG_RUNTIME_ROOT";
+        const REQUIRE_DEFAULT_COMMAND: &str = "CODEX_TEST_REQUIRE_DEFAULT_COMMAND";
 
         if env::var_os(CHILD).is_none() {
             let python = test_executable("python3");
-            for case in ["present", "absent"] {
+            for case in ["present", "absent", "empty"] {
                 let root = test_root(&format!("npm-shebang-trusted-node-{case}"));
                 let ambient_dir = root.join("ambient-bin");
+                let runtime_root = PathBuf::from("/tmp").join(format!(
+                    "cdx-npm-{}-{}",
+                    std::process::id(),
+                    random_hex(4).unwrap()
+                ));
                 fs::create_dir_all(&ambient_dir).unwrap();
                 fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
                 fs::set_permissions(&ambient_dir, fs::Permissions::from_mode(0o700)).unwrap();
@@ -3383,14 +3419,25 @@ while True:
                     .env(CASE, case)
                     .env(ROOT, &root)
                     .env(PYTHON, &python)
-                    .env("CODEX_TEST_PATH_RECORD", root.join("child-path.txt"));
-                if case == "present" {
-                    command.env("PATH", &ambient_dir);
-                } else {
-                    command.env_remove("PATH");
+                    .env(RUNTIME_ROOT, &runtime_root)
+                    .env("CODEX_TEST_PATH_RECORD", root.join("child-path.txt"))
+                    .env_remove(REQUIRE_DEFAULT_COMMAND);
+                match case {
+                    "present" => {
+                        command.env("PATH", &ambient_dir);
+                    }
+                    "absent" => {
+                        command.env_remove("PATH");
+                        command.env(REQUIRE_DEFAULT_COMMAND, "1");
+                    }
+                    "empty" => {
+                        command.env("PATH", "");
+                    }
+                    _ => unreachable!(),
                 }
                 let output = command.output().unwrap();
                 let _ = fs::remove_dir_all(&root);
+                let _ = fs::remove_dir_all(&runtime_root);
                 assert!(
                     output.status.success(),
                     "npm shebang subprocess ({case}) failed\nstdout:\n{}\nstderr:\n{}",
@@ -3403,6 +3450,7 @@ while True:
 
         let root = PathBuf::from(env::var_os(ROOT).unwrap());
         let python = PathBuf::from(env::var_os(PYTHON).unwrap());
+        let runtime_root = PathBuf::from(env::var_os(RUNTIME_ROOT).unwrap());
         let (fake_cli, node) = fake_npm_socket_app_server(&root, &python);
         let path_record = root.join("child-path.txt");
         let ambient_path = env::var_os("PATH");
@@ -3416,14 +3464,13 @@ while True:
         entry.paths.codex_cli_path = fs::canonicalize(fake_cli).unwrap();
         entry.paths.codex_home = root.clone();
         entry.paths.node_path = fs::canonicalize(node).unwrap();
-        let runtime_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .join(format!(
-                "cdx-npm-shebang-{}-{}",
-                std::process::id(),
-                random_hex(4).unwrap()
-            ));
+        let expected_socket_path =
+            runtime_root.join(format!("a-{}.sock", short_hash(b"sidepanel-npm-shebang")));
+        assert!(
+            unix_socket_path_fits(&expected_socket_path),
+            "npm shebang fixture socket path is too long: {}",
+            expected_socket_path.display()
+        );
 
         let process = start_app_server(
             &entry,
@@ -3441,26 +3488,32 @@ while True:
                 panic!("npm shebang app-server failed: {error:?}");
             }
         };
-        let expected_path = env::join_paths(
-            std::iter::once(entry.paths.node_path.parent().unwrap().to_path_buf()).chain(
-                ambient_path
-                    .as_deref()
-                    .map(env::split_paths)
-                    .into_iter()
-                    .flatten(),
-            ),
-        )
-        .unwrap();
         let recorded_path = fs::read(path_record).unwrap();
+        let recorded_paths =
+            env::split_paths(std::ffi::OsStr::from_bytes(&recorded_path)).collect::<Vec<_>>();
+        let expected_node_dir = entry.paths.node_path.parent().unwrap().to_path_buf();
 
-        stop_managed_process(&mut process);
-        fs::remove_dir_all(runtime_root).unwrap();
         assert_eq!(
-            recorded_path,
-            expected_path.as_os_str().as_bytes(),
+            recorded_paths.first(),
+            Some(&expected_node_dir),
             "{} ambient PATH case",
             env::var(CASE).unwrap()
         );
+        match env::var(CASE).unwrap().as_str() {
+            "present" => {
+                assert_eq!(recorded_paths[1..], [PathBuf::from(ambient_path.unwrap())])
+            }
+            "absent" => assert!(recorded_paths.len() > 1),
+            "empty" => assert_eq!(recorded_paths[1..], [PathBuf::new()]),
+            _ => unreachable!(),
+        }
+        assert_eq!(
+            fs::metadata(&runtime_root).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+
+        stop_managed_process(&mut process);
+        fs::remove_dir_all(runtime_root).unwrap();
     }
 
     #[test]

--- a/computer-use-linux/src/chrome_runtime.rs
+++ b/computer-use-linux/src/chrome_runtime.rs
@@ -3297,14 +3297,14 @@ mod tests {
             .unwrap_or_else(|| panic!("could not resolve test executable from PATH: {name}"))
     }
 
-    fn fake_path_dependent_python_launcher(root: &Path, python: &Path) -> PathBuf {
+    fn fake_basename_sensitive_python_launcher(root: &Path, python: &Path) -> PathBuf {
         fs::create_dir_all(root).unwrap();
         fs::set_permissions(root, fs::Permissions::from_mode(0o700)).unwrap();
-        std::os::unix::fs::symlink(python, root.join("selected-python")).unwrap();
+        std::os::unix::fs::symlink(python, root.join("native-python")).unwrap();
         let launcher = root.join("python3");
         fs::write(
             &launcher,
-            "#!/usr/bin/env bash\nexec \"${0%/*}/selected-python\" \"$@\"\n",
+            "#!/usr/bin/env bash\nname=\"${0##*/}\"\nif [[ \"$name\" != \"python3\" ]]; then\n  echo \"pyenv: $name: command not found\" >&2\n  exit 127\nfi\nexec \"${0%/*}/native-python\" \"$@\"\n",
         )
         .unwrap();
         fs::set_permissions(&launcher, fs::Permissions::from_mode(0o700)).unwrap();
@@ -3445,14 +3445,14 @@ while True:
         const REQUIRE_DEFAULT_COMMAND: &str = "CODEX_TEST_REQUIRE_DEFAULT_COMMAND";
 
         if env::var_os(CHILD).is_none() {
-            let python_launcher_root = test_root("npm-shebang-python-launcher");
-            let python_launcher = fake_path_dependent_python_launcher(
-                &python_launcher_root,
-                &test_executable("python3"),
-            );
-            let python = resolve_test_python_interpreter(&python_launcher);
-            fs::remove_dir_all(&python_launcher_root).unwrap();
-            assert!(!python.starts_with(&python_launcher_root));
+            let native_python = resolve_test_python_interpreter(&test_executable("python3"));
+            let basename_sensitive_root = test_root("npm-shebang-basename-sensitive-python");
+            let basename_sensitive_python =
+                fake_basename_sensitive_python_launcher(&basename_sensitive_root, &native_python);
+            let python = resolve_test_python_interpreter(&basename_sensitive_python);
+            fs::remove_dir_all(&basename_sensitive_root).unwrap();
+            assert_eq!(python, native_python);
+            assert!(!python.starts_with(&basename_sensitive_root));
             for case in ["present", "absent", "empty"] {
                 let root = test_root(&format!("npm-shebang-trusted-node-{case}"));
                 let ambient_dir = root.join("ambient-bin");

--- a/computer-use-linux/src/chrome_runtime.rs
+++ b/computer-use-linux/src/chrome_runtime.rs
@@ -1248,7 +1248,7 @@ fn validate_runtime_entry_for_host(
     validate_owned_dir(&entry.paths.resources_path, false)?;
     entry.paths.codex_cli_path = validate_owned_file(&entry.paths.codex_cli_path, true)?;
     validate_owned_file(&entry.paths.extension_host_path, true)?;
-    validate_owned_file(&entry.paths.node_path, true)?;
+    entry.paths.node_path = validate_owned_file(&entry.paths.node_path, true)?;
     if let Some(path) = &entry.paths.node_repl_path {
         validate_owned_file(path, true)?;
     }
@@ -1480,6 +1480,7 @@ fn start_app_server(
         }
     }
 
+    let child_path = app_server_child_path(&entry.paths.node_path)?;
     let mut command = Command::new(&entry.paths.codex_cli_path);
     command
         .arg("-c")
@@ -1495,6 +1496,7 @@ fn start_app_server(
         .env("CODEX_BROWSER_USE_NODE_PATH", &entry.paths.node_path)
         .env("CODEX_APP_SERVER_PROXY_HOST", &entry.proxy_host)
         .env("CODEX_APP_SERVER_PROXY_PORT", proxy_port.to_string())
+        .env("PATH", child_path)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
@@ -1607,6 +1609,24 @@ fn start_app_server(
     Err(RuntimeError::internal(
         "Timed out waiting for Codex app-server to start",
     ))
+}
+
+fn app_server_child_path(node_path: &Path) -> RuntimeResult<std::ffi::OsString> {
+    let node_dir = node_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .ok_or_else(|| RuntimeError::internal("Validated Node path has no parent directory"))?;
+    let ambient_path = env::var_os("PATH");
+    let paths = std::iter::once(node_dir.to_path_buf()).chain(
+        ambient_path
+            .as_deref()
+            .map(env::split_paths)
+            .into_iter()
+            .flatten(),
+    );
+    env::join_paths(paths).map_err(|error| {
+        RuntimeError::internal(format!("Failed to construct app-server PATH: {error}"))
+    })
 }
 
 fn stop_managed_process(process: &mut ManagedProcess) {
@@ -2926,6 +2946,43 @@ mod tests {
     }
 
     #[test]
+    fn node_path_validation_canonicalizes_and_rejects_unsafe_executables() {
+        let root = test_root("canonical-node-path");
+        let runtime_dir = root.join("runtime/bin");
+        let manifest_dir = root.join("manifest/bin");
+        fs::create_dir_all(&runtime_dir).unwrap();
+        fs::create_dir_all(&manifest_dir).unwrap();
+        for directory in [
+            root.clone(),
+            root.join("runtime"),
+            runtime_dir.clone(),
+            root.join("manifest"),
+            manifest_dir.clone(),
+        ] {
+            fs::set_permissions(directory, fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        let canonical_node = runtime_dir.join("node");
+        fs::write(&canonical_node, "synthetic node").unwrap();
+        fs::set_permissions(&canonical_node, fs::Permissions::from_mode(0o700)).unwrap();
+        let manifest_node = manifest_dir.join("node");
+        std::os::unix::fs::symlink(&canonical_node, &manifest_node).unwrap();
+
+        assert_eq!(
+            validate_owned_file(&manifest_node, true).unwrap(),
+            canonical_node
+        );
+        fs::set_permissions(&canonical_node, fs::Permissions::from_mode(0o720)).unwrap();
+        assert!(validate_owned_file(&manifest_node, true).is_err());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn app_server_child_path_rejects_a_node_path_without_a_parent() {
+        let error = app_server_child_path(Path::new("/")).unwrap_err();
+        assert_eq!(error.message, "Validated Node path has no parent directory");
+    }
+
+    #[test]
     fn executable_validation_rejects_a_group_writable_parent() {
         let root = test_root("group-writable-parent");
         let unsafe_parent = root.join("shared");
@@ -3242,6 +3299,168 @@ while True:
         .unwrap();
         fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
         path
+    }
+
+    fn fake_npm_socket_app_server(root: &Path, python: &Path) -> (PathBuf, PathBuf) {
+        let node_dir = root.join("managed-node/bin");
+        let cli_dir = root.join("npm/lib/node_modules/@openai/codex/bin");
+        fs::create_dir_all(&node_dir).unwrap();
+        fs::create_dir_all(&cli_dir).unwrap();
+        for directory in [
+            root.to_path_buf(),
+            root.join("managed-node"),
+            node_dir.clone(),
+            root.join("npm"),
+            root.join("npm/lib"),
+            root.join("npm/lib/node_modules"),
+            root.join("npm/lib/node_modules/@openai"),
+            root.join("npm/lib/node_modules/@openai/codex"),
+            cli_dir.clone(),
+        ] {
+            fs::set_permissions(directory, fs::Permissions::from_mode(0o700)).unwrap();
+        }
+
+        let python_literal = serde_json::to_string(&python.to_string_lossy()).unwrap();
+        let node = node_dir.join("node");
+        fs::write(
+            &node,
+            format!(
+                "#!{}\nimport os, sys\nos.execv({python_literal}, [{python_literal}, *sys.argv[1:]])\n",
+                python.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&node, fs::Permissions::from_mode(0o700)).unwrap();
+
+        let cli = cli_dir.join("codex.js");
+        fs::write(
+            &cli,
+            r#"#!/usr/bin/env node
+import os
+import signal
+import socket
+import sys
+import time
+
+with open(os.environ["CODEX_TEST_PATH_RECORD"], "w", encoding="utf-8") as record:
+    record.write(os.environ.get("PATH", "<missing>"))
+listen = sys.argv[sys.argv.index("--listen") + 1]
+socket_path = listen.removeprefix("unix://")
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+server.bind(socket_path)
+server.listen()
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+while True:
+    time.sleep(0.1)
+"#,
+        )
+        .unwrap();
+        fs::set_permissions(&cli, fs::Permissions::from_mode(0o700)).unwrap();
+        (cli, node)
+    }
+
+    #[test]
+    fn npm_shebang_launcher_uses_trusted_node_when_ambient_path_lacks_node() {
+        const CHILD: &str = "CODEX_TEST_NPM_SHEBANG_CHILD";
+        const CASE: &str = "CODEX_TEST_NPM_SHEBANG_CASE";
+        const ROOT: &str = "CODEX_TEST_NPM_SHEBANG_ROOT";
+        const PYTHON: &str = "CODEX_TEST_NPM_SHEBANG_PYTHON";
+
+        if env::var_os(CHILD).is_none() {
+            let python = test_executable("python3");
+            for case in ["present", "absent"] {
+                let root = test_root(&format!("npm-shebang-trusted-node-{case}"));
+                let ambient_dir = root.join("ambient-bin");
+                fs::create_dir_all(&ambient_dir).unwrap();
+                fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+                fs::set_permissions(&ambient_dir, fs::Permissions::from_mode(0o700)).unwrap();
+                let mut command = Command::new(env::current_exe().unwrap());
+                command
+                    .arg("--exact")
+                    .arg("chrome_runtime::tests::npm_shebang_launcher_uses_trusted_node_when_ambient_path_lacks_node")
+                    .arg("--nocapture")
+                    .env(CHILD, "1")
+                    .env(CASE, case)
+                    .env(ROOT, &root)
+                    .env(PYTHON, &python)
+                    .env("CODEX_TEST_PATH_RECORD", root.join("child-path.txt"));
+                if case == "present" {
+                    command.env("PATH", &ambient_dir);
+                } else {
+                    command.env_remove("PATH");
+                }
+                let output = command.output().unwrap();
+                let _ = fs::remove_dir_all(&root);
+                assert!(
+                    output.status.success(),
+                    "npm shebang subprocess ({case}) failed\nstdout:\n{}\nstderr:\n{}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            return;
+        }
+
+        let root = PathBuf::from(env::var_os(ROOT).unwrap());
+        let python = PathBuf::from(env::var_os(PYTHON).unwrap());
+        let (fake_cli, node) = fake_npm_socket_app_server(&root, &python);
+        let path_record = root.join("child-path.txt");
+        let ambient_path = env::var_os("PATH");
+        let mut entry = test_entry();
+        for executable in [&fake_cli, &node] {
+            let metadata = fs::metadata(executable).unwrap();
+            assert_eq!(metadata.uid(), unsafe { libc::geteuid() });
+            assert_eq!(metadata.permissions().mode() & 0o077, 0);
+            assert_ne!(metadata.permissions().mode() & 0o111, 0);
+        }
+        entry.paths.codex_cli_path = fs::canonicalize(fake_cli).unwrap();
+        entry.paths.codex_home = root.clone();
+        entry.paths.node_path = fs::canonicalize(node).unwrap();
+        let runtime_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join(format!(
+                "cdx-npm-shebang-{}-{}",
+                std::process::id(),
+                random_hex(4).unwrap()
+            ));
+
+        let process = start_app_server(
+            &entry,
+            "abcdefghijklmnopabcdefghijklmnop",
+            "sidepanel-npm-shebang",
+            41000,
+            &runtime_root,
+            1,
+            Duration::from_secs(1),
+        );
+        let mut process = match process {
+            Ok(process) => process,
+            Err(error) => {
+                let _ = fs::remove_dir_all(&runtime_root);
+                panic!("npm shebang app-server failed: {error:?}");
+            }
+        };
+        let expected_path = env::join_paths(
+            std::iter::once(entry.paths.node_path.parent().unwrap().to_path_buf()).chain(
+                ambient_path
+                    .as_deref()
+                    .map(env::split_paths)
+                    .into_iter()
+                    .flatten(),
+            ),
+        )
+        .unwrap();
+        let recorded_path = fs::read(path_record).unwrap();
+
+        stop_managed_process(&mut process);
+        fs::remove_dir_all(runtime_root).unwrap();
+        assert_eq!(
+            recorded_path,
+            expected_path.as_os_str().as_bytes(),
+            "{} ambient PATH case",
+            env::var(CASE).unwrap()
+        );
     }
 
     #[test]

--- a/computer-use-linux/src/chrome_runtime.rs
+++ b/computer-use-linux/src/chrome_runtime.rs
@@ -3297,6 +3297,53 @@ mod tests {
             .unwrap_or_else(|| panic!("could not resolve test executable from PATH: {name}"))
     }
 
+    fn fake_path_dependent_python_launcher(root: &Path, python: &Path) -> PathBuf {
+        fs::create_dir_all(root).unwrap();
+        fs::set_permissions(root, fs::Permissions::from_mode(0o700)).unwrap();
+        std::os::unix::fs::symlink(python, root.join("selected-python")).unwrap();
+        let launcher = root.join("python3");
+        fs::write(
+            &launcher,
+            "#!/usr/bin/env bash\nexec \"${0%/*}/selected-python\" \"$@\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&launcher, fs::Permissions::from_mode(0o700)).unwrap();
+        launcher
+    }
+
+    fn resolve_test_python_interpreter(launcher: &Path) -> PathBuf {
+        let output = Command::new(launcher)
+            .arg("-c")
+            .arg(
+                "import os, sys; sys.stdout.buffer.write(os.fsencode(os.path.realpath(sys.executable)))",
+            )
+            .output()
+            .unwrap_or_else(|error| {
+                panic!(
+                    "failed to query Python interpreter through {}: {error}",
+                    launcher.display()
+                )
+            });
+        assert!(
+            output.status.success(),
+            "Python interpreter query through {} failed\nstdout:\n{}\nstderr:\n{}",
+            launcher.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let interpreter = PathBuf::from(OsString::from_vec(output.stdout));
+        let interpreter = fs::canonicalize(&interpreter).unwrap_or_else(|error| {
+            panic!(
+                "failed to canonicalize resolved Python interpreter {}: {error}",
+                interpreter.display()
+            )
+        });
+        let metadata = fs::metadata(&interpreter).unwrap();
+        assert!(metadata.is_file());
+        assert_ne!(metadata.permissions().mode() & 0o111, 0);
+        interpreter
+    }
+
     fn fake_socket_app_server(root: &Path) -> PathBuf {
         let path = root.join("fake-app-server.py");
         let python = test_executable("python3");
@@ -3398,7 +3445,14 @@ while True:
         const REQUIRE_DEFAULT_COMMAND: &str = "CODEX_TEST_REQUIRE_DEFAULT_COMMAND";
 
         if env::var_os(CHILD).is_none() {
-            let python = test_executable("python3");
+            let python_launcher_root = test_root("npm-shebang-python-launcher");
+            let python_launcher = fake_path_dependent_python_launcher(
+                &python_launcher_root,
+                &test_executable("python3"),
+            );
+            let python = resolve_test_python_interpreter(&python_launcher);
+            fs::remove_dir_all(&python_launcher_root).unwrap();
+            assert!(!python.starts_with(&python_launcher_root));
             for case in ["present", "absent", "empty"] {
                 let root = test_root(&format!("npm-shebang-trusted-node-{case}"));
                 let ambient_dir = root.join("ambient-bin");


### PR DESCRIPTION
## Summary

Fix the Linux ChatGPT Chrome side-panel startup failure for a trusted npm-managed Codex CLI whose launcher uses `#!/usr/bin/env node` when the Chrome native host's GUI `PATH` does not contain Node.

The Chrome runtime now retains the canonical, already-validated manifest `nodePath` and prepends its parent directory only to the spawned app-server child's `PATH`.

PATH handling preserves existing command lookup semantics:

- when ambient `PATH` is present and non-empty, its entries remain available afterward in their original order;
- when ambient `PATH` is absent, the child appends the platform default executable search path from `_CS_PATH`, with `/bin:/usr/bin` as a fallback;
- a present-but-empty `PATH` remains distinct from an absent `PATH`.

This keeps the trusted managed Node first for npm `#!/usr/bin/env node` launchers without preventing the app-server from resolving normal system commands such as `sh` or `git`.

## Root cause

The native host validated both `codexCliPath` and `nodePath`, but launched `codexCliPath` directly with the ambient GUI `PATH`.

For an npm-managed launcher using:

```text
#!/usr/bin/env node
```

a normal GUI-launched Chrome process can have no `node` in `PATH`. In that case `/usr/bin/env node` exits before the app-server Unix socket becomes ready, and the Chrome side panel reports:

```text
Codex app-server exited before becoming ready
```

The manifest's managed `nodePath` is the appropriate source for the fix because it already passes the runtime's existing ownership, executable, permission, canonicalization, and trusted-parent-chain checks. This change does not trust an additional environment variable or weaken those checks.

## Source and scope

- Changed only `computer-use-linux/src/chrome_runtime.rs`.
- Canonicalized and retained the validated `nodePath`.
- Constructed the app-server child `PATH` with platform path-list APIs.
- Kept the validated managed Node directory first.
- Preserved existing ambient `PATH` ordering when present.
- Restored normal system command lookup when ambient `PATH` is absent.
- Preserved present-but-empty `PATH` as a distinct case.
- Scoped the `PATH` override only to the spawned Chrome side-panel app-server child.
- Preserved direct/binary Codex CLI launch behavior and the rest of the child environment.
- Did not change launcher/updater CLI selection, Chrome registration/cache state, Computer Use UI, packaging policy, or the installed app.

## Regression coverage

The regression launches a synthetic trusted npm-style Codex CLI through the real Chrome runtime process boundary with:

- `#!/usr/bin/env node`;
- no ambient Node available;
- a separate trusted executable `nodePath`;
- real app-server Unix-socket readiness;
- `PATH` present, absent, and present-but-empty cases;
- preservation of existing ambient `PATH`;
- default system command lookup when `PATH` is absent;
- a short private `/tmp` runtime root so the Unix socket fixture is independent of checkout-directory length.

The absent-`PATH` case requires the synthetic app-server to successfully execute:

```text
sh -c true
```

so the test directly verifies that normal command lookup remains usable outside the managed Node directory.

The Python-based synthetic fixture is also independent of the selected `python3` launcher's later `PATH` requirements. It resolves the environment-selected launcher through its original `python3` path/name while the normal parent environment is still intact, then passes only the resolved absolute native interpreter into the `PATH`-mutated subprocesses.

Deterministic basename-sensitive coverage models pyenv-style behavior: the synthetic launcher must retain the `python3` basename/argv0, and the test reproduced the prior failure mode:

```text
pyenv: selected-python: command not found
```

before the fixture was corrected.

Actual pyenv was not available in the development environment, so no real pyenv-backed run is claimed.

The original pre-fix npm-shebang regression failed with:

```text
env: 'node': No such file or directory
Codex app-server exited before becoming ready
```

and now passes through the full process/shebang/socket boundary.

Node canonicalization and unsafe executable validation, direct CLI launch, process lifecycle, readiness, cleanup, and trust tests also remain covered.

## Validation

- `cargo fmt --all -- --check`
- focused npm-shebang regression with deterministic basename-sensitive launcher coverage
- `env TMPDIR=/tmp cargo test -p codex-computer-use-linux --bin codex-chrome-extension-host` — 80 passed
- `cargo check --workspace --all-targets`
- `env TMPDIR=/tmp cargo test --workspace --all-targets` — all workspace targets passed
- `git diff --check upstream/main...HEAD`
- GitHub Actions CI for current PR head `07b8b422b73899a1e4e70653809353ad7e8b721e` — passed (`31393585527`)

`cargo clippy --workspace --all-targets -- -D warnings` remains blocked only by two unchanged upstream `clippy::nonminimal_bool` warnings in `computer-use-linux/src/diagnostics.rs` and `computer-use-linux/src/server.rs` under Clippy 1.96.0. This PR changes neither file.

No validation for the final fixture follow-ups required modifying the installed Desktop application, the user's normal Chrome profile/extension registration, the system CLI, NVM tree, Codex runtime/cache state, or user services.

## Security

The prepended directory comes only from the canonical path returned by the existing trusted executable validator.

The validator continues to reject unsafe ownership, permissions, executable state, and parent chains.

The child `PATH` is constructed using `split_paths` / `join_paths`; malformed path-list construction fails closed. The native-host/parent process environment is not mutated.

When the parent `PATH` is absent, the additional fallback search path comes from the platform's `_CS_PATH`, with `/bin:/usr/bin` only as a fallback if `_CS_PATH` cannot be obtained.

No ambient Node binary is trusted ahead of the validated managed Node.

## Evidence and remaining live validation

- Real-system reproduction: normal Chrome/native-host GUI `PATH` without Node produced `Codex app-server exited before becoming ready`.
- Real-system workaround: launching Chrome with the managed Node directory prepended to `PATH` made the ChatGPT side panel work.
- Source-fix evidence: the process-boundary regression now passes with present, absent, and present-but-empty `PATH`, preserves the managed Node prefix, verifies default system-command lookup when `PATH` is absent, and uses a PATH-independent Python fixture with basename-sensitive launcher coverage.
- Remote CI for the current PR head is green.
- Remaining gap: the final patched development branch has not been exercised through the user's live Chrome side panel because doing so would require touching shared Chrome/native-host/runtime state.

A manual side-by-side validation remains possible: launch Chrome normally without the temporary `PATH` workaround, confirm the side panel starts and handles a read-only request, and confirm ordinary Desktop Chrome control still connects.

## Relationship to #805

#805 was a different failure: an npm ESM launcher had been copied away from its package metadata and dependencies.

The fix for that issue preserves the real canonical npm CLI path. This change keeps that invariant and addresses the later child-environment failure where the preserved launcher is valid but `/usr/bin/env node` cannot resolve Node from the Chrome native host's GUI `PATH`.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area. (Not applicable: this is a native-host child-environment fix.)
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.