### PR TITLE
Retarget Dock icon and Suggested Prompts to the current DMG

### DIFF
--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -28,8 +28,8 @@ const {
 const currentAppInfoSource = [
   "function F_(e,t){return`icon-chatgpt`}",
   "function I_(e){return{dark:`icon-codex-dark-color.png`,light:`icon-codex-light.png`}}",
-  "function R_(e,t){if(process.platform!==`darwin`||t==null)return null;let n=I_(e),r=MS(`${F_(e,t)}.png`),i=MS(n.dark),a=MS(n.light);return r==null||i==null||a==null?null:{appDefault:r,codexDark:i,codexLight:a}}",
-  "function MS(e){if(e==null)return null;let t=l.app.isPackaged?(0,p.join)(process.resourcesPath,e):null,n=t!=null&&(0,_.existsSync)(t)?t:(0,p.join)(l.app.getAppPath(),`src`,`icons`,e),r=l.nativeImage.createFromPath(n);return r.isEmpty()?null:r.resize({width:128,height:128,quality:`best`}).toDataURL()}",
+  "function R_(e,t){if(process.platform!==`darwin`||t==null)return null;let n=I_(e),r=PS(`${F_(e,t)}.png`),i=PS(n.dark),a=PS(n.light);return r==null||i==null||a==null?null:{appDefault:r,codexDark:i,codexLight:a}}",
+  "function PS(e){if(e==null)return null;let t=l.app.isPackaged?(0,p.join)(process.resourcesPath,e):null,n=t!=null&&(0,_.existsSync)(t)?t:(0,p.join)(l.app.getAppPath(),`src`,`icons`,e),r=l.nativeImage.createFromPath(n);return r.isEmpty()?null:r.resize({width:128,height:128,quality:`best`}).toDataURL()}",
 ].join("");
 
 const currentRuntimeSource = [
@@ -37,8 +37,8 @@ const currentRuntimeSource = [
   "let T=(0,p.join)(g,`electron`,`src`,`icons`),E=e=>{if(!l.app.isPackaged)return null;let t=(0,p.join)(process.resourcesPath,e);return(0,_.existsSync)(t)?t:null},",
   "D=e=>null,O=e=>E(e)??D(e),k=()=>f.get(n.js.DOCK_ICON_PREFERENCE)??`app-default`,",
   "A=()=>O(`${hS(i,e)}.png`),j=process.platform===`linux`?W5(i,e,T):null,M=gS(i),N=()=>l.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?M.dark:M.light,",
-  "P=t=>{if(t===`app-default`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.gc.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)},",
-  "F=()=>{if(!v)return;let e=k();P(e),Yce({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})};",
+  "P=t=>{if(t===`app-default`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.Sc.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)},",
+  "F=()=>{if(!v)return;let e=k();P(e),dle({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})};",
   "if(v){F();let e=()=>{let e=k();e===`codex-system`&&P(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}",
   "let I=null,L=new xwe({onWindowRegistered:e=>{I?.registerWindow(e),C?.(e)}});",
   "return{updateDockIcon:F,windowManager:L}}",
@@ -166,8 +166,8 @@ test("main patch enables official previews and synchronizes Linux window and tra
   assert.match(patched, /codexLinuxDockIconResourcePath/);
   assert.match(patched, /codexLinuxApplyDockIcon/);
   assert.match(patched, /i!==a\.a\.Dev/);
-  assert.match(patched, /e===n\.gc\.ChatGPT/);
-  assert.doesNotMatch(patched, /n\.Ec\.ChatGPT/);
+  assert.match(patched, /e===n\.Sc\.ChatGPT/);
+  assert.doesNotMatch(patched, /n\.gc\.ChatGPT/);
   assert.match(patched, /process\.platform!==`darwin`&&process\.platform!==`linux`/);
   assert.match(
     patched,
@@ -200,7 +200,7 @@ test("main patch enables official previews and synchronizes Linux window and tra
 test("main patch rejects drift at every current-DMG insertion point byte-identically", () => {
   const insertionPoints = [
     "if(process.platform!==`darwin`||t==null)return null",
-    "function MS(e){if(e==null)return null",
+    "function PS(e){if(e==null)return null",
     "E=e=>{if(!l.app.isPackaged)return null",
     "P=t=>{if(t===`app-default`",
     "F=()=>{if(!v)return",

--- a/linux-features/ui-tweaks/patches/dock-icon.js
+++ b/linux-features/ui-tweaks/patches/dock-icon.js
@@ -4,21 +4,21 @@ const currentPreviewGate = "if(process.platform!==`darwin`||t==null)return null"
 const patchedPreviewGate =
   "if(process.platform!==`darwin`&&process.platform!==`linux`||t==null)return null";
 const currentAppInfoResource =
-  "function MS(e){if(e==null)return null;let t=l.app.isPackaged?(0,p.join)(process.resourcesPath,e):null";
+  "function PS(e){if(e==null)return null;let t=l.app.isPackaged?(0,p.join)(process.resourcesPath,e):null";
 const patchedAppInfoResource =
-  "function codexLinuxDockIconResourcePath(e){return process.platform===`linux`?(0,p.join)(process.resourcesPath,`dock-icon`,e):(0,p.join)(process.resourcesPath,e)}function MS(e){if(e==null)return null;let t=l.app.isPackaged||process.platform===`linux`?codexLinuxDockIconResourcePath(e):null";
+  "function codexLinuxDockIconResourcePath(e){return process.platform===`linux`?(0,p.join)(process.resourcesPath,`dock-icon`,e):(0,p.join)(process.resourcesPath,e)}function PS(e){if(e==null)return null;let t=l.app.isPackaged||process.platform===`linux`?codexLinuxDockIconResourcePath(e):null";
 const currentWindowResource =
   "E=e=>{if(!l.app.isPackaged)return null;let t=(0,p.join)(process.resourcesPath,e);return(0,_.existsSync)(t)?t:null}";
 const patchedWindowResource =
   "E=e=>{if(!l.app.isPackaged&&process.platform!==`linux`)return null;let t=codexLinuxDockIconResourcePath(e);return(0,_.existsSync)(t)?t:null}";
 const currentApplyIcon =
-  "P=t=>{if(t===`app-default`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.gc.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)}";
+  "P=t=>{if(t===`app-default`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.Sc.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)}";
 const patchedApplyIcon =
-  "P=function codexLinuxApplyDockIcon(t){if(t===`app-default`&&process.platform!==`linux`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.gc.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);if(s.isEmpty())return;if(process.platform===`linux`){let codexLinuxIconSelection=t===`codex-system`?(l.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?`codex-dark`:`codex-light`):`chatgpt`;codexLinuxIconSelection===`codex-dark`?s=s.crop({x:34,y:34,width:956,height:956}):codexLinuxIconSelection===`codex-light`&&(s=s.crop({x:13,y:23,width:998,height:998}));globalThis.codexLinuxDockIconImage=s;for(let e of l.BrowserWindow.getAllWindows())e.isDestroyed()||e.setIcon(s);codexLinuxTray!=null&&!codexLinuxTray.isDestroyed()&&codexLinuxTray.setImage(s);let codexLinuxSyncScript=codexLinuxDockIconResourcePath(`sync-desktop-icon.sh`);if(_.existsSync(codexLinuxSyncScript))try{let e=require(`node:child_process`).spawn(codexLinuxSyncScript,[codexLinuxIconSelection],{detached:!0,stdio:[`pipe`,`ignore`,`ignore`]});e.on(`error`,()=>{}),e.stdin.on(`error`,()=>{}),e.stdin.end(s.toPNG()),e.unref()}catch(e){}return}l.app.dock?.setIcon(s)}";
+  "P=function codexLinuxApplyDockIcon(t){if(t===`app-default`&&process.platform!==`linux`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.Sc.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);if(s.isEmpty())return;if(process.platform===`linux`){let codexLinuxIconSelection=t===`codex-system`?(l.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?`codex-dark`:`codex-light`):`chatgpt`;codexLinuxIconSelection===`codex-dark`?s=s.crop({x:34,y:34,width:956,height:956}):codexLinuxIconSelection===`codex-light`&&(s=s.crop({x:13,y:23,width:998,height:998}));globalThis.codexLinuxDockIconImage=s;for(let e of l.BrowserWindow.getAllWindows())e.isDestroyed()||e.setIcon(s);codexLinuxTray!=null&&!codexLinuxTray.isDestroyed()&&codexLinuxTray.setImage(s);let codexLinuxSyncScript=codexLinuxDockIconResourcePath(`sync-desktop-icon.sh`);if(_.existsSync(codexLinuxSyncScript))try{let e=require(`node:child_process`).spawn(codexLinuxSyncScript,[codexLinuxIconSelection],{detached:!0,stdio:[`pipe`,`ignore`,`ignore`]});e.on(`error`,()=>{}),e.stdin.on(`error`,()=>{}),e.stdin.end(s.toPNG()),e.unref()}catch(e){}return}l.app.dock?.setIcon(s)}";
 const currentUpdateGate =
-  "F=()=>{if(!v)return;let e=k();P(e),Yce({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})}";
+  "F=()=>{if(!v)return;let e=k();P(e),dle({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})}";
 const patchedUpdateGate =
-  "F=()=>{if(!v&&process.platform!==`linux`)return;let e=k();P(e),Yce({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})}";
+  "F=()=>{if(!v&&process.platform!==`linux`)return;let e=k();P(e),dle({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})}";
 const currentThemeGate =
   "if(v){F();let e=()=>{let e=k();e===`codex-system`&&P(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}";
 const patchedThemeGate =

--- a/linux-features/ui-tweaks/patches/suggested-prompts.js
+++ b/linux-features/ui-tweaks/patches/suggested-prompts.js
@@ -36,6 +36,10 @@ function mainEligibilityPattern() {
   return /let\{ambientSuggestionsStaleTimeMs:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\);if\(!([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\|\|\1==null\)return\{enabled:!1\};let\{account:([A-Za-z_$][\w$]*)\}=await ([A-Za-z_$][\w$]*)\.getAccount\(\);return ([A-Za-z_$][\w$]*)\(\5\)\?\{enabled:!0,staleTimeMs:\1\}:\{enabled:!1\}/gu;
 }
 
+function patchedMainEligibilityPattern() {
+  return /let\{ambientSuggestionsStaleTimeMs:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\);if\(!([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\|\|\1==null\)return\{enabled:!1\};let\{account:([A-Za-z_$][\w$]*)\}=await ([A-Za-z_$][\w$]*)\.getAccount\(\);return\(([A-Za-z_$][\w$]*)\(\5\),function codexLinuxUiTweaksSuggestedPromptsMainEnabled\(\)\{return!0\}\(\)\)\?\{enabled:!0,staleTimeMs:\1\}:\{enabled:!1\}/gu;
+}
+
 function settingsEligibilityPattern() {
   return /if\(!([A-Za-z_$][\w$]*)\(\{authMethod:([A-Za-z_$][\w$]*),email:([A-Za-z_$][\w$]*)\?\.email\?\?([A-Za-z_$][\w$]*),plan:\3\?\.plan\?\?([A-Za-z_$][\w$]*)\}\)\)return null;/gu;
 }
@@ -105,6 +109,21 @@ function suggestedPromptsHomeContentContract(source) {
   return "drifted";
 }
 
+function suggestedPromptsMainContract(source) {
+  if (typeof source !== "string") {
+    return "drifted";
+  }
+  const cleanMatches = matchCount(source, mainEligibilityPattern());
+  const patchedMatches = matchCount(source, patchedMainEligibilityPattern());
+  if (cleanMatches === 1 && patchedMatches === 0) {
+    return "current";
+  }
+  if (cleanMatches === 0 && patchedMatches === 1) {
+    return "patched";
+  }
+  return "drifted";
+}
+
 function replaceRolloutGates(source) {
   return source.replace(
     gateAssignmentPattern(),
@@ -139,14 +158,11 @@ function applySuggestedPromptsAppPagePatch(source) {
 
 function applySuggestedPromptsMainPatch(source) {
   try {
-    const markerMatches = typeof source === "string"
-      ? source.split(MAIN_ELIGIBILITY_MARKER).length - 1
-      : 0;
-    const cleanMatches = typeof source === "string" ? matchCount(source, mainEligibilityPattern()) : 0;
-    if (markerMatches === 1 && cleanMatches === 0) {
+    const contract = suggestedPromptsMainContract(source);
+    if (contract === "patched") {
       return source;
     }
-    if (markerMatches !== 0 || cleanMatches !== 1) {
+    if (contract !== "current") {
       warn("main process");
       return source;
     }

--- a/linux-features/ui-tweaks/patches/suggested-prompts.js
+++ b/linux-features/ui-tweaks/patches/suggested-prompts.js
@@ -33,7 +33,7 @@ function appPageEligibilityPattern() {
 }
 
 function mainEligibilityPattern() {
-  return /return\{enabled:([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\.account\),staleTimeMs:\1\.([A-Za-z_$][\w$]*)\(\3\.account\)\}/gu;
+  return /let\{ambientSuggestionsStaleTimeMs:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\);if\(!([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\|\|\1==null\)return\{enabled:!1\};let\{account:([A-Za-z_$][\w$]*)\}=await ([A-Za-z_$][\w$]*)\.getAccount\(\);return ([A-Za-z_$][\w$]*)\(\5\)\?\{enabled:!0,staleTimeMs:\1\}:\{enabled:!1\}/gu;
 }
 
 function settingsEligibilityPattern() {
@@ -153,8 +153,17 @@ function applySuggestedPromptsMainPatch(source) {
 
     return source.replace(
       mainEligibilityPattern(),
-      (_match, namespace, enabledMethod, accountName, staleMethod) =>
-        `return{enabled:(${namespace}.${enabledMethod}(${accountName}.account),function ${MAIN_ELIGIBILITY_MARKER}(){return!0}()),staleTimeMs:${namespace}.${staleMethod}(${accountName}.account)}`,
+      (
+        _match,
+        staleTimeName,
+        featureStateName,
+        settingsEligibilityName,
+        settingsStoreName,
+        accountName,
+        appServerConnectionName,
+        accountEligibilityName,
+      ) =>
+        `let{ambientSuggestionsStaleTimeMs:${staleTimeName}}=${featureStateName}();if(!${settingsEligibilityName}(${settingsStoreName})||${staleTimeName}==null)return{enabled:!1};let{account:${accountName}}=await ${appServerConnectionName}.getAccount();return(${accountEligibilityName}(${accountName}),function ${MAIN_ELIGIBILITY_MARKER}(){return!0}())?{enabled:!0,staleTimeMs:${staleTimeName}}:{enabled:!1}`,
     );
   } catch (error) {
     console.warn(

--- a/linux-features/ui-tweaks/patches/suggested-prompts.js
+++ b/linux-features/ui-tweaks/patches/suggested-prompts.js
@@ -113,12 +113,13 @@ function suggestedPromptsMainContract(source) {
   if (typeof source !== "string") {
     return "drifted";
   }
+  const markerMatches = source.split(MAIN_ELIGIBILITY_MARKER).length - 1;
   const cleanMatches = matchCount(source, mainEligibilityPattern());
   const patchedMatches = matchCount(source, patchedMainEligibilityPattern());
-  if (cleanMatches === 1 && patchedMatches === 0) {
+  if (markerMatches === 0 && cleanMatches === 1 && patchedMatches === 0) {
     return "current";
   }
-  if (cleanMatches === 0 && patchedMatches === 1) {
+  if (markerMatches === 1 && cleanMatches === 0 && patchedMatches === 1) {
     return "patched";
   }
   return "drifted";

--- a/linux-features/ui-tweaks/suggested-prompts.test.js
+++ b/linux-features/ui-tweaks/suggested-prompts.test.js
@@ -54,10 +54,10 @@ function appPageFixture() {
 
 function mainFixture() {
   return [
-    "function nt(e){return Xe().ambientSuggestions&&e.getEffective(n.oa.enabled.key)===!0}",
-    "async function rt({appServerConnection:e,settingsStore:t}){",
-    "if(!nt(t))return{enabled:!1,staleTimeMs:n.ml(null)};let r=await e.getAccount();",
-    "return{enabled:n.pl(r.account),staleTimeMs:n.ml(r.account)}}",
+    "function Or(e){return br().ambientSuggestions&&e.getEffective(n.Wi.enabled.key)===!0}",
+    "async function kr({appServerConnection:e,settingsStore:t}){",
+    "let{ambientSuggestionsStaleTimeMs:n}=br();if(!Or(t)||n==null)return{enabled:!1};",
+    "let{account:r}=await e.getAccount();return ie(r)?{enabled:!0,staleTimeMs:n}:{enabled:!1}}",
   ].join("");
 }
 
@@ -134,8 +134,9 @@ test("main patch enables refresh while preserving the upstream account call", ()
 
   assert.notEqual(patched, source);
   assert.equal((patched.match(new RegExp(MAIN_ELIGIBILITY_MARKER, "g")) || []).length, 1);
-  assert.match(patched, /n\.pl\(r\.account\)/);
-  assert.match(patched, /staleTimeMs:n\.ml\(r\.account\)/);
+  assert.match(patched, /ie\(r\)/);
+  assert.match(patched, /staleTimeMs:n/);
+  assert.match(patched, /await e\.getAccount\(\)/);
   assert.equal(applySuggestedPromptsMainPatch(patched), patched);
 });
 

--- a/linux-features/ui-tweaks/suggested-prompts.test.js
+++ b/linux-features/ui-tweaks/suggested-prompts.test.js
@@ -174,6 +174,8 @@ test("main patch rejects incomplete, duplicate, and mixed contracts byte-identic
     current + current,
     patched + patched,
     current + patched,
+    `${current}function ${MAIN_ELIGIBILITY_MARKER}(){return!0}`,
+    `${patched}function ${MAIN_ELIGIBILITY_MARKER}(){return!0}`,
   ];
 
   for (const source of sources) {

--- a/linux-features/ui-tweaks/suggested-prompts.test.js
+++ b/linux-features/ui-tweaks/suggested-prompts.test.js
@@ -140,6 +140,50 @@ test("main patch enables refresh while preserving the upstream account call", ()
   assert.equal(applySuggestedPromptsMainPatch(patched), patched);
 });
 
+test("main patch preserves current minified aliases", () => {
+  const source = [
+    "async function refresh({appServerConnection:connection,settingsStore:store}){",
+    "let{ambientSuggestionsStaleTimeMs:stale}=featureState();",
+    "if(!settingsEligible(store)||stale==null)return{enabled:!1};",
+    "let{account:account}=await connection.getAccount();",
+    "return accountEligible(account)?{enabled:!0,staleTimeMs:stale}:{enabled:!1}}",
+  ].join("");
+  const patched = applySuggestedPromptsMainPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /featureState\(\)/);
+  assert.match(patched, /settingsEligible\(store\)/);
+  assert.match(patched, /await connection\.getAccount\(\)/);
+  assert.match(patched, /accountEligible\(account\)/);
+  assert.match(patched, /staleTimeMs:stale/);
+  assert.equal(applySuggestedPromptsMainPatch(patched), patched);
+});
+
+test("main patch rejects incomplete, duplicate, and mixed contracts byte-identically", () => {
+  const current = mainFixture();
+  const patched = applySuggestedPromptsMainPatch(current);
+  const sources = [
+    current.replace("ambientSuggestionsStaleTimeMs", "ambientSuggestionStaleTimeMs"),
+    current.replace("await e.getAccount()", "await e.account()"),
+    patched.replace("(ie(r),function", "(ie(r)&&function"),
+    patched.replace("staleTimeMs:n", "staleTimeMs:refreshMs"),
+    patched.replace(
+      `function ${MAIN_ELIGIBILITY_MARKER}(){return!0}`,
+      `function ${MAIN_ELIGIBILITY_MARKER}(){return!1}`,
+    ),
+    current + current,
+    patched + patched,
+    current + patched,
+  ];
+
+  for (const source of sources) {
+    const result = captureWarnings(() => applySuggestedPromptsMainPatch(source));
+    assert.equal(result.value, source);
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /current Suggested Prompts main process contract/);
+  }
+});
+
 test("Home content renders generated suggestions instead of selecting curated cards", () => {
   const source = homeContentFixture();
   const patched = applySuggestedPromptsHomeContentPatch(source);


### PR DESCRIPTION
## Summary

- retarget the Dock icon main-process contract to the current minified aliases
- retarget Suggested Prompts to the current stale-time, settings, account, and eligibility contract
- fail closed on incomplete, duplicate, mixed, or orphan-marker states without retaining legacy DMG shapes

## Reproduction

With only `ui-tweaks`, `appearance.dockIcon`, and `home.suggestedPrompts` enabled, the current DMG candidate was rejected by exactly these enabled-feature blockers:

- `feature:ui-tweaks:appearance-dock-icon-main-process`
- `feature:ui-tweaks:home-suggested-prompts-main-process`

The five renderer descriptors for the same opt-ins still applied. The active main bundle is `main-D-bfL1Mp.js`.

Current upstream identity used for reproduction and validation:

- app: `26.803.61601`
- Electron: `42.3.0`
- SHA-256: `f02641573285e88312f07fabe694cfbb01859de244e25c6ce57ed526facac56b`
- size: `556141982` bytes
- ETag: `0x8DEF70C307A986A`
- Last-Modified: `Mon, 10 Aug 2026 18:21:25 GMT`

## Contract

Dock icon now recognizes the current `PS`, `Sc`, and `dle` aliases while preserving all existing atomic insertion points, BrowserWindow updates, and tray updates.

Suggested Prompts preserves the upstream settings eligibility check, null stale-time gate, `getAccount()` call, account eligibility diagnostic, and stale-time result. The opt-in only overrides the final eligibility result. Its classifier requires the complete current contract with zero markers or the complete patched contract with exactly one marker; all other states remain byte-identical and warn.

No compatibility fallback or old-DMG branch is retained.

## Validation

- focused Dock icon and Suggested Prompts tests: `37/37`
- full UI Tweaks suite: `97/97`
- patcher suite with `TMPDIR=/tmp`: `428/428`
- `node --check` on changed sources, tests, and all five generated affected bundles
- `git diff --check`
- first pass: all seven Dock icon and Suggested Prompts descriptors `applied`
- accepted candidate: `accepted_with_warnings`, zero blockers, clean Git provenance at `0b89c079`
- required-upstream patch-report validation passed
- second pass: all seven descriptors `already-applied`; extracted tree hash stayed `4787b5d9582570ef9b27e647a4df05a6dae78f83c5cbcb7c5853ea3909d79ae1`

The sole candidate warning is the unrelated optional core descriptor `linux-browser-use-external-availability`.

Side-by-side runtime on Plasma Wayland confirmed:

- Suggested Prompts appears on Home and in General settings
- Dock icon appears in Appearance
- ChatGPT to Codex changed the candidate tray pixmap from `2048x2048` to `956x956` immediately
- Codex remained selected and the `956x956` tray pixmap persisted after a cold restart

The installed daily driver was not replaced.

As with the earlier Dock icon and Suggested Prompts contributions, I will continue monitoring and maintaining both opt-ins against future current-DMG drift.
