### PR TITLE
Fix Chrome side-panel CLI trust selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,11 @@ platform binary is present. The launcher does not rank installed CLIs by
 version; it uses an explicit `CODEX_CLI_PATH` first, then the normal lookup
 order, and logs the resolved CLI path plus best-effort version so GUI PATH
 issues are visible. Set `CODEX_CLI_PATH=/path/to/codex` when you want to pin a
-specific binary.
+specific binary. Chrome's side-panel runtime keeps its stricter path trust
+checks. For an implicit unsafe npm selection, the launcher may register the
+same-version CLI from the trusted dedicated `~/.codex-cli-npm` prefix for
+Chrome only; Desktop continues using its normal selection. An explicit
+`CODEX_CLI_PATH` is never replaced.
 
 Local AppImage builds can optionally embed that CLI and its matching Linux
 platform package. Set `CODEX_CLI_BUNDLE_SOURCE` to an installed

--- a/computer-use-linux/src/bin/codex-chrome-extension-host.rs
+++ b/computer-use-linux/src/bin/codex-chrome-extension-host.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use serde_json::{json, Value};
 use std::{
     collections::HashMap,
@@ -510,6 +510,10 @@ impl RolloutTracker {
 }
 
 fn main() -> Result<()> {
+    if let Some(result) = run_cli_selection_mode() {
+        return result;
+    }
+
     let effective_uid = unsafe { libc::geteuid() };
     let socket_dir = socket_dir(effective_uid);
     let socket_path = socket_path(&socket_dir)?;
@@ -543,6 +547,24 @@ fn main() -> Result<()> {
     runtime_manager.shutdown();
     remove_socket_if_present(&socket_path)?;
     result
+}
+
+fn run_cli_selection_mode() -> Option<Result<()>> {
+    let args = env::args_os().skip(1).collect::<Vec<_>>();
+    if args.first().is_none_or(|arg| arg != "--select-chrome-cli") {
+        return None;
+    }
+    Some((|| {
+        if args.len() != 3 {
+            bail!("usage: codex-chrome-extension-host --select-chrome-cli SELECTED FALLBACK");
+        }
+        let selected = Path::new(&args[1]);
+        let fallback = Path::new(&args[2]);
+        let trusted = chrome_runtime::select_trusted_chrome_cli_path(selected, Some(fallback))
+            .map_err(|error| anyhow!(error.message().to_string()))?;
+        println!("{}", trusted.display());
+        Ok(())
+    })())
 }
 
 fn socket_dir(effective_uid: u32) -> PathBuf {

--- a/computer-use-linux/src/chrome_runtime.rs
+++ b/computer-use-linux/src/chrome_runtime.rs
@@ -56,17 +56,22 @@ const UNCONNECTED_PROCESS_TIMEOUT: Duration = Duration::from_secs(15);
 const DISCONNECTED_PROCESS_GRACE: Duration = Duration::from_secs(2);
 const MANIFEST_FILE_NAME: &str = "chrome-native-hosts-v2.json";
 const OPEN_LOCAL_FILE_METHOD: &str = "codexRuntime/openLocalFile";
+const MAX_NPM_PACKAGE_METADATA_BYTES: u64 = 64 * 1024;
 
 type RuntimeResult<T> = std::result::Result<T, RuntimeError>;
 
 #[derive(Debug)]
-struct RuntimeError {
+pub(crate) struct RuntimeError {
     code: i64,
     message: String,
     kind: Option<&'static str>,
 }
 
 impl RuntimeError {
+    pub(crate) fn message(&self) -> &str {
+        &self.message
+    }
+
     fn invalid_params(message: impl Into<String>) -> Self {
         Self {
             code: -32602,
@@ -1290,6 +1295,76 @@ fn validate_owned_file(path: &Path, executable: bool) -> RuntimeResult<PathBuf> 
     }
     validate_trusted_parent_chain(&canonical)?;
     Ok(canonical)
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+struct NpmCliPackageIdentity {
+    name: String,
+    version: String,
+}
+
+pub(crate) fn select_trusted_chrome_cli_path(
+    selected_path: &Path,
+    fallback_path: Option<&Path>,
+) -> RuntimeResult<PathBuf> {
+    if let Ok(canonical) = validate_owned_file(selected_path, true) {
+        return Ok(canonical);
+    }
+
+    let fallback_path = fallback_path.ok_or_else(chrome_cli_selection_error)?;
+    let trusted_fallback =
+        validate_owned_file(fallback_path, true).map_err(|_| chrome_cli_selection_error())?;
+    let selected_identity =
+        npm_cli_package_identity(selected_path, false).ok_or_else(chrome_cli_selection_error)?;
+    let fallback_identity =
+        npm_cli_package_identity(&trusted_fallback, true).ok_or_else(chrome_cli_selection_error)?;
+    if selected_identity != fallback_identity {
+        return Err(chrome_cli_selection_error());
+    }
+
+    Ok(trusted_fallback)
+}
+
+fn npm_cli_package_identity(path: &Path, require_trust: bool) -> Option<NpmCliPackageIdentity> {
+    let canonical = fs::canonicalize(path).ok()?;
+    if canonical.file_name()? != "codex.js" || canonical.parent()?.file_name()? != "bin" {
+        return None;
+    }
+    let package_root = canonical.parent()?.parent()?;
+    let package_json = package_root.join("package.json");
+    let package_json = if require_trust {
+        validate_owned_file(&package_json, false).ok()?
+    } else {
+        fs::canonicalize(package_json).ok()?
+    };
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(&package_json)
+        .ok()?;
+    let metadata = file.metadata().ok()?;
+    if !metadata.is_file() || metadata.len() > MAX_NPM_PACKAGE_METADATA_BYTES {
+        return None;
+    }
+    let mut contents = Vec::new();
+    file.take(MAX_NPM_PACKAGE_METADATA_BYTES + 1)
+        .read_to_end(&mut contents)
+        .ok()?;
+    if contents.len() as u64 > MAX_NPM_PACKAGE_METADATA_BYTES {
+        return None;
+    }
+    let identity: NpmCliPackageIdentity = serde_json::from_slice(&contents).ok()?;
+    if identity.name != "@openai/codex" || identity.version.trim().is_empty() {
+        return None;
+    }
+    Some(identity)
+}
+
+fn chrome_cli_selection_error() -> RuntimeError {
+    RuntimeError::typed(
+        "trusted_cli_unavailable",
+        "No trusted compatible Codex CLI is available for the Chrome side panel",
+    )
 }
 
 fn validate_owned_dir(path: &Path, require_user_owner: bool) -> RuntimeResult<()> {
@@ -2964,6 +3039,80 @@ mod tests {
     }
 
     #[test]
+    fn chrome_cli_selection_keeps_a_safe_normal_first_choice() {
+        let root = test_root("safe-chrome-cli-first-choice");
+        fs::create_dir_all(&root).unwrap();
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+        let selected = write_npm_cli_fixture(&root.join("selected"), "0.147.0", 0o700);
+        let fallback = write_npm_cli_fixture(&root.join("fallback"), "0.147.0", 0o700);
+
+        assert_eq!(
+            select_trusted_chrome_cli_path(&selected, Some(&fallback)).unwrap(),
+            fs::canonicalize(&selected).unwrap()
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn chrome_cli_selection_uses_a_trusted_same_version_npm_fallback() {
+        let root = test_root("trusted-chrome-cli-fallback");
+        fs::create_dir_all(&root).unwrap();
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+        let selected = write_npm_cli_fixture(&root.join("nvm"), "0.147.0", 0o770);
+        let fallback = write_npm_cli_fixture(&root.join("dedicated"), "0.147.0", 0o700);
+
+        assert_eq!(
+            select_trusted_chrome_cli_path(&selected, Some(&fallback)).unwrap(),
+            fs::canonicalize(&fallback).unwrap()
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn chrome_cli_selection_rejects_an_unsafe_path_without_a_trusted_fallback() {
+        let root = test_root("missing-trusted-chrome-cli-fallback");
+        fs::create_dir_all(&root).unwrap();
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+        let selected = write_npm_cli_fixture(&root.join("nvm"), "0.147.0", 0o770);
+
+        let error = select_trusted_chrome_cli_path(&selected, None).unwrap_err();
+        assert_eq!(error.kind, Some("trusted_cli_unavailable"));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn chrome_cli_selection_does_not_switch_npm_versions() {
+        let root = test_root("mismatched-chrome-cli-fallback");
+        fs::create_dir_all(&root).unwrap();
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+        let selected = write_npm_cli_fixture(&root.join("nvm"), "0.148.0", 0o770);
+        let fallback = write_npm_cli_fixture(&root.join("dedicated"), "0.147.0", 0o700);
+
+        let error = select_trusted_chrome_cli_path(&selected, Some(&fallback)).unwrap_err();
+        assert_eq!(error.kind, Some("trusted_cli_unavailable"));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn chrome_cli_selection_does_not_switch_install_types() {
+        let root = test_root("mismatched-chrome-cli-install-type");
+        fs::create_dir_all(&root).unwrap();
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+        let selected_parent = root.join("standalone/bin");
+        fs::create_dir_all(&selected_parent).unwrap();
+        fs::set_permissions(root.join("standalone"), fs::Permissions::from_mode(0o700)).unwrap();
+        fs::set_permissions(&selected_parent, fs::Permissions::from_mode(0o700)).unwrap();
+        let selected = selected_parent.join("codex");
+        fs::write(&selected, "synthetic standalone launcher").unwrap();
+        fs::set_permissions(&selected, fs::Permissions::from_mode(0o770)).unwrap();
+        let fallback = write_npm_cli_fixture(&root.join("dedicated"), "0.147.0", 0o700);
+
+        let error = select_trusted_chrome_cli_path(&selected, Some(&fallback)).unwrap_err();
+        assert_eq!(error.kind, Some("trusted_cli_unavailable"));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn node_path_validation_canonicalizes_and_rejects_unsafe_executables() {
         let root = test_root("canonical-node-path");
         let runtime_dir = root.join("runtime/bin");
@@ -3282,6 +3431,45 @@ mod tests {
             std::process::id(),
             random_hex(4).unwrap()
         ))
+    }
+
+    fn write_npm_cli_fixture(root: &Path, version: &str, executable_mode: u32) -> PathBuf {
+        let package_root = root.join("lib/node_modules/@openai/codex");
+        let package_bin = package_root.join("bin");
+        let visible_bin = root.join("bin");
+        fs::create_dir_all(&package_bin).unwrap();
+        fs::create_dir_all(&visible_bin).unwrap();
+        for directory in [
+            root.to_path_buf(),
+            root.join("lib"),
+            root.join("lib/node_modules"),
+            root.join("lib/node_modules/@openai"),
+            package_root.clone(),
+            package_bin.clone(),
+            visible_bin.clone(),
+        ] {
+            fs::set_permissions(directory, fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        fs::write(
+            package_root.join("package.json"),
+            serde_json::to_vec(&json!({
+                "name": "@openai/codex",
+                "version": version
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::set_permissions(
+            package_root.join("package.json"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let executable = package_bin.join("codex.js");
+        fs::write(&executable, "synthetic npm launcher").unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(executable_mode)).unwrap();
+        let visible = visible_bin.join("codex");
+        std::os::unix::fs::symlink(&executable, &visible).unwrap();
+        visible
     }
 
     fn test_executable(name: &str) -> PathBuf {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,7 +117,13 @@ Tectonic runtime has a verified Linux staging path.
 
 The build stages the upstream Chrome plugin, patches its Linux compatibility
 paths, builds the native messaging host from Rust, and installs browser
-manifests for Chrome, Brave, and Chromium.
+manifests for Chrome, Brave, and Chromium. The native host strictly validates
+the registered app-server CLI and its canonical parent chain. The launcher
+uses that exact validator to prepare a Chrome-only CLI path: the normal safe
+selection wins, while an unsafe implicit npm selection may fall back only to a
+trusted `@openai/codex` launcher with the same package version in the dedicated
+managed npm prefix. Explicit `CODEX_CLI_PATH` values remain authoritative, and
+Desktop's normal CLI selection is unchanged.
 
 ## Validation
 

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -147,6 +147,17 @@ need to pin a particular binary from a GUI-launched session. `CODEX_CLI_PATH`
 does not bypass install-type detection; if it points at a pacman-managed CLI,
 the same non-npm guidance applies.
 
+Chrome app-server registration has a narrower trust requirement than normal
+Desktop launch. After normal launcher/updater selection finishes, the launcher
+asks the bundled Chrome native host to validate that path without executing it.
+For a non-explicit unsafe npm selection, only the known
+`~/.codex-cli-npm/bin/codex` candidate is considered, and only when its trusted
+package metadata identifies the same `@openai/codex` version. This selection is
+exported to Chrome registration separately and does not change Desktop or
+updater CLI identity. An explicit `CODEX_CLI_PATH` never falls through. If no
+trusted compatible fallback exists, Desktop remains usable and the Chrome
+native host rejects the registered path under its existing fail-closed policy.
+
 ## Inspect State
 
 ```bash

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -135,6 +135,12 @@ MULTI_LAUNCH_REQUESTED=0
 MULTI_LAUNCH_ACTIVE=0
 CODEX_LINUX_INSTANCE_ID=""
 LAUNCHER_ARGS=()
+CODEX_CLI_PATH_EXPLICIT=0
+if [ -n "${CODEX_CLI_PATH:-}" ]; then
+    CODEX_CLI_PATH_EXPLICIT=1
+fi
+# Internal Chrome selection is recomputed from the current launcher policy.
+unset CODEX_CHROME_CLI_PATH
 
 # Multi-launch requests are one launcher invocation wide. Keep the public
 # compatibility flag long enough to parse this invocation, but do not leak it
@@ -2024,6 +2030,44 @@ find_codex_cli() {
     done
 
     return 1
+}
+
+select_chrome_cli_path() {
+    local selected_path="${CODEX_CLI_PATH:-}"
+    local fallback_path="$HOME/.codex-cli-npm/bin/codex"
+    local extension_arch=""
+    local selection_host=""
+    local trusted_path=""
+
+    [ -n "$selected_path" ] || return 1
+    if [ "$CODEX_CLI_PATH_EXPLICIT" -eq 1 ]; then
+        CODEX_CHROME_CLI_PATH="$selected_path"
+        export CODEX_CHROME_CLI_PATH
+        echo "Chrome side-panel CLI follows explicit CODEX_CLI_PATH=$CODEX_CHROME_CLI_PATH"
+        return 0
+    fi
+
+    if extension_arch="$(chrome_extension_host_arch)"; then
+        selection_host="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/chrome/extension-host/linux/$extension_arch/extension-host"
+    fi
+    if [ -x "$selection_host" ] && \
+       trusted_path="$(codex_run_host_command "$selection_host" --select-chrome-cli "$selected_path" "$fallback_path" 2>/dev/null)" && \
+       [ -n "$trusted_path" ]; then
+        CODEX_CHROME_CLI_PATH="$trusted_path"
+        export CODEX_CHROME_CLI_PATH
+        if [ "$CODEX_CHROME_CLI_PATH" != "$selected_path" ]; then
+            echo "Chrome side-panel CLI uses trusted compatible npm fallback: $CODEX_CHROME_CLI_PATH"
+        else
+            echo "Chrome side-panel CLI uses the normal Desktop CLI: $CODEX_CHROME_CLI_PATH"
+        fi
+        return 0
+    fi
+
+    # Keep Desktop usable under the deliberately permissive launcher policy.
+    # The native host will apply its unchanged strict checks and fail closed.
+    CODEX_CHROME_CLI_PATH="$selected_path"
+    export CODEX_CHROME_CLI_PATH
+    echo "No trusted compatible Chrome side-panel CLI fallback was found; the native host will validate the normal Desktop CLI."
 }
 
 find_mise_codex_cli() {
@@ -4668,6 +4712,9 @@ if needs_cold_start; then
         log_phase "cli_preflight_backgrounded"
     fi
 fi
+
+select_chrome_cli_path
+log_phase "chrome_cli_selected"
 
 export_packaged_runtime_env
 if needs_cold_start; then

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -8868,10 +8868,11 @@ test("uses Linux managed runtime paths for Electron 42 Browser Use runtime resol
   const files = new Set([
     "/opt/codex/resources/node-runtime/bin/node",
     "/opt/codex/resources/node_repl",
+    "/home/josh/.codex-cli-npm/bin/codex",
     "/home/josh/.local/bin/codex",
   ]);
   const result = vm.runInNewContext(
-    `${patched};Hn({env:{CODEX_CLI_PATH:"/home/josh/.local/bin/codex",PATH:""},isPackaged:true,platform:"linux",repoRoot:null,resolveCodexPath:()=>null,resolveNodePath:()=>null,resolveNodeReplPath:()=>null,resolvePrimaryRuntimeNodePath:()=>null,resourcesPath:"/opt/codex/resources"});`,
+    `${patched};Hn({env:{CODEX_CHROME_CLI_PATH:"/home/josh/.codex-cli-npm/bin/codex",CODEX_CLI_PATH:"/home/josh/.local/bin/codex",PATH:""},isPackaged:true,platform:"linux",repoRoot:null,resolveCodexPath:()=>null,resolveNodePath:()=>null,resolveNodeReplPath:()=>null,resolvePrimaryRuntimeNodePath:()=>null,resourcesPath:"/opt/codex/resources"});`,
     {
       require(moduleName) {
         if (moduleName === "node:path") {
@@ -8900,7 +8901,7 @@ test("uses Linux managed runtime paths for Electron 42 Browser Use runtime resol
   );
 
   assert.deepEqual(JSON.parse(JSON.stringify(result)), {
-    codexCliPath: "/home/josh/.local/bin/codex",
+    codexCliPath: "/home/josh/.codex-cli-npm/bin/codex",
     codexCliPathSource: "env-override",
     nodeModuleDirs: [],
     nodePath: "/opt/codex/resources/node-runtime/bin/node",

--- a/scripts/patches/impl/chrome-plugin.js
+++ b/scripts/patches/impl/chrome-plugin.js
@@ -127,13 +127,13 @@ function hasCompleteCurrentChromeAppServerRuntimePatch(source) {
     matchesExactlyOnce(
       source,
       new RegExp(
-        String.raw`\/\*codexLinuxChromeNativeHostAppServerRuntime\*\/async function ${IDENTIFIER_PATTERN}\((?<runtimeConfig>${IDENTIFIER_PATTERN})\)\{let ${IDENTIFIER_PATTERN}=${IDENTIFIER_PATTERN}\(\k<runtimeConfig>\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(\`CODEX_CLI_PATH\`\)\?\?codexLinuxChromeNativeHostRuntimePath\(\`codex\`\),${IDENTIFIER_PATTERN}=${IDENTIFIER_PATTERN}\(\k<runtimeConfig>\.resourcesPath\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(\`CODEX_BROWSER_USE_NODE_PATH\`\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(\`NODE_REPL_NODE_PATH\`\)\?\?codexLinuxChromeNativeHostRuntimeFile\(\k<runtimeConfig>\.resourcesPath,\[\[\`node-runtime\`,\`bin\`,process\.platform===\`win32\`\?\`node\.exe\`:\`node\`\]\]\),${IDENTIFIER_PATTERN}=${IDENTIFIER_PATTERN}\(\k<runtimeConfig>\.resourcesPath\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(\`CODEX_NODE_REPL_PATH\`\)\?\?codexLinuxChromeNativeHostRuntimeFile\(\k<runtimeConfig>\.resourcesPath,\[\[process\.platform===\`win32\`\?\`node_repl\.exe\`:\`node_repl\`\]\]\),`,
+        String.raw`\/\*codexLinuxChromeNativeHostAppServerRuntime\*\/async function ${IDENTIFIER_PATTERN}\((?<runtimeConfig>${IDENTIFIER_PATTERN})\)\{let ${IDENTIFIER_PATTERN}=${IDENTIFIER_PATTERN}\(\k<runtimeConfig>\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(\`CODEX_CHROME_CLI_PATH\`\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(\`CODEX_CLI_PATH\`\)\?\?codexLinuxChromeNativeHostRuntimePath\(\`codex\`\),${IDENTIFIER_PATTERN}=${IDENTIFIER_PATTERN}\(\k<runtimeConfig>\.resourcesPath\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(\`CODEX_BROWSER_USE_NODE_PATH\`\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(\`NODE_REPL_NODE_PATH\`\)\?\?codexLinuxChromeNativeHostRuntimeFile\(\k<runtimeConfig>\.resourcesPath,\[\[\`node-runtime\`,\`bin\`,process\.platform===\`win32\`\?\`node\.exe\`:\`node\`\]\]\),${IDENTIFIER_PATTERN}=${IDENTIFIER_PATTERN}\(\k<runtimeConfig>\.resourcesPath\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(\`CODEX_NODE_REPL_PATH\`\)\?\?codexLinuxChromeNativeHostRuntimeFile\(\k<runtimeConfig>\.resourcesPath,\[\[process\.platform===\`win32\`\?\`node_repl\.exe\`:\`node_repl\`\]\]\),`,
       ),
     ) &&
     matchesExactlyOnce(
       source,
       new RegExp(
-        String.raw`\/\*codexLinuxChromeNativeHostAppServerCodexRuntime\*\/async function ${IDENTIFIER_PATTERN}\((?<codexConfig>${IDENTIFIER_PATTERN})\)\{let (?<codexPath>${IDENTIFIER_PATTERN})=${IDENTIFIER_PATTERN}\(\k<codexConfig>\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(\`CODEX_CLI_PATH\`\)\?\?codexLinuxChromeNativeHostRuntimePath\(\`codex\`\);if\(\k<codexPath>==null\)throw Error\(.+?\);return ${IDENTIFIER_PATTERN}\(\{codexCliPath:\k<codexPath>,codexHome:\k<codexConfig>\.codexHome,nativeHostName:\k<codexConfig>\.nativeHostName\}\)\}`,
+        String.raw`\/\*codexLinuxChromeNativeHostAppServerCodexRuntime\*\/async function ${IDENTIFIER_PATTERN}\((?<codexConfig>${IDENTIFIER_PATTERN})\)\{let (?<codexPath>${IDENTIFIER_PATTERN})=${IDENTIFIER_PATTERN}\(\k<codexConfig>\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(\`CODEX_CHROME_CLI_PATH\`\)\?\?codexLinuxChromeNativeHostRuntimeEnv\(\`CODEX_CLI_PATH\`\)\?\?codexLinuxChromeNativeHostRuntimePath\(\`codex\`\);if\(\k<codexPath>==null\)throw Error\(.+?\);return ${IDENTIFIER_PATTERN}\(\{codexCliPath:\k<codexPath>,codexHome:\k<codexConfig>\.codexHome,nativeHostName:\k<codexConfig>\.nativeHostName\}\)\}`,
       ),
     ) &&
     matchesExactlyOnce(
@@ -367,7 +367,7 @@ function applyModernChromeNativeHostRuntimePatch(currentSource, helper) {
   const [, envVar, platformVar, , resourcesVar] = varsMatch;
   let patchedResolver = resolverSource;
   const codexPathRegex = new RegExp(
-    String.raw`(rawValue:${envVar}\.CODEX_CLI_PATH,resolveWindowsAppsPath:[A-Za-z_$][\w$]*\}\)\?\?)([A-Za-z_$][\w$]*)\(\{devRelativePathSegments:\[\`extension\`,\`bin\`,\`codex\`\]`,
+    String.raw`(rawValue:)${envVar}\.CODEX_CLI_PATH(,resolveWindowsAppsPath:[A-Za-z_$][\w$]*\}\)\?\?)([A-Za-z_$][\w$]*)\(\{devRelativePathSegments:\[\`extension\`,\`bin\`,\`codex\`\]`,
   );
   const nodePathRegex = new RegExp(
     String.raw`(rawValue:${envVar}\.CODEX_BROWSER_USE_NODE_PATH,resolveWindowsAppsPath:[A-Za-z_$][\w$]*\}\)\?\?)(\([A-Za-z_$][\w$]*\.path==null&&[A-Za-z_$][\w$]*!=null\?)`,
@@ -378,8 +378,8 @@ function applyModernChromeNativeHostRuntimePatch(currentSource, helper) {
 
   patchedResolver = patchedResolver.replace(
     codexPathRegex,
-    (_match, prefix, resolverFn) =>
-      `${prefix}codexLinuxChromeNativeHostRuntimeEntry(codexLinuxChromeNativeHostRuntimePath(\`codex\`),\`linux-path\`)??${resolverFn}({devRelativePathSegments:[\`extension\`,\`bin\`,\`codex\`]`,
+    (_match, prefix, suffix, resolverFn) =>
+      `${prefix}${envVar}.CODEX_CHROME_CLI_PATH??${envVar}.CODEX_CLI_PATH${suffix}codexLinuxChromeNativeHostRuntimeEntry(codexLinuxChromeNativeHostRuntimePath(\`codex\`),\`linux-path\`)??${resolverFn}({devRelativePathSegments:[\`extension\`,\`bin\`,\`codex\`]`,
   );
   if (patchedResolver === resolverSource) {
     return null;
@@ -666,7 +666,7 @@ function applyChromePluginAppServerRuntimePatch(currentSource, helper) {
     nodeReplResolverFn,
   ] = match;
   const replacement =
-    `${helper}${LINUX_CHROME_NATIVE_HOST_RUNTIME_APP_SERVER_RUNTIME_MARKER}async function ${resolverFn}(${configVar}){let ${codexVar}=${codexResolverFn}(${configVar})??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_CLI_PATH\`)??codexLinuxChromeNativeHostRuntimePath(\`codex\`),${nodeVar}=${nodeResolverFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_BROWSER_USE_NODE_PATH\`)??codexLinuxChromeNativeHostRuntimeEnv(\`NODE_REPL_NODE_PATH\`)??codexLinuxChromeNativeHostRuntimeFile(${configVar}.resourcesPath,[[\`node-runtime\`,\`bin\`,process.platform===\`win32\`?\`node.exe\`:\`node\`]]),${nodeReplVar}=${nodeReplResolverFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_NODE_REPL_PATH\`)??codexLinuxChromeNativeHostRuntimeFile(${configVar}.resourcesPath,[[process.platform===\`win32\`?\`node_repl.exe\`:\`node_repl\`]]),`;
+    `${helper}${LINUX_CHROME_NATIVE_HOST_RUNTIME_APP_SERVER_RUNTIME_MARKER}async function ${resolverFn}(${configVar}){let ${codexVar}=${codexResolverFn}(${configVar})??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_CHROME_CLI_PATH\`)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_CLI_PATH\`)??codexLinuxChromeNativeHostRuntimePath(\`codex\`),${nodeVar}=${nodeResolverFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_BROWSER_USE_NODE_PATH\`)??codexLinuxChromeNativeHostRuntimeEnv(\`NODE_REPL_NODE_PATH\`)??codexLinuxChromeNativeHostRuntimeFile(${configVar}.resourcesPath,[[\`node-runtime\`,\`bin\`,process.platform===\`win32\`?\`node.exe\`:\`node\`]]),${nodeReplVar}=${nodeReplResolverFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_NODE_REPL_PATH\`)??codexLinuxChromeNativeHostRuntimeFile(${configVar}.resourcesPath,[[process.platform===\`win32\`?\`node_repl.exe\`:\`node_repl\`]]),`;
   return currentSource.replace(originalPrefix, replacement);
 }
 
@@ -686,7 +686,7 @@ function applyChromePluginCodexAppServerRuntimePatch(currentSource, helper) {
     syncFn,
   ] = match;
   const replacement =
-    `${helper}${LINUX_CHROME_NATIVE_HOST_RUNTIME_APP_SERVER_CODEX_MARKER}async function ${resolverFn}(${configVar}){let ${codexVar}=${bundledCodexResolverFn}(${configVar})??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_CLI_PATH\`)??codexLinuxChromeNativeHostRuntimePath(\`codex\`);if(${codexVar}==null)throw Error(\`Missing bundled Electron Codex runtime required to sync Chrome plugin app server for \${${configVar}.nativeHostName} (resourcesPath: \${${configVar}.resourcesPath??\`<none>\`}).\`);return ${syncFn}({codexCliPath:${codexVar},codexHome:${configVar}.codexHome,nativeHostName:${configVar}.nativeHostName})}`;
+    `${helper}${LINUX_CHROME_NATIVE_HOST_RUNTIME_APP_SERVER_CODEX_MARKER}async function ${resolverFn}(${configVar}){let ${codexVar}=${bundledCodexResolverFn}(${configVar})??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_CHROME_CLI_PATH\`)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_CLI_PATH\`)??codexLinuxChromeNativeHostRuntimePath(\`codex\`);if(${codexVar}==null)throw Error(\`Missing bundled Electron Codex runtime required to sync Chrome plugin app server for \${${configVar}.nativeHostName} (resourcesPath: \${${configVar}.resourcesPath??\`<none>\`}).\`);return ${syncFn}({codexCliPath:${codexVar},codexHome:${configVar}.codexHome,nativeHostName:${configVar}.nativeHostName})}`;
   return currentSource.replace(original, replacement);
 }
 

--- a/scripts/patches/impl/chrome-plugin.test.js
+++ b/scripts/patches/impl/chrome-plugin.test.js
@@ -326,6 +326,50 @@ test("patches the complete current Chrome runtime asset set transactionally", as
   }
 });
 
+test("registers the launcher-selected trusted Chrome CLI separately from Desktop", async () => {
+  const unsafeDesktopCli = "/home/test/.nvm/versions/node/current/bin/codex";
+  const trustedChromeCli = "/home/test/.codex-cli-npm/bin/codex";
+  const patched = applyLinuxChromeNativeHostRuntimePatch(
+    currentChromePluginAppServerSourceBundleFixture(),
+  );
+  const files = new Set([
+    unsafeDesktopCli,
+    trustedChromeCli,
+    "/opt/codex/resources/node-runtime/bin/node",
+    "/opt/codex/resources/node_repl",
+  ]);
+
+  const runtime = await vm.runInNewContext(
+    `${patched};vq({resourcesPath:"/opt/codex/resources",codexHome:"/tmp/codex",devRuntimeRepoRoot:null,nativeHostName:"com.openai.codexextension"});`,
+    {
+      require(moduleName) {
+        if (moduleName === "node:path") return path;
+        if (moduleName === "node:fs") {
+          return {
+            statSync(filePath) {
+              if (!files.has(filePath)) {
+                throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+              }
+              return { isFile: () => true };
+            },
+          };
+        }
+        return require(moduleName);
+      },
+      process: {
+        env: {
+          CODEX_CHROME_CLI_PATH: trustedChromeCli,
+          CODEX_CLI_PATH: unsafeDesktopCli,
+          PATH: "",
+        },
+        platform: "linux",
+      },
+    },
+  );
+
+  assert.equal(runtime.codexCliPath, trustedChromeCli);
+});
+
 test("registers the durable trusted Linux runtime cache instead of the installed cache", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-chrome-runtime-trust-"));
   try {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -7072,7 +7072,7 @@ functions = [source[
     source.index("codex_restore_original_ld_library_path() {"):
     source.index("# Capture before package-specific launcher patches")
 ]]
-for name in ("cached_codex_cli_path", "find_fnm_codex_cli", "find_mise_codex_cli", "is_codex_cli_path", "find_codex_cli", "verify_cli_launch_path", "pid_parent_matches", "codex_cli_version_probe", "codex_cli_version", "codex_cli_missing_optional_dependency", "log_codex_cli_path"):
+for name in ("cached_codex_cli_path", "find_fnm_codex_cli", "find_mise_codex_cli", "is_codex_cli_path", "find_codex_cli", "chrome_extension_host_arch", "select_chrome_cli_path", "verify_cli_launch_path", "pid_parent_matches", "codex_cli_version_probe", "codex_cli_version", "codex_cli_missing_optional_dependency", "log_codex_cli_path"):
     match = re.search(r"^" + re.escape(name) + r"\(\) \{[\s\S]*?^\}\n", source, re.M)
     if match is None:
         raise SystemExit(f"missing {name}")
@@ -7113,6 +7113,14 @@ case "${1:?}" in
         verify_cli_launch_path
         printf 'path=%s\n' "$CODEX_CLI_PATH"
         printf 'source=%s\n' "$CODEX_CLI_SOURCE_PATH"
+        ;;
+    chrome-select)
+        SCRIPT_DIR="${CHROME_APP_DIR:?}"
+        CODEX_CLI_PATH="${2:-}"
+        CODEX_CLI_PATH_EXPLICIT="${CHROME_CLI_EXPLICIT:-0}"
+        export CODEX_CLI_PATH
+        select_chrome_cli_path >/dev/null
+        printf '%s\n' "$CODEX_CHROME_CLI_PATH"
         ;;
     *)
         exit 64
@@ -7164,6 +7172,7 @@ codex_cli_missing_optional_dependency() {
     [ "${BROKEN_CLI:-0}" = "1" ]
 }
 run_cli_preflight_background() { printf 'background=1\n' >> "$ROUTING_LOG"; }
+select_chrome_cli_path() { :; }
 log_codex_cli_path() { printf 'version=final\n' >> "$ROUTING_LOG"; }
 launch_electron() { printf 'electron=launch\n' >> "$ROUTING_LOG"; }
 '''
@@ -7276,6 +7285,55 @@ PY
     chmod +x "$override_cli"
     log_output="$(env -i PATH="$path_cli_bin:$HOST_TOOL_PATH" HOME="$fake_home" "$launcher_probe" log "$override_cli")"
     [[ "$log_output" == "Using CODEX_CLI_PATH=$override_cli (version 0.42.0)" ]] || fail "CODEX_CLI_PATH must remain an explicit override with version logging: $log_output"
+
+    local chrome_app_dir="$workspace/chrome-app"
+    local chrome_selection_host="$chrome_app_dir/resources/plugins/openai-bundled/plugins/chrome/extension-host/linux/x64/extension-host"
+    local chrome_host_called="$workspace/chrome-host-called"
+    local unsafe_normal_cli="$workspace/nvm-like/codex"
+    local trusted_fallback_cli="$fake_home/.codex-cli-npm/bin/codex"
+    local chrome_selection
+    mkdir -p "$(dirname "$chrome_selection_host")" "$(dirname "$unsafe_normal_cli")" "$(dirname "$trusted_fallback_cli")"
+    printf '#!/usr/bin/env bash\nprintf "called\\n" > "${CHROME_HOST_CALLED:?}"\n[ "$1" = --select-chrome-cli ]\n[ "$2" = "${EXPECTED_SELECTED:?}" ]\nprintf "%%s\\n" "${TRUSTED_CHROME_RESULT:?}"\n' > "$chrome_selection_host"
+    chmod 0755 "$chrome_selection_host"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$unsafe_normal_cli"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$trusted_fallback_cli"
+    chmod 0775 "$unsafe_normal_cli"
+    chmod 0755 "$trusted_fallback_cli"
+
+    chrome_selection="$(env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" \
+        CHROME_APP_DIR="$chrome_app_dir" CHROME_CLI_EXPLICIT=1 \
+        CHROME_HOST_CALLED="$chrome_host_called" EXPECTED_SELECTED="$unsafe_normal_cli" \
+        TRUSTED_CHROME_RESULT="$trusted_fallback_cli" \
+        "$launcher_probe" chrome-select "$unsafe_normal_cli")"
+    [ "$chrome_selection" = "$unsafe_normal_cli" ] || \
+        fail "explicit CODEX_CLI_PATH must remain authoritative for Chrome: $chrome_selection"
+    [ ! -e "$chrome_host_called" ] || \
+        fail "explicit CODEX_CLI_PATH must not silently consult a fallback"
+
+    chrome_selection="$(env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" \
+        CHROME_APP_DIR="$chrome_app_dir" CHROME_CLI_EXPLICIT=0 \
+        CHROME_HOST_CALLED="$chrome_host_called" EXPECTED_SELECTED="$unsafe_normal_cli" \
+        TRUSTED_CHROME_RESULT="$trusted_fallback_cli" \
+        "$launcher_probe" chrome-select "$unsafe_normal_cli")"
+    [ "$chrome_selection" = "$trusted_fallback_cli" ] || \
+        fail "implicit unsafe Desktop CLI must allow a trusted compatible Chrome fallback: $chrome_selection"
+    assert_file_exists "$chrome_host_called"
+
+    rm -f "$chrome_host_called"
+    chrome_selection="$(env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" \
+        CHROME_APP_DIR="$chrome_app_dir" CHROME_CLI_EXPLICIT=0 \
+        CHROME_HOST_CALLED="$chrome_host_called" EXPECTED_SELECTED="$trusted_fallback_cli" \
+        TRUSTED_CHROME_RESULT="$trusted_fallback_cli" \
+        "$launcher_probe" chrome-select "$trusted_fallback_cli")"
+    [ "$chrome_selection" = "$trusted_fallback_cli" ] || \
+        fail "safe normal first-choice CLI must remain selected for Chrome: $chrome_selection"
+
+    rm -f "$chrome_host_called"
+    chrome_selection="$(env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" \
+        CHROME_APP_DIR="$workspace/missing-chrome-host" CHROME_CLI_EXPLICIT=0 \
+        "$launcher_probe" chrome-select "$unsafe_normal_cli")"
+    [ "$chrome_selection" = "$unsafe_normal_cli" ] || \
+        fail "no trusted fallback must preserve Desktop CLI while Chrome fails closed: $chrome_selection"
 
     local dash_version_cli="$workspace/dash-version-codex"
     local fallback_version_cli="$workspace/fallback-version-codex"


### PR DESCRIPTION
## Summary

Plain Desktop launches can select an NVM/npm Codex CLI that is valid under the current Desktop launcher policy but fails the stricter Chrome native-host path policy. The launcher then exports that path into both Chrome v2 runtime manifests, so the side panel reports `Unable to start ChatGPT` even when a trusted same-version Codex CLI is already installed under the dedicated npm prefix. Users currently have to pin that second path with `CODEX_CLI_PATH` before launching Desktop.

This change keeps normal Desktop and updater selection intact and adds a separate Chrome-only reconciliation step:

- the shipped Rust Chrome native host validates the normal selected path with the existing ownership, executable, permission, canonicalization, and parent-chain checks;
- a safe normal selection remains selected;
- for an unsafe implicit npm selection, only the dedicated `~/.codex-cli-npm` candidate is eligible, and only when both package metadata files identify the exact same `@openai/codex` version;
- the candidates are not executed to determine trust or compatibility;
- Chrome registration receives the result through an internal `CODEX_CHROME_CLI_PATH`, while Desktop continues using `CODEX_CLI_PATH`;
- explicit `CODEX_CLI_PATH` remains authoritative and never silently falls through;
- without a safe compatible fallback, Desktop remains usable and Chrome still fails closed under its existing validator.

The source-of-truth changes are in:

- `launcher/start.sh.template`
- `computer-use-linux/src/bin/codex-chrome-extension-host.rs`
- `computer-use-linux/src/chrome_runtime.rs`
- `scripts/patches/impl/chrome-plugin.js`
- adjacent launcher, Chrome patcher, Electron 42, and Rust tests
- `README.md`, `docs/architecture.md`, and `docs/updater.md`

### Policy and security context

PR #962 originally made strict path trust a broad launcher/updater execution gate and recommended a fresh dedicated npm prefix instead of changing modes in an already-untrusted tree. PR #1002 later deliberately relaxed normal launch validation to a canonical regular-executable check so ordinary user installs created under `umask 0002` remain usable. The Chrome runtime retained its stricter trust policy, including through the Nix correction in #1003.

This PR does not blindly restore #962's obsolete global launch gate. It reconciles the policies only for Chrome registration and directly reuses the existing Rust Chrome validator. It does not chmod an NVM tree, set a global umask, reorder all CLI sources, change the user's terminal `codex`, or weaken Chrome trust.

PR #1286 fixed a different layer: once a trusted npm `codex.js` is accepted, its `#!/usr/bin/env node` child must receive a trusted managed Node path even when GUI `PATH` lacks Node. This PR does not alter that child-`PATH` behavior, and its regression test remains green.

The fallback cannot change install channels or versions: it is npm-to-npm only, the package name must be exactly `@openai/codex`, and the version strings must match exactly. Direct, standalone, system-package, AppImage, Nix, updater, and no-updater normal selections are otherwise unchanged.

Open draft PR #1304 addresses a separate mise multicall-shim dispatch problem. It does not apply Chrome path trust or provide a same-version trusted npm fallback, so this change does not duplicate it.

## Validation

TDD red before implementation:

- `node scripts/patches/impl/chrome-plugin.test.js` — 15 passed, 1 failed; the new registration regression received the NVM-style Desktop path instead of the trusted dedicated-prefix path.

Green after implementation:

- `node scripts/patches/impl/chrome-plugin.test.js` — 16 passed.
- `env TMPDIR=/tmp node --test scripts/patch-linux-window-ui.test.js` — 428 passed.
- `bash tests/scripts_smoke.sh` — passed, including launcher routing and cross-format packaging smoke checks.
- `env TMPDIR=/tmp cargo test -p codex-computer-use-linux --bin codex-chrome-extension-host` — 85 passed, including same-version fallback, explicit/safe-first/fail-closed semantics, no version/channel switching, unchanged trust checks, and the #1286 npm-shebang test.
- `env TMPDIR=/tmp cargo test --workspace --all-targets` — passed.
- `env TMPDIR=/tmp cargo check --workspace --all-targets` — passed.
- `env TMPDIR=/tmp cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `bash -n launcher/start.sh.template tests/scripts_smoke.sh` — passed.
- `git diff --check upstream/main...HEAD` — passed.

Live installed-app validation of the automatic NVM-to-dedicated-prefix Chrome fallback has not been performed; the exact installed environment currently works with the equivalent explicit CODEX_CLI_PATH workaround.

### Non-goals

- Changing global Desktop/updater CLI discovery order or update policy.
- Repairing or changing permissions on existing npm/NVM installations.
- Weakening Chrome native-host trust validation.
- Switching versions or install channels to find any merely available CLI.
- Changing #1286's managed-Node child environment.
- Modifying Chrome profiles, native-host registrations, installed packages, or updater state as part of this source change.

## Checklist

- [x] This pull request is ready for review and is no longer a draft. 
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area. (Not an upstream-drift fix; current-DMG fixtures pass.)
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass. 
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
