### PR TITLE
chore(computer-use): satisfy stable Clippy

### DIFF
--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -490,9 +490,9 @@ fn desktop_env_hydration_updates(
         && current_env
             .get("DISPLAY")
             .is_some_and(|value| !value.trim().is_empty())
-        && !current_env
+        && current_env
             .get("WAYLAND_DISPLAY")
-            .is_some_and(|value| !value.trim().is_empty());
+            .is_none_or(|value| value.trim().is_empty());
 
     DESKTOP_ENV_KEYS
         .iter()

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -3869,7 +3869,7 @@ fn native_x11_xdotool_pointer_session(
     wayland_display: Option<&str>,
 ) -> bool {
     session_type.is_some_and(|value| value.trim().eq_ignore_ascii_case("x11"))
-        && !wayland_display.is_some_and(|value| !value.trim().is_empty())
+        && wayland_display.is_none_or(|value| value.trim().is_empty())
 }
 
 fn prefer_xdotool_pointer(


### PR DESCRIPTION
## Summary

- replace two negated `Option::is_some_and` checks with the equivalent `Option::is_none_or` form
- preserve the missing-or-empty `WAYLAND_DISPLAY` semantics used by native X11 session detection and xdotool pointer selection
- restore the workspace Clippy gate on Rust 1.97.1 stable

## Root cause

Rust 1.97.1's Clippy reports these expressions as `nonminimal_bool`. Because CI promotes Clippy warnings to errors with `-D warnings`, the latest-stable toolchain failed validation even though the runtime behavior was correct.

This is a maintenance follow-up in the native X11 logic exercised by #963; it does not reopen or close that issue.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `TMPDIR=/tmp cargo test --workspace --all-targets`
- `bash tests/scripts_smoke.sh`
  - warm-start recovery and window-reopen scenarios passed
  - webview probe equivalence passed 21/21
- latest upstream DMG `26.803.81509` rebuilt with verdict `accepted`
- clean provenance verified at commit `30cdedfc` with `dirty: false`
- isolated X11 runtime acceptance reached Electron spawn, Codex CLI initialization, renderer route mount, and ready state