### PR TITLE
fix(remote): keep Remote Control in one Desktop instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Native remote-mobile builds now route side-by-side `--new-instance` launches
+  through the normal single-instance handoff, preventing competing Desktop
+  Remote Control owners. Nix module sessions instead proxy every Desktop
+  app-server RPC to the single declarative systemd owner, so enablement,
+  pairing, and status calls reach the process listening on the Unix control
+  socket without restricting non-owner Desktop instances.
 - Deferred upstream DMGs are revalidated before a build. A newer candidate
   supersedes the pending download, and a deleted cached DMG is redownloaded in
   the same explicit check. Fresh app-launch checks preserve the stable deferred

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -262,6 +262,32 @@ This installs the selected ChatGPT Desktop package variant and starts a user
 codex app-server --remote-control --listen unix://
 ```
 
+That service is the only Remote Control owner. The module exports
+`CODEX_REMOTE_CONTROL_APP_SERVER_MODE=proxy` to the graphical session, so the
+app-server child started by Desktop uses this route:
+
+```text
+Desktop -> codex app-server proxy --sock <owner socket>
+        -> Unix control socket -> systemd app-server --remote-control
+```
+
+The proxy forwards the complete Desktop stdio RPC stream, including host
+enablement, pairing, and status calls. The single-instance marker is therefore
+not enforced for this topology: multiple Desktop instances may use the one
+declarative owner. The module exports
+`CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET` so custom `codexHome` and
+absolute `unix:///path` listener settings select the same socket in the service
+and Desktop proxy; non-Unix listeners are rejected. By default the module also
+exports
+`CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED=1` to suppress the mutable
+launcher fallback. If the service or socket is unavailable, proxy startup
+fails instead of creating another owner.
+
+The selected CLI must support `codex app-server proxy` (validated with Codex
+CLI 0.147.0). After changing these session variables, start a new graphical
+session or otherwise refresh the session environment before relaunching
+Desktop.
+
 A `nixosModules.default` export is also available for system-level
 configurations that prefer a global user unit.
 

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -120,6 +120,7 @@ LAUNCH_ACTION_RUNTIME_DIR="${XDG_RUNTIME_DIR:-$APP_STATE_DIR}/$CODEX_LINUX_APP_I
 LAUNCH_ACTION_SOCKET="$LAUNCH_ACTION_RUNTIME_DIR/launch-action.sock"
 PACKAGED_RUNTIME_HELPER="$SCRIPT_DIR/.codex-linux/codex-packaged-runtime.sh"
 COLD_START_HOOK_DIR="$SCRIPT_DIR/.codex-linux/cold-start.d"
+SINGLE_INSTANCE_REQUIRED_MARKER="$SCRIPT_DIR/.codex-linux/single-instance-required"
 FEATURE_ENV_DIR="$SCRIPT_DIR/.codex-linux/env.d"
 FEATURE_PRELAUNCH_HOOK_DIR="$SCRIPT_DIR/.codex-linux/prelaunch.d"
 FEATURE_ELECTRON_ARGS_DIR="$SCRIPT_DIR/.codex-linux/electron-args.d"
@@ -257,6 +258,14 @@ parse_launcher_args() {
 configure_multi_launch_instance() {
     parse_launcher_args "$@"
     [ "$MULTI_LAUNCH_REQUESTED" -eq 1 ] || return 0
+
+    if [ "${CODEX_REMOTE_CONTROL_APP_SERVER_MODE:-}" != "proxy" ] &&
+       [ -f "$SINGLE_INSTANCE_REQUIRED_MARKER" ] &&
+       [ ! -L "$SINGLE_INSTANCE_REQUIRED_MARKER" ]; then
+        echo "$CODEX_LINUX_APP_DISPLAY_NAME requires one Desktop instance while Remote Control is enabled; using the existing instance." >&2
+        MULTI_LAUNCH_REQUESTED=0
+        return 0
+    fi
 
     local base_state_dir="$APP_STATE_DIR"
     local selected_port

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -83,12 +83,16 @@ What it changes:
 - Preserves `remote_control = true` / `features.remote_control = true` in the
   local Codex config instead of letting upstream strip it before app-server
   startup.
+- Starts the native Desktop app-server with `--remote-control`, or starts
+  `codex app-server proxy` when a declarative service owns the control socket.
+  The proxy forwards the complete Desktop RPC stream instead of splitting
+  enablement, pairing, status, and conversation RPCs between two processes.
 - Updates Remote settings and mobile setup copy so the experimental Linux flow
   is not described as Mac-only.
 - Stages `.codex-linux/cold-start.d/remote-mobile-control`, a feature-owned
   cold-start hook that provisions the upstream managed standalone daemon runtime
   when it is missing, then starts the managed app-server daemon with
-  `remote-control start`.
+  `remote-control start`. It also stages a single-instance requirement marker.
 
 ## Control topology boundaries
 
@@ -111,7 +115,7 @@ feature descriptor to appear exactly once in this table.
 | --- | --- | --- |
 | `linux-remote-control-device-key` | `outbound-control` | Provides the client key used to enroll this Desktop against another remote-control host. |
 | `linux-remote-control-client-revocation-recovery` | `outbound-control` | Clears revoked client material before re-enrollment. |
-| `linux-remote-mobile-app-server-remote-control` | `mobile-host` | Starts this Desktop app-server with remote-control host support. |
+| `linux-remote-mobile-app-server-remote-control` | `mobile-host` | Starts a native Desktop-owned app-server or proxies Desktop RPCs to a declarative owner. |
 | `linux-remote-control-load-gate` | `outbound-control` | Allows remote-control environments to load in Connections. |
 | `linux-remote-control-feature-sync` | `shared-boundary` | Enables `remote_control` only for the local host and excludes Remote SSH hosts. |
 | `linux-remote-control-visibility` | `outbound-control` | Exposes remote-control Connections UI when the server permits it. |
@@ -140,12 +144,27 @@ Feature-owned surfaces outside the descriptor array are also topology-scoped:
 
 | Surface | Primary responsibility | Contract |
 | --- | --- | --- |
-| `stage.sh` | `mobile-host` | Stages the host marker, cold-start hook, and optional Chrome bridge patch. |
+| `stage.sh` | `mobile-host` | Stages the host marker, single-instance requirement, cold-start hook, and optional Chrome bridge patch. |
 | `cold-start-hook.sh` | `mobile-host` | Elects one local remote-control runtime owner and starts only the standalone fallback. |
 | `applyLinuxRemoteMobileChromeBridgePatch` | `mobile-host` | Keeps local Browser Use available to an authorized mobile-controlled session. |
 | Nix `codex-remote-control.service` | `mobile-host` | Replaces the mutable standalone fallback with one declarative local app-server owner. |
 | `applyLinuxRemoteControlSshInstallActionPatch` | `remote-ssh` | Keeps the existing Remote SSH install action available. |
 | `applyLinuxRemoteControlSshInstallReleasePatch` | `remote-ssh` | Sends an explicit Codex release only to the Remote SSH install/update action. |
+
+The app-server has exactly one Remote Control owner in either supported
+topology:
+
+```text
+Native: Desktop -> codex app-server --remote-control
+Nix:    Desktop -> codex app-server proxy --sock <owner socket>
+               -> Unix control socket -> systemd app-server --remote-control
+```
+
+The packaged single-instance marker is enforced only in the native topology,
+where a second Desktop would create a second Remote Control owner. In the Nix
+topology, multiple Desktop instances may proxy to the same declarative owner.
+The selected CLI must provide `codex app-server proxy`; this path is validated
+with Codex CLI 0.147.0 and follows the repository's current-CLI policy.
 
 The main RPC boundaries are:
 
@@ -204,9 +223,19 @@ On NixOS, prefer the flake's Home Manager module instead of the launcher hook:
 
 The module installs the remote-mobile package variant and manages
 `codex-remote-control.service` as a user systemd unit running
-`codex app-server --remote-control --listen unix://`. It also sets
-`CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED=1` so the launcher does not
-start a second mutable standalone daemon.
+`codex app-server --remote-control --listen unix://`. It sets
+`CODEX_REMOTE_CONTROL_APP_SERVER_MODE=proxy`, so the app-server child spawned
+by Desktop runs `codex app-server proxy` and forwards its complete stdio RPC
+stream to the service's Unix control socket. The companion
+`CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET` value keeps the proxy aligned
+with the service when `codexHome` or `listen` is customized. Only `unix://` and
+absolute `unix:///path` listeners are supported. The module also sets
+`CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED=1` by default so the launcher
+does not start a second mutable standalone daemon.
+
+If the service or socket is unavailable, the Desktop proxy fails visibly; it
+does not fall back to launching another Desktop-owned app-server. Fix the user
+service or its shared CLI state instead of creating a competing owner.
 
 At cold start, an active, enabled, or otherwise installed systemd user unit is
 the remote-control runtime owner. Without that unit, the launcher defers to a

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -48,9 +48,9 @@ const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileLo
 const REMOTE_MOBILE_APP_SERVER_BASE_ARGS_NEEDLE = "[`-c`,`features.code_mode_host=true`]";
 const REMOTE_MOBILE_APP_SERVER_LAUNCH_TAIL = "`app-server`,`--analytics-default-enabled`]}";
 const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_HELPER =
-  "function codexLinuxRemoteMobileLocalAppServerArgs(){return process.platform===`linux`?[`--remote-control`]:[]}";
+  "function codexLinuxRemoteMobileLocalAppServerArgs(){if(process.platform===`linux`&&process.env.CODEX_REMOTE_CONTROL_APP_SERVER_MODE===`proxy`){let e=process.env.CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET;if(e?.startsWith(`%h/`)&&process.env.HOME)e=`${process.env.HOME}${e.slice(2)}`;return[`app-server`,`proxy`,...(e?[`--sock`,e]:[])]}return[`app-server`,...(process.platform===`linux`?[`--remote-control`]:[]),`--analytics-default-enabled`]}";
 const REMOTE_MOBILE_APP_SERVER_PATCHED_LAUNCH_TAIL =
-  "`app-server`,...codexLinuxRemoteMobileLocalAppServerArgs(),`--analytics-default-enabled`]}";
+  "...codexLinuxRemoteMobileLocalAppServerArgs()]}";
 const REMOTE_CONTROL_APP_INITIAL_ASSET_PATTERN = /^app-initial-[^.]+\.js$/u;
 const REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS = [
   ["defaultMessage:`Mac`", "defaultMessage:`Linux`"],

--- a/linux-features/remote-mobile-control/stage.sh
+++ b/linux-features/remote-mobile-control/stage.sh
@@ -8,6 +8,7 @@ feature_marker="$feature_marker_dir/remote-mobile-control-enabled"
 desktop_remote_control_marker="$feature_marker_dir/desktop-app-server-remote-control-enabled"
 cold_start_hook_dir="$feature_marker_dir/cold-start.d"
 cold_start_hook="$cold_start_hook_dir/remote-mobile-control"
+single_instance_marker="$feature_marker_dir/single-instance-required"
 
 mkdir -p "$feature_marker_dir" "$cold_start_hook_dir"
 printf '%s\n' "remote-mobile-control" > "$feature_marker"
@@ -32,10 +33,11 @@ const found = fs.readdirSync(buildDir).some((name) => {
 process.exit(found ? 0 : 1);
 NODE
 then
-    rm -f "$desktop_remote_control_marker"
+    rm -f "$desktop_remote_control_marker" "$single_instance_marker"
     printf '%s\n' "version=1" "owner=desktop" > "$desktop_remote_control_marker"
+    printf '%s\n' "version=1" "feature=remote-mobile-control" > "$single_instance_marker"
 else
-    rm -f "$desktop_remote_control_marker"
+    rm -f "$desktop_remote_control_marker" "$single_instance_marker"
     echo "WARN: Desktop app-server remote-control marker not found; standalone remote mobile daemon remains enabled" >&2
 fi
 

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -500,6 +500,44 @@ function runStageHook(env) {
   });
 }
 
+function runLauncherMultiLaunchPolicy(installDir, env = {}) {
+  const launcher = fs.readFileSync(path.join(REPO_ROOT, "launcher", "start.sh.template"), "utf8");
+  const functions = launcher
+    .split("early_truthy_env_value() {", 2)[1]
+    .split('configure_multi_launch_instance "$@"', 1)[0];
+  const probe = path.join(installDir, "multi-launch-policy-probe.sh");
+  fs.writeFileSync(probe, [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    `SCRIPT_DIR=${JSON.stringify(installDir)}`,
+    'SINGLE_INSTANCE_REQUIRED_MARKER="$SCRIPT_DIR/.codex-linux/single-instance-required"',
+    'CODEX_LINUX_APP_ID="codex-remote-policy-test"',
+    'CODEX_LINUX_APP_DISPLAY_NAME="ChatGPT"',
+    'CODEX_LINUX_WEBVIEW_PORT="62000"',
+    'CODEX_MULTI_LAUNCH_PORT_RANGE="62000-62004"',
+    'CODEX_MULTI_LAUNCH_REQUEST=""',
+    'APP_STATE_DIR="$SCRIPT_DIR/state"',
+    'APP_PID_FILE="$APP_STATE_DIR/app.pid"',
+    'WEBVIEW_PID_FILE="$APP_STATE_DIR/webview.pid"',
+    'LAUNCH_ACTION_RUNTIME_DIR="$APP_STATE_DIR/runtime"',
+    'LAUNCH_ACTION_SOCKET="$LAUNCH_ACTION_RUNTIME_DIR/launch-action.sock"',
+    'LOG_DIR="$SCRIPT_DIR/log"',
+    'MULTI_LAUNCH_REQUESTED=0',
+    'MULTI_LAUNCH_ACTIVE=0',
+    'CODEX_LINUX_INSTANCE_ID=""',
+    'LAUNCHER_ARGS=()',
+    "early_truthy_env_value() {",
+    functions,
+    'configure_multi_launch_instance "$@"',
+    'printf "active=%s port=%s args=%s\\n" "$MULTI_LAUNCH_ACTIVE" "$CODEX_LINUX_WEBVIEW_PORT" "${LAUNCHER_ARGS[*]}"',
+    "",
+  ].join("\n"));
+  return spawnSync("bash", [probe, "--new-instance"], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
 function writeDesktopAppServerRemoteControlMarker(appDir) {
   const marker = path.join(appDir, ".codex-linux", "desktop-app-server-remote-control-enabled");
   fs.mkdirSync(path.dirname(marker), { recursive: true });
@@ -524,7 +562,7 @@ test("remote mobile control feature exposes its stage hook when enabled", () => 
   });
 });
 
-test("remote mobile stage hook is idempotent and stages its markers and executable hook", () => {
+test("remote mobile stage hook reserves one Desktop instance only for Desktop ownership", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-stage-"));
   try {
     const installDir = path.join(tempRoot, "package", "opt", "codex-desktop");
@@ -533,6 +571,7 @@ test("remote mobile stage hook is idempotent and stages its markers and executab
     const featureMarker = path.join(installDir, ".codex-linux", "remote-mobile-control-enabled");
     const marker = path.join(installDir, ".codex-linux", "desktop-app-server-remote-control-enabled");
     const coldStartHook = path.join(installDir, ".codex-linux", "cold-start.d", "remote-mobile-control");
+    const singleInstanceMarker = path.join(installDir, ".codex-linux", "single-instance-required");
     const env = {
       ARCH: "x64",
       CODEX_UPSTREAM_APP_DIR: path.join(tempRoot, "upstream-app"),
@@ -554,11 +593,23 @@ test("remote mobile stage hook is idempotent and stages its markers and executab
     assert.equal(second.status, 0, second.stderr || second.stdout);
     assert.equal(fs.readFileSync(featureMarker, "utf8"), "remote-mobile-control\n");
     assert.equal(fs.readFileSync(marker, "utf8"), "version=1\nowner=desktop\n");
+    assert.equal(
+      fs.readFileSync(singleInstanceMarker, "utf8"),
+      "version=1\nfeature=remote-mobile-control\n",
+    );
     assert.equal(fs.statSync(coldStartHook).mode & 0o777, 0o755);
     assert.equal(
       fs.readFileSync(coldStartHook, "utf8"),
       fs.readFileSync(path.join(__dirname, "cold-start-hook.sh"), "utf8"),
     );
+    const policy = runLauncherMultiLaunchPolicy(installDir);
+    assert.equal(policy.status, 0, policy.stderr || policy.stdout);
+    assert.equal(policy.stdout.trim(), "active=0 port=62000 args=");
+    const proxyPolicy = runLauncherMultiLaunchPolicy(installDir, {
+      CODEX_REMOTE_CONTROL_APP_SERVER_MODE: "proxy",
+    });
+    assert.equal(proxyPolicy.status, 0, proxyPolicy.stderr || proxyPolicy.stdout);
+    assert.equal(proxyPolicy.stdout.trim(), "active=1 port=62000 args=");
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
@@ -1242,22 +1293,57 @@ test("Linux remote-control client recovery handles bare missing key material err
   assert.match(patched, /e\.message===`Remote-control client key material missing`/);
 });
 
-test("Linux remote mobile app-server launch enables remote control on the Desktop app-server", () => {
-  const source = syntheticCurrentLocalAppServerLaunchBundle();
-  const patched = applyLinuxRemoteMobileAppServerRemoteControlPatch(source);
+test("Linux remote mobile app-server launch keeps Desktop as the native Remote Control owner", () => {
+  const patched = applyLinuxRemoteMobileAppServerRemoteControlPatch(
+    syntheticCurrentLocalAppServerLaunchBundle(),
+  );
+  const context = {
+    JSON,
+    module: { exports: {} },
+    process: { env: {}, platform: "linux" },
+  };
 
-  assert.notEqual(patched, source);
-  assert.match(patched, /codexLinuxRemoteMobileLocalAppServerArgs/);
-  assert.match(
-    patched,
-    /process\.platform===`linux`\?\[`--remote-control`\]:\[\]/,
-  );
-  assert.match(
-    patched,
-    /return\[\.\.\.Iz,\.\.\.Lz\.flatMap\(.+`app-server`,\.\.\.codexLinuxRemoteMobileLocalAppServerArgs\(\),`--analytics-default-enabled`\]\}/,
-  );
+  vm.runInNewContext(`${patched};module.exports=uB;`, context);
+
+  assert.deepEqual(Array.from(context.module.exports()), [
+    "-c",
+    "features.code_mode_host=true",
+    "app-server",
+    "--remote-control",
+    "--analytics-default-enabled",
+  ]);
   assert.equal(applyLinuxRemoteMobileAppServerRemoteControlPatch(patched), patched);
   assert.equal(hasLinuxRemoteMobileLocalAppServerRemoteControlPatch(patched), true);
+});
+
+test("Linux remote mobile app-server launch proxies Desktop RPCs to the declarative owner", () => {
+  const patched = applyLinuxRemoteMobileAppServerRemoteControlPatch(
+    syntheticCurrentLocalAppServerLaunchBundle(),
+  );
+  const context = {
+    JSON,
+    module: { exports: {} },
+    process: {
+      env: {
+        CODEX_REMOTE_CONTROL_APP_SERVER_MODE: "proxy",
+        CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET:
+          "%h/.codex/app-server-control/app-server-control.sock",
+        HOME: "/home/tester",
+      },
+      platform: "linux",
+    },
+  };
+
+  vm.runInNewContext(`${patched};module.exports=uB;`, context);
+
+  assert.deepEqual(Array.from(context.module.exports()), [
+    "-c",
+    "features.code_mode_host=true",
+    "app-server",
+    "proxy",
+    "--sock",
+    "/home/tester/.codex/app-server-control/app-server-control.sock",
+  ]);
 });
 
 test("Linux remote mobile app-server launch rejects an incomplete local patch marker", () => {

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -66,7 +66,8 @@ let
   codexHome =
     if remoteCfg.codexHome != null then remoteCfg.codexHome else "${config.home.homeDirectory}/.codex";
   remoteControlListenIsUnixSocket =
-    remoteCfg.listen == "unix://" || lib.hasPrefix "unix:///" remoteCfg.listen;
+    remoteCfg.listen == "unix://"
+    || builtins.match "unix:///[^/].*" remoteCfg.listen != null;
   remoteControlProxySocket =
     if remoteCfg.listen == "unix://" then
       "${codexHome}/app-server-control/app-server-control.sock"

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -65,6 +65,13 @@ let
   desktopPackage = if codexCliPath != null then withCodexCliPath basePackage else basePackage;
   codexHome =
     if remoteCfg.codexHome != null then remoteCfg.codexHome else "${config.home.homeDirectory}/.codex";
+  remoteControlListenIsUnixSocket =
+    remoteCfg.listen == "unix://" || lib.hasPrefix "unix:///" remoteCfg.listen;
+  remoteControlProxySocket =
+    if remoteCfg.listen == "unix://" then
+      "${codexHome}/app-server-control/app-server-control.sock"
+    else
+      lib.removePrefix "unix://" remoteCfg.listen;
   remoteControlPath = lib.makeSearchPath "bin" (
     [
       config.home.profileDirectory
@@ -169,8 +176,10 @@ in
         type = lib.types.str;
         default = "unix://";
         description = ''
-          Local app-server transport endpoint passed to
-          {command}`codex app-server --listen`.
+          Unix-socket app-server endpoint passed to
+          {command}`codex app-server --listen`. Use {option}`unix://` for the
+          default socket under {env}`CODEX_HOME`, or an absolute
+          {option}`unix:///path` endpoint.
         '';
       };
 
@@ -248,6 +257,10 @@ in
         message = "`programs.codexDesktopLinux.remoteControl.enable` is only supported on Linux";
       }
       {
+        assertion = !remoteCfg.enable || remoteControlListenIsUnixSocket;
+        message = "`programs.codexDesktopLinux.remoteControl.listen` must be `unix://` or an absolute `unix:///path` endpoint";
+      }
+      {
         assertion =
           remoteCfg.environmentFile == null
           || (!builtins.hasContext remoteCfg.environmentFile && remoteEnvironmentFileIsCanonical);
@@ -275,13 +288,25 @@ in
       desktopPackage
     ];
 
-    home.sessionVariables = lib.mkIf (remoteCfg.enable && remoteCfg.disableLauncherAutostart) {
-      CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED = "1";
-    };
+    home.sessionVariables = lib.mkIf remoteCfg.enable (
+      {
+        CODEX_REMOTE_CONTROL_APP_SERVER_MODE = "proxy";
+        CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET = remoteControlProxySocket;
+      }
+      // lib.optionalAttrs remoteCfg.disableLauncherAutostart {
+        CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED = "1";
+      }
+    );
 
-    systemd.user.sessionVariables = lib.mkIf (remoteCfg.enable && remoteCfg.disableLauncherAutostart) {
-      CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED = "1";
-    };
+    systemd.user.sessionVariables = lib.mkIf remoteCfg.enable (
+      {
+        CODEX_REMOTE_CONTROL_APP_SERVER_MODE = "proxy";
+        CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET = remoteControlProxySocket;
+      }
+      // lib.optionalAttrs remoteCfg.disableLauncherAutostart {
+        CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED = "1";
+      }
+    );
 
     systemd.user.services.codex-remote-control = lib.mkIf remoteCfg.enable {
       Unit = {

--- a/nix/linux-features-test.nix
+++ b/nix/linux-features-test.nix
@@ -192,12 +192,24 @@ let
   '';
   customConfig = combinedConfig // { package = customPackage; };
   nixosCustom = evalNixOS customConfig;
+  remoteControlTestPackage = pkgs.writeShellScriptBin "codex" "exit 0";
+  expectedRemoteControlExecStart = lib.escapeShellArgs [
+    (lib.getExe remoteControlTestPackage)
+    "app-server"
+    "--remote-control"
+    "--listen"
+    "unix://"
+  ];
+  expectedHomeRemoteControlProxySocket =
+    "/home/tester/.codex/app-server-control/app-server-control.sock";
+  expectedNixOSRemoteControlProxySocket =
+    "%h/.codex/app-server-control/app-server-control.sock";
   remoteControlConfig = {
     enable = true;
     package = customPackage;
     remoteControl = {
       enable = true;
-      package = pkgs.writeShellScriptBin "codex" "exit 0";
+      package = remoteControlTestPackage;
       environmentFile = "/run/secrets/codex-remote-control.env";
     };
   };
@@ -206,10 +218,35 @@ let
     // {
       remoteControl = remoteControlConfig.remoteControl // { inherit environmentFile; };
     };
-  homeRemoteService =
-    (evalHomeManager remoteControlConfig).config.systemd.user.services.codex-remote-control;
-  nixosRemoteService =
-    (evalNixOS remoteControlConfig).config.systemd.user.services.codex-remote-control;
+  remoteControlLauncherAutostartConfig = remoteControlConfig // {
+    remoteControl = remoteControlConfig.remoteControl // {
+      disableLauncherAutostart = false;
+    };
+  };
+  remoteControlCustomSocketConfig = remoteControlConfig // {
+    remoteControl = remoteControlConfig.remoteControl // {
+      listen = "unix:///run/user/1000/codex-custom.sock";
+    };
+  };
+  remoteControlInvalidListenConfig = remoteControlConfig // {
+    remoteControl = remoteControlConfig.remoteControl // {
+      listen = "ws://127.0.0.1:8765";
+    };
+  };
+  homeRemoteConfig = (evalHomeManager remoteControlConfig).config;
+  nixosRemoteConfig = (evalNixOS remoteControlConfig).config;
+  homeRemoteLauncherAutostartConfig =
+    (evalHomeManager remoteControlLauncherAutostartConfig).config;
+  nixosRemoteLauncherAutostartConfig =
+    (evalNixOS remoteControlLauncherAutostartConfig).config;
+  homeRemoteCustomSocketConfig = (evalHomeManager remoteControlCustomSocketConfig).config;
+  nixosRemoteCustomSocketConfig = (evalNixOS remoteControlCustomSocketConfig).config;
+  homeRemoteInvalidListenAssertions =
+    (evalHomeManager remoteControlInvalidListenConfig).config.assertions;
+  nixosRemoteInvalidListenAssertions =
+    (evalNixOS remoteControlInvalidListenConfig).config.assertions;
+  homeRemoteService = homeRemoteConfig.systemd.user.services.codex-remote-control;
+  nixosRemoteService = nixosRemoteConfig.systemd.user.services.codex-remote-control;
   optionalHomeRemoteService =
     (evalHomeManager (
       remoteControlConfigWithEnvironmentFile "-/run/secrets/codex-remote-control.env"
@@ -387,6 +424,75 @@ assert lib.assertMsg
   "the package builder rejected the shallow repository-watch feature";
 assert lib.assertMsg (!invalidHomeManager.success) "Home Manager accepted an unsupported feature";
 assert lib.assertMsg (!invalidNixOS.success) "NixOS accepted an unsupported feature";
+assert lib.assertMsg
+  (homeRemoteConfig.home.sessionVariables.CODEX_REMOTE_CONTROL_APP_SERVER_MODE == "proxy")
+  "Home Manager did not route Desktop RPCs to the declarative Remote Control owner";
+assert lib.assertMsg
+  (homeRemoteConfig.systemd.user.sessionVariables.CODEX_REMOTE_CONTROL_APP_SERVER_MODE == "proxy")
+  "Home Manager did not export proxy mode to systemd user sessions";
+assert lib.assertMsg
+  (nixosRemoteConfig.environment.sessionVariables.CODEX_REMOTE_CONTROL_APP_SERVER_MODE == "proxy")
+  "NixOS did not route Desktop RPCs to the declarative Remote Control owner";
+assert lib.assertMsg
+  (lib.any (item: !item.assertion) homeRemoteInvalidListenAssertions)
+  "Home Manager accepted a non-Unix Remote Control owner that Desktop cannot proxy to";
+assert lib.assertMsg
+  (lib.any (item: !item.assertion) nixosRemoteInvalidListenAssertions)
+  "NixOS accepted a non-Unix Remote Control owner that Desktop cannot proxy to";
+assert lib.assertMsg
+  (
+    homeRemoteConfig.home.sessionVariables.CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET
+      == expectedHomeRemoteControlProxySocket
+  )
+  "Home Manager did not point Desktop proxy RPCs at the declarative owner socket";
+assert lib.assertMsg
+  (
+    homeRemoteConfig.systemd.user.sessionVariables.CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET
+      == expectedHomeRemoteControlProxySocket
+  )
+  "Home Manager did not export the declarative owner socket to systemd user sessions";
+assert lib.assertMsg
+  (
+    nixosRemoteConfig.environment.sessionVariables.CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET
+      == expectedNixOSRemoteControlProxySocket
+  )
+  "NixOS did not point Desktop proxy RPCs at the declarative owner socket";
+assert lib.assertMsg
+  (
+    homeRemoteCustomSocketConfig.home.sessionVariables.CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET
+      == "/run/user/1000/codex-custom.sock"
+  )
+  "Home Manager did not route Desktop RPCs to a custom declarative owner socket";
+assert lib.assertMsg
+  (
+    nixosRemoteCustomSocketConfig.environment.sessionVariables.CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET
+      == "/run/user/1000/codex-custom.sock"
+  )
+  "NixOS did not route Desktop RPCs to a custom declarative owner socket";
+assert lib.assertMsg
+  (homeRemoteService.Service.ExecStart == expectedRemoteControlExecStart)
+  "Home Manager Remote Control service is not the Unix-socket owner";
+assert lib.assertMsg
+  (nixosRemoteService.serviceConfig.ExecStart == expectedRemoteControlExecStart)
+  "NixOS Remote Control service is not the Unix-socket owner";
+assert lib.assertMsg
+  (homeRemoteLauncherAutostartConfig.home.sessionVariables.CODEX_REMOTE_CONTROL_APP_SERVER_MODE == "proxy")
+  "Home Manager tied Desktop proxy mode to launcher daemon suppression";
+assert lib.assertMsg
+  (homeRemoteLauncherAutostartConfig.systemd.user.sessionVariables.CODEX_REMOTE_CONTROL_APP_SERVER_MODE == "proxy")
+  "Home Manager omitted systemd proxy mode when launcher daemon suppression is disabled";
+assert lib.assertMsg
+  (nixosRemoteLauncherAutostartConfig.environment.sessionVariables.CODEX_REMOTE_CONTROL_APP_SERVER_MODE == "proxy")
+  "NixOS tied Desktop proxy mode to launcher daemon suppression";
+assert lib.assertMsg
+  (!(homeRemoteLauncherAutostartConfig.home.sessionVariables ? CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED))
+  "Home Manager suppressed launcher daemon autostart after its option was disabled";
+assert lib.assertMsg
+  (!(homeRemoteLauncherAutostartConfig.systemd.user.sessionVariables ? CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED))
+  "Home Manager exported systemd launcher daemon suppression after its option was disabled";
+assert lib.assertMsg
+  (!(nixosRemoteLauncherAutostartConfig.environment.sessionVariables ? CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED))
+  "NixOS suppressed launcher daemon autostart after its option was disabled";
 assert lib.assertMsg
   (homeRemoteService.Service.EnvironmentFile == "/run/secrets/codex-remote-control.env")
   "Home Manager changed the runtime remote-control environment-file path";

--- a/nix/linux-features-test.nix
+++ b/nix/linux-features-test.nix
@@ -228,11 +228,13 @@ let
       listen = "unix:///run/user/1000/codex-custom.sock";
     };
   };
-  remoteControlInvalidListenConfig = remoteControlConfig // {
-    remoteControl = remoteControlConfig.remoteControl // {
-      listen = "ws://127.0.0.1:8765";
-    };
-  };
+  remoteControlInvalidListenConfigs = map (
+    listen:
+    remoteControlConfig
+    // {
+      remoteControl = remoteControlConfig.remoteControl // { inherit listen; };
+    }
+  ) [ "ws://127.0.0.1:8765" "unix:///" "unix:////run/user/1000/codex.sock" ];
   homeRemoteConfig = (evalHomeManager remoteControlConfig).config;
   nixosRemoteConfig = (evalNixOS remoteControlConfig).config;
   homeRemoteLauncherAutostartConfig =
@@ -241,10 +243,12 @@ let
     (evalNixOS remoteControlLauncherAutostartConfig).config;
   homeRemoteCustomSocketConfig = (evalHomeManager remoteControlCustomSocketConfig).config;
   nixosRemoteCustomSocketConfig = (evalNixOS remoteControlCustomSocketConfig).config;
-  homeRemoteInvalidListenAssertions =
-    (evalHomeManager remoteControlInvalidListenConfig).config.assertions;
-  nixosRemoteInvalidListenAssertions =
-    (evalNixOS remoteControlInvalidListenConfig).config.assertions;
+  homeRemoteInvalidListenAssertions = map (
+    config: (evalHomeManager config).config.assertions
+  ) remoteControlInvalidListenConfigs;
+  nixosRemoteInvalidListenAssertions = map (
+    config: (evalNixOS config).config.assertions
+  ) remoteControlInvalidListenConfigs;
   homeRemoteService = homeRemoteConfig.systemd.user.services.codex-remote-control;
   nixosRemoteService = nixosRemoteConfig.systemd.user.services.codex-remote-control;
   optionalHomeRemoteService =
@@ -434,11 +438,11 @@ assert lib.assertMsg
   (nixosRemoteConfig.environment.sessionVariables.CODEX_REMOTE_CONTROL_APP_SERVER_MODE == "proxy")
   "NixOS did not route Desktop RPCs to the declarative Remote Control owner";
 assert lib.assertMsg
-  (lib.any (item: !item.assertion) homeRemoteInvalidListenAssertions)
-  "Home Manager accepted a non-Unix Remote Control owner that Desktop cannot proxy to";
+  (lib.all (assertions: lib.any (item: !item.assertion) assertions) homeRemoteInvalidListenAssertions)
+  "Home Manager accepted an invalid Remote Control owner socket";
 assert lib.assertMsg
-  (lib.any (item: !item.assertion) nixosRemoteInvalidListenAssertions)
-  "NixOS accepted a non-Unix Remote Control owner that Desktop cannot proxy to";
+  (lib.all (assertions: lib.any (item: !item.assertion) assertions) nixosRemoteInvalidListenAssertions)
+  "NixOS accepted an invalid Remote Control owner socket";
 assert lib.assertMsg
   (
     homeRemoteConfig.home.sessionVariables.CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -69,7 +69,8 @@ let
   remoteControlCodexHome =
     if remoteCfg.codexHome != null then remoteCfg.codexHome else "%h/.codex";
   remoteControlListenIsUnixSocket =
-    remoteCfg.listen == "unix://" || lib.hasPrefix "unix:///" remoteCfg.listen;
+    remoteCfg.listen == "unix://"
+    || builtins.match "unix:///[^/].*" remoteCfg.listen != null;
   remoteControlProxySocket =
     if remoteCfg.listen == "unix://" then
       "${remoteControlCodexHome}/app-server-control/app-server-control.sock"

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -66,6 +66,15 @@ let
       meta = base.meta or { };
     };
   desktopPackage = if codexCliPath != null then withCodexCliPath basePackage else basePackage;
+  remoteControlCodexHome =
+    if remoteCfg.codexHome != null then remoteCfg.codexHome else "%h/.codex";
+  remoteControlListenIsUnixSocket =
+    remoteCfg.listen == "unix://" || lib.hasPrefix "unix:///" remoteCfg.listen;
+  remoteControlProxySocket =
+    if remoteCfg.listen == "unix://" then
+      "${remoteControlCodexHome}/app-server-control/app-server-control.sock"
+    else
+      lib.removePrefix "unix://" remoteCfg.listen;
   remoteControlPath = lib.makeSearchPath "bin" (
     [
       "/run/current-system/sw"
@@ -73,7 +82,7 @@ let
     ++ remoteCfg.extraPackages
   );
   remoteControlEnvironment = {
-    CODEX_HOME = if remoteCfg.codexHome != null then remoteCfg.codexHome else "%h/.codex";
+    CODEX_HOME = remoteControlCodexHome;
     PATH = remoteControlPath;
   }
   // remoteCfg.environment;
@@ -170,8 +179,10 @@ in
         type = lib.types.str;
         default = "unix://";
         description = ''
-          Local app-server transport endpoint passed to
-          {command}`codex app-server --listen`.
+          Unix-socket app-server endpoint passed to
+          {command}`codex app-server --listen`. Use {option}`unix://` for the
+          default socket under {env}`CODEX_HOME`, or an absolute
+          {option}`unix:///path` endpoint.
         '';
       };
 
@@ -250,6 +261,10 @@ in
         message = "`programs.codexDesktopLinux.remoteControl.enable` is only supported on Linux";
       }
       {
+        assertion = !remoteCfg.enable || remoteControlListenIsUnixSocket;
+        message = "`programs.codexDesktopLinux.remoteControl.listen` must be `unix://` or an absolute `unix:///path` endpoint";
+      }
+      {
         assertion =
           remoteCfg.environmentFile == null
           || (!builtins.hasContext remoteCfg.environmentFile && remoteEnvironmentFileIsCanonical);
@@ -281,9 +296,15 @@ in
       basePackage
     ];
 
-    environment.sessionVariables = lib.mkIf (remoteCfg.enable && remoteCfg.disableLauncherAutostart) {
-      CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED = "1";
-    };
+    environment.sessionVariables = lib.mkIf remoteCfg.enable (
+      {
+        CODEX_REMOTE_CONTROL_APP_SERVER_MODE = "proxy";
+        CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET = remoteControlProxySocket;
+      }
+      // lib.optionalAttrs remoteCfg.disableLauncherAutostart {
+        CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED = "1";
+      }
+    );
 
     systemd.user.services.codex-remote-control = lib.mkIf remoteCfg.enable {
       description = "Codex remote-control app-server";


### PR DESCRIPTION
## Summary

- keep native Remote Control in the Desktop app-server, with single-instance enforcement only when Desktop owns the relay
- keep the declarative Nix systemd app-server as the sole Remote Control owner while Desktop launches `codex app-server proxy --sock <owner socket>`
- route the entire Desktop app-server byte stream to the Nix owner so enablement, pairing, status, and other RPCs reach the owning runtime
- export and test the exact Home Manager/NixOS owner socket, including custom `codexHome`, absolute Unix listeners, and rejection of unsupported non-Unix listeners
- remove the earlier unverified one-time process-killing migration; this replacement is based on the source used by the currently working 5080 package

## Ownership model

Native installs:

```text
Desktop -> codex app-server --remote-control
```

Declarative Nix installs:

```text
Desktop -> codex app-server proxy --sock <owner socket>
        -> systemd codex app-server --remote-control --listen unix://
```

`CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED=1` only suppresses the mutable fallback service. `CODEX_REMOTE_CONTROL_APP_SERVER_MODE=proxy` selects Desktop proxy mode, and `CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET` keeps the Desktop proxy aligned with the systemd owner's Unix socket. Proxy mode deliberately has no fallback to a second Desktop-owned app-server.

The packaged single-instance marker is still present for native Remote Control builds, but the launcher ignores it in proxy mode. This keeps multiple Nix Desktop windows able to attach to one declarative owner without creating competing relay owners.

## Why

The earlier service-only topology put the Remote Control owner in systemd while Desktop's settings UI still sent enablement, pairing, and status RPCs to its own app-server. Conversely, always adding `--remote-control` to Desktop would create a second owner in the Nix topology. The stock Codex CLI proxy subcommand provides the missing local RPC bridge while preserving one owner in both topologies.

## Validation

- `node --test linux-features/remote-mobile-control/test.js` — 117/117 passing
- real Codex CLI 0.147.0 authority/proxy WebSocket integration — 1/1 passing, including the default `unix://` socket
- `bash tests/scripts_smoke.sh` — all script smoke tests passing
- `path:/src#checks.x86_64-linux.nix-linux-features-evaluation` built with Nix 2.24.11
- full upstream DMG 26.803.41515 rebuild — accepted with no blockers or warnings
- Debian package built without installation: `codex-desktop_2026.08.11.1294_amd64.deb`
- package SHA-256: `656e495fe7e36880c34d755800de90fdeab91d5bf3fb15e56cd633aa107b6fe7`
- the working 5080 installation (`2026.08.11.024022`) was left unchanged

## Scope

This PR addresses process ownership and local Desktop-to-owner RPC routing. It does not claim to change account enrollment/rollout, relay availability, mobile backgrounding/network behavior, CLI-version mismatches outside the current-CLI policy, or SSH/tunnel recovery.

GitHub Actions passed on this revision: `CI` and `Upstream Build App` both completed successfully.