### PR TITLE
Fix upstream DMG drift

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -94,10 +94,10 @@
 
         codexDmg = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg";
-          hash = "sha256-+KWnSss4qrSlmsCtf+87tLtPKAp+0l88t+9hRd9eh0c=";
+          hash = "sha256-8CZBVzKF6IMS8H+r5pTPuwGFneJE4lxs5X7VJvrKxWs=";
         };
 
-        codexVersion = "26.803.41515";
+        codexVersion = "26.803.61601";
         electronVersion = "42.3.0";
         electronPlatform =
           {


### PR DESCRIPTION
<!-- upstream-dmg-sha256:f02641573285e88312f07fabe694cfbb01859de244e25c6ce57ed526facac56b -->

## Summary
- repair Linux compatibility drift for the current upstream DMG
- remove obsolete compatibility paths replaced by the current DMG shape

## Validation
- exact current-DMG acceptance recorded by watchdog v2
- GitHub CI must pass, including Nix Package Builds
