### PR TITLE
Fix optional upstream DMG drift

### DIFF
--- a/scripts/patches/impl/webview-browser-use-external.test.js
+++ b/scripts/patches/impl/webview-browser-use-external.test.js
@@ -50,9 +50,9 @@ function currentMainCallerFixture() {
 
 function currentRendererFixture() {
   return [
-    currentBrowserRegistry("Fu"),
-    "function Pu(e){return Object.hasOwn(Fu,e)}",
-    "function rendererLinuxRegistry(){return Object.keys(Fu).filter(Pu).map(e=>({browserFamily:e,installations:Fu[e].linux.installations,manifestDirectories:Fu[e].linux.nativeMessagingManifestDirectories,processNames:Fu[e].linux.processNames}))}",
+    currentBrowserRegistry("Lu"),
+    "function Iu(e){return Object.hasOwn(Lu,e)}",
+    "function rendererLinuxRegistry(){return Object.keys(Lu).filter(Iu).map(e=>({browserFamily:e,installations:Lu[e].linux.installations,manifestDirectories:Lu[e].linux.nativeMessagingManifestDirectories,processNames:Lu[e].linux.processNames}))}",
     "function wfi(){return{enabled:!1,featureName:`browser_use_external`,gate:`410065390`}}",
     "function Sfi({isExternalBrowserUseFeatureEnabled:e,isExternalBrowserUseFeatureLoading:t,isExternalBrowserUseGateEnabled:n,runCodexInWsl:r,windowType:i}){return i===`chrome-extension`?`available`:t?`loading`:n?e?r?`wsl-disabled`:`available`:`config-requirement-disabled`:`statsig-disabled`}",
     "globalThis.rendererLinuxRegistry=rendererLinuxRegistry;",

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -1526,10 +1526,10 @@ function currentBrowserUseMainRegistryContract(source) {
 }
 
 function currentBrowserUseRendererContract(source) {
-  return currentNativeBrowserUseRegistryContract(source, "Fu", "Pu") &&
+  return currentNativeBrowserUseRegistryContract(source, "Lu", "Iu") &&
     source.includes("featureName:`browser_use_external`") &&
     source.includes("410065390") &&
-    source.includes("Object.keys(Fu).filter(Pu)") &&
+    source.includes("Object.keys(Lu).filter(Iu)") &&
     (externalBrowserUseAvailabilityCurrentPattern.test(source) ||
       externalBrowserUseAvailabilityPatchedPattern.test(source));
 }


### PR DESCRIPTION
<!-- optional-upstream-dmg-sha256:91fc4b809c2730b39e57d9adbc6b30c669ef074c900ca28c63a1e0b6fa41268c -->
<!-- optional-review-policy:7 -->

## Summary
- repair best-effort optional Linux patch drift for the completed upstream DMG
- preserve the completed main watchdog and Nix campaign

## Validation
- warning-free exact-DMG acceptance recorded by the optional follow-up
- independent read-only review approved head `76c7aa2770a37bb58d2972768467c0639e0d5ec7`
- general review evidence `71255e23250d8dc1359691b1b2d71404ec4e5ab0c8de80b3cc447b4206de0aec`
- removal audit evidence `not-required`
- all required GitHub checks must pass before guarded merge
