### PR TITLE
Fix updater drift for current DMG and replaced app liveness

### DIFF
--- a/linux-features/read-aloud/patch.js
+++ b/linux-features/read-aloud/patch.js
@@ -166,10 +166,12 @@ function applyAssistantRenderPatch(source) {
   }
   const jsxCallPattern =
     /\(0,([A-Za-z_$][\w$]*)\.jsx\)\(([A-Za-z_$][\w$]*),\{(?=[^{}]*\bitem:)(?=[^{}]*\bassistantCopyText:)(?=[^{}]*\bconversationId:)(?=[^{}]*\brenderCodeBlocksAsWritingBlocks:)([^{}]*)\}\)/g;
+  const currentAssistantRenderPattern =
+    /\(0,([A-Za-z_$][\w$]*)\.jsx\)\(([A-Za-z_$][\w$]*),\{(?=[^{}]*\bitem:)(?=[^{}]*\bassistantCopyText:)(?=[^{}]*\bconversationId:)([^{}]*)\}\)/g;
   const readProp = (props, name) =>
     new RegExp(`(?:^|,)${name}:([A-Za-z_$][\\w$]*)`).exec(props)?.[1] ?? null;
-  const patched = source.replace(
-    jsxCallPattern,
+  const patchMatchingRenderCalls = (pattern) => source.replace(
+    pattern,
     (match, jsxVar, _component, props) => {
       const itemVar = readProp(props, "item");
       const copyVar = readProp(props, "assistantCopyText");
@@ -180,8 +182,12 @@ function applyAssistantRenderPatch(source) {
       return `(0,${jsxVar}.jsxs)(${jsxVar}.Fragment,{children:[${match},${readAloudButtonRowSource(jsxVar, itemVar, copyVar, conversationVar, "e")}]})`;
     },
   );
-  if (patched !== source) {
-    return patched;
+  const patched = patchMatchingRenderCalls(jsxCallPattern);
+  const patchedCurrent = patched === source
+    ? patchMatchingRenderCalls(currentAssistantRenderPattern)
+    : patched;
+  if (patchedCurrent !== source) {
+    return patchedCurrent;
   }
 
   if (ASSISTANT_RENDER_CANDIDATE_PATTERN.test(source)) {
@@ -793,7 +799,8 @@ module.exports = {
       phase: "webview-asset",
       order: 20620,
       ciPolicy: "optional",
-      pattern: /^app-initial-[A-Za-z0-9_-]+\.js$/,
+      pattern: /^(?:app-initial|local-conversation-turn)-(?!current\.js$)[A-Za-z0-9_-]+\.js$/,
+      assetMatch: (source) => ASSISTANT_RENDER_CANDIDATE_PATTERN.test(source),
       missingDescription: "current primary thread assistant bundle",
       skipDescription: "read aloud assistant runtime patch",
       apply: applyWebviewPatch,

--- a/linux-features/read-aloud/test.js
+++ b/linux-features/read-aloud/test.js
@@ -1008,12 +1008,27 @@ test("assistant render patch covers the current shared assistant message call", 
   assert.match(patched, /globalThis\.codexLinuxReadAloudClick\?\.\(n,b,d,e\.currentTarget\)/);
 });
 
+test("assistant render patch covers the current local conversation turn call", () => {
+  const source = "return (0,$.jsx)(Rr,{item:B,historyEntityKey:o,isHeartbeatAutomationRequest:qe.some(e=>e.heartbeatTrigger!=null),isHeartbeatAutomationTurn:p?.automationKind===`heartbeat`,conversationId:r,getVisualizeTurnTriggerType:Ae,hostId:a,conversationDetailLevel:I,isTurnInProgress:P,cwd:b,resolvedApps:k,renderMcpApps:L,reportEntityType:A,toolActivityTurnKey:F,turnId:Ut??void 0,projectlessOutputDirectory:P?null:E,assistantCopyText:Pt??void 0,assistantAfter:ir,autoReviewStats:Kt,hookStats:qt,completedThreadGoal:j,hasArtifacts:tr,alwaysShowAssistantMessageActions:C,showAssistantMessageActionRow:n==null&&!An&&!Bt.hasPendingItems,allowAddSelectedTextToChat:!w,onAssistantFileLinkOpen:zt,onForkTurn:ue})";
+  const patched = twice(applyAssistantRenderPatch, source);
+
+  assert.match(patched, /\$\.Fragment/);
+  assert.match(patched, /\(0,\$\.jsx\)\("button"/);
+  assert.match(patched, /globalThis\.codexLinuxReadAloudClick\?\.\(B,Pt,r,e\.currentTarget\)/);
+});
+
 test("assistant runtime descriptor targets current shared assistant bundles", () => {
   const descriptor = featurePatches.find((patch) => patch.id === "assistant-runtime");
   assert.ok(descriptor);
   assert.equal(
     descriptor.pattern.test(
       "app-initial-BHB6SClA.js",
+    ),
+    true,
+  );
+  assert.equal(
+    descriptor.pattern.test(
+      "local-conversation-turn-DF8fx5gl.js",
     ),
     true,
   );
@@ -1050,7 +1065,7 @@ test("assistant runtime descriptor fails soft and atomically when the current re
     assert.equal(fs.readFileSync(assetPath, "utf8"), source);
     assert.equal(report.patches.length, 1);
     assert.equal(report.patches[0].status, "skipped-optional");
-    assert.match(report.patches[0].reason, /Could not find assistant message render call/);
+    assert.match(report.patches[0].reason, /Could not find current primary thread assistant bundle/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/updater/src/liveness.rs
+++ b/updater/src/liveness.rs
@@ -59,8 +59,19 @@ fn scan_proc_for_executable(expected: &Path) -> Result<bool> {
 fn process_matches(pid: u32, expected: &Path) -> bool {
     is_process_alive(pid)
         && read_exe_link(pid)
-            .map(|path| path == expected)
+            .map(|path| executable_paths_match(&path, expected))
             .unwrap_or(false)
+}
+
+fn executable_paths_match(actual: &Path, expected: &Path) -> bool {
+    if actual == expected {
+        return true;
+    }
+
+    actual
+        .to_str()
+        .and_then(|path| path.strip_suffix(" (deleted)"))
+        .is_some_and(|path| path == expected.to_string_lossy())
 }
 
 fn is_process_alive(pid: u32) -> bool {
@@ -106,5 +117,17 @@ mod tests {
             &config.app_executable_path
         ));
         Ok(())
+    }
+
+    #[test]
+    fn replaced_electron_executable_still_matches_managed_path() {
+        let actual = Path::new("/opt/codex-desktop/electron (deleted)");
+        let expected = Path::new("/opt/codex-desktop/electron");
+
+        assert!(executable_paths_match(actual, expected));
+        assert!(!executable_paths_match(
+            Path::new("/opt/other/electron (deleted)"),
+            expected,
+        ));
     }
 }


### PR DESCRIPTION
[Local Agent]\n\n## Summary\n- update the read-aloud feature matcher for the current local-conversation-turn bundle and select the matching asset semantically\n- detect a still-running Electron process whose executable was replaced during package installation\n\n## Root cause\nThe cached upstream DMG moved the assistant render call from app-initial into local-conversation-turn, causing the enabled read-aloud feature to be silently omitted by acceptance. Replacing /opt/codex-desktop/electron exposes the existing process as a deleted executable in proc, which made diagnostics report the app as stopped.\n\n## Validation\n- 60 read-aloud tests passed\n- 428 patcher tests passed\n- targeted updater liveness tests passed\n- real DMG required-patch acceptance passed with warnings; read-aloud applied and integrity findings were 0\n- installed and verified locally as 2026.08.11.220000+d9e0901\n\nThe only build warning is the existing optional Browser Use external availability drift.