### PR TITLE
Keep GUI integrations off mise multicall shims

### DIFF
--- a/launcher/cli-launch-path.py
+++ b/launcher/cli-launch-path.py
@@ -31,6 +31,33 @@ def resolve_cli_launch_path(raw_path: str) -> Path:
 
     if not stat.S_ISREG(metadata.st_mode) or not os.access(canonical_cli, os.X_OK):
         raise LaunchPathError(f"Selected Codex CLI target {canonical_cli} is not an executable file")
+
+    # mise uses a multicall binary: its shims all point at the mise executable,
+    # which selects the requested tool from the shim's argv[0]. GUI children
+    # such as Chrome native hosts do not provide mise's normal shell context,
+    # so register the concrete npm-installed CLI instead of either the shim or
+    # the canonical mise multicall binary.
+    if selected_path.is_symlink() and canonical_cli.name == "mise":
+        mise_install = (
+            selected_path.parent.parent
+            / "installs"
+            / "node"
+            / "latest"
+            / "bin"
+            / selected_path.name
+        )
+        try:
+            installed_cli = mise_install.resolve(strict=True)
+            installed_metadata = installed_cli.stat()
+        except OSError as error:
+            raise LaunchPathError(
+                f"Failed to resolve the installed Codex CLI behind mise shim {selected_path}: {error}"
+            ) from error
+        if not stat.S_ISREG(installed_metadata.st_mode) or not os.access(installed_cli, os.X_OK):
+            raise LaunchPathError(
+                f"Installed Codex CLI target {installed_cli} is not an executable file"
+            )
+        return installed_cli
     return canonical_cli
 
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -7451,6 +7451,17 @@ SCRIPT
     stable_path="$(HOME="$trust_workspace/home" python3 "$REPO_DIR/launcher/cli-launch-path.py" "$visible_cli")"
     [ "$stable_path" = "$(realpath "$external_root/bin/codex")" ] || \
         fail "launcher CLI resolution must follow external package-manager symlink targets"
+
+    local mise_bin="$trust_workspace/mise/bin/mise"
+    local mise_shim="$trust_workspace/mise/shims/codex"
+    local mise_installed_cli="$trust_workspace/mise/installs/node/latest/bin/codex"
+    mkdir -p "$(dirname "$mise_bin")" "$(dirname "$mise_shim")" "$(dirname "$mise_installed_cli")"
+    cp "$release/bin/codex" "$mise_bin"
+    cp "$release/bin/codex" "$mise_installed_cli"
+    ln -s "$mise_bin" "$mise_shim"
+    stable_path="$(HOME="$trust_workspace/home" python3 "$REPO_DIR/launcher/cli-launch-path.py" "$mise_shim")"
+    [ "$stable_path" = "$(realpath "$mise_installed_cli")" ] || \
+        fail "launcher CLI resolution must bypass mise multicall shims for GUI children"
 }
 
 test_webview_server_cache_policy() {


### PR DESCRIPTION
## What changed

- Detect Codex CLI paths that are mise multicall shims.
- Resolve those shims to the concrete CLI installed under mise's active Node installation.
- Add a launcher smoke-test fixture covering the mise layout.

## Why

Chrome native hosts and other GUI children do not reliably have mise's shell dispatch context. Registering the shim caused `codex app-server` to exit before becoming ready, breaking the ChatGPT Chrome integration after desktop or session restarts.

## Impact

GUI integrations now receive a directly executable Codex CLI path while non-mise CLI resolution behavior remains unchanged.

## Validation

- `python3 -m py_compile launcher/cli-launch-path.py`
- `bash -n launcher/start.sh.template`
- Isolated mise-shim resolution fixture
- `git diff --check`
- Rebuilt and installed the pacman package locally
- Confirmed the Chrome runtime manifest registered the concrete CLI path
- Confirmed the exact Chrome app-server launch stayed running until the verification timeout
