### PR TITLE
fix(agent-workspace): resolve current DMG runtime bindings

### DIFF
--- a/linux-features/agent-workspace/patch.js
+++ b/linux-features/agent-workspace/patch.js
@@ -4,13 +4,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const {
   findCodexRequestWebviewAsset,
-  findImportedAsset,
-  findRequiredWebviewAsset,
 } = require("../../scripts/patches/lib/assets.js");
-const {
-  requireName,
-} = require("../../scripts/patches/lib/minified-js.js");
-
 const SETTINGS_ASSET = "agent-workspaces-linux.js";
 const SETTINGS_SLUG = "agent-workspaces";
 const SETTINGS_COMMAND_KEY = "codex-linux-agent-workspace-command";
@@ -20,11 +14,17 @@ function warn(message, patchName) {
   console.warn(`WARN: ${message} - skipping ${patchName}`);
 }
 
+const NODE_MODULE_EXPRESSIONS = Object.freeze({
+  childProcessVar: 'require("node:child_process")',
+  fsVar: 'require("node:fs")',
+  pathVar: 'require("node:path")',
+});
+
 function agentWorkspaceAppPickerBridgeSource({ fsVar, pathVar }) {
   return [
-    `"linux-agent-workspace-pick-app":async()=>{let __codexElectron;try{__codexElectron=require("electron")}catch(e){return{ok:!1,action:"pickStartupApp",message:"file picker unavailable"}}`,
+    `"linux-agent-workspace-pick-app":async()=>{let __codexFsModule=${fsVar},__codexPathModule=${pathVar},__codexElectron;try{__codexElectron=require("electron")}catch(e){return{ok:!1,action:"pickStartupApp",message:"file picker unavailable"}}`,
     `let __codexDesktopTokens=e=>{let t=[],n="",r=null,a=!1,o=String(e||"");for(let i=0;i<o.length;i++){let c=o[i];if(a){n+=c,a=!1;continue}if(c==="\\\\"){a=!0;continue}if(r){if(c===r)r=null;else n+=c;continue}if(c==="'"||c==='"'){r=c;continue}if(/\\s/.test(c)){if(n)t.push(n),n="";continue}n+=c}if(a)n+="\\\\";if(n)t.push(n);return t};`,
-    `let __codexDesktopEntry=__codexPath=>{if(typeof __codexPath!=="string"||!__codexPath.endsWith(".desktop"))return null;try{let __codexText=${fsVar}.readFileSync(__codexPath,"utf8"),__codexInEntry=!1,__codexName=null,__codexExec=null;for(let __codexLine of __codexText.split(/\\r?\\n/)){let __codexTrimmed=__codexLine.trim();if(!__codexTrimmed||__codexTrimmed.startsWith("#"))continue;if(__codexTrimmed.startsWith("[")&&__codexTrimmed.endsWith("]")){__codexInEntry=__codexTrimmed==="[Desktop Entry]";continue}if(!__codexInEntry)continue;let __codexEquals=__codexTrimmed.indexOf("=");if(__codexEquals<1)continue;let __codexKey=__codexTrimmed.slice(0,__codexEquals),__codexValue=__codexTrimmed.slice(__codexEquals+1).trim();if((__codexKey==="Name"||__codexKey.startsWith("Name["))&&!__codexName)__codexName=__codexValue;else if(__codexKey==="Exec"&&!__codexExec)__codexExec=__codexValue}if(!__codexExec)return null;let __codexPercent="__CODEX_PERCENT__",__codexCleanExec=__codexExec.replace(/%%/g,__codexPercent).replace(/%[A-Za-z]/g,"").replace(new RegExp(__codexPercent,"g"),"%").trim(),__codexCommand=__codexDesktopTokens(__codexCleanExec);return __codexCommand.length?{name:__codexName||${pathVar}.basename(__codexPath,".desktop"),command:__codexCommand,desktop_file:__codexPath}:null}catch{return null}};`,
+    `let __codexDesktopEntry=__codexPath=>{if(typeof __codexPath!=="string"||!__codexPath.endsWith(".desktop"))return null;try{let __codexText=__codexFsModule.readFileSync(__codexPath,"utf8"),__codexInEntry=!1,__codexName=null,__codexExec=null;for(let __codexLine of __codexText.split(/\\r?\\n/)){let __codexTrimmed=__codexLine.trim();if(!__codexTrimmed||__codexTrimmed.startsWith("#"))continue;if(__codexTrimmed.startsWith("[")&&__codexTrimmed.endsWith("]")){__codexInEntry=__codexTrimmed==="[Desktop Entry]";continue}if(!__codexInEntry)continue;let __codexEquals=__codexTrimmed.indexOf("=");if(__codexEquals<1)continue;let __codexKey=__codexTrimmed.slice(0,__codexEquals),__codexValue=__codexTrimmed.slice(__codexEquals+1).trim();if((__codexKey==="Name"||__codexKey.startsWith("Name["))&&!__codexName)__codexName=__codexValue;else if(__codexKey==="Exec"&&!__codexExec)__codexExec=__codexValue}if(!__codexExec)return null;let __codexPercent="__CODEX_PERCENT__",__codexCleanExec=__codexExec.replace(/%%/g,__codexPercent).replace(/%[A-Za-z]/g,"").replace(new RegExp(__codexPercent,"g"),"%").trim(),__codexCommand=__codexDesktopTokens(__codexCleanExec);return __codexCommand.length?{name:__codexName||__codexPathModule.basename(__codexPath,".desktop"),command:__codexCommand,desktop_file:__codexPath}:null}catch{return null}};`,
     `try{let e=await __codexElectron.dialog.showOpenDialog({title:"Choose startup app",properties:["openFile"]});let t=Array.isArray(e.filePaths)?e.filePaths:[],n=t[0]||null,r=__codexDesktopEntry(n);return{ok:!e.canceled&&t.length>0,action:"pickStartupApp",json:{canceled:!!e.canceled,path:n,paths:t,startup_app:r,desktop:!!r}}}catch(e){return{ok:!1,action:"pickStartupApp",message:e instanceof Error?e.message:String(e)}}}`,
   ].join("");
 }
@@ -61,10 +61,31 @@ function useUserWritableNpmPrefixForInstallRuntime(source) {
 }
 
 function agentWorkspaceBridgeWithWorkspaceStartSource(args) {
-  return useUserWritableNpmPrefixForInstallRuntime(AGENT_WORKSPACE_BRIDGE_SOURCE_TEMPLATE)
-    .split("__CODEX_CHILD_PROCESS_VAR__").join(args.childProcessVar)
-    .split("__CODEX_FS_VAR__").join(args.fsVar)
-    .split("__CODEX_PATH_VAR__").join(args.pathVar);
+  let source = useUserWritableNpmPrefixForInstallRuntime(AGENT_WORKSPACE_BRIDGE_SOURCE_TEMPLATE)
+    .split("__CODEX_CHILD_PROCESS_VAR__").join("__codexChildProcessModule")
+    .split("__CODEX_FS_VAR__").join("__codexFsModule")
+    .split("__CODEX_PATH_VAR__").join("__codexPathModule");
+  const captures = [
+    [
+      `"linux-agent-workspace-pick-app":async()=>{`,
+      `let __codexFsModule=${args.fsVar},__codexPathModule=${args.pathVar};`,
+    ],
+    [
+      `"linux-agent-workspace-copy-browser-data":async({sourcePath:__codexSourcePath,profileId:__codexProfileId}={})=>{`,
+      `let __codexFsModule=${args.fsVar},__codexPathModule=${args.pathVar};`,
+    ],
+    [
+      `"linux-agent-workspace":async({action:__codexAction,timeoutMs:__codexTimeoutMs,profileId:__codexProfileId,profile:__codexProfile,replace:__codexReplace,dryRun:__codexDryRun,workspaceId:__codexWorkspaceId,purpose:__codexPurpose,runSetup:__codexRunSetup,ackHiddenWorkspace:__codexAckHiddenWorkspace,ackUnenforcedPolicy:__codexAckUnenforcedPolicy,startupWaitWindow:__codexStartupWaitWindow,startupScreenshotWindow:__codexStartupScreenshotWindow,cleanupId:__codexCleanupId,outputPath:__codexOutputPath,templateKind:__codexTemplateKind,hostPath:__codexHostPath,browserPath:__codexBrowserPath,userDataDir:__codexUserDataDir,alwaysOnTop:__codexAlwaysOnTop,permissions:__codexPermissions}={})=>{`,
+      `let __codexChildProcessModule=${args.childProcessVar},__codexFsModule=${args.fsVar},__codexPathModule=${args.pathVar};`,
+    ],
+  ];
+  for (const [marker, capture] of captures) {
+    if (!source.includes(marker)) {
+      throw new Error(`could not add agent workspace module capture for ${marker}`);
+    }
+    source = source.replace(marker, `${marker}${capture}`);
+  }
+  return source;
 }
 
 function agentWorkspaceActionBridgeSource(args) {
@@ -140,28 +161,13 @@ function replaceAgentWorkspaceActionBridge(currentSource, actionBridgeSource) {
 function applyAgentWorkspaceMainBridgePatch(currentSource) {
   const patchName = "agent workspace main bridge patch";
   if (currentSource.includes('"linux-agent-workspace":async')) {
-    const childProcessVar = requireName(currentSource, "node:child_process");
-    const fsVar = requireName(currentSource, "node:fs");
-    const pathVar = requireName(currentSource, "node:path");
-    if (childProcessVar == null || fsVar == null || pathVar == null) {
-      warn("Could not find Node module aliases for agent workspace bridge upgrade", patchName);
-      return currentSource;
-    }
-    const args = { childProcessVar, fsVar, pathVar };
+    const args = NODE_MODULE_EXPRESSIONS;
     let patchedSource = currentSource;
     patchedSource = ensureAgentWorkspaceBridgeEntry(patchedSource, agentWorkspaceAppPickerBridgeSource(args));
     patchedSource = ensureAgentWorkspaceBridgeEntry(patchedSource, agentWorkspaceMountPickerBridgeSource());
     patchedSource = ensureAgentWorkspaceBridgeEntry(patchedSource, agentWorkspaceBrowserDataPickerBridgeSource());
     patchedSource = ensureAgentWorkspaceBridgeEntry(patchedSource, agentWorkspaceBrowserDataCopyBridgeSource(args));
     return replaceAgentWorkspaceActionBridge(patchedSource, agentWorkspaceActionBridgeSource(args));
-  }
-
-  const childProcessVar = requireName(currentSource, "node:child_process");
-  const fsVar = requireName(currentSource, "node:fs");
-  const pathVar = requireName(currentSource, "node:path");
-  if (childProcessVar == null || fsVar == null || pathVar == null) {
-    warn("Could not find Node module aliases", patchName);
-    return currentSource;
   }
 
   const handlerNeedle = `"get-global-state":async({key:`;
@@ -172,12 +178,13 @@ function applyAgentWorkspaceMainBridgePatch(currentSource) {
 
   return currentSource.replace(
     handlerNeedle,
-    `${agentWorkspaceBridgeWithWorkspaceStartSource({ childProcessVar, fsVar, pathVar })},${handlerNeedle}`,
+    `${agentWorkspaceBridgeWithWorkspaceStartSource(NODE_MODULE_EXPRESSIONS)},${handlerNeedle}`,
   );
 }
 
 function buildAgentWorkspaceSettingsSource({
   chunkAsset,
+  chunkExportName = "s",
   reactAsset,
   reactExportName = "t",
   codexRequestAsset,
@@ -185,7 +192,7 @@ function buildAgentWorkspaceSettingsSource({
   vscodeApiAsset,
 }) {
   const requestAsset = codexRequestAsset ?? vscodeApiAsset;
-  return `import{s as __toESM}from"./${chunkAsset}";
+  return `import{${chunkExportName} as __toESM}from"./${chunkAsset}";
 import{${reactExportName} as __reactFactory}from"./${reactAsset}";
 import{${codexRequestExportName} as __post}from"./${requestAsset}";
 
@@ -1817,20 +1824,25 @@ function inferRuntimeDependenciesFromSettingsSource(source) {
   const jsxFactoryLocal = source.match(
     new RegExp(`${escapeRegExp(jsxLocal)}=([A-Za-z_$][\\w$]*)\\(\\)`),
   )?.[1] ?? null;
-  const reactFactoryLocal = source.match(
-    new RegExp(`${escapeRegExp(reactLocal)}=[A-Za-z_$][\\w$]*\\(([A-Za-z_$][\\w$]*)\\(\\),1\\)`),
-  )?.[1] ?? null;
-  if (jsxFactoryLocal == null || reactFactoryLocal == null) {
+  const reactInitialization = source.match(
+    new RegExp(`${escapeRegExp(reactLocal)}=([A-Za-z_$][\\w$]*)\\(([A-Za-z_$][\\w$]*)\\(\\),1\\)`),
+  );
+  const chunkHelperLocal = reactInitialization?.[1] ?? null;
+  const reactFactoryLocal = reactInitialization?.[2] ?? null;
+  if (jsxFactoryLocal == null || chunkHelperLocal == null || reactFactoryLocal == null) {
     return null;
   }
 
   const bindings = importBindings(source);
+  const chunkBinding = bindings.get(chunkHelperLocal);
   const reactBinding = bindings.get(reactFactoryLocal);
-  if (bindings.get(jsxFactoryLocal) == null || reactBinding == null) {
+  if (bindings.get(jsxFactoryLocal) == null || chunkBinding == null || reactBinding == null) {
     return null;
   }
 
   return {
+    chunkAsset: chunkBinding.assetName,
+    chunkExportName: chunkBinding.exportName,
     reactAsset: reactBinding.assetName,
     reactExportName: reactBinding.exportName,
   };
@@ -1859,31 +1871,22 @@ function resolveAgentWorkspaceSettingsAsset(extractedDir) {
   }
 
   const runtimeDependencies = inferRuntimeDependenciesFromSettingsAssets(assetsDir);
-  let reactAsset;
-  let reactExportName;
-  if (runtimeDependencies != null) {
-    ({ reactAsset, reactExportName } = runtimeDependencies);
-  } else {
-    const jsxRuntimeAsset = findRequiredWebviewAsset(
-      assetsDir,
-      /^jsx-runtime-.*\.js$/,
-      "react.transitional.element",
-      "JSX runtime asset",
-    );
-    const jsxRuntimeSource = fs.readFileSync(path.join(assetsDir, jsxRuntimeAsset), "utf8");
-    const jsxExportsReactFactory = /export\{[^}]*\bn\b/.test(jsxRuntimeSource);
-    reactAsset = jsxExportsReactFactory
-      ? jsxRuntimeAsset
-      : findRequiredWebviewAsset(assetsDir, /^react-.*\.js$/, "react.transitional.element", "React asset");
-    reactExportName = jsxExportsReactFactory ? "n" : "t";
+  if (runtimeDependencies == null) {
+    throw new Error("could not resolve current settings runtime dependencies");
   }
-  const chunkAsset = findImportedAsset(assetsDir, reactAsset, "React shared chunk asset");
+  const {
+    chunkAsset,
+    chunkExportName,
+    reactAsset,
+    reactExportName,
+  } = runtimeDependencies;
   const codexRequestAsset = findCodexRequestWebviewAsset(assetsDir);
 
   return {
     filePath: path.join(assetsDir, SETTINGS_ASSET),
     source: buildAgentWorkspaceSettingsSource({
       chunkAsset,
+      chunkExportName,
       reactAsset,
       reactExportName,
       codexRequestAsset: codexRequestAsset.assetName,
@@ -1994,10 +1997,12 @@ function applyAgentWorkspaceSettingsSharedPatch(currentSource) {
       throw new Error("could not add agent workspace section title");
     }
     const sectionRendererMatch = patchedSource.match(
-      /case`worktrees`:\{[\s\S]*?\(0,([A-Za-z_$][\w$]*)\.jsx\)\(([A-Za-z_$][\w$]*),\{id:`settings\.section\.worktrees`/,
+      /case`local-environments`:\{[\s\S]*?\(0,([A-Za-z_$][\w$]*)\.jsx\)\(([A-Za-z_$][\w$]*),\{id:`settings\.section\.local-environments`/,
     );
-    const jsxAlias = sectionRendererMatch?.[1] ?? "d";
-    const messageComponent = sectionRendererMatch?.[2] ?? "n";
+    if (sectionRendererMatch == null) {
+      throw new Error("could not resolve current settings section renderer aliases");
+    }
+    const [, jsxAlias, messageComponent] = sectionRendererMatch;
     patchedSource = patchedSource.replace(
       sectionNeedle,
       `case\`${SETTINGS_SLUG}\`:{return (0,${jsxAlias}.jsx)(${messageComponent},{id:\`settings.section.${SETTINGS_SLUG}\`,defaultMessage:\`Agent Workspaces\`,description:\`Title for Agent Workspaces settings section\`})}${sectionNeedle}`,

--- a/linux-features/agent-workspace/test.js
+++ b/linux-features/agent-workspace/test.js
@@ -148,8 +148,8 @@ function syntheticCurrentSettingsMetadata() {
     "});",
     "function m(e){let t=(0,u.c)(30),{slug:r}=e;switch(r){",
     "case`general-settings`:{let e;return t[0]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`}),t[0]=e):e=t[0],e}",
-    "case`local-environments`:{let e;return t[21]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.local-environments`,defaultMessage:`Environments`}),t[21]=e):e=t[21],e}",
-    "case`worktrees`:{let e;return t[22]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.worktrees`,defaultMessage:`Worktrees`}),t[22]=e):e=t[22],e}",
+    "case`local-environments`:{let e;return t[21]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,g7.jsx)(Z,{id:`settings.section.local-environments`,defaultMessage:`Environments`}),t[21]=e):e=t[21],e}",
+    "case`worktrees`:{let e;return t[22]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,g7.jsx)(Z,{id:`settings.section.worktrees.v2`,defaultMessage:`Worktrees`}),t[22]=e):e=t[22],e}",
     "}}",
   ].join("");
 }
@@ -166,7 +166,7 @@ function syntheticCurrentAppInitialBundle() {
 
 function syntheticCurrentSettingsNavigation() {
   return [
-    'import{s as __toESM}from"./chunk-test.js";',
+    'import{o as __toESM}from"./chunk-test.js";',
     'import{r as ReactFactory,j as jsxFactory}from"./runtime-test.js";',
     'var React=__toESM(ReactFactory(),1),$=jsxFactory();',
     'function RuntimeProbe(){let [value]=(0,React.useState)(0);return (0,$.jsx)("span",{children:value})}',
@@ -221,7 +221,7 @@ function writeSyntheticExtractedApp(root) {
   fs.writeFileSync(path.join(assetsDir, "composer-test.js"), syntheticComposerBundle());
   fs.writeFileSync(path.join(assetsDir, "mcp-settings-test.js"), syntheticMcpSettingsBundle());
   fs.writeFileSync(path.join(assetsDir, "general-settings-test.js"), syntheticGeneralSettingsBundle());
-  fs.writeFileSync(path.join(assetsDir, "chunk-test.js"), "export function s(e){return e}");
+  fs.writeFileSync(path.join(assetsDir, "chunk-test.js"), "export function o(e){return e}");
   fs.writeFileSync(
     path.join(assetsDir, "setting-storage-test.js"),
     "async function send(e,t,n,r,i){return fetch(`vscode://codex/${e}`)}async function request(...e){let[t,n]=e,{params:r,select:i,signal:a,source:o}=n??{};return send(t,r,i,a,o)}export{request as l};",
@@ -234,7 +234,7 @@ function writeSyntheticExtractedApp(root) {
 function rewriteSettingsAssetsWithConsolidatedCurrentLayout(assetsDir) {
   fs.writeFileSync(
     path.join(assetsDir, "runtime-test.js"),
-    'import{s}from"./chunk-test.js";export{ReactFactory as r,jsxFactory as j};function ReactFactory(){return{createElement(){return{}},useState(value){return[value,()=>{}]},useCallback(fn){return fn},useEffect(){}}}function jsxFactory(){return{jsx(){},jsxs(){}}}',
+    'import{o}from"./chunk-test.js";export{ReactFactory as r,jsxFactory as j};function ReactFactory(){return{createElement(){return{}},useState(value){return[value,()=>{}]},useCallback(fn){return fn},useEffect(){}}}function jsxFactory(){return{jsx(){},jsxs(){}}}',
   );
   fs.writeFileSync(
     path.join(assetsDir, "settings-page-test.js"),
@@ -492,8 +492,9 @@ test("agent-workspace declarative staging copies skill and prelaunch hook into t
   });
 });
 
-test("main bridge patch resolves quoted require aliases", () => {
+test("main bridge patch captures explicit Node modules despite nearby require calls", () => {
   const quotedBundle = [
+    "function distractors(){let __codexChild=require(`node:child_process`).spawn(`true`);let t=require('node:path').join(`a`,`b`);let n=require(\"node:fs\").existsSync(`a`)}",
     "let c=require(\"node:child_process\"),o=require('node:fs'),i=require(`node:path`);",
     "class Host{handlers(){return {",
     '"get-global-state":async({key:t})=>({value:this.globalState.get(t)}),',
@@ -502,6 +503,12 @@ test("main bridge patch resolves quoted require aliases", () => {
   ].join("");
   const patched = applyAgentWorkspaceMainBridgePatch(quotedBundle);
   assert.match(patched, /"linux-agent-workspace":async/);
+  assert.match(
+    patched,
+    /let __codexChildProcessModule=require\("node:child_process"\),__codexFsModule=require\("node:fs"\),__codexPathModule=require\("node:path"\);/,
+  );
+  assert.match(patched, /__codexPathModule\.join\(/);
+  assert.match(patched, /__codexFsModule\.existsSync\(/);
   assert.match(patched, /execFile\(__codexCommand,__codexArgs/);
   assert.equal(applyAgentWorkspaceMainBridgePatch(patched), patched);
 });
@@ -575,7 +582,7 @@ test("main bridge patch adds an allowlisted linux-agent-workspace handler", () =
 
   const { value, warnings } = captureWarns(() => applyAgentWorkspaceMainBridgePatch("real bundle"));
   assert.equal(value, "real bundle");
-  assert.match(warnings.join("\n"), /Could not find Node module aliases/);
+  assert.match(warnings.join("\n"), /Could not find global-state handler insertion point/);
 });
 
 test("main bridge generator does not carry removed conversation monitor observe code", () => {
@@ -1598,6 +1605,14 @@ test("settings asset patches add navigation, route, visibility, and title", () =
   const shared = applyAgentWorkspaceSettingsSharedPatch(syntheticCurrentAppInitialBundle());
   assert.match(shared, new RegExp(`settings\\.nav\\.${SETTINGS_SLUG}`));
   assert.match(shared, new RegExp(`settings\\.section\\.${SETTINGS_SLUG}`));
+  assert.match(
+    shared,
+    /case`agent-workspaces`:\{return \(0,g7\.jsx\)\(Z,\{id:`settings\.section\.agent-workspaces`/,
+  );
+  assert.doesNotMatch(
+    shared,
+    /case`agent-workspaces`:\{return \(0,d\.jsx\)\(n,/,
+  );
   assert.equal(applyAgentWorkspaceSettingsSharedPatch(shared), shared);
 
   const currentAppMain = applyAgentWorkspaceSettingsIndexPatch(shared);
@@ -1634,6 +1649,17 @@ test("settings asset patches add navigation, route, visibility, and title", () =
     /case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return!0/,
   );
   assert.equal(applyAgentWorkspaceSettingsPagePatch(settingsVisibility), settingsVisibility);
+});
+
+test("settings title patch rejects unresolved renderer aliases", () => {
+  const source = syntheticCurrentAppInitialBundle().replace(
+    "(0,g7.jsx)(Z,{id:`settings.section.local-environments`",
+    "renderMessage({id:`settings.section.local-environments`",
+  );
+  assert.throws(
+    () => applyAgentWorkspaceSettingsSharedPatch(source),
+    /could not resolve current settings section renderer aliases/,
+  );
 });
 
 test("agent-workspace feature participates in ASAR patching and reports", () => {
@@ -1716,6 +1742,7 @@ test("agent-workspace settings infer runtime dependencies from bundled settings 
       warnings.join("\n"),
     );
     const settingsSource = fs.readFileSync(path.join(assetsDir, SETTINGS_ASSET), "utf8");
+    assert.match(settingsSource, /import\{o as __toESM\}from"\.\/chunk-test\.js"/);
     assert.match(settingsSource, /import\{r as __reactFactory\}from"\.\/runtime-test\.js"/);
     assert.match(settingsSource, /function SettingsPage/);
     assert.match(settingsSource, /AgentWorkspacesSettings/);


### PR DESCRIPTION

## Summary

Fixes #1300.

This updates the optional Agent Workspace feature for the current upstream DMG bundle shape:

- infer the JSX and message aliases from the current `local-environments` settings section instead of using stale fallback names;
- infer the settings converter export from the current shared-chunk import;
- capture `node:child_process`, `node:fs`, and `node:path` explicitly in generated main-process handlers so minified local bindings cannot shadow them;
- remove the obsolete legacy renderer fallback from this current-DMG path; and
- add regression tests for the current contracts and fail-closed behavior.

The change is confined to `linux-features/agent-workspace/` and does not enable the optional feature in committed configuration.

## Validation

- `node --test linux-features/agent-workspace/test.js` (33 passed)
- `node --test scripts/patch-linux-window-ui.test.js` (428 passed)
- `node --test linux-features/*/test.js` (888 passed, 1 skipped, 0 failed)
- `git diff --check origin/main...HEAD`
- Full build from current `CODEX.DMG` with only `agent-workspace` enabled:
  - app `26.803.41515`, Electron `42.3.0`
  - DMG SHA-256 `f8a5a74acb38aab4a59ac0ad7fef3bb4f280a7ed25f3cb7ef6145df5e8747`
  - acceptance verdict `accepted`, with both Agent Workspace patches applied and no feature drift warnings or blockers
- Clean baseline reproduction on `origin/main` at `6a62d3a09ccef3fae01ecb01aa6088034aef7ddf`:
  - source build with only `agent-workspace` enabled
  - settings route rendered the generic error screen
  - renderer console reported `TypeError: (0, d.jsx) is not a function`
- Side-by-side runtime validation of the generated app:
  - Agent Workspaces settings route rendered without the generic error screen
  - no `t.join` or child-process binding error
  - `permissionConfig`, `profileList`, and `workspaceList` bridge actions returned successfully
- `bash tests/scripts_smoke.sh` exercised the package and launcher checks through its warm-start recovery section, where the local run was blocked by a concurrently running installed desktop process/pidfd condition. The changed files do not touch launcher code; the hosted `Rust and Smoke Tests` check subsequently passed.
- All hosted checks passed: upstream DMG build, Rust and smoke tests, Debian, RPM, pacman, Nix, and contributor PR limit enforcement.

## Checklist

- [ ] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.