### PR TITLE
perf(linux): avoid replaying Markdown fade animations

### DIFF
--- a/.agents/plans/2026-08-10-linux-streaming-markdown-animation-performance.md
+++ b/.agents/plans/2026-08-10-linux-streaming-markdown-animation-performance.md
@@ -1,0 +1,54 @@
+# Linux streaming Markdown animation performance
+
+## Goal
+
+Remove the session-switch freeze caused by replaying word-level Markdown fade
+animations across a large in-progress turn, without changing message content,
+Browser Use webview retention, scrolling, or image enter motion.
+
+## Evidence and root cause
+
+- A representative running session mounted one 4,920 px turn containing 2,484
+  descendants, 24 animated Markdown roots, and 1,181 fade spans. Most animated
+  roots were outside the viewport.
+- Chromium traces attributed the switch stall to renderer program work plus
+  `UpdateLayoutTree`, `Layout`, `Layerize`, and `Commit`; reducing the chunked
+  message batch size did not improve these costs.
+- Same-renderer A/B on the heavy `21 -> 7` switch reduced total long-task time
+  from 2,881/2,608 ms to 930/884 ms and the longest task from 660/636 ms to
+  392/389 ms when only Markdown text/list-marker animation was disabled.
+- Fresh-app 25-session A/B used the same fingerprint sequence and reached the
+  same maximum of eight retained Browser Use webviews. Total long-task time
+  fell from 16,119 ms to 12,866 ms, maximum task duration from 760 ms to 518 ms,
+  and median longest task from 217 ms to 189 ms.
+
+## Implementation
+
+1. Add an optional, Linux-only webview CSS descriptor targeting the unique
+   streaming Markdown animation contract in the current `app-initial` asset.
+2. Render streaming text, block elements, and list markers immediately instead
+   of allocating hundreds of fade animations on session restore.
+3. Preserve image enter animation and all content/streaming behavior.
+4. Keep the patch semantic, idempotent, ambiguity-rejecting, and fail-soft on
+   upstream drift.
+
+## Regression coverage
+
+- Exact output contract for text/list-marker animation removal.
+- Image enter motion remains byte-identical.
+- Unpatched and patched assets both match exactly once.
+- Generic, drifted, and ambiguous assets are not modified.
+- Descriptor discovery, CSS-only targeting, and optional drift policy.
+
+## Validation
+
+- Focused Node tests for the patch and descriptor.
+- Full script smoke suite, separating pre-existing environment failures.
+- Patch the exact current DMG stylesheet and verify idempotence.
+- Fresh baseline/candidate 25-session sweep and targeted heavy-session A/B.
+
+## Non-goals
+
+- Do not detach or cap Browser Use webviews.
+- Do not change transcript virtualization or message data.
+- Do not include the rejected chunk-decoder micro-optimization.

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -193,6 +193,7 @@ const {
   applyLinuxOpaqueWindowsDefaultPatch,
   applyLinuxSettingsSearchVisibilityPatch,
   applyLinuxAppShellTabLayoutPerformancePatch,
+  applyLinuxMarkdownAnimationPerformancePatch,
   applyLinuxSidebarScrollPerformancePatch,
   applyLinuxSkillsListDedupePatch,
   applyLinuxThreadSidePanelNativeTooltipPatch,
@@ -201,6 +202,7 @@ const {
   applySubagentNicknameMetadataPatch,
   codexLinuxWatchBrowserWebviewAttachment,
   matchesLinuxAppShellTabLayoutPerformanceContract,
+  matchesLinuxMarkdownAnimationPerformanceContract,
   matchesLinuxSidebarScrollPerformanceContract,
 } = require("./patches/impl/webview/index.js");
 const {
@@ -1040,6 +1042,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-settings-search-visibility",
     "linux-sidebar-scroll-performance",
     "linux-app-shell-tab-layout-performance",
+    "linux-markdown-animation-performance",
     "linux-i18n-gate",
     "automation-schedule-multi-time-rrule",
     "automation-update-eager-tool",
@@ -1155,6 +1158,26 @@ test("default core patch descriptors are grouped and unique", () => {
   assert.equal(sidebarScrollPerformance?.pattern.test("app-DuLjgNkx.css"), false);
   assert.equal(sidebarScrollPerformance?.assetMatch(sidebarScrollFixture()), true);
   assert.equal(sidebarScrollPerformance?.assetMatch("function unrelated(){}"), false);
+  const markdownAnimationPerformance = descriptors.find(
+    (descriptor) => descriptor.id === "linux-markdown-animation-performance",
+  );
+  assert.equal(markdownAnimationPerformance?.ciPolicy, "optional");
+  assert.equal(
+    markdownAnimationPerformance?.pattern.test("app-initial-AYgnwUwc.css"),
+    true,
+  );
+  assert.equal(
+    markdownAnimationPerformance?.pattern.test("app-initial-Biw83Aiz.js"),
+    false,
+  );
+  assert.equal(
+    markdownAnimationPerformance?.assetMatch(markdownAnimationFixture()),
+    true,
+  );
+  assert.equal(
+    markdownAnimationPerformance?.assetMatch("._MarkdownRoot_other{}"),
+    false,
+  );
   assert.equal(
     descriptors.find((descriptor) => descriptor.id === "linux-computer-use-avatar-cursor")?.ciPolicy,
     "optional",
@@ -3739,6 +3762,78 @@ test("leaves ambiguous app-shell tab animation assets byte-identical", () => {
   assert.equal(value, source);
   assert.deepEqual(warnings, [
     "WARN: Could not uniquely identify the app-shell tab layout contract — skipping Linux tab layout performance patch",
+  ]);
+});
+
+function markdownAnimationFixture() {
+  return [
+    "._MarkdownRoot_y8xrz_132[data-markdown-animated] :is(._FadeIn_y8xrz_535,hr,li,tr,blockquote){opacity:0;animation:_fade-in_y8xrz_1 var(--duration,var(--transition-duration-basic)) var(--fade-easing,cubic-bezier(.37, .55, .86, .88)) forwards;animation-delay:var(--fade-delay,0s)}",
+    "._MarkdownRoot_y8xrz_132[data-markdown-animated] ._FadeListDecoration_y8xrz_542::marker{animation:_fade-in-marker_y8xrz_1 var(--duration,var(--transition-duration-basic)) var(--fade-easing,cubic-bezier(.37, .55, .86, .88)) forwards;animation-delay:var(--fade-delay,0s)}",
+    "._MarkdownRoot_y8xrz_132[data-markdown-animated] ._ImageEnter_y8xrz_548{transform-origin:50%;animation:.18s ease-out both _image-enter_y8xrz_1}",
+  ].join("");
+}
+
+test("renders streaming Markdown text immediately while preserving image enter motion", () => {
+  assert.equal(typeof applyLinuxMarkdownAnimationPerformancePatch, "function");
+  const source = markdownAnimationFixture();
+
+  const patched = applyPatchTwice(
+    applyLinuxMarkdownAnimationPerformancePatch,
+    source,
+  );
+
+  assert.equal(
+    patched,
+    "._MarkdownRoot_y8xrz_132[data-markdown-animated] :is(._FadeIn_y8xrz_535,hr,li,tr,blockquote){opacity:1;animation:none}" +
+      "._MarkdownRoot_y8xrz_132[data-markdown-animated] ._FadeListDecoration_y8xrz_542::marker{animation:none}" +
+      "._MarkdownRoot_y8xrz_132[data-markdown-animated] ._ImageEnter_y8xrz_548{transform-origin:50%;animation:.18s ease-out both _image-enter_y8xrz_1}",
+  );
+  assert.equal(matchesLinuxMarkdownAnimationPerformanceContract(patched), true);
+});
+
+test("matches only one complete streaming Markdown animation contract", () => {
+  const generic =
+    ".generic[data-markdown-animated] ._FadeIn_other_1{opacity:0;animation:fade 1s}";
+
+  assert.equal(
+    matchesLinuxMarkdownAnimationPerformanceContract(markdownAnimationFixture()),
+    true,
+  );
+  assert.equal(matchesLinuxMarkdownAnimationPerformanceContract(generic), false);
+  assert.equal(
+    matchesLinuxMarkdownAnimationPerformanceContract(
+      markdownAnimationFixture() + markdownAnimationFixture(),
+    ),
+    false,
+  );
+});
+
+test("leaves drifted streaming Markdown animation styles byte-identical", () => {
+  const source = markdownAnimationFixture().replace(
+    "animation-delay:var(--fade-delay,0s)",
+    "animation-delay:var(--upstream-delay,0s)",
+  );
+
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxMarkdownAnimationPerformancePatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not uniquely identify the streaming Markdown animation contract — skipping Linux Markdown animation performance patch",
+  ]);
+});
+
+test("leaves ambiguous streaming Markdown animation styles byte-identical", () => {
+  const source = markdownAnimationFixture() + markdownAnimationFixture();
+
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxMarkdownAnimationPerformancePatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not uniquely identify the streaming Markdown animation contract — skipping Linux Markdown animation performance patch",
   ]);
 });
 

--- a/scripts/patches/core/all-linux/webview/markdown-animation-performance/patch.js
+++ b/scripts/patches/core/all-linux/webview/markdown-animation-performance/patch.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const {
+  CI_POLICY_OPTIONAL,
+  webviewAssetPatch,
+} = require("../../../../descriptor.js");
+const {
+  applyLinuxMarkdownAnimationPerformancePatch,
+  matchesLinuxMarkdownAnimationPerformanceContract,
+} = require("../../../../impl/webview/index.js");
+
+module.exports = [
+  webviewAssetPatch({
+    id: "linux-markdown-animation-performance",
+    phase: "webview-asset",
+    order: 1047,
+    ciPolicy: CI_POLICY_OPTIONAL,
+    pattern: /^app-initial-[^.]+\.css$/,
+    assetMatch: matchesLinuxMarkdownAnimationPerformanceContract,
+    missingDescription: "streaming Markdown animation stylesheet",
+    skipDescription: "Linux Markdown animation performance patch",
+    apply: applyLinuxMarkdownAnimationPerformancePatch,
+  }),
+];

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -35,8 +35,71 @@ const LINUX_SIDEBAR_SCROLL_DRIFT_WARNING =
   "WARN: Could not uniquely identify the main sidebar scroll container — skipping Linux sidebar scroll performance patch";
 const LINUX_APP_SHELL_TAB_LAYOUT_DRIFT_WARNING =
   "WARN: Could not uniquely identify the app-shell tab layout contract — skipping Linux tab layout performance patch";
+const LINUX_MARKDOWN_ANIMATION_DRIFT_WARNING =
+  "WARN: Could not uniquely identify the streaming Markdown animation contract — skipping Linux Markdown animation performance patch";
 const LINUX_APP_SHELL_TAB_OVERFLOW_HELPER =
   "const codexLinuxAppShellTabOverflowFrames=new WeakMap;function codexLinuxScheduleAppShellTabOverflow(e,t){if(e?.isConnected&&!codexLinuxAppShellTabOverflowFrames.has(e)){let n=requestAnimationFrame(()=>{codexLinuxAppShellTabOverflowFrames.delete(e),e.isConnected&&t(e.scrollWidth>e.clientWidth)});codexLinuxAppShellTabOverflowFrames.set(e,n)}}";
+
+// Restoring a running thread replays the per-word fade for every incomplete
+// Markdown item in its active turn. Large agent timelines can create more than
+// a thousand animations at once, forcing expensive layerization even for text
+// above the viewport. Text still streams normally when rendered immediately;
+// retain the separate image-enter transition because it is bounded per image.
+function linuxMarkdownAnimationRules(currentSource) {
+  const unpatchedPattern =
+    /(\._MarkdownRoot_([A-Za-z0-9]+)_\d+\[data-markdown-animated\] :is\(\._FadeIn_\2_\d+,hr,li,tr,blockquote\))\{opacity:0;animation:_fade-in_\2_1 ([^{}]+);animation-delay:var\(--fade-delay,0s\)\}(\._MarkdownRoot_\2_\d+\[data-markdown-animated\] \._FadeListDecoration_\2_\d+::marker)\{animation:_fade-in-marker_\2_1 \3;animation-delay:var\(--fade-delay,0s\)\}(\._MarkdownRoot_\2_\d+\[data-markdown-animated\] \._ImageEnter_\2_\d+\{transform-origin:50%;animation:\.18s ease-out both _image-enter_\2_1\})/gu;
+  const patchedPattern =
+    /(\._MarkdownRoot_([A-Za-z0-9]+)_\d+\[data-markdown-animated\] :is\(\._FadeIn_\2_\d+,hr,li,tr,blockquote\))\{opacity:1;animation:none\}(\._MarkdownRoot_\2_\d+\[data-markdown-animated\] \._FadeListDecoration_\2_\d+::marker)\{animation:none\}(\._MarkdownRoot_\2_\d+\[data-markdown-animated\] \._ImageEnter_\2_\d+\{transform-origin:50%;animation:\.18s ease-out both _image-enter_\2_1\})/gu;
+  const candidates = [];
+
+  for (const match of currentSource.matchAll(unpatchedPattern)) {
+    candidates.push({
+      end: match.index + match[0].length,
+      patched: false,
+      replacement:
+        `${match[1]}{opacity:1;animation:none}` +
+        `${match[4]}{animation:none}` +
+        match[5],
+      start: match.index,
+    });
+  }
+  for (const match of currentSource.matchAll(patchedPattern)) {
+    candidates.push({
+      end: match.index + match[0].length,
+      patched: true,
+      replacement: match[0],
+      start: match.index,
+    });
+  }
+  return candidates;
+}
+
+function matchesLinuxMarkdownAnimationPerformanceContract(currentSource) {
+  return linuxMarkdownAnimationRules(currentSource).length === 1;
+}
+
+function applyLinuxMarkdownAnimationPerformancePatch(currentSource) {
+  const candidates = linuxMarkdownAnimationRules(currentSource);
+  if (candidates.length === 1) {
+    const [candidate] = candidates;
+    if (candidate.patched) {
+      return currentSource;
+    }
+    return (
+      currentSource.slice(0, candidate.start) +
+      candidate.replacement +
+      currentSource.slice(candidate.end)
+    );
+  }
+
+  if (
+    currentSource.includes("data-markdown-animated") &&
+    currentSource.includes("_FadeListDecoration_")
+  ) {
+    console.warn(LINUX_MARKDOWN_ANIMATION_DRIFT_WARNING);
+  }
+  return currentSource;
+}
 
 function enclosingFunction(currentSource, targetIndex) {
   const functionPattern =
@@ -2759,6 +2822,7 @@ module.exports = {
   applyLinuxAppSunsetPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
   applyLinuxAppShellTabLayoutPerformancePatch,
+  applyLinuxMarkdownAnimationPerformancePatch,
   applyLinuxThreadSidePanelNativeTooltipPatch,
   applyLinuxTooltipWindowControlsCollisionPatch,
   applyLinuxWindowControlsSafeAreaPatch,
@@ -2770,6 +2834,7 @@ module.exports = {
   applySubagentNicknameMetadataPatch,
   codexLinuxWatchBrowserWebviewAttachment,
   matchesLinuxAppShellTabLayoutPerformanceContract,
+  matchesLinuxMarkdownAnimationPerformanceContract,
   matchesLinuxSidebarScrollPerformanceContract,
   patchBrowserPagePreloadBundle,
 };


### PR DESCRIPTION
## Summary

- render streaming Markdown text and list markers immediately on Linux instead of replaying per-item fades when a running thread is restored
- preserve message content, streaming behavior, image-enter motion, and Browser Use webview retention
- add a semantic, idempotent, ambiguity-rejecting, fail-soft CSS patch and focused regression coverage

## Root cause

A profiled active turn mounted 24 animated Markdown roots and 1,181 fade spans, including offscreen content. Restoring it replayed those animations and caused renderer spikes in layout, layerization, and commit work. Reducing the chunk decoder batch size did not materially improve the stall.

## Results

Same-renderer A/B on the heavy session switch:

| Metric | Baseline | Patched | Result |
| --- | ---: | ---: | ---: |
| Total long-task time | 2,608-2,881 ms | 884-930 ms | about 66% lower |
| Longest task | 636-660 ms | 389-392 ms | about 39% lower |

Fresh 25-session sweep using the exact same fingerprint sequence; both variants retained at most eight Browser Use webviews:

| Metric | Baseline | Patched | Change |
| --- | ---: | ---: | ---: |
| Total long-task time | 16,119 ms | 12,866 ms | -20.2% |
| Maximum task | 760 ms | 518 ms | -31.8% |
| Median longest task | 217 ms | 189 ms | -12.9% |
| Median total long-task time | 417 ms | 417 ms | unchanged |

## Validation

- focused patch and descriptor tests: 5/5 passed
- exact current DMG stylesheet: matched, changed, idempotent, and image-enter animation preserved
- Node syntax checks and `git diff --check` passed
- full Node suite: 423/428; the remaining five failures were reproduced before this change and depend on the local desktop/plugin environment
- the full smoke test reached its warm-start safety gate, which correctly refused to launch a duplicate app while the installed `/opt/codex-desktop` instance was running

Closes #1287
