### PR TITLE
fix launcher planned termination status

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,6 +85,11 @@ then starts Electron.
 Warm-start launches hand off actions such as `--new-chat` over a Unix-domain
 socket instead of spawning a second app process.
 
+Launcher signals are forwarded to Electron. A planned `SIGTERM`, including a
+desktop-session or `systemd --user` stop, exits successfully so it does not
+leave a false failed-unit state; interactive interrupt and hangup statuses stay
+distinct.
+
 Native-package-only launcher behavior, such as desktop-entry hints and default
 update-manager startup, lives in:
 

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -4247,6 +4247,17 @@ cleanup_launcher() {
     fi
 }
 
+handle_launcher_signal() {
+    local signal_name="$1"
+    local exit_status="$2"
+
+    trap - "$signal_name"
+    if [ -n "${ELECTRON_PID:-}" ] && kill -0 "$ELECTRON_PID" 2>/dev/null; then
+        kill -s "$signal_name" "$ELECTRON_PID" 2>/dev/null || true
+    fi
+    exit "$exit_status"
+}
+
 launcher_lock_wait_seconds() {
     local value="${CODEX_LAUNCHER_LOCK_WAIT_SECONDS:-5}"
 
@@ -4549,9 +4560,9 @@ log_phase "initial_launch_state_refresh_start"
 refresh_launch_state
 log_phase "initial_launch_state_refreshed"
 trap cleanup_launcher EXIT
-trap 'exit 130' INT
-trap 'exit 143' TERM
-trap 'exit 129' HUP
+trap 'handle_launcher_signal INT 130' INT
+trap 'handle_launcher_signal TERM 0' TERM
+trap 'handle_launcher_signal HUP 129' HUP
 
 recover_unhealthy_running_app
 prepare_launch_state_under_lock

--- a/tests/launcher_warm_start_recovery.sh
+++ b/tests/launcher_warm_start_recovery.sh
@@ -4,6 +4,7 @@ set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
+TEST_APP_ID="codex-test-$$"
 APP_DIR="$TMP_DIR/app"
 REMOUNT_APP_DIR="$TMP_DIR/remounted-app"
 SECOND_APP_DIR="$APP_DIR"
@@ -11,11 +12,11 @@ APPIMAGE_PATH="$TMP_DIR/codex-desktop.AppImage"
 APPIMAGE_RECOVERY="${CODEX_TEST_APPIMAGE_REMOUNT:-0}"
 HOME_DIR="$TMP_DIR/home"
 RUNTIME_DIR="$TMP_DIR/runtime"
-STATE_DIR="$HOME_DIR/.local/state/codex-desktop"
-SOCKET_PATH="$RUNTIME_DIR/codex-desktop/launch-action.sock"
+STATE_DIR="$HOME_DIR/.local/state/$TEST_APP_ID"
+SOCKET_PATH="$RUNTIME_DIR/$TEST_APP_ID/launch-action.sock"
 FIRST_LOG="$TMP_DIR/first-launch.log"
 SECOND_LOG="$TMP_DIR/second-launch.log"
-APP_LOG="$HOME_DIR/.cache/codex-desktop/launcher.log"
+APP_LOG="$HOME_DIR/.cache/$TEST_APP_ID/launcher.log"
 LAUNCHER_PID=""
 SOCKET_PID=""
 HOOK_PID=""
@@ -64,7 +65,7 @@ wait_for() {
     local description="$1"
     shift
     local attempt
-    for attempt in $(seq 1 100); do
+    for attempt in $(seq 1 200); do
         "$@" && return 0
         sleep 0.05
     done
@@ -103,9 +104,9 @@ mkdir -p \
     "$APP_DIR/.codex-linux/after-exit.d" \
     "$APP_DIR/content/webview" \
     "$APP_DIR/resources/node-runtime/bin" \
-    "$HOME_DIR/.config/codex-desktop" \
+    "$HOME_DIR/.config/$TEST_APP_ID" \
     "$HOME_DIR" \
-    "$RUNTIME_DIR/codex-desktop"
+    "$RUNTIME_DIR/$TEST_APP_ID"
 
 if [ "${CODEX_TEST_DISABLE_PIDFD:-0}" = "1" ]; then
     mkdir -p "$TMP_DIR/python-site"
@@ -124,7 +125,7 @@ fi
 
 if [ "${CODEX_TEST_DISABLE_WARM_START:-0}" = "1" ]; then
     printf '%s\n' '{"codex-linux-warm-start-enabled":false}' \
-        > "$HOME_DIR/.config/codex-desktop/settings.json"
+        > "$HOME_DIR/.config/$TEST_APP_ID/settings.json"
 fi
 
 PORT="$(python3 - <<'PY'
@@ -138,8 +139,9 @@ PY
 {
     printf '%s\n' \
         '#!/usr/bin/env bash' \
-        'set -Eeuo pipefail' \
-        'CODEX_LINUX_APP_ID=codex-desktop' \
+        'set -Eeuo pipefail'
+    printf 'CODEX_LINUX_APP_ID=%q\n' "$TEST_APP_ID"
+    printf '%s\n' \
         'CODEX_LINUX_APP_DISPLAY_NAME="ChatGPT Desktop"' \
         'CODEX_LINUX_WEBVIEW_PORT="${CODEX_WEBVIEW_PORT:-5175}"'
     cat "$REPO_DIR/launcher/start.sh.template"
@@ -256,6 +258,24 @@ wait_for "first Electron" pid_file_is_live
 wait_for "first launcher lock release" grep -q "electron_spawned" "$APP_LOG"
 wait_for "first packaged webview" webview_is_ready
 FIRST_ELECTRON_PID="$(read_live_app_pid)"
+
+if [ "${CODEX_TEST_TERM_STATUS:-0}" = "1" ]; then
+    kill -TERM "$LAUNCHER_PID"
+    set +e
+    wait "$LAUNCHER_PID"
+    LAUNCHER_STATUS=$?
+    set -e
+    LAUNCHER_PID=""
+    [ "$LAUNCHER_STATUS" -eq 0 ] \
+        || fail "planned launcher SIGTERM exited with status $LAUNCHER_STATUS"
+    electron_is_down() {
+        ! kill -0 "$FIRST_ELECTRON_PID" 2>/dev/null
+    }
+    wait_for "Electron signal forwarding" electron_is_down
+    wait_for "webview cleanup after planned TERM" webview_is_down
+    printf '%s\n' "launcher planned TERM status test passed"
+    exit 0
+fi
 
 if [ "${CODEX_TEST_NORMAL_LOCK_ONLY:-0}" = "1" ]; then
     flock -n "$STATE_DIR/launcher.lock" true \

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5925,8 +5925,13 @@ if 'CODEX_LINUX_INSTANCE_ID=$CODEX_LINUX_INSTANCE_ID' not in instance_match_body
     raise SystemExit("pid_in_same_launch_instance must match instance identity from the process environment")
 if not re.search(r'log_phase "initial_launch_state_refresh_start"\s+refresh_launch_state\s+log_phase "initial_launch_state_refreshed"\s+trap cleanup_launcher EXIT', source):
     raise SystemExit("launcher must do an initial runtime-state refresh before warm-start IPC")
-if "trap 'exit 130' INT" not in source or "trap 'exit 143' TERM" not in source or "trap 'exit 129' HUP" not in source:
-    raise SystemExit("launcher must cleanup through EXIT after INT/TERM/HUP")
+if "trap 'handle_launcher_signal INT 130' INT" not in source or "trap 'handle_launcher_signal TERM 0' TERM" not in source or "trap 'handle_launcher_signal HUP 129' HUP" not in source:
+    raise SystemExit("launcher must cleanup through EXIT and treat planned TERM as success")
+signal_body = source.split("handle_launcher_signal() {", 1)[1].split("launcher_lock_wait_seconds() {", 1)[0]
+if 'kill -s "$signal_name" "$ELECTRON_PID"' not in signal_body:
+    raise SystemExit("launcher signal handling must forward the signal to Electron")
+if 'exit "$exit_status"' not in signal_body:
+    raise SystemExit("launcher signal handling must use the signal-specific service status")
 prepare_body = source.split("prepare_launch_state_under_lock() {", 1)[1].split("launch_electron() {", 1)[0]
 if "acquire_launcher_lock" not in prepare_body or "refresh_launch_state_quick" not in prepare_body:
     raise SystemExit("launcher must refresh launch state under the launcher lock before cold-start work")
@@ -11163,6 +11168,7 @@ EOF
 
 test_launcher_warm_start_recovery() {
     info "Checking warm-start recovery after launcher SIGKILL"
+    CODEX_TEST_TERM_STATUS=1 bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
     bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
     CODEX_TEST_APPIMAGE_REMOUNT=1 bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
     CODEX_TEST_DISABLE_WARM_START=1 bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"


### PR DESCRIPTION
## Summary
- forward launcher signals to Electron
- treat planned SIGTERM as a successful service stop
- isolate launcher recovery tests from an installed Codex instance

## Validation
- bash syntax checks pass
- all launcher warm-start/recovery variants pass, including the planned TERM status regression
- packaging/script smoke coverage before the launcher recovery group passes