### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           bash -n scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh
       - name: Node tests
         run: |
+          node --test scripts/ci/*.test.js
           node --test scripts/lib/upstream-linux-package.test.js
           node --test scripts/lib/package-common.test.js
           node --check scripts/ci/verify-official-linux-features.js

--- a/.github/workflows/install-deps.yml
+++ b/.github/workflows/install-deps.yml
@@ -16,10 +16,14 @@ on:
       - packaging/linux/control
       - .github/workflows/install-deps.yml
 
+permissions:
+  contents: read
+
 jobs:
   apt-node-bootstrap:
     name: ${{ matrix.image }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: ${{ matrix.image }}
       options: --user root
@@ -33,7 +37,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Bootstrap sudo
         run: |

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -1,26 +1,8 @@
 name: Official Linux package build
 
 on:
-  schedule:
-    - cron: '30 * * * *'
   workflow_dispatch:
   pull_request:
-    paths:
-      - install.sh
-      - Makefile
-      - assets/openai-codex-linux-repository-key.gpg.base64
-      - launcher/**
-      - scripts/build-*.sh
-      - scripts/lib/package-common.sh
-      - scripts/lib/upstream-linux-package.*
-      - scripts/automation/upstream-linux-package-watchdog/**
-      - scripts/patches/**
-      - linux-features/**
-      - packaging/**
-      - updater/**
-      - flake.nix
-      - nix/**
-      - .github/workflows/upstream-build-app.yml
   push:
     branches: [main]
     paths:
@@ -38,6 +20,7 @@ on:
       - updater/**
       - flake.nix
       - nix/**
+      - .github/workflows/upstream-build-app.yml
 
 permissions:
   contents: read
@@ -101,6 +84,7 @@ jobs:
         with:
           name: official-linux-${{ matrix.architecture }}-metadata
           path: upstream/${{ matrix.architecture }}.json
+          retention-days: 7
 
   package-matrix:
     needs: signed-baseline
@@ -141,3 +125,22 @@ jobs:
         with:
           node-version: 24
       - run: node scripts/automation/upstream-linux-package-watchdog/watchdog.js --json
+
+  official-linux-gate:
+    if: ${{ always() }}
+    needs:
+      - signed-baseline
+      - package-matrix
+      - watchdog
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every official Linux validation job
+        env:
+          SIGNED_BASELINE_RESULT: ${{ needs.signed-baseline.result }}
+          PACKAGE_MATRIX_RESULT: ${{ needs.package-matrix.result }}
+          WATCHDOG_RESULT: ${{ needs.watchdog.result }}
+        run: |
+          test "$SIGNED_BASELINE_RESULT" = success
+          test "$PACKAGE_MATRIX_RESULT" = success
+          test "$WATCHDOG_RESULT" = success

--- a/scripts/ci/github-actions-runtime.test.js
+++ b/scripts/ci/github-actions-runtime.test.js
@@ -9,16 +9,13 @@ const workflowsDir = path.join(repoRoot, ".github/workflows");
 const approvedNode24Actions = new Set([
   "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
   "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-  "actions/checkout@v7",
   "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131",
   "actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71",
-  "actions/github-script@v9",
   "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
-  "actions/setup-node@v7",
   "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
 ]);
 
-test("workflows use approved Node 24 first-party actions", () => {
+test("workflows pin external actions and use approved Node 24 first-party actions", () => {
   const workflowNames = fs
     .readdirSync(workflowsDir)
     .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
@@ -37,12 +34,23 @@ test("workflows use approved Node 24 first-party actions", () => {
       `${workflowName} must not force an action onto a runtime it does not declare`,
     );
 
-    for (const match of workflow.matchAll(
-      /uses:\s*(actions\/(?:cache|checkout|download-artifact|github-script|setup-node|upload-artifact)@[^\s#]+)/g,
-    )) {
-      actionCount += 1;
-      if (!approvedNode24Actions.has(match[1])) {
-        unapproved.push(`${workflowName}: ${match[1]}`);
+    for (const match of workflow.matchAll(/uses:\s*([^\s#]+)/g)) {
+      const action = match[1];
+      if (action.startsWith("./") || action.startsWith("docker://")) continue;
+
+      const separator = action.lastIndexOf("@");
+      const ref = separator === -1 ? "" : action.slice(separator + 1);
+      assert.match(
+        ref,
+        /^[0-9a-f]{40}$/,
+        `${workflowName}: ${action} must use a full commit SHA`,
+      );
+
+      if (action.startsWith("actions/")) {
+        actionCount += 1;
+        if (!approvedNode24Actions.has(action)) {
+          unapproved.push(`${workflowName}: ${action}`);
+        }
       }
     }
   }

--- a/scripts/ci/github-actions-runtime.test.js
+++ b/scripts/ci/github-actions-runtime.test.js
@@ -15,6 +15,60 @@ const approvedNode24Actions = new Set([
   "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
 ]);
 
+function pinnedExternalActions(workflow, workflowName) {
+  const actions = [];
+
+  for (const [index, line] of workflow.split("\n").entries()) {
+    const usesKey = /(?:^|[{,])[ \t]*(?:-[ \t]*)?(?:"uses"|'uses'|uses)[ \t]*:/g;
+    const explicitUsesKey = /^[ \t]*\?[ \t]*(?:"uses"|'uses'|uses)[ \t]*$/;
+    if (!usesKey.test(line) && !explicitUsesKey.test(line)) continue;
+
+    const canonical = line.match(
+      /^[ \t]*(?:-[ \t]*)?uses:[ \t]+([^\s#]+)(?:[ \t]+#.*)?$/,
+    );
+    assert.ok(
+      canonical,
+      `${workflowName}:${index + 1} must use canonical "uses: owner/action@commit" syntax`,
+    );
+
+    const action = canonical[1];
+    if (action.startsWith("./") || action.startsWith("docker://")) continue;
+
+    const separator = action.lastIndexOf("@");
+    const ref = separator === -1 ? "" : action.slice(separator + 1);
+    assert.match(
+      ref,
+      /^[0-9a-f]{40}$/,
+      `${workflowName}:${index + 1}: ${action} must use a full commit SHA`,
+    );
+    actions.push(action);
+  }
+
+  return actions;
+}
+
+test("pinning validation rejects tags, branches, and noncanonical YAML keys", () => {
+  const validSha = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0";
+  assert.deepEqual(
+    pinnedExternalActions(`      - uses: actions/checkout@${validSha}`, "fixture.yml"),
+    [`actions/checkout@${validSha}`],
+  );
+
+  for (const invalid of [
+    "      - uses: actions/checkout@v7",
+    "      - uses: actions/checkout@main",
+    "      - uses : actions/checkout@v7",
+    "      - \"uses\": actions/checkout@v7",
+    "      - {'uses': actions/checkout@v7}",
+    "      ? uses\n      : actions/checkout@v7",
+  ]) {
+    assert.throws(
+      () => pinnedExternalActions(invalid, "fixture.yml"),
+      /full commit SHA|canonical/,
+    );
+  }
+});
+
 test("workflows pin external actions and use approved Node 24 first-party actions", () => {
   const workflowNames = fs
     .readdirSync(workflowsDir)
@@ -34,18 +88,7 @@ test("workflows pin external actions and use approved Node 24 first-party action
       `${workflowName} must not force an action onto a runtime it does not declare`,
     );
 
-    for (const match of workflow.matchAll(/uses:\s*([^\s#]+)/g)) {
-      const action = match[1];
-      if (action.startsWith("./") || action.startsWith("docker://")) continue;
-
-      const separator = action.lastIndexOf("@");
-      const ref = separator === -1 ? "" : action.slice(separator + 1);
-      assert.match(
-        ref,
-        /^[0-9a-f]{40}$/,
-        `${workflowName}: ${action} must use a full commit SHA`,
-      );
-
+    for (const action of pinnedExternalActions(workflow, workflowName)) {
       if (action.startsWith("actions/")) {
         actionCount += 1;
         if (!approvedNode24Actions.has(action)) {

--- a/scripts/ci/github-actions-workflows.test.js
+++ b/scripts/ci/github-actions-workflows.test.js
@@ -52,10 +52,26 @@ test("official Linux metadata expires after seven days", () => {
 test("official Linux gate fails closed unless every dependency succeeds", () => {
   const workflow = read(".github/workflows/upstream-build-app.yml");
   const gate = job(workflow, "official-linux-gate");
-  assert.match(gate, /if: \$\{\{ always\(\) \}\}/);
-  for (const dependency of ["signed-baseline", "package-matrix", "watchdog"]) {
-    assert.match(gate, new RegExp(`^      - ${dependency}$`, "m"));
-    assert.match(gate, new RegExp(`needs\\.${dependency}\\.result`));
+  assert.match(
+    gate,
+    /^  official-linux-gate:\n    if: \$\{\{ always\(\) \}\}\n    needs:\n      - signed-baseline\n      - package-matrix\n      - watchdog\n    runs-on:/,
+  );
+
+  for (const [dependency, resultVariable] of [
+    ["signed-baseline", "SIGNED_BASELINE_RESULT"],
+    ["package-matrix", "PACKAGE_MATRIX_RESULT"],
+    ["watchdog", "WATCHDOG_RESULT"],
+  ]) {
+    assert.match(
+      gate,
+      new RegExp(
+        `^          ${resultVariable}: \\$\\{\\{ needs\\.${dependency}\\.result \\}\\}$`,
+        "m",
+      ),
+    );
+    assert.match(
+      gate,
+      new RegExp(`^          test "\\$${resultVariable}" = success$`, "m"),
+    );
   }
-  assert.equal((gate.match(/= success/g) || []).length, 3);
 });

--- a/scripts/ci/github-actions-workflows.test.js
+++ b/scripts/ci/github-actions-workflows.test.js
@@ -1,0 +1,61 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function job(workflow, jobName) {
+  const lines = workflow.split("\n");
+  const start = lines.findIndex((line) => line === `  ${jobName}:`);
+  assert.notEqual(start, -1, `expected ${jobName} job`);
+  const end = lines.findIndex(
+    (line, index) => index > start && /^  [a-zA-Z0-9_-]+:$/.test(line),
+  );
+  return lines.slice(start, end === -1 ? undefined : end).join("\n");
+}
+
+test("CI runs the complete workflow regression suite", () => {
+  const workflow = read(".github/workflows/ci.yml");
+  assert.match(workflow, /node --test scripts\/ci\/\*\.test\.js/);
+});
+
+test("official Linux validation runs fully on every pull request but not hourly", () => {
+  const workflow = read(".github/workflows/upstream-build-app.yml");
+  assert.doesNotMatch(workflow, /^  schedule:/m);
+  assert.match(workflow, /^  pull_request:\s*\n  push:/m);
+  assert.match(workflow, /^      - \.github\/workflows\/upstream-build-app\.yml$/m);
+  assert.match(job(workflow, "signed-baseline"), /architecture: \[amd64, arm64\]/);
+
+  const packageMatrix = job(workflow, "package-matrix");
+  assert.match(packageMatrix, /architecture: amd64/);
+  assert.match(packageMatrix, /architecture: arm64/);
+  assert.match(packageMatrix, /\.\/scripts\/build-deb\.sh/);
+  assert.match(packageMatrix, /\.\/scripts\/build-rpm\.sh/);
+  assert.match(packageMatrix, /\.\/scripts\/build-pacman\.sh/);
+  assert.match(packageMatrix, /\.\/scripts\/build-appimage\.sh/);
+});
+
+test("official Linux metadata expires after seven days", () => {
+  const workflow = read(".github/workflows/upstream-build-app.yml");
+  const signedBaseline = job(workflow, "signed-baseline");
+  assert.match(signedBaseline, /name: official-linux-\$\{\{ matrix\.architecture \}\}-metadata/);
+  assert.match(signedBaseline, /retention-days: 7/);
+});
+
+test("official Linux gate fails closed unless every dependency succeeds", () => {
+  const workflow = read(".github/workflows/upstream-build-app.yml");
+  const gate = job(workflow, "official-linux-gate");
+  assert.match(gate, /if: \$\{\{ always\(\) \}\}/);
+  for (const dependency of ["signed-baseline", "package-matrix", "watchdog"]) {
+    assert.match(gate, new RegExp(`^      - ${dependency}$`, "m"));
+    assert.match(gate, new RegExp(`needs\\.${dependency}\\.result`));
+  }
+  assert.equal((gate.match(/= success/g) || []).length, 3);
+});


### PR DESCRIPTION
Summary
- Run the full workflow regression suite in CI and require commit-SHA pinning for external actions.
- Run the complete official Linux matrix on every PR, move hourly work to the signed pin poll, and add a fail-closed official-linux-gate.
- Harden dependency-install permissions/timeouts and retain official metadata for seven days.

Tests/checks
- node --test scripts/ci/*.test.js
- watchdog, package-common, and upstream package tests
- shell syntax checks and tests/scripts_smoke.sh
- git diff --check

Notes
- Nix validation remains covered by GitHub CI because Nix is not installed locally.
- Required-check ruleset migration and legacy Actions cleanup are separate repository settings operations performed only after the new contexts appear and the PR is merged.