### PR TITLE
fix(launcher): keep GPU compositing enabled on Wayland sessions

### DIFF
--- a/docs/launcher-performance.md
+++ b/docs/launcher-performance.md
@@ -3,13 +3,13 @@
 ## Context
 
 This decision record captures a performance comparison between ChatGPT Desktop
-and another Electron 42 app (Claude Desktop) running side by side on the same
-X11 GNOME 4K host, what the launcher changed as a result, and — just as
-importantly — what was reviewed and deliberately left alone so future work
-does not re-litigate it without new evidence.
+and another Electron app (Claude Desktop) running side by side on the same
+GNOME Wayland multi-monitor host, what the launcher changed as a result, and —
+just as importantly — what was reviewed and deliberately left alone so future
+work does not re-litigate it without new evidence.
 
-Evidence came from live process command lines, `/proc/<pid>/maps`, the
-launcher log, and repository history rather than synthetic benchmarks.
+Evidence came from live process command lines, `pidstat`, `/proc/<pid>/maps`,
+the launcher log, and repository history rather than synthetic benchmarks.
 
 ## What Changed
 
@@ -31,10 +31,18 @@ launcher log, and repository history rather than synthetic benchmarks.
   ppid-guarded watchdog pattern capped at 0.5 s, so a broken session bus
   counts as "not detected" instead of delaying launch.
   Override: `CODEX_FORCE_RENDERER_ACCESSIBILITY=1|0`.
+- GPU compositing now stays enabled by default, including when Electron runs
+  through XWayland. In an eight-second same-app A/B sample with active sessions
+  and browser tabs, removing the automatic `--disable-gpu-compositing` flag
+  reduced GPU-process CPU from 48–100% to 14–19%, Viz compositor CPU from
+  about 99% to 6%, and GPU-process minor faults from roughly 154,000/s to
+  350–1,100/s. Claude Desktop also keeps GPU compositing enabled on this host.
+  The side-panel flicker workaround remains available with
+  `CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1` or the matching command-line flag.
 
-Both decisions are visible at runtime in the `Electron launch mode:` line of
+These decisions are visible at runtime in the `Electron launch mode:` line of
 `~/.cache/codex-desktop/launcher.log` (`dev_shm_usage_disabled=`,
-`renderer_accessibility_forced=`).
+`renderer_accessibility_forced=`, `gpu_compositing_disabled=`).
 
 ## Reviewed And Deliberately Not Changed
 
@@ -45,14 +53,6 @@ factors. Removing them is a separate compatibility project: the Electron
 SUID/user-namespace sandbox behaves differently across distributions and
 container/AppImage environments, and the troubleshooting docs currently
 promise `--no-sandbox` behavior. Out of scope for performance work.
-
-### Wayland `--disable-gpu-compositing` workaround
-
-On Wayland sessions the launcher intentionally trades compositing performance
-for side-panel rendering stability. That is a documented workaround with an
-explicit opt-out (`CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0`); do not remove
-it for performance reasons without re-testing the side-panel flicker it
-papers over.
 
 ### Webview server model
 

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -373,7 +373,7 @@ Environment:
                               Auto-detect WSLg, keep generic Linux defaults, force the WSLg profile,
                               or force native Wayland with GPU compositing enabled
   CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0|1
-                              Override Wayland side-panel compositing workaround; 1 forces and 0 disables
+                              Set to 1 to enable the side-panel flicker workaround; 0 keeps GPU compositing enabled
   CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=auto|0|1
                               Override --disable-dev-shm-usage; auto keeps it only when /dev/shm is missing or small
   CODEX_LAUNCHER_LOCK_WAIT_SECONDS=N
@@ -3638,13 +3638,6 @@ should_disable_gpu_compositing() {
             return 1
         fi
         echo "Invalid CODEX_ELECTRON_DISABLE_GPU_COMPOSITING='${CODEX_ELECTRON_DISABLE_GPU_COMPOSITING:-}'; using rendering profile default" >&2
-    fi
-
-    if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] &&
-        [ "$ELECTRON_RENDERING_MODE" != "wayland-gpu" ] &&
-        [ "$ELECTRON_RENDERING_MODE" != "wslg" ]; then
-        echo "Detected Wayland session; adding --disable-gpu-compositing for side-panel rendering stability. Set CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0 to opt out."
-        return 0
     fi
 
     return 1

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6097,7 +6097,7 @@ EOF
     [[ "$output" == *"renderer_accessibility=0"* && "$output" != *"<--force-renderer-accessibility>"* ]] || fail "default Linux profile must not force renderer accessibility without assistive technology: $output"
 
     output="$(env -i PATH="$PATH" HOME="$HOME" XDG_SESSION_TYPE=wayland CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
-    [[ "$output" == *"comp=1"* && "$output" == *"<--disable-gpu-compositing>"* ]] || fail "Wayland default profile must disable GPU compositing for side-panel stability: $output"
+    [[ "$output" == *"comp=0"* && "$output" != *"<--disable-gpu-compositing>"* ]] || fail "Wayland default profile must keep GPU compositing enabled: $output"
 
     local drm_stub_dir="$TMP_DIR/drm-stubs/two"
     mkdir -p "$drm_stub_dir/card0-DP-2" "$drm_stub_dir/card0-HDMI-3"
@@ -6106,9 +6106,10 @@ EOF
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_TEST_ASSUME_NON_WSL=1 CODEX_DRM_CLASS_ROOT="$drm_stub_dir" DISPLAY=:0 XDG_SESSION_TYPE=wayland XDG_CURRENT_DESKTOP=ubuntu:GNOME "$launcher_probe" probe)"
     [[ "$output" == *"mode=gnome-wayland-multi-monitor"* && "$output" == *"<--ozone-platform=x11>"* ]] || fail "GNOME Wayland multi-monitor auto profile must force X11 for stable maximize/scale behavior: $output"
     [[ "$output" != *"<--ozone-platform-hint=auto>"* ]] || fail "GNOME Wayland multi-monitor auto profile must not leave backend selection to Electron: $output"
+    [[ "$output" == *"comp=0"* && "$output" != *"<--disable-gpu-compositing>"* ]] || fail "GNOME Wayland multi-monitor auto profile must keep GPU compositing enabled: $output"
 
     output="$(env -i PATH="$PATH" HOME="$HOME" XDG_SESSION_TYPE=wayland CODEX_LINUX_RENDERING_MODE=default CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0 "$launcher_probe" probe)"
-    [[ "$output" == *"comp=0"* && "$output" != *"<--disable-gpu-compositing>"* ]] || fail "CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0 must suppress the Wayland compositor workaround: $output"
+    [[ "$output" == *"comp=0"* && "$output" != *"<--disable-gpu-compositing>"* ]] || fail "CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0 must keep GPU compositing enabled: $output"
 
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe -- --ozone-platform=x11)"
     [[ "$output" == *"electron=<--ozone-platform=x11>"* ]] || fail "pass-through ozone platform must reach Electron: $output"


### PR DESCRIPTION
## Summary

- stop automatically adding `--disable-gpu-compositing` merely because the desktop session is Wayland
- preserve the explicit environment and command-line compatibility fallbacks
- add regression coverage for default Wayland and GNOME Wayland multi-monitor/XWayland launches
- document the same-host A/B result and the behavior intentionally left unchanged

## Root cause

The launcher chooses the effective rendering profile separately from its compositor fallback. On GNOME Wayland with multiple monitors, the auto profile intentionally uses `--ozone-platform=x11`, but the fallback then checks raw `XDG_SESSION_TYPE=wayland` and also appends `--disable-gpu-compositing`.

That raw-session check regressed the behavior introduced by `5887e92fe65e992df9fbca0a40560132cd20a640` when it was restored in `d17d5d436eaf71380e046d36d71205e3031aaf91`.

## Measured impact

Same host, installed app, profile, active sessions, and Browser Use state; only the automatic compositor-disable flag changed:

| Metric | Before | After |
| --- | ---: | ---: |
| Electron GPU process CPU | 48-100% | 14-19% |
| `VizCompositorThread` CPU | 98.8% under load | 5.75-5.99% |
| GPU-process minor faults | ~154,420/s | ~351-1,105/s |

The host still had 60-69% aggregate CPU idle time and about 15 GiB available RAM during the baseline, ruling out general CPU, memory, or storage saturation. No renderer crash, GPU-process failure, or unresponsive-window event appeared in the composited test run.

## Compatibility

`CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1` and an explicit `--disable-gpu-compositing` argument still enable the side-panel flicker fallback. This PR does not change the GNOME Wayland multi-monitor X11/XWayland selection and does not opt users into native Wayland.

## Validation

- red/green launcher regression test: the updated expectation fails with the prior production branch and passes with this change
- `bash -n launcher/start.sh.template`
- `bash -n tests/scripts_smoke.sh`
- `git diff --check`
- full `bash tests/scripts_smoke.sh` in an isolated PID namespace: all script smoke tests passed
- live same-app A/B sampling with `pidstat`; no crash/unresponsive/GPU failure observed

Closes #1291
