### PR TITLE
Fix Nix libGL runtime dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,8 +42,8 @@
         };
         runtimeLibraries = with pkgs; [
           alsa-lib atk at-spi2-atk at-spi2-core cairo cups dbus expat
-          gdk-pixbuf glib graphite2 gtk3 libdrm libgbm libnotify libusb1 libxkbcommon
-          mesa nspr nss openssl pango systemd stdenv.cc.cc.lib wayland xz
+          gdk-pixbuf glib graphite2 gtk3 libdrm libgbm libglvnd libnotify libusb1
+          libxkbcommon mesa nspr nss openssl pango systemd stdenv.cc.cc.lib wayland xz
           libX11 libXcomposite libXdamage libXext libXfixes libXrandr
           libxcb libxcrypt-legacy zlib
         ];

--- a/scripts/lib/package-common.test.js
+++ b/scripts/lib/package-common.test.js
@@ -77,7 +77,7 @@ test("non-Debian package formats map the official runtime libraries", () => {
     assert.match(pacman, new RegExp(`'${packageName}'`));
   }
   assert.match(rpm, /Requires:.*\bxz\b/);
-  for (const packageName of ["graphite2", "openssl", "xz"]) {
+  for (const packageName of ["graphite2", "libglvnd", "openssl", "xz"]) {
     assert.match(flake, new RegExp(`\\b${packageName}\\b`));
   }
 });


### PR DESCRIPTION
## Summary
- add `libglvnd` to the Nix runtime library closure so Electron can load `libGL.so.1`
- cover the dependency in the existing non-Debian runtime mapping test

Fixes #1320

## Tests
- `node --test scripts/lib/package-common.test.js`
- `scripts/ci/validate-nix-pins.sh`
- `bash tests/scripts_smoke.sh`
- `node --test scripts/lib/upstream-linux-package.test.js`
- shell syntax checks for install, launcher, package, and library scripts
- `git diff --check`

## Notes
- Local Nix execution was unavailable because `nix` is not installed on the development host; the GitHub Nix job validates the flake.