### PR TITLE
Offer a local project when ChatGPT handoff would go projectless

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -100,6 +100,7 @@ const {
   applyLinuxHostProcessEnvironmentPatch,
   applyLinuxFileManagerPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
+  applyLinuxPickLocalProjectHandlerPatch,
   applyLinuxLocalAppServerFeatureEnablementHandlerPatch,
   applyLinuxOwlFeatureBindingFallbackPatch,
   applyLinuxRemoteControlConfigPreservationPatch,
@@ -197,6 +198,8 @@ const {
   applyLinuxSidebarScrollPerformancePatch,
   applyLinuxSkillsListDedupePatch,
   applyLinuxThreadSidePanelNativeTooltipPatch,
+  applyLinuxChatGptHandoffLocalProjectPatch,
+  applyLinuxDesktopRequestGlobalPatch,
   applyLinuxTooltipWindowControlsCollisionPatch,
   applyLinuxWindowControlsSafeAreaPatch,
   applySubagentNicknameMetadataPatch,
@@ -1054,11 +1057,14 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-application-menu",
     "linux-app-reload-shortcuts",
     "linux-x11-project-picker",
+    "linux-pick-local-project-handler",
     "opaque-window-default-general-settings",
     "opaque-window-default-webview-index",
     "linux-window-controls-safe-area",
     "linux-tooltip-window-controls-collision",
     "linux-thread-side-panel-native-tooltip",
+    "linux-desktop-request-global",
+    "linux-chatgpt-handoff-local-project",
     "linux-fast-mode-model-guard",
     "subagent-nickname-metadata-shape",
     "local-environment-action-modal-draft",
@@ -1108,6 +1114,16 @@ test("default core patch descriptors are grouped and unique", () => {
   );
   assert.equal(
     descriptors.find((descriptor) => descriptor.id === "linux-x11-project-picker")?.ciPolicy,
+    "optional",
+  );
+  assert.equal(
+    descriptors.find((descriptor) => descriptor.id === "linux-pick-local-project-handler")
+      ?.ciPolicy,
+    "optional",
+  );
+  assert.equal(
+    descriptors.find((descriptor) => descriptor.id === "linux-chatgpt-handoff-local-project")
+      ?.ciPolicy,
     "optional",
   );
   assert.equal(
@@ -2039,6 +2055,104 @@ test("opens the project picker without a parent window on Linux X11", async () =
     argumentCount: 2,
     roots: ["/tmp/project"],
   });
+});
+
+function pickLocalProjectHandlerFixture({ pickedRoots = "[`/tmp/work`]" } = {}) {
+  return [
+    "var n={Oa:e=>e[0]??null,ks:{LOCAL_PROJECTS:`LOCAL_PROJECTS`,PROJECT_ORDER:`PROJECT_ORDER`}};",
+    "function V(e){return `display:${e}`}",
+    "class T{constructor(){this.globalState={projects:{}};this.localProjectsManager={",
+    "addWorkspaceRootFromRenderer:async()=>{},",
+    `pickLocalWorkspaceRoots:async(e,t)=>(this.pickArgs={origin:e,allowMultiple:t},${pickedRoots}),`,
+    "createProjectForRoot:async(e,t)=>(this.created={root:e,label:t},{id:`project1`}),",
+    "notifyGlobalStateChanged:e=>this.globalStateChanged=e,",
+    "sendWorkspaceRootOptionsUpdated:e=>this.workspaceRootOptionsTarget=e",
+    "};this.threadProjectAssignments={setAssignment:async()=>{this.assigned=!0}}}",
+    "shouldUseWslPaths(){return!1}",
+    'handlers={"workspace-root-options":async()=>({}),',
+    '"add-workspace-root-option":async({root:e,label:t,setActive:n,origin:r})=>(await this.localProjectsManager.addWorkspaceRootFromRenderer(r,e,t,n),{success:!0}),',
+    '"electron-clone-workspace-repo":async()=>({success:!1,canceled:!1,error:`Not implemented in Electron.`})}}',
+  ].join("");
+}
+
+test("adds a Linux handler that resolves a local project from the native picker", async () => {
+  const patched = applyPatchTwice(
+    applyLinuxPickLocalProjectHandlerPatch,
+    pickLocalProjectHandlerFixture(),
+  );
+  assert.match(patched, /"linux-pick-local-project":async/);
+
+  const context = {};
+  vm.runInNewContext(`${patched};manager=new T`, context);
+  const origin = { id: "webContents" };
+  const result = await context.manager.handlers["linux-pick-local-project"]({ origin });
+
+  assert.deepEqual(JSON.parse(JSON.stringify(result)), {
+    canceled: false,
+    projectId: "project1",
+    root: "display:/tmp/work",
+  });
+  assert.deepEqual(JSON.parse(JSON.stringify(context.manager.pickArgs)), {
+    origin,
+    allowMultiple: false,
+  });
+  assert.equal(context.manager.created.root, "/tmp/work");
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(context.manager.globalStateChanged)),
+    ["LOCAL_PROJECTS", "PROJECT_ORDER"],
+  );
+  assert.equal(context.manager.workspaceRootOptionsTarget, origin);
+  // The handler must never write a thread assignment; the thread does not exist yet.
+  assert.equal(context.manager.assigned, undefined);
+});
+
+test("normalizes a trailing separator so one directory is one project", async () => {
+  // `/tmp/work` and `/tmp/work/` previously minted two projects for the same
+  // directory, which accumulated in the project list.
+  const patched = applyPatchTwice(
+    applyLinuxPickLocalProjectHandlerPatch,
+    pickLocalProjectHandlerFixture({ pickedRoots: "[`/tmp/work///`]" }),
+  );
+
+  const context = {};
+  vm.runInNewContext(`${patched};manager=new T`, context);
+  const result = await context.manager.handlers["linux-pick-local-project"]({
+    origin: { id: "webContents" },
+  });
+
+  assert.equal(context.manager.created.root, "/tmp/work");
+  assert.equal(result.root, "display:/tmp/work");
+});
+
+test("normalization never reduces the filesystem root", async () => {
+  const patched = applyLinuxPickLocalProjectHandlerPatch(
+    pickLocalProjectHandlerFixture({ pickedRoots: "[`/`]" }),
+  );
+
+  const context = {};
+  vm.runInNewContext(`${patched};manager=new T`, context);
+  await context.manager.handlers["linux-pick-local-project"]({
+    origin: { id: "webContents" },
+  });
+
+  assert.equal(context.manager.created.root, "/");
+});
+
+test("creates no project when the local project picker is canceled", async () => {
+  const patched = applyLinuxPickLocalProjectHandlerPatch(
+    pickLocalProjectHandlerFixture({ pickedRoots: "[]" }),
+  );
+
+  const context = {};
+  vm.runInNewContext(`${patched};manager=new T`, context);
+  const result = await context.manager.handlers["linux-pick-local-project"]({
+    origin: { id: "webContents" },
+  });
+
+  assert.deepEqual(JSON.parse(JSON.stringify(result)), { canceled: true });
+  assert.equal(context.manager.created, undefined);
+  assert.equal(context.manager.globalStateChanged, undefined);
+  assert.equal(context.manager.workspaceRootOptionsTarget, undefined);
 });
 
 test("adds Linux file manager support to the worker open target registry", () => {
@@ -3847,6 +3961,127 @@ test("removes native title tooltip from the thread side panel toolbar action", (
   assert.match(patched, /"aria-label":i/);
   assert.match(patched, /tooltipContent:i/);
   assert.doesNotMatch(patched, /title:i/);
+});
+
+test("publishes the desktop request helper on globalThis", () => {
+  const source =
+    "function U6e(e,t,n,r,i){return{method:e,params:t}}" +
+    "function Om(...e){let[t,n]=e,{params:r,select:i,signal:a,source:o}=n??{};return U6e(t,r,i,a,o)}" +
+    "function Pm(){return 1}";
+
+  const patched = applyPatchTwice(applyLinuxDesktopRequestGlobalPatch, source);
+  assert.match(patched, /\}globalThis\.codexLinuxDesktopRequest=Om;/);
+
+  const context = {};
+  vm.runInNewContext(patched, context);
+  assert.equal(typeof context.codexLinuxDesktopRequest, "function");
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(context.codexLinuxDesktopRequest("m", { params: { a: 1 } }))),
+    { method: "m", params: { a: 1 } },
+  );
+});
+
+test("leaves the desktop request helper alone when the upstream shape changes", () => {
+  const source = "function Om(e,t){return U6e(e,t)}";
+  assert.equal(applyLinuxDesktopRequestGlobalPatch(source), source);
+});
+
+function chatGptHandoffFixture() {
+  return (
+    "function Ii(e){return e?.startsWith(`g-p-`)===!0}" +
+    "async function de(e,t){return e.resolved}" +
+    "async function Lo(e){return e}" +
+    "async function il(e,{chatGptThreadId:t}){" +
+    "let o=e.gizmoId,s=o!=null&&Ii(o),l=s?await de(e,o):null;" +
+    "if(s&&l==null)return null;" +
+    "let u=l==null?{type:`projectless`}:{type:`project`,projectId:l.projectId,environment:{type:`local`}}," +
+    "d=await Lo({target:u});return d}"
+  );
+}
+
+test("prompts for a local project when the ChatGPT handoff would go projectless", async () => {
+  const patched = applyPatchTwice(
+    applyLinuxChatGptHandoffLocalProjectPatch,
+    chatGptHandoffFixture(),
+  );
+  assert.match(patched, /async function codexLinuxPickLocalProjectId\(\)/);
+  assert.match(patched, /`linux-pick-local-project`/);
+
+  const requests = [];
+  const context = {
+    codexLinuxDesktopRequest: async (method, options) => {
+      requests.push([method, options]);
+      return { canceled: false, projectId: "project1", root: "/tmp/work" };
+    },
+  };
+  vm.runInNewContext(`${patched};handoff=il`, context);
+
+  const result = await context.handoff({ gizmoId: null }, { chatGptThreadId: "c1" });
+  assert.deepEqual(JSON.parse(JSON.stringify(result)), {
+    target: { type: "project", projectId: "project1", environment: { type: "local" } },
+  });
+  assert.deepEqual(JSON.parse(JSON.stringify(requests)), [
+    ["linux-pick-local-project", { params: {} }],
+  ]);
+});
+
+test("keeps the upstream ChatGPT project target without prompting", async () => {
+  const patched = applyLinuxChatGptHandoffLocalProjectPatch(chatGptHandoffFixture());
+
+  let requested = false;
+  const context = {
+    codexLinuxDesktopRequest: async () => {
+      requested = true;
+      return { canceled: false, projectId: "picked" };
+    },
+  };
+  vm.runInNewContext(`${patched};handoff=il`, context);
+
+  const result = await context.handoff(
+    { gizmoId: "g-p-abc", resolved: { projectId: "synced" } },
+    { chatGptThreadId: "c1" },
+  );
+  assert.deepEqual(JSON.parse(JSON.stringify(result)), {
+    target: { type: "project", projectId: "synced", environment: { type: "local" } },
+  });
+  assert.equal(requested, false);
+});
+
+test("falls back to a projectless ChatGPT handoff when no project is picked", async () => {
+  const patched = applyLinuxChatGptHandoffLocalProjectPatch(chatGptHandoffFixture());
+
+  const canceled = { codexLinuxDesktopRequest: async () => ({ canceled: true }) };
+  vm.runInNewContext(`${patched};handoff=il`, canceled);
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(await canceled.handoff({ gizmoId: null }, { chatGptThreadId: "c1" }))),
+    { target: { type: "projectless" } },
+  );
+
+  // The request-global patch may be skipped independently; the handoff must degrade.
+  const missing = {};
+  vm.runInNewContext(`${patched};handoff=il`, missing);
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(await missing.handoff({ gizmoId: null }, { chatGptThreadId: "c1" }))),
+    { target: { type: "projectless" } },
+  );
+
+  const throwing = {
+    codexLinuxDesktopRequest: async () => {
+      throw new Error("bridge unavailable");
+    },
+  };
+  vm.runInNewContext(`${patched};handoff=il`, throwing);
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(await throwing.handoff({ gizmoId: null }, { chatGptThreadId: "c1" }))),
+    { target: { type: "projectless" } },
+  );
+});
+
+test("leaves the ChatGPT handoff alone when the upstream target shape changes", () => {
+  const source =
+    "async function il(e,t){let u=l==null?{type:`projectless`}:{type:`project`,projectId:l.id};return u}" +
+    "//Failed to create Codex thread from ChatGPT conversation";
+  assert.equal(applyLinuxChatGptHandoffLocalProjectPatch(source), source);
 });
 
 function managedWindowMenuFixture(

--- a/scripts/patches/core/all-linux/main-process/window-shell/patch.js
+++ b/scripts/patches/core/all-linux/main-process/window-shell/patch.js
@@ -24,6 +24,7 @@ const {
   applyLinuxTerminalUserPathPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
   applyLinuxX11ProjectPickerPatch,
+  applyLinuxPickLocalProjectHandlerPatch,
 } = require("../../../../impl/main-process/misc.js");
 const {
   applyLinuxBuildInfoTrayPatch,
@@ -127,6 +128,13 @@ module.exports = [
     order: 82,
     ciPolicy: "optional",
     apply: applyLinuxX11ProjectPickerPatch,
+  }),
+  mainBundlePatch({
+    id: "linux-pick-local-project-handler",
+    phase: "main-bundle",
+    order: 83,
+    ciPolicy: "optional",
+    apply: applyLinuxPickLocalProjectHandlerPatch,
   }),
   mainBundlePatch({
     id: "linux-avatar-overlay-mouse-passthrough",

--- a/scripts/patches/core/all-linux/webview/chatgpt-handoff-local-project/patch.js
+++ b/scripts/patches/core/all-linux/webview/chatgpt-handoff-local-project/patch.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const {
+  webviewAssetPatch,
+} = require("../../../../descriptor.js");
+const {
+  applyLinuxChatGptHandoffLocalProjectPatch,
+  applyLinuxDesktopRequestGlobalPatch,
+} = require("../../../../impl/webview/index.js");
+
+module.exports = [
+  webviewAssetPatch({
+    id: "linux-desktop-request-global",
+    phase: "webview-asset",
+    order: 1070,
+    ciPolicy: "optional",
+    pattern: /^app-initial-[^.]+\.js$/,
+    missingDescription: "app initial bundle",
+    skipDescription: "Linux desktop request global patch",
+    apply: applyLinuxDesktopRequestGlobalPatch,
+  }),
+  webviewAssetPatch({
+    id: "linux-chatgpt-handoff-local-project",
+    phase: "webview-asset",
+    order: 1071,
+    ciPolicy: "optional",
+    pattern: /^use-chatgpt-composer-controller-[^.]+\.js$/,
+    missingDescription: "ChatGPT composer controller bundle",
+    skipDescription: "Linux ChatGPT handoff local project patch",
+    apply: applyLinuxChatGptHandoffLocalProjectPatch,
+  }),
+];

--- a/scripts/patches/impl/main-process/misc.js
+++ b/scripts/patches/impl/main-process/misc.js
@@ -580,6 +580,50 @@ function applyLinuxLocalAppServerFeatureEnablementHandlerPatch(currentSource) {
   return patchedSource;
 }
 
+// The ChatGPT -> Work handoff creates a Work thread targeting a local project.
+// Upstream only resolves that project by syncing a ChatGPT Project, so a
+// conversation outside one always lands projectless. This exposes the existing
+// native picker so the handoff can resolve a project from a folder instead.
+// It mirrors addWorkspaceRootFromRenderer's side effects but returns the id and
+// never marks the project active.
+function applyLinuxPickLocalProjectHandlerPatch(currentSource) {
+  const method = "linux-pick-local-project";
+  if (currentSource.includes(`"${method}":async`)) {
+    return currentSource;
+  }
+
+  const workspaceRootHandlerRegex =
+    /("add-workspace-root-option":async\(\{root:([A-Za-z_$][\w$]*),label:([A-Za-z_$][\w$]*),setActive:([A-Za-z_$][\w$]*),origin:([A-Za-z_$][\w$]*)\}\)=>\(await this\.localProjectsManager\.addWorkspaceRootFromRenderer\(\5,\2,\3,\4\),\{success:!0\}\),)/u;
+  const match = currentSource.match(workspaceRootHandlerRegex);
+  if (match == null) {
+    if (
+      currentSource.includes('"add-workspace-root-option":async') &&
+      currentSource.includes("localProjectsManager.addWorkspaceRootFromRenderer")
+    ) {
+      console.warn(
+        "WARN: Could not find local project picker insertion point — skipping Linux pick local project handler patch",
+      );
+    }
+    return currentSource;
+  }
+
+  const [, existingHandler] = match;
+  const handler =
+    `"${method}":async({origin:__codexOrigin})=>{` +
+    "let __codexRoots=await this.localProjectsManager.pickLocalWorkspaceRoots(__codexOrigin,!1),__codexRoot=n.Oa(__codexRoots);" +
+    "if(__codexRoot==null)return{canceled:!0};" +
+    // A trailing separator makes a distinct root, so `/x` and `/x/` mint two
+    // projects for the same directory. Normalize before creating. `/` is length
+    // one and must survive.
+    "while(__codexRoot.length>1&&__codexRoot.endsWith(`/`))__codexRoot=__codexRoot.slice(0,-1);" +
+    "let __codexProject=await this.localProjectsManager.createProjectForRoot(__codexRoot);" +
+    "this.localProjectsManager.notifyGlobalStateChanged([n.ks.LOCAL_PROJECTS,n.ks.PROJECT_ORDER]);" +
+    "this.localProjectsManager.sendWorkspaceRootOptionsUpdated(__codexOrigin);" +
+    "return{canceled:!1,projectId:__codexProject.id,root:V(__codexRoot,this.shouldUseWslPaths())}},";
+
+  return currentSource.replace(workspaceRootHandlerRegex, `${existingHandler}${handler}`);
+}
+
 module.exports = {
   applyLinuxHostProcessEnvironmentPatch,
   applyLinuxFileManagerPatch,
@@ -588,6 +632,7 @@ module.exports = {
   applyLinuxTerminalHostEnvironmentPatch,
   applyLinuxTerminalUserPathPatch,
   applyLinuxLocalAppServerFeatureEnablementHandlerPatch,
+  applyLinuxPickLocalProjectHandlerPatch,
   applyLinuxOwlFeatureBindingFallbackPatch,
   applyLinuxWorkerFileManagerPatch,
   patchLinuxOwlFeatureBindingFallbackAssets,

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -758,6 +758,76 @@ function applyLinuxThreadSidePanelNativeTooltipPatch(currentSource) {
   return currentSource;
 }
 
+// The desktop request helper lives in the app-initial chunk and is not imported
+// by the module holding the handoff. Publishing it on globalThis keeps the
+// handoff patch free of cross-chunk import surgery; if this patch is skipped the
+// handoff patch degrades to upstream behavior instead of failing to load.
+function applyLinuxDesktopRequestGlobalPatch(currentSource) {
+  const marker = "codexLinuxDesktopRequest";
+  if (currentSource.includes(marker)) {
+    return currentSource;
+  }
+
+  const requestHelperRegex =
+    /function ([A-Za-z_$][\w$]*)\(\.\.\.([A-Za-z_$][\w$]*)\)\{let\[([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\]=\2,\{params:([A-Za-z_$][\w$]*),select:([A-Za-z_$][\w$]*),signal:([A-Za-z_$][\w$]*),source:([A-Za-z_$][\w$]*)\}=\4\?\?\{\};return ([A-Za-z_$][\w$]*)\(\3,\5,\6,\7,\8\)\}/u;
+  const match = currentSource.match(requestHelperRegex);
+  if (match == null) {
+    console.warn(
+      "WARN: Could not find the desktop request helper — skipping Linux desktop request global patch",
+    );
+    return currentSource;
+  }
+
+  const [helperSource, helperName] = match;
+  return currentSource.replace(
+    requestHelperRegex,
+    `${helperSource}globalThis.codexLinuxDesktopRequest=${helperName};`,
+  );
+}
+
+// Traps the ChatGPT -> Work handoff at the point it decides the new Work
+// thread's target. Upstream resolves a local project only by syncing a ChatGPT
+// Project, so conversations outside one always fall to `projectless` and the
+// resulting thread has no cwd. When that branch is taken, prompt for a folder
+// instead. Cancellation, a skipped request-global patch, or any failure falls
+// through to `projectless`, which is upstream's current behavior.
+function applyLinuxChatGptHandoffLocalProjectPatch(currentSource) {
+  const marker = "codexLinuxPickLocalProjectId";
+  if (currentSource.includes(marker)) {
+    return currentSource;
+  }
+
+  const handoffTargetRegex =
+    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)==null\?\{type:`projectless`\}:\{type:`project`,projectId:\2\.projectId,environment:\{type:`local`\}\}/u;
+  const match = currentSource.match(handoffTargetRegex);
+  if (match == null) {
+    if (currentSource.includes("Failed to create Codex thread from ChatGPT conversation")) {
+      console.warn(
+        "WARN: Could not find the ChatGPT handoff target insertion point — skipping Linux ChatGPT handoff local project patch",
+      );
+    }
+    return currentSource;
+  }
+
+  const [, targetVar, resolvedProjectVar] = match;
+  const helper = [
+    "async function codexLinuxPickLocalProjectId(){",
+    "try{",
+    "let e=globalThis.codexLinuxDesktopRequest;",
+    "if(typeof e!==`function`)return null;",
+    "let t=await e(`linux-pick-local-project`,{params:{}});",
+    "return t==null||t.canceled===!0?null:t.projectId??null",
+    "}catch{return null}",
+    "}",
+  ].join("");
+
+  const replacement =
+    `let codexLinuxProjectId=${resolvedProjectVar}!=null?${resolvedProjectVar}.projectId:await codexLinuxPickLocalProjectId(),` +
+    `${targetVar}=codexLinuxProjectId==null?{type:\`projectless\`}:{type:\`project\`,projectId:codexLinuxProjectId,environment:{type:\`local\`}}`;
+
+  return `${helper}${currentSource.replace(handoffTargetRegex, replacement)}`;
+}
+
 function applyLinuxAppSunsetPatch(currentSource) {
   const statsigKey = "2929582856";
   const disabledGatePattern = /if\(!1&&([A-Za-z_$][\w$]*)\(`2929582856`\)\)\{/u;
@@ -2824,6 +2894,8 @@ module.exports = {
   applyLinuxAppShellTabLayoutPerformancePatch,
   applyLinuxMarkdownAnimationPerformancePatch,
   applyLinuxThreadSidePanelNativeTooltipPatch,
+  applyLinuxDesktopRequestGlobalPatch,
+  applyLinuxChatGptHandoffLocalProjectPatch,
   applyLinuxTooltipWindowControlsCollisionPatch,
   applyLinuxWindowControlsSafeAreaPatch,
   applyLinuxSettingsSearchVisibilityPatch,


### PR DESCRIPTION
Fixes #1309.

## Summary

This PR solves the Linux ChatGPT -> Work handoff case that would otherwise become projectless.

When upstream has no synced ChatGPT Project to reuse, the Linux wrapper now prompts for a local folder during the handoff, creates or reuses the corresponding local project, and starts the new Work thread with that folder as its project root. Canceling the picker preserves upstream behavior and continues projectless.

## User-visible behavior

1. Start in a normal ChatGPT conversation.
2. Use the existing ChatGPT -> Work handoff action.
3. If upstream would otherwise create a projectless Work thread, Linux asks for a local folder.
4. Picking a folder hands off into a local-project Work thread with filesystem hands for that folder.

The UX is slightly awkward because plain ChatGPT conversations do not have a project folder designation or cwd to edit in place. The handoff is the moment the Work thread exists, so it is also the right moment to choose the folder.

## Why this works

ChatGPT conversations are projectless by design. For conversations outside synced ChatGPT Projects, upstream currently chooses `{type: "projectless"}`, which gives the new Work thread no cwd or local workspace-write boundary.

This patch keeps the upstream handoff path intact, but replaces only that otherwise-projectless target with a local project selected by the user. After handoff, normal Work-mode shell behavior applies: users can still ask the assistant to `cd /whatever`, but that only changes the shell cwd; it does not change the project root or workspace-write boundary selected at handoff time.

## Source of truth files changed

- `scripts/patches/core/all-linux/main-process/window-shell/patch.js`
- `scripts/patches/core/all-linux/webview/chatgpt-handoff-local-project/patch.js`
- `scripts/patches/impl/main-process/misc.js`
- `scripts/patches/impl/webview/index.js`
- `scripts/patch-linux-window-ui.test.js`

## Validation

- `node --test scripts/patch-linux-window-ui.test.js`
  - 438 pass, 0 fail
- `node --check` on changed patch/impl files
  - clean
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh`
  - clean from earlier pre-push validation; this PR does not change shell files
- `cargo check -p codex-update-manager`
  - ok from earlier pre-push validation; this PR does not change Rust files

Environment caveats:

- `cargo test -p codex-update-manager` has one pre-existing failure on this machine: `trusted_standalone_installer_path_ignores_inherited_user_tools`. It fails the same way on stock `main`; this PR changes no Rust files.
- `tests/scripts_smoke.sh` is partial here because warm-start recovery is affected by local environment: `python3` resolves to miniconda 3.13.12 without `os.pidfd_open`, and the warm-start test's 5s Electron appearance window is tight for this machine. `launcher/`, `scripts/lib/`, and `install.sh` are byte-identical to `main` on this branch.