### PR TITLE
Restore Dock icon on the official Linux package

### DIFF
--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -117,6 +117,79 @@ jobs:
           PACMAN_STAGE_ONLY=1 ./scripts/build-pacman.sh
           APPIMAGE_STAGE_ONLY=1 ./scripts/build-appimage.sh
 
+  dock-icon-feature-alone:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dpkg-dev gnupg
+      - name: Build Dock icon feature alone from the signed package
+        env:
+          CODEX_LINUX_FEATURES_CONFIG: ${{ github.workspace }}/dock-icon-features.json
+          CODEX_INSTALL_DIR: ${{ github.workspace }}/codex-app-dock-icon
+          CODEX_PATCH_REPORT_JSON: ${{ github.workspace }}/dock-icon-report/patch-report.json
+          CODEX_TARGET_ARCH: amd64
+        run: |
+          set -euo pipefail
+          cat > "$CODEX_LINUX_FEATURES_CONFIG" <<'JSON'
+          {
+            "enabled": ["ui-tweaks"],
+            "settings": {
+              "ui-tweaks": {
+                "tweaks": {
+                  "appearance": {
+                    "dockIcon": { "enabled": true }
+                  }
+                }
+              }
+            }
+          }
+          JSON
+          mkdir -p upstream
+          package="$(node scripts/lib/upstream-linux-package.js \
+            --output-dir upstream/amd64 \
+            --metadata upstream/amd64.json \
+            --key-base64 assets/openai-codex-linux-repository-key.gpg.base64 \
+            --arch amd64)"
+          ./install.sh "$package"
+          node scripts/ci/validate-patch-report.js "$CODEX_PATCH_REPORT_JSON" \
+            --require-enabled-feature ui-tweaks \
+            --require-applied feature:ui-tweaks:appearance-dock-icon-main-process \
+            --require-applied feature:ui-tweaks:appearance-dock-icon-settings-row
+          node - "$CODEX_PATCH_REPORT_JSON" <<'NODE'
+          const fs = require("node:fs");
+          const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const dock = report.patches.filter(({ name }) => name.includes(":appearance-dock-icon-"));
+          if (dock.length !== 2 || dock.some(({ status }) => status !== "applied")) {
+            throw new Error(`Expected Dock descriptors 2/2 applied, got ${JSON.stringify(dock)}`);
+          }
+          NODE
+          payload="$CODEX_INSTALL_DIR/resources/dock-icon"
+          diff -u <(printf '%s\n' \
+            icon-chatgpt.png \
+            icon-codex-dark-color.png \
+            icon-codex-light.png \
+            sync-desktop-icon.sh | sort) \
+            <(find "$payload" -mindepth 1 -maxdepth 1 -type f -printf '%f\n' | sort)
+          upstream_root="$(mktemp -d)"
+          dpkg-deb -x "$package" "$upstream_root"
+          cmp "$upstream_root/usr/lib/chatgpt/resources/icon-chatgpt.png" "$payload/icon-chatgpt.png"
+          cmp assets/codex-linux.png "$payload/icon-codex-dark-color.png"
+          cmp assets/codex-linux.png "$payload/icon-codex-light.png"
+          cmp linux-features/ui-tweaks/sync-desktop-icon.sh "$payload/sync-desktop-icon.sh"
+          test -x "$payload/sync-desktop-icon.sh"
+          hook="$CODEX_INSTALL_DIR/.codex-linux/prelaunch.d/ui-tweaks-dock-icon-cleanup.sh"
+          cmp linux-features/ui-tweaks/sync-desktop-icon.sh "$hook"
+          test -x "$hook"
+
   watchdog:
     runs-on: ubuntu-latest
     steps:
@@ -131,6 +204,7 @@ jobs:
     needs:
       - signed-baseline
       - package-matrix
+      - dock-icon-feature-alone
       - watchdog
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -139,8 +213,10 @@ jobs:
         env:
           SIGNED_BASELINE_RESULT: ${{ needs.signed-baseline.result }}
           PACKAGE_MATRIX_RESULT: ${{ needs.package-matrix.result }}
+          DOCK_ICON_FEATURE_ALONE_RESULT: ${{ needs.dock-icon-feature-alone.result }}
           WATCHDOG_RESULT: ${{ needs.watchdog.result }}
         run: |
           test "$SIGNED_BASELINE_RESULT" = success
           test "$PACKAGE_MATRIX_RESULT" = success
+          test "$DOCK_ICON_FEATURE_ALONE_RESULT" = success
           test "$WATCHDOG_RESULT" = success

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -178,7 +178,15 @@ jobs:
             icon-codex-dark-color.png \
             icon-codex-light.png \
             sync-desktop-icon.sh | sort) \
-            <(find "$payload" -mindepth 1 -maxdepth 1 -type f -printf '%f\n' | sort)
+            <(find "$payload" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)
+          for resource in \
+            icon-chatgpt.png \
+            icon-codex-dark-color.png \
+            icon-codex-light.png \
+            sync-desktop-icon.sh; do
+            test -f "$payload/$resource"
+            test ! -L "$payload/$resource"
+          done
           upstream_root="$(mktemp -d)"
           dpkg-deb -x "$package" "$upstream_root"
           cmp "$upstream_root/usr/lib/chatgpt/resources/icon-chatgpt.png" "$payload/icon-chatgpt.png"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- The opt-in Dock icon tweak is restored for the signed official Linux package,
+  using its ChatGPT icon and desktop metadata while preserving ChatGPT
+  Community window, tray, and managed launcher synchronization.
 - Native remote-mobile builds now route side-by-side `--new-instance` launches
   through the normal single-instance handoff, preventing competing Desktop
   Remote Control owners. Nix module sessions instead proxy every Desktop

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
         ];
         runtimeLibraryPath = lib.makeLibraryPath runtimeLibraries;
         runtimePath = lib.makeBinPath (with pkgs; [
-          bash coreutils findutils gnugrep gnused nodejs python3 systemd xdg-utils
+          bash coreutils findutils gnugrep gnused nodejs python3 systemd util-linux xdg-utils
         ]);
         emptyFeaturesConfig = pkgs.writeText "empty-features.json" ''{"enabled":[]}'';
 

--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -65,7 +65,8 @@ payload. The desktop helper writes only a full-state-hash-owned launcher derived
 from an identity-matching packaged entry. AppImage launch commands are rewritten
 to the persistent AppImage path instead of the temporary mounted `AppRun`.
 The prelaunch hook removes only an unchanged managed override after the nested
-tweak is disabled; any user edit preserves the launcher and its icons.
+tweak is disabled. Desktop entries and icon files have separate content-hash
+ownership proofs, so any user edit or pre-existing icon preserves that resource.
 
 This tweak is independently disabled by default:
 

--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -65,8 +65,10 @@ payload. The desktop helper writes only a full-state-hash-owned launcher derived
 from an identity-matching packaged entry. AppImage launch commands are rewritten
 to the persistent AppImage path instead of the temporary mounted `AppRun`.
 The prelaunch hook removes only an unchanged managed override after the nested
-tweak is disabled. Desktop entries and icon files have separate content-hash
-ownership proofs, so any user edit or pre-existing icon preserves that resource.
+tweak is disabled. Desktop entries carry a full-content digest, while icon files
+use content-addressed names whose digest must match their bytes. Any user edit or
+pre-existing conflicting icon is preserved, and interrupted sync or cleanup can
+resume without a separate ownership sidecar.
 
 This tweak is independently disabled by default:
 

--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -68,7 +68,9 @@ The prelaunch hook removes only an unchanged managed override after the nested
 tweak is disabled. Desktop entries carry a full-content digest, while icon files
 use content-addressed names whose digest must match their bytes. Any user edit or
 pre-existing conflicting icon is preserved, and interrupted sync or cleanup can
-resume without a separate ownership sidecar.
+resume without a separate ownership sidecar. A per-app lock serializes runtime
+updates, and later runs remove only digest-verified orphan icons from the three
+feature-owned selection namespaces.
 
 This tweak is independently disabled by default:
 

--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -89,6 +89,13 @@ Config keys:
 - `enabled`: `true` applies the two current official-package Dock descriptors
   and stages their resources. `false` leaves official Linux behavior unchanged.
 
+To remove `ui-tweaks` after using a custom Dock icon, first keep the feature
+enabled, set `appearance.dockIcon.enabled` to `false`, rebuild and install, and
+launch the app once. That launch lets the marker-safe prelaunch hook remove its
+managed desktop override and icons. The feature can then be removed from the
+next rebuild. Removing `ui-tweaks` directly does not run feature-owned local
+cleanup, by design.
+
 ### `home.suggestedPrompts`
 
 Exposes the upstream Suggested Prompts row in General Settings and enables the

--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -59,11 +59,13 @@ signed official Linux package. The alternate choice uses the existing ChatGPT
 Community package icon; retired macOS DMG icon resources are not imported.
 
 Staging validates the official package's `chatgpt.desktop` identity before it
-copies the ChatGPT icon. Missing or changed package resources leave the Dock
-payload absent and emit a warning. The desktop helper writes only a
-marker-owned launcher derived from an identity-matching packaged entry, and the
-prelaunch hook removes only that managed override after the nested tweak is
-disabled.
+copies the ChatGPT icon. Missing or changed package resources reject the
+candidate so an enabled Dock tweak cannot be installed without its runtime
+payload. The desktop helper writes only a full-state-hash-owned launcher derived
+from an identity-matching packaged entry. AppImage launch commands are rewritten
+to the persistent AppImage path instead of the temporary mounted `AppRun`.
+The prelaunch hook removes only an unchanged managed override after the nested
+tweak is disabled; any user edit preserves the launcher and its icons.
 
 This tweak is independently disabled by default:
 
@@ -194,11 +196,12 @@ Config keys:
 
 ## Drift Behavior
 
-The patches are fail-soft. If upstream bundle markers drift, the feature writes
-a `WARN` message and leaves the asset unchanged. The patch report exposes that
-warning, and acceptance rejects a candidate when the enabled feature has drifted.
-Missing Dock icon package resources or metadata also warn, remove only the Dock
-icon payload, and do not abort staging. Suggested Prompts validates every current insertion point
+The ASAR patches are fail-soft. If upstream bundle markers drift, the feature
+writes a `WARN` message and leaves the asset unchanged. The patch report exposes
+that warning, and acceptance rejects a candidate when the enabled feature has
+drifted. Missing Dock icon package resources or metadata fail the stage hook,
+remove only the incomplete Dock icon payload, and reject candidate promotion.
+Suggested Prompts validates every current insertion point
 before changing an asset and leaves mixed or drifted input byte-identical.
 Invalid style values warn and fall back to the default bold style.
 

--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -17,6 +17,7 @@ Enable it in the local, gitignored feature config:
 
 | Tweak | Patch module | What it does | Settings |
 | --- | --- | --- | --- |
+| `appearance.dockIcon` | `patches/dock-icon.js` | Exposes the upstream Dock icon selector and synchronizes the selected icon across Linux windows, tray, and supported desktop launchers. | `tweaks.appearance.dockIcon.enabled` |
 | `home.suggestedPrompts` | `patches/suggested-prompts.js` | Exposes the upstream Suggested Prompts setting and enables generated project-aware cards on Home. | `tweaks.home.suggestedPrompts.enabled` |
 | `modelPicker.showModelsByDefault` | `patches/model-picker-model-list.js` | Opens the advanced picker by default and shows model choices inline instead of hiding them behind the compact Power slider and a nested Model submenu. | `tweaks.modelPicker.showModelsByDefault.enabled` |
 | `reasoning.keepEffortLabelsEnglish` | `patches/reasoning-effort-labels.js` | Keeps reasoning effort values in English in the Simplified Chinese UI while leaving the surrounding interface translated. | `tweaks.reasoning.keepEffortLabelsEnglish.enabled` |
@@ -48,6 +49,45 @@ Example local config:
 ```
 
 Each tweak documents its own config keys below.
+
+### `appearance.dockIcon`
+
+Exposes the upstream Appearance row on Linux and applies the selection to
+existing and newly registered windows, the official Linux tray, and a managed
+user-local desktop entry. The ChatGPT choice uses `icon-chatgpt.png` from the
+signed official Linux package. The alternate choice uses the existing ChatGPT
+Community package icon; retired macOS DMG icon resources are not imported.
+
+Staging validates the official package's `chatgpt.desktop` identity before it
+copies the ChatGPT icon. Missing or changed package resources leave the Dock
+payload absent and emit a warning. The desktop helper writes only a
+marker-owned launcher derived from an identity-matching packaged entry, and the
+prelaunch hook removes only that managed override after the nested tweak is
+disabled.
+
+This tweak is independently disabled by default:
+
+```json
+{
+  "enabled": ["ui-tweaks"],
+  "settings": {
+    "ui-tweaks": {
+      "tweaks": {
+        "appearance": {
+          "dockIcon": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Config keys:
+
+- `enabled`: `true` applies the two current official-package Dock descriptors
+  and stages their resources. `false` leaves official Linux behavior unchanged.
 
 ### `home.suggestedPrompts`
 
@@ -150,8 +190,8 @@ Config keys:
 The patches are fail-soft. If upstream bundle markers drift, the feature writes
 a `WARN` message and leaves the asset unchanged. The patch report exposes that
 warning, and acceptance rejects a candidate when the enabled feature has drifted.
-Missing Dock icon resources also warn, remove only the Dock icon payload, and do
-not abort staging. Suggested Prompts validates every current insertion point
+Missing Dock icon package resources or metadata also warn, remove only the Dock
+icon payload, and do not abort staging. Suggested Prompts validates every current insertion point
 before changing an asset and leaves mixed or drifted input byte-identical.
 Invalid style values warn and fall back to the default bold style.
 

--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -9,7 +9,9 @@ const path = require("node:path");
 const test = require("node:test");
 
 const {
+  enabledLinuxFeatureInstallPlan,
   loadLinuxFeaturePatchDescriptors,
+  stageEnabledLinuxFeatureInstall,
 } = require("../../scripts/lib/linux-features.js");
 const { patchUniqueAssetFile } = require("../../scripts/patches/lib/assets.js");
 const {
@@ -123,6 +125,47 @@ test("Dock icon descriptors remain disabled until the nested tweak is enabled", 
     assert.equal(dockDescriptors.every((descriptor) => descriptor.enabled({}) === true), true);
   });
   assert.equal(dockIconEnabled({}), false);
+});
+
+test("ui-tweaks keeps the Dock cleanup hook staged while the nested tweak is disabled", () => {
+  const featuresRoot = path.resolve(__dirname, "..");
+  withFeatureConfig(dockConfig(false), () => {
+    const plan = enabledLinuxFeatureInstallPlan({ featuresRoot });
+    assert.deepEqual(
+      plan.runtimeHooks.map((hook) => [
+        hook.id,
+        hook.key,
+        path.relative(featuresRoot, hook.source),
+        hook.target,
+        hook.mode,
+      ]),
+      [[
+        "ui-tweaks",
+        "prelaunch",
+        path.join("ui-tweaks", "sync-desktop-icon.sh"),
+        ".codex-linux/prelaunch.d/ui-tweaks-dock-icon-cleanup.sh",
+        0o755,
+      ]],
+    );
+
+    const appDir = fs.mkdtempSync(path.join(os.tmpdir(), "dock-icon-hook-stage-"));
+    try {
+      stageEnabledLinuxFeatureInstall(appDir, { featuresRoot });
+      const hook = path.join(
+        appDir,
+        ".codex-linux",
+        "prelaunch.d",
+        "ui-tweaks-dock-icon-cleanup.sh",
+      );
+      assert.equal(
+        fs.readFileSync(hook, "utf8"),
+        fs.readFileSync(path.join(__dirname, "sync-desktop-icon.sh"), "utf8"),
+      );
+      assert.equal(fs.statSync(hook).mode & 0o777, 0o755);
+    } finally {
+      fs.rmSync(appDir, { recursive: true, force: true });
+    }
+  });
 });
 
 test("main patch restores official previews and synchronizes Linux windows and tray", () => {
@@ -288,62 +331,262 @@ test("nested disable leaves no Dock payload", () => {
   }
 });
 
-test("desktop synchronization updates and cleans up only its managed launcher", () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dock-icon-desktop-"));
-  const dataHome = path.join(root, "share");
-  const source = path.join(root, "codex-desktop.desktop");
-  const helper = path.join(__dirname, "sync-desktop-icon.sh");
-  const appDir = path.join(root, "app");
-  fs.mkdirSync(path.join(appDir, "resources", "dock-icon"), { recursive: true });
-  fs.copyFileSync(helper, path.join(appDir, "resources", "dock-icon", "sync-desktop-icon.sh"));
+function createDesktopSyncFixture() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dock-icon-desktop-"));
+  const dataHome = path.join(tempDir, "data");
+  const sourceDesktop = path.join(tempDir, "codex-desktop.desktop");
+  const firstIcon = path.join(tempDir, "first.png");
+  const secondIcon = path.join(tempDir, "second.png");
+  const binDir = path.join(tempDir, "bin");
+  const callsPath = path.join(tempDir, "calls.log");
+  fs.mkdirSync(binDir, { recursive: true });
   fs.writeFileSync(
-    source,
+    sourceDesktop,
     "[Desktop Entry]\nName=ChatGPT Community\nExec=/usr/bin/codex-desktop %u\nIcon=codex-desktop\nStartupWMClass=codex-desktop\n",
   );
-  try {
-    const sync = childProcess.spawnSync("bash", [helper, "chatgpt"], {
-      input: Buffer.from("selected-icon"),
-      env: {
-        ...process.env,
-        CODEX_LINUX_DESKTOP_FILE_SOURCE: source,
-        XDG_DATA_HOME: dataHome,
-      },
-    });
-    assert.equal(sync.status, 0, sync.stderr?.toString());
-    const desktop = path.join(dataHome, "applications", "codex-desktop.desktop");
-    assert.match(fs.readFileSync(desktop, "utf8"), /X-Codex-Linux-Dock-Icon=1/);
-    assert.match(fs.readFileSync(desktop, "utf8"), /Icon=.*codex-desktop-dock-chatgpt\.png/);
+  fs.writeFileSync(firstIcon, "first-icon");
+  fs.writeFileSync(secondIcon, "second-icon");
+  const refreshCommand = path.join(binDir, "kbuildsycoca6");
+  fs.writeFileSync(
+    refreshCommand,
+    "#!/usr/bin/env bash\nprintf '%s\\n' kbuildsycoca6 >> \"$CODEX_TEST_CALLS\"\n",
+  );
+  fs.chmodSync(refreshCommand, 0o755);
+  return {
+    callsPath,
+    dataHome,
+    env: {
+      ...process.env,
+      CODEX_LINUX_APP_ID: "codex-desktop",
+      CODEX_LINUX_DESKTOP_FILE_SOURCE: sourceDesktop,
+      CODEX_TEST_CALLS: callsPath,
+      HOME: tempDir,
+      PATH: `${binDir}:${process.env.PATH}`,
+      XDG_CURRENT_DESKTOP: "KDE",
+      XDG_DATA_HOME: dataHome,
+    },
+    firstIcon,
+    managedDesktop: path.join(dataHome, "applications", "codex-desktop.desktop"),
+    managedIcon: (selection, appId = "codex-desktop") =>
+      path.join(
+        dataHome,
+        "icons",
+        "hicolor",
+        "256x256",
+        "apps",
+        `${appId}-dock-${selection}.png`,
+      ),
+    secondIcon,
+    tempDir,
+  };
+}
 
-    fs.rmSync(path.join(appDir, "resources", "dock-icon"), { recursive: true, force: true });
-    const cleanup = childProcess.spawnSync("bash", [helper, appDir], {
+function runDesktopSync(selection, iconPath, env) {
+  return childProcess.spawnSync(
+    "bash",
+    [path.join(__dirname, "sync-desktop-icon.sh"), selection],
+    { encoding: "utf8", env, input: fs.readFileSync(iconPath) },
+  );
+}
+
+function runDesktopCleanup(appDir, env) {
+  return childProcess.spawnSync(
+    "bash",
+    [path.join(__dirname, "sync-desktop-icon.sh"), appDir],
+    {
+      encoding: "utf8",
       env: {
-        ...process.env,
-        CODEX_LINUX_FEATURE_HOOK_PHASE: "prelaunch",
+        ...env,
         CODEX_LINUX_APP_DIR: appDir,
-        XDG_DATA_HOME: dataHome,
+        CODEX_LINUX_FEATURE_HOOK_PHASE: "prelaunch",
       },
-    });
-    assert.equal(cleanup.status, 0, cleanup.stderr?.toString());
-    assert.equal(fs.existsSync(desktop), false);
+    },
+  );
+}
+
+test("desktop synchronization updates a managed KDE launcher atomically", () => {
+  const fixture = createDesktopSyncFixture();
+  try {
+    const first = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
+    assert.equal(first.status, 0, first.stderr);
+    assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), "first-icon");
+    assert.match(fs.readFileSync(fixture.managedDesktop, "utf8"), /^X-Codex-Linux-Dock-Icon=1$/m);
+    assert.deepEqual(fs.readFileSync(fixture.callsPath, "utf8").trim().split("\n"), [
+      "kbuildsycoca6",
+    ]);
+
+    const repeated = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
+    assert.equal(repeated.status, 0, repeated.stderr);
+    assert.deepEqual(fs.readFileSync(fixture.callsPath, "utf8").trim().split("\n"), [
+      "kbuildsycoca6",
+    ]);
+
+    const second = runDesktopSync("codex-dark", fixture.secondIcon, fixture.env);
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(fs.readFileSync(fixture.managedIcon("codex-dark"), "utf8"), "second-icon");
+    assert.match(fs.readFileSync(fixture.managedDesktop, "utf8"), /dock-codex-dark\.png$/m);
   } finally {
-    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
   }
 });
 
-test("desktop synchronization preserves unmanaged launchers", () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dock-icon-unmanaged-"));
-  const dataHome = path.join(root, "share");
-  const desktop = path.join(dataHome, "applications", "codex-desktop.desktop");
-  fs.mkdirSync(path.dirname(desktop), { recursive: true });
-  fs.writeFileSync(desktop, "[Desktop Entry]\nName=Custom\nIcon=custom\n");
+test("desktop synchronization leaves an unmanaged user launcher untouched", () => {
+  const fixture = createDesktopSyncFixture();
   try {
-    const result = childProcess.spawnSync("bash", [path.join(__dirname, "sync-desktop-icon.sh"), "chatgpt"], {
-      input: Buffer.from("selected-icon"),
-      env: { ...process.env, XDG_DATA_HOME: dataHome },
-    });
-    assert.equal(result.status, 0, result.stderr?.toString());
-    assert.equal(fs.readFileSync(desktop, "utf8"), "[Desktop Entry]\nName=Custom\nIcon=custom\n");
+    fs.mkdirSync(path.dirname(fixture.managedDesktop), { recursive: true });
+    fs.writeFileSync(
+      fixture.managedDesktop,
+      "[Desktop Entry]\nName=Custom\nIcon=/tmp/custom.png\n",
+    );
+
+    const result = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      fs.readFileSync(fixture.managedDesktop, "utf8"),
+      "[Desktop Entry]\nName=Custom\nIcon=/tmp/custom.png\n",
+    );
+    assert.equal(fs.existsSync(fixture.managedIcon("chatgpt")), false);
+    assert.equal(fs.existsSync(fixture.callsPath), false);
   } finally {
-    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test("desktop synchronization ignores unknown selections", () => {
+  const fixture = createDesktopSyncFixture();
+  try {
+    const result = runDesktopSync("custom", fixture.firstIcon, fixture.env);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.existsSync(fixture.managedDesktop), false);
+    assert.equal(fs.existsSync(fixture.managedIcon("custom")), false);
+    assert.equal(fs.existsSync(fixture.callsPath), false);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test("prelaunch cleanup removes only marker-owned Dock launcher artifacts", () => {
+  const fixture = createDesktopSyncFixture();
+  const appDir = path.join(fixture.tempDir, "app");
+  try {
+    fs.mkdirSync(appDir, { recursive: true });
+    assert.equal(runDesktopSync("chatgpt", fixture.firstIcon, fixture.env).status, 0);
+    assert.equal(runDesktopSync("codex-dark", fixture.secondIcon, fixture.env).status, 0);
+
+    const cleaned = runDesktopCleanup(appDir, fixture.env);
+
+    assert.equal(cleaned.status, 0, cleaned.stderr);
+    assert.equal(fs.existsSync(fixture.managedDesktop), false);
+    assert.equal(fs.existsSync(fixture.managedIcon("chatgpt")), false);
+    assert.equal(fs.existsSync(fixture.managedIcon("codex-dark")), false);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test("prelaunch cleanup preserves symlinked and customized launcher artifacts", () => {
+  for (const kind of ["symlink", "customized"]) {
+    const fixture = createDesktopSyncFixture();
+    const appDir = path.join(fixture.tempDir, "app");
+    try {
+      fs.mkdirSync(path.dirname(fixture.managedDesktop), { recursive: true });
+      fs.mkdirSync(path.dirname(fixture.managedIcon("chatgpt")), { recursive: true });
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.writeFileSync(fixture.managedIcon("chatgpt"), "unproven-icon");
+      if (kind === "symlink") {
+        const outside = path.join(fixture.tempDir, "outside.desktop");
+        fs.writeFileSync(outside, "[Desktop Entry]\nIcon=outside\nX-Codex-Linux-Dock-Icon=1\n");
+        fs.symlinkSync(outside, fixture.managedDesktop);
+      } else {
+        fs.writeFileSync(
+          fixture.managedDesktop,
+          "[Desktop Entry]\nName=Customized\nIcon=/tmp/custom.png\nX-Codex-Linux-Dock-Icon=1\n",
+        );
+      }
+
+      const cleaned = runDesktopCleanup(appDir, fixture.env);
+
+      assert.equal(cleaned.status, 0, cleaned.stderr);
+      assert.equal(fs.existsSync(fixture.managedDesktop), true);
+      assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), "unproven-icon");
+      assert.equal(fs.existsSync(fixture.callsPath), false);
+    } finally {
+      fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("prelaunch cleanup keeps managed artifacts while the Dock payload is enabled", () => {
+  const fixture = createDesktopSyncFixture();
+  const appDir = path.join(fixture.tempDir, "app");
+  try {
+    assert.equal(runDesktopSync("chatgpt", fixture.firstIcon, fixture.env).status, 0);
+    const payloadHelper = path.join(appDir, "resources", "dock-icon", "sync-desktop-icon.sh");
+    fs.mkdirSync(path.dirname(payloadHelper), { recursive: true });
+    fs.writeFileSync(payloadHelper, "enabled");
+
+    const cleaned = runDesktopCleanup(appDir, fixture.env);
+
+    assert.equal(cleaned.status, 0, cleaned.stderr);
+    assert.equal(fs.existsSync(fixture.managedDesktop), true);
+    assert.equal(fs.existsSync(fixture.managedIcon("chatgpt")), true);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test("desktop synchronization discovers side-by-side launchers after an incompatible BAMF hint", () => {
+  const fixture = createDesktopSyncFixture();
+  try {
+    const appId = "codex-dock-xdg";
+    const dataDir = path.join(fixture.tempDir, "profile", "share");
+    const sourceDir = path.join(dataDir, "applications");
+    fs.mkdirSync(sourceDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sourceDir, `${appId}.desktop`),
+      [
+        "[Desktop Entry]",
+        "Name=Side by side",
+        `Exec=env BAMF_DESKTOP_FILE_HINT=${sourceDir}/${appId}.desktop CHROME_DESKTOP=${appId}.desktop /opt/${appId}/start.sh %u`,
+        `Icon=${appId}`,
+        `StartupWMClass=${appId}`,
+        `X-GNOME-WMClass=${appId}`,
+      ].join("\n"),
+    );
+    delete fixture.env.CODEX_LINUX_DESKTOP_FILE_SOURCE;
+    fixture.env.BAMF_DESKTOP_FILE_HINT = path.join(fixture.tempDir, "codex-desktop.desktop");
+    fixture.env.CODEX_LINUX_APP_ID = appId;
+    fixture.env.XDG_DATA_DIRS = dataDir;
+
+    const result = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
+    const managedDesktop = path.join(fixture.dataHome, "applications", `${appId}.desktop`);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt", appId), "utf8"), "first-icon");
+    assert.match(fs.readFileSync(managedDesktop, "utf8"), /^X-Codex-Linux-Dock-Icon=1$/m);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test("desktop synchronization rejects a default launcher for a side-by-side app id", () => {
+  const fixture = createDesktopSyncFixture();
+  try {
+    const appId = "chatgpt-dock-side";
+    fixture.env.CODEX_LINUX_APP_ID = appId;
+
+    const result = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      fs.existsSync(path.join(fixture.dataHome, "applications", `${appId}.desktop`)),
+      false,
+    );
+    assert.equal(fs.existsSync(fixture.managedIcon("chatgpt", appId)), false);
+    assert.equal(fs.existsSync(fixture.callsPath), false);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
   }
 });

--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const childProcess = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const { patchUniqueAssetFile } = require("../../scripts/patches/lib/assets.js");
+const {
+  applyDockIconMainPatch,
+  applyDockIconSettingsPatch,
+  descriptors,
+  dockIconEnabled,
+} = require("./patches/dock-icon.js");
+
+const currentAppInfoSource = [
+  "function NS(e){return{dark:`icon-codex-dark-color.png`,light:`icon-codex-light.png`}}",
+  "function pae(e,t){if(process.platform!==`darwin`||t==null)return null;let n=NS(e),r=PS(`${MS(e,t)}.png`),i=PS(n.dark),a=PS(n.light);return r==null||i==null||a==null?null:{appDefault:r,codexDark:i,codexLight:a}}",
+  "function PS(e){if(e==null)return null;let t=l.app.isPackaged?(0,p.join)(process.resourcesPath,e):null,n=t!=null&&(0,_.existsSync)(t)?t:(0,p.join)(l.app.getAppPath(),`src`,`icons`,e),r=l.nativeImage.createFromPath(n);return r.isEmpty()?null:r.resize({width:128,height:128,quality:`best`}).toDataURL()}",
+].join("");
+
+const currentRuntimeSource = [
+  "function $Te({appBrand:e,buildFlavor:i,settingsStore:f,repoRoot:g,isMacOS:v,onWindowRegistered:C,disposables:w}){",
+  "let T=(0,p.join)(g,`electron`,`src`,`icons`),E=e=>{if(!l.app.isPackaged)return null;let t=(0,p.join)(process.resourcesPath,e);return(0,_.existsSync)(t)?t:null},",
+  "D=e=>null,O=e=>E(e)??D(e),k=()=>f.get(n.ks.DOCK_ICON_PREFERENCE)??`app-default`,A=()=>O(`${MS(i,e)}.png`),j=process.platform===`linux`?G5(i,e,T):null,M=NS(i),N=()=>l.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?M.dark:M.light,",
+  "P=t=>{if(t===`app-default`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.Sc.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)},",
+  "F=()=>{if(!v)return;let e=k();P(e),dle({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})};",
+  "if(v){F();let e=()=>{let e=k();e===`codex-system`&&P(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}",
+  "let I=null,L=new VTe({onWindowRegistered:e=>{I?.registerWindow(e),C?.(e)}});return{updateDockIcon:F,windowManager:L}}",
+].join("");
+
+const currentTraySource =
+  "let V9=null,H9=null,W9=!1;async function gEe(e){return H9??V9??(H9=(async()=>{let t=await _Ee(e.buildFlavor,e.appBrand,e.repoRoot),n=new l.Tray(t.defaultIcon,process.platform===`win32`&&l.app.isPackaged?dEe(e.buildFlavor):void 0);if(!W9)return n.destroy(),null;return V9=new Jxe(n)})(),H9)}";
+
+const currentMainSource = currentAppInfoSource + currentRuntimeSource + currentTraySource;
+const currentSettingsSource =
+  "function oa(){let e=(0,Q.c)(27),t=B(C),n=z(),{platform:r}=_t(),{data:i}=H(Kn),a=V(K.dockIconPreference);if(r!==`macOS`||ke.ChatGPT!==`chatgpt`||sr.Agent===`prod`)return null;let c=i?.dockIconPreviews;if(c==null)return null;return W(c,a)}";
+
+function withFeatureConfig(config, fn) {
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dock-icon-config-"));
+  process.env.CODEX_LINUX_FEATURES_CONFIG = path.join(tempDir, "features.json");
+  try {
+    fs.writeFileSync(process.env.CODEX_LINUX_FEATURES_CONFIG, JSON.stringify(config));
+    return fn();
+  } finally {
+    if (originalConfig == null) delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+    else process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function captureWarns(fn) {
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (message) => warnings.push(String(message));
+  try {
+    return { value: fn(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+function dockConfig(enabled) {
+  return {
+    enabled: ["ui-tweaks"],
+    settings: {
+      "ui-tweaks": { tweaks: { appearance: { dockIcon: { enabled } } } },
+    },
+  };
+}
+
+function runStage({ enabled = true, officialIcon = "official-icon", desktopMetadata = true } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dock-icon-stage-"));
+  const upstream = path.join(root, "upstream");
+  const install = path.join(root, "install");
+  const config = path.join(root, "features.json");
+  fs.mkdirSync(path.join(upstream, "resources"), { recursive: true });
+  fs.mkdirSync(path.join(install, ".codex-linux", "upstream-package"), { recursive: true });
+  if (officialIcon != null) {
+    fs.writeFileSync(path.join(upstream, "resources", "icon-chatgpt.png"), officialIcon);
+  }
+  if (desktopMetadata) {
+    fs.writeFileSync(
+      path.join(install, ".codex-linux", "upstream-package", "chatgpt.desktop"),
+      "[Desktop Entry]\nName=ChatGPT\nExec=chatgpt %U\nIcon=chatgpt\n",
+    );
+  }
+  fs.writeFileSync(config, JSON.stringify(dockConfig(enabled)));
+  const result = childProcess.spawnSync("bash", [path.join(__dirname, "stage.sh")], {
+    cwd: path.resolve(__dirname, "../.."),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CODEX_LINUX_FEATURES_CONFIG: config,
+      CODEX_UPSTREAM_APP_DIR: upstream,
+      INSTALL_DIR: install,
+      SCRIPT_DIR: path.resolve(__dirname, "../.."),
+    },
+  });
+  return { root, upstream, install, result };
+}
+
+test("Dock icon descriptors remain disabled until the nested tweak is enabled", () => {
+  withFeatureConfig({ enabled: ["ui-tweaks"] }, () => {
+    const dockDescriptors = loadLinuxFeaturePatchDescriptors().filter((descriptor) =>
+      descriptor.id.includes(":appearance-dock-icon-"),
+    );
+    assert.equal(dockDescriptors.length, 2);
+    assert.equal(dockDescriptors.every((descriptor) => descriptor.enabled({}) === false), true);
+  });
+  withFeatureConfig(dockConfig(true), () => {
+    const dockDescriptors = loadLinuxFeaturePatchDescriptors().filter((descriptor) =>
+      descriptor.id.includes(":appearance-dock-icon-"),
+    );
+    assert.equal(dockDescriptors.length, 2);
+    assert.equal(dockDescriptors.every((descriptor) => descriptor.enabled({}) === true), true);
+  });
+  assert.equal(dockIconEnabled({}), false);
+});
+
+test("main patch restores official previews and synchronizes Linux windows and tray", () => {
+  const patched = applyDockIconMainPatch(currentMainSource);
+  assert.notEqual(patched, currentMainSource);
+  assert.match(patched, /function codexLinuxDockIconResourcePath/);
+  assert.match(patched, /function codexLinuxApplyDockIcon/);
+  assert.match(patched, /BrowserWindow\.getAllWindows\(\)/);
+  assert.match(patched, /V9\.tray\.setImage\(s\)/);
+  assert.match(patched, /globalThis\.codexLinuxDockIconImage/);
+  assert.match(patched, /spawn\(codexLinuxSyncScript/);
+  assert.equal(applyDockIconMainPatch(patched), patched);
+});
+
+test("main patch rejects drift at every official-package insertion point byte-identically", () => {
+  const patched = applyDockIconMainPatch(currentMainSource);
+  const currentPoints = [
+    "if(process.platform!==`darwin`||t==null)return null",
+    "function PS(e){if(e==null)return null;let t=l.app.isPackaged?(0,p.join)(process.resourcesPath,e):null",
+    "E=e=>{if(!l.app.isPackaged)return null;let t=(0,p.join)(process.resourcesPath,e);return(0,_.existsSync)(t)?t:null}",
+    "P=t=>{if(t===`app-default`",
+    "F=()=>{if(!v)return;",
+    "if(v){F();let e=()=>",
+    "onWindowRegistered:e=>{I?.registerWindow(e),C?.(e)}",
+    "n=new l.Tray(t.defaultIcon,process.platform===`win32`",
+  ];
+  const patchedPoints = [
+    "if(process.platform!==`darwin`&&process.platform!==`linux`||t==null)return null",
+    "function codexLinuxDockIconResourcePath",
+    "E=e=>{if(!l.app.isPackaged&&process.platform!==`linux`)return null",
+    "P=function codexLinuxApplyDockIcon",
+    "F=()=>{if(!v&&process.platform!==`linux`)return;",
+    "if(v||process.platform===`linux`){F();let e=()=>",
+    "onWindowRegistered:e=>{I?.registerWindow(e),C?.(e),process.platform===`linux`&&setImmediate(F)}",
+    "n=new l.Tray(process.platform===`linux`&&globalThis.codexLinuxDockIconImage",
+  ];
+
+  for (const point of currentPoints) {
+    const driftedPoint = `${point.slice(0, -1)}DRIFT${point.slice(-1)}`;
+    const drifted = currentMainSource.replace(point, driftedPoint);
+    const result = captureWarns(() => applyDockIconMainPatch(drifted));
+    assert.equal(result.value, drifted, point);
+    assert.match(result.warnings.join("\n"), /complete current Dock icon main-process contract/);
+  }
+  for (const point of patchedPoints) {
+    const driftedPoint = `${point.slice(0, -1)}DRIFT${point.slice(-1)}`;
+    const drifted = patched.replace(point, driftedPoint);
+    const result = captureWarns(() => applyDockIconMainPatch(drifted));
+    assert.equal(result.value, drifted, point);
+    assert.match(result.warnings.join("\n"), /complete current Dock icon main-process contract/);
+  }
+
+  const mixed = currentMainSource.replace(currentPoints[0], patchedPoints[0]);
+  assert.equal(captureWarns(() => applyDockIconMainPatch(mixed)).value, mixed);
+  const duplicate = currentMainSource + currentMainSource;
+  assert.equal(captureWarns(() => applyDockIconMainPatch(duplicate)).value, duplicate);
+});
+
+test("settings patch exposes the official row on Linux across minified aliases", () => {
+  const patched = applyDockIconSettingsPatch(currentSettingsSource);
+  assert.match(
+    patched,
+    /if\(r!==`macOS`&&r!==`linux`\|\|ke\.ChatGPT!==`chatgpt`\|\|sr\.Agent===`prod`\)return null/,
+  );
+  assert.equal(applyDockIconSettingsPatch(patched), patched);
+
+  const aliases = currentSettingsSource
+    .replace("r!==`macOS`", "platform!==`macOS`")
+    .replace("ke.ChatGPT", "brand.ChatGPT")
+    .replace("sr.Agent", "flavor.Agent");
+  assert.match(applyDockIconSettingsPatch(aliases), /platform!==`linux`/);
+});
+
+test("settings drift, duplicates, and mixed contracts remain byte-identical", () => {
+  const patched = applyDockIconSettingsPatch(currentSettingsSource);
+  for (const source of [
+    currentSettingsSource.replace(".dockIconPreviews", ".dockIconPreviewsDrift"),
+    currentSettingsSource + currentSettingsSource,
+    currentSettingsSource + patched,
+  ]) {
+    const result = captureWarns(() => applyDockIconSettingsPatch(source));
+    assert.equal(result.value, source);
+    assert.match(result.warnings.join("\n"), /current Dock icon settings contract/);
+  }
+});
+
+test("descriptors select only current official-package contracts", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dock-icon-assets-"));
+  try {
+    const assets = path.join(root, "webview", "assets");
+    fs.mkdirSync(assets, { recursive: true });
+    fs.writeFileSync(path.join(assets, "general-settings-h4wYKRAT.js"), currentSettingsSource);
+    fs.writeFileSync(path.join(assets, "general-settings-CsA3Lt9Z.js"), "old DMG fixture");
+    const settingsDescriptor = descriptors.find((descriptor) =>
+      descriptor.id.endsWith("settings-row"),
+    );
+    const result = patchUniqueAssetFile(
+      root,
+      settingsDescriptor.pattern,
+      settingsDescriptor.assetMatch,
+      settingsDescriptor.apply,
+      settingsDescriptor.missingDescription,
+      "ambiguous Dock icon Settings bundles",
+    );
+    assert.deepEqual(result, {
+      matched: 1,
+      changed: 1,
+      assetName: "general-settings-h4wYKRAT.js",
+    });
+    assert.match(
+      fs.readFileSync(path.join(assets, "general-settings-h4wYKRAT.js"), "utf8"),
+      /!==`linux`/,
+    );
+    assert.equal(
+      fs.readFileSync(path.join(assets, "general-settings-CsA3Lt9Z.js"), "utf8"),
+      "old DMG fixture",
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("staging copies the signed-package icon and current package metadata contract", () => {
+  const { root, install, result } = runStage();
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    const target = path.join(install, "resources", "dock-icon");
+    assert.equal(fs.readFileSync(path.join(target, "icon-chatgpt.png"), "utf8"), "official-icon");
+    assert.deepEqual(
+      fs.readFileSync(path.join(target, "icon-codex-dark-color.png")),
+      fs.readFileSync(path.resolve(__dirname, "../../assets/codex-linux.png")),
+    );
+    assert.deepEqual(
+      fs.readFileSync(path.join(target, "icon-codex-light.png")),
+      fs.readFileSync(path.resolve(__dirname, "../../assets/codex-linux.png")),
+    );
+    assert.equal(fs.statSync(path.join(target, "sync-desktop-icon.sh")).mode & 0o777, 0o755);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("staging fails soft and removes its payload when official resources or metadata drift", () => {
+  for (const options of [{ officialIcon: null }, { desktopMetadata: false }]) {
+    const { root, install, result } = runStage(options);
+    try {
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(result.stderr, /WARN: Official Linux Dock icon/);
+      assert.equal(fs.existsSync(path.join(install, "resources", "dock-icon")), false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("nested disable leaves no Dock payload", () => {
+  const { root, install, result } = runStage({ enabled: false });
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.existsSync(path.join(install, "resources", "dock-icon")), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("desktop synchronization updates and cleans up only its managed launcher", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dock-icon-desktop-"));
+  const dataHome = path.join(root, "share");
+  const source = path.join(root, "codex-desktop.desktop");
+  const helper = path.join(__dirname, "sync-desktop-icon.sh");
+  const appDir = path.join(root, "app");
+  fs.mkdirSync(path.join(appDir, "resources", "dock-icon"), { recursive: true });
+  fs.copyFileSync(helper, path.join(appDir, "resources", "dock-icon", "sync-desktop-icon.sh"));
+  fs.writeFileSync(
+    source,
+    "[Desktop Entry]\nName=ChatGPT Community\nExec=/usr/bin/codex-desktop %u\nIcon=codex-desktop\nStartupWMClass=codex-desktop\n",
+  );
+  try {
+    const sync = childProcess.spawnSync("bash", [helper, "chatgpt"], {
+      input: Buffer.from("selected-icon"),
+      env: {
+        ...process.env,
+        CODEX_LINUX_DESKTOP_FILE_SOURCE: source,
+        XDG_DATA_HOME: dataHome,
+      },
+    });
+    assert.equal(sync.status, 0, sync.stderr?.toString());
+    const desktop = path.join(dataHome, "applications", "codex-desktop.desktop");
+    assert.match(fs.readFileSync(desktop, "utf8"), /X-Codex-Linux-Dock-Icon=1/);
+    assert.match(fs.readFileSync(desktop, "utf8"), /Icon=.*codex-desktop-dock-chatgpt\.png/);
+
+    fs.rmSync(path.join(appDir, "resources", "dock-icon"), { recursive: true, force: true });
+    const cleanup = childProcess.spawnSync("bash", [helper, appDir], {
+      env: {
+        ...process.env,
+        CODEX_LINUX_FEATURE_HOOK_PHASE: "prelaunch",
+        CODEX_LINUX_APP_DIR: appDir,
+        XDG_DATA_HOME: dataHome,
+      },
+    });
+    assert.equal(cleanup.status, 0, cleanup.stderr?.toString());
+    assert.equal(fs.existsSync(desktop), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("desktop synchronization preserves unmanaged launchers", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dock-icon-unmanaged-"));
+  const dataHome = path.join(root, "share");
+  const desktop = path.join(dataHome, "applications", "codex-desktop.desktop");
+  fs.mkdirSync(path.dirname(desktop), { recursive: true });
+  fs.writeFileSync(desktop, "[Desktop Entry]\nName=Custom\nIcon=custom\n");
+  try {
+    const result = childProcess.spawnSync("bash", [path.join(__dirname, "sync-desktop-icon.sh"), "chatgpt"], {
+      input: Buffer.from("selected-icon"),
+      env: { ...process.env, XDG_DATA_HOME: dataHome },
+    });
+    assert.equal(result.status, 0, result.stderr?.toString());
+    assert.equal(fs.readFileSync(desktop, "utf8"), "[Desktop Entry]\nName=Custom\nIcon=custom\n");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -3,6 +3,7 @@
 
 const assert = require("node:assert/strict");
 const childProcess = require("node:child_process");
+const crypto = require("node:crypto");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -379,24 +380,21 @@ function createDesktopSyncFixture() {
     },
     firstIcon,
     managedDesktop: path.join(dataHome, "applications", "codex-desktop.desktop"),
-    managedIcon: (selection, appId = "codex-desktop") =>
+    managedIcon: (
+      selection,
+      appId = "codex-desktop",
+      content = selection === "chatgpt" ? "first-icon" : "second-icon",
+    ) =>
       path.join(
         dataHome,
         "icons",
         "hicolor",
         "256x256",
         "apps",
-        `${appId}-dock-${selection}.png`,
+        `${appId}-dock-${selection}-${crypto.createHash("sha256").update(content).digest("hex")}.png`,
       ),
-    managedIconOwnership: (selection, appId = "codex-desktop") =>
-      `${path.join(
-        dataHome,
-        "icons",
-        "hicolor",
-        "256x256",
-        "apps",
-        `${appId}-dock-${selection}.png`,
-      )}.codex-linux-sha256`,
+    legacyIcon: (selection, appId = "codex-desktop") =>
+      path.join(dataHome, "icons", "hicolor", "256x256", "apps", `${appId}-dock-${selection}.png`),
     secondIcon,
     tempDir,
   };
@@ -432,10 +430,6 @@ test("desktop synchronization updates a managed KDE launcher atomically", () => 
     assert.equal(first.status, 0, first.stderr);
     assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), "first-icon");
     assert.match(
-      fs.readFileSync(fixture.managedIconOwnership("chatgpt"), "utf8"),
-      /^[0-9a-f]{64}\n$/,
-    );
-    assert.match(
       fs.readFileSync(fixture.managedDesktop, "utf8"),
       /^X-Codex-Linux-Dock-Icon-SHA256=[0-9a-f]{64}$/m,
     );
@@ -452,7 +446,10 @@ test("desktop synchronization updates a managed KDE launcher atomically", () => 
     const second = runDesktopSync("codex-dark", fixture.secondIcon, fixture.env);
     assert.equal(second.status, 0, second.stderr);
     assert.equal(fs.readFileSync(fixture.managedIcon("codex-dark"), "utf8"), "second-icon");
-    assert.match(fs.readFileSync(fixture.managedDesktop, "utf8"), /dock-codex-dark\.png$/m);
+    assert.match(
+      fs.readFileSync(fixture.managedDesktop, "utf8"),
+      /dock-codex-dark-[0-9a-f]{64}\.png$/m,
+    );
   } finally {
     fs.rmSync(fixture.tempDir, { recursive: true, force: true });
   }
@@ -509,8 +506,6 @@ test("prelaunch cleanup removes only marker-owned Dock launcher artifacts", () =
     assert.equal(fs.existsSync(fixture.managedDesktop), false);
     assert.equal(fs.existsSync(fixture.managedIcon("chatgpt")), false);
     assert.equal(fs.existsSync(fixture.managedIcon("codex-dark")), false);
-    assert.equal(fs.existsSync(fixture.managedIconOwnership("chatgpt")), false);
-    assert.equal(fs.existsSync(fixture.managedIconOwnership("codex-dark")), false);
   } finally {
     fs.rmSync(fixture.tempDir, { recursive: true, force: true });
   }
@@ -519,7 +514,7 @@ test("prelaunch cleanup removes only marker-owned Dock launcher artifacts", () =
 test("prelaunch cleanup preserves a legacy marker without full managed-state proof", () => {
   const fixture = createDesktopSyncFixture();
   const appDir = path.join(fixture.tempDir, "app");
-  const legacyIcon = fixture.managedIcon("selection");
+  const legacyIcon = fixture.legacyIcon("selection");
   try {
     fs.mkdirSync(path.dirname(fixture.managedDesktop), { recursive: true });
     fs.mkdirSync(path.dirname(legacyIcon), { recursive: true });
@@ -552,9 +547,9 @@ test("prelaunch cleanup preserves symlinked and customized launcher artifacts", 
     const appDir = path.join(fixture.tempDir, "app");
     try {
       fs.mkdirSync(path.dirname(fixture.managedDesktop), { recursive: true });
-      fs.mkdirSync(path.dirname(fixture.managedIcon("chatgpt")), { recursive: true });
+      fs.mkdirSync(path.dirname(fixture.legacyIcon("chatgpt")), { recursive: true });
       fs.mkdirSync(appDir, { recursive: true });
-      fs.writeFileSync(fixture.managedIcon("chatgpt"), "unproven-icon");
+      fs.writeFileSync(fixture.legacyIcon("chatgpt"), "unproven-icon");
       if (kind === "symlink") {
         const outside = path.join(fixture.tempDir, "outside.desktop");
         fs.writeFileSync(outside, "[Desktop Entry]\nIcon=outside\nX-Codex-Linux-Dock-Icon=1\n");
@@ -570,7 +565,7 @@ test("prelaunch cleanup preserves symlinked and customized launcher artifacts", 
 
       assert.equal(cleaned.status, 0, cleaned.stderr);
       assert.equal(fs.existsSync(fixture.managedDesktop), true);
-      assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), "unproven-icon");
+      assert.equal(fs.readFileSync(fixture.legacyIcon("chatgpt"), "utf8"), "unproven-icon");
       assert.equal(fs.existsSync(fixture.callsPath), false);
     } finally {
       fs.rmSync(fixture.tempDir, { recursive: true, force: true });
@@ -625,17 +620,51 @@ test("sync and cleanup preserve pre-existing and modified icon resources", () =>
       }
 
       const before = fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8");
-      const sync = runDesktopSync("chatgpt", fixture.secondIcon, fixture.env);
+      const sync = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
       assert.equal(sync.status, 0, `${kind}: ${sync.stderr}`);
-      assert.match(sync.stderr, /not an unchanged managed resource/);
       assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), before, kind);
 
       const cleanup = runDesktopCleanup(appDir, fixture.env);
       assert.equal(cleanup.status, 0, `${kind}: ${cleanup.stderr}`);
       assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), before, kind);
+      if (kind === "modified") {
+        fs.rmSync(fixture.managedIcon("chatgpt"));
+        const resumed = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
+        assert.equal(resumed.status, 0, resumed.stderr);
+        assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), "first-icon");
+      }
     } finally {
       fs.rmSync(fixture.tempDir, { recursive: true, force: true });
     }
+  }
+});
+
+test("content-addressed icons recover interrupted sync and cleanup states", () => {
+  const fixture = createDesktopSyncFixture();
+  const appDir = path.join(fixture.tempDir, "app");
+  try {
+    fs.mkdirSync(appDir, { recursive: true });
+    const icon = fixture.managedIcon("chatgpt");
+
+    fs.mkdirSync(path.dirname(icon), { recursive: true });
+    fs.writeFileSync(icon, "first-icon");
+    const resumedInitialSync = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
+    assert.equal(resumedInitialSync.status, 0, resumedInitialSync.stderr);
+    assert.equal(fs.existsSync(fixture.managedDesktop), true);
+    assert.equal(fs.readFileSync(icon, "utf8"), "first-icon");
+
+    fs.rmSync(icon);
+    const resumedUpdate = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
+    assert.equal(resumedUpdate.status, 0, resumedUpdate.stderr);
+    assert.equal(fs.readFileSync(icon, "utf8"), "first-icon");
+
+    fs.rmSync(icon);
+    const resumedCleanup = runDesktopCleanup(appDir, fixture.env);
+    assert.equal(resumedCleanup.status, 0, resumedCleanup.stderr);
+    assert.equal(fs.existsSync(fixture.managedDesktop), false);
+    assert.equal(fs.existsSync(icon), false);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
   }
 });
 

--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -571,22 +571,83 @@ test("desktop synchronization discovers side-by-side launchers after an incompat
   }
 });
 
-test("desktop synchronization rejects a default launcher for a side-by-side app id", () => {
-  const fixture = createDesktopSyncFixture();
-  try {
-    const appId = "chatgpt-dock-side";
-    fixture.env.CODEX_LINUX_APP_ID = appId;
+test("desktop synchronization rejects every mismatched side-by-side identity field", () => {
+  const appId = "chatgpt-dock-side";
+  const validExec =
+    `Exec=env BAMF_DESKTOP_FILE_HINT=/usr/share/applications/${appId}.desktop ` +
+    `CHROME_DESKTOP=${appId}.desktop CODEX_APP_ID=${appId} /opt/${appId}/start.sh %u`;
+  const cases = [
+    [
+      "Exec",
+      "Exec=/usr/bin/codex-desktop %u",
+      `StartupWMClass=${appId}`,
+      `X-GNOME-WMClass=${appId}`,
+    ],
+    [
+      "StartupWMClass",
+      validExec,
+      "StartupWMClass=codex-desktop",
+      `X-GNOME-WMClass=${appId}`,
+    ],
+    [
+      "X-GNOME-WMClass",
+      validExec,
+      `StartupWMClass=${appId}`,
+      "X-GNOME-WMClass=codex-desktop",
+    ],
+    [
+      "CHROME_DESKTOP",
+      validExec.replace(`CHROME_DESKTOP=${appId}.desktop`, "CHROME_DESKTOP=codex-desktop.desktop"),
+      `StartupWMClass=${appId}`,
+      `X-GNOME-WMClass=${appId}`,
+    ],
+    [
+      "BAMF_DESKTOP_FILE_HINT",
+      validExec.replace(
+        `BAMF_DESKTOP_FILE_HINT=/usr/share/applications/${appId}.desktop`,
+        "BAMF_DESKTOP_FILE_HINT=/usr/share/applications/codex-desktop.desktop",
+      ),
+      `StartupWMClass=${appId}`,
+      `X-GNOME-WMClass=${appId}`,
+    ],
+    [
+      "CODEX_APP_ID",
+      validExec.replace(`CODEX_APP_ID=${appId}`, "CODEX_APP_ID=codex-desktop"),
+      `StartupWMClass=${appId}`,
+      `X-GNOME-WMClass=${appId}`,
+    ],
+  ];
 
-    const result = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
+  for (const [field, execLine, startupClass, gnomeClass] of cases) {
+    const fixture = createDesktopSyncFixture();
+    try {
+      const source = path.join(fixture.tempDir, `${appId}.desktop`);
+      fs.writeFileSync(
+        source,
+        [
+          "[Desktop Entry]",
+          "Name=Wrong identity",
+          execLine,
+          `Icon=${appId}`,
+          startupClass,
+          gnomeClass,
+        ].join("\n"),
+      );
+      fixture.env.CODEX_LINUX_APP_ID = appId;
+      fixture.env.CODEX_LINUX_DESKTOP_FILE_SOURCE = source;
 
-    assert.equal(result.status, 0, result.stderr);
-    assert.equal(
-      fs.existsSync(path.join(fixture.dataHome, "applications", `${appId}.desktop`)),
-      false,
-    );
-    assert.equal(fs.existsSync(fixture.managedIcon("chatgpt", appId)), false);
-    assert.equal(fs.existsSync(fixture.callsPath), false);
-  } finally {
-    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+      const result = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
+
+      assert.equal(result.status, 0, `${field}: ${result.stderr}`);
+      assert.equal(
+        fs.existsSync(path.join(fixture.dataHome, "applications", `${appId}.desktop`)),
+        false,
+        field,
+      );
+      assert.equal(fs.existsSync(fixture.managedIcon("chatgpt", appId)), false, field);
+      assert.equal(fs.existsSync(fixture.callsPath), false, field);
+    } finally {
+      fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+    }
   }
 });

--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -663,7 +663,64 @@ test("content-addressed icons recover interrupted sync and cleanup states", () =
     assert.equal(resumedCleanup.status, 0, resumedCleanup.stderr);
     assert.equal(fs.existsSync(fixture.managedDesktop), false);
     assert.equal(fs.existsSync(icon), false);
+
+    const orphanChatgpt = fixture.managedIcon("chatgpt");
+    const orphanCodex = fixture.managedIcon("codex-dark");
+    fs.writeFileSync(orphanChatgpt, "first-icon");
+    fs.writeFileSync(orphanCodex, "second-icon");
+    const recoveredOrphans = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
+    assert.equal(recoveredOrphans.status, 0, recoveredOrphans.stderr);
+    assert.equal(fs.existsSync(orphanChatgpt), true);
+    assert.equal(fs.existsSync(orphanCodex), false);
+
+    const modifiedOrphan = fixture.managedIcon("codex-light", "codex-desktop", "owned-before-edit");
+    fs.writeFileSync(modifiedOrphan, "user-modified");
+    const preservedModifiedOrphan = runDesktopCleanup(appDir, fixture.env);
+    assert.equal(preservedModifiedOrphan.status, 0, preservedModifiedOrphan.stderr);
+    assert.equal(fs.readFileSync(modifiedOrphan, "utf8"), "user-modified");
+
+    fs.writeFileSync(orphanCodex, "second-icon");
+    const recoveredInitialOrphan = runDesktopCleanup(appDir, fixture.env);
+    assert.equal(recoveredInitialOrphan.status, 0, recoveredInitialOrphan.stderr);
+    assert.equal(fs.existsSync(orphanCodex), false);
+    assert.equal(fs.readFileSync(modifiedOrphan, "utf8"), "user-modified");
   } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test("desktop synchronization serializes the per-app launcher transaction", async () => {
+  const fixture = createDesktopSyncFixture();
+  const applicationsDir = path.join(fixture.dataHome, "applications");
+  let holder;
+  let sync;
+  try {
+    fs.mkdirSync(applicationsDir, { recursive: true });
+    holder = childProcess.spawn("flock", [applicationsDir, "bash", "-c", "printf locked; sleep 1"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    await new Promise((resolve, reject) => {
+      holder.stdout.once("data", resolve);
+      holder.once("error", reject);
+    });
+    sync = childProcess.spawn(
+      "bash",
+      [path.join(__dirname, "sync-desktop-icon.sh"), "chatgpt"],
+      { env: fixture.env, stdio: ["pipe", "ignore", "pipe"] },
+    );
+    sync.stdin.end(fs.readFileSync(fixture.firstIcon));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(sync.exitCode, null);
+    await new Promise((resolve, reject) => {
+      sync.once("exit", resolve);
+      sync.once("error", reject);
+    });
+    assert.equal(sync.exitCode, 0);
+    assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), "first-icon");
+  } finally {
+    holder?.kill();
+    sync?.kill();
     fs.rmSync(fixture.tempDir, { recursive: true, force: true });
   }
 });

--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -486,6 +486,38 @@ test("prelaunch cleanup removes only marker-owned Dock launcher artifacts", () =
   }
 });
 
+test("prelaunch cleanup removes the marker-owned legacy Dock launcher", () => {
+  const fixture = createDesktopSyncFixture();
+  const appDir = path.join(fixture.tempDir, "app");
+  const legacyIcon = fixture.managedIcon("selection");
+  try {
+    fs.mkdirSync(path.dirname(fixture.managedDesktop), { recursive: true });
+    fs.mkdirSync(path.dirname(legacyIcon), { recursive: true });
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(legacyIcon, "legacy-icon");
+    fs.writeFileSync(
+      fixture.managedDesktop,
+      [
+        "[Desktop Entry]",
+        "Name=ChatGPT Community",
+        `Icon=${legacyIcon}`,
+        "X-Codex-Linux-Dock-Icon=1",
+      ].join("\n"),
+    );
+
+    const cleaned = runDesktopCleanup(appDir, fixture.env);
+
+    assert.equal(cleaned.status, 0, cleaned.stderr);
+    assert.equal(fs.existsSync(fixture.managedDesktop), false);
+    assert.equal(fs.existsSync(legacyIcon), false);
+    assert.deepEqual(fs.readFileSync(fixture.callsPath, "utf8").trim().split("\n"), [
+      "kbuildsycoca6",
+    ]);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
 test("prelaunch cleanup preserves symlinked and customized launcher artifacts", () => {
   for (const kind of ["symlink", "customized"]) {
     const fixture = createDesktopSyncFixture();

--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -689,7 +689,7 @@ test("content-addressed icons recover interrupted sync and cleanup states", () =
   }
 });
 
-test("desktop synchronization serializes the per-app launcher transaction", async () => {
+test("desktop synchronization serializes the per-app launcher transaction with a timeout", async () => {
   const fixture = createDesktopSyncFixture();
   const applicationsDir = path.join(fixture.dataHome, "applications");
   let holder;
@@ -718,6 +718,20 @@ test("desktop synchronization serializes the per-app launcher transaction", asyn
     });
     assert.equal(sync.exitCode, 0);
     assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), "first-icon");
+
+    holder = childProcess.spawn("flock", [applicationsDir, "bash", "-c", "printf locked; sleep 7"], {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    await new Promise((resolve, reject) => {
+      holder.stdout.once("data", resolve);
+      holder.once("error", reject);
+    });
+    const started = Date.now();
+    const timedOut = runDesktopSync("codex-dark", fixture.secondIcon, fixture.env);
+    assert.equal(timedOut.status, 0, timedOut.stderr);
+    assert.match(timedOut.stderr, /Could not lock Dock icon launcher state/);
+    assert.ok(Date.now() - started >= 4500);
+    assert.ok(Date.now() - started < 6500);
   } finally {
     holder?.kill();
     sync?.kill();

--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -78,13 +78,22 @@ function dockConfig(enabled) {
   };
 }
 
-function runStage({ enabled = true, officialIcon = "official-icon", desktopMetadata = true } = {}) {
+function runStage({
+  enabled = true,
+  officialIcon = "official-icon",
+  desktopMetadata = true,
+  stalePayload = false,
+} = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "dock-icon-stage-"));
   const upstream = path.join(root, "upstream");
   const install = path.join(root, "install");
   const config = path.join(root, "features.json");
   fs.mkdirSync(path.join(upstream, "resources"), { recursive: true });
   fs.mkdirSync(path.join(install, ".codex-linux", "upstream-package"), { recursive: true });
+  if (stalePayload) {
+    fs.mkdirSync(path.join(install, "resources", "dock-icon"), { recursive: true });
+    fs.writeFileSync(path.join(install, "resources", "dock-icon", "stale"), "stale");
+  }
   if (officialIcon != null) {
     fs.writeFileSync(path.join(upstream, "resources", "icon-chatgpt.png"), officialIcon);
   }
@@ -308,12 +317,15 @@ test("staging copies the signed-package icon and current package metadata contra
   }
 });
 
-test("staging fails soft and removes its payload when official resources or metadata drift", () => {
-  for (const options of [{ officialIcon: null }, { desktopMetadata: false }]) {
+test("staging rejects an incomplete candidate when official resources or metadata drift", () => {
+  for (const options of [
+    { officialIcon: null, stalePayload: true },
+    { desktopMetadata: false, stalePayload: true },
+  ]) {
     const { root, install, result } = runStage(options);
     try {
-      assert.equal(result.status, 0, result.stderr);
-      assert.match(result.stderr, /WARN: Official Linux Dock icon/);
+      assert.equal(result.status, 1, result.stderr);
+      assert.match(result.stderr, /ERROR: Official Linux Dock icon/);
       assert.equal(fs.existsSync(path.join(install, "resources", "dock-icon")), false);
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
@@ -410,7 +422,10 @@ test("desktop synchronization updates a managed KDE launcher atomically", () => 
     const first = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
     assert.equal(first.status, 0, first.stderr);
     assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), "first-icon");
-    assert.match(fs.readFileSync(fixture.managedDesktop, "utf8"), /^X-Codex-Linux-Dock-Icon=1$/m);
+    assert.match(
+      fs.readFileSync(fixture.managedDesktop, "utf8"),
+      /^X-Codex-Linux-Dock-Icon-SHA256=[0-9a-f]{64}$/m,
+    );
     assert.deepEqual(fs.readFileSync(fixture.callsPath, "utf8").trim().split("\n"), [
       "kbuildsycoca6",
     ]);
@@ -486,7 +501,7 @@ test("prelaunch cleanup removes only marker-owned Dock launcher artifacts", () =
   }
 });
 
-test("prelaunch cleanup removes the marker-owned legacy Dock launcher", () => {
+test("prelaunch cleanup preserves a legacy marker without full managed-state proof", () => {
   const fixture = createDesktopSyncFixture();
   const appDir = path.join(fixture.tempDir, "app");
   const legacyIcon = fixture.managedIcon("selection");
@@ -508,11 +523,9 @@ test("prelaunch cleanup removes the marker-owned legacy Dock launcher", () => {
     const cleaned = runDesktopCleanup(appDir, fixture.env);
 
     assert.equal(cleaned.status, 0, cleaned.stderr);
-    assert.equal(fs.existsSync(fixture.managedDesktop), false);
-    assert.equal(fs.existsSync(legacyIcon), false);
-    assert.deepEqual(fs.readFileSync(fixture.callsPath, "utf8").trim().split("\n"), [
-      "kbuildsycoca6",
-    ]);
+    assert.equal(fs.existsSync(fixture.managedDesktop), true);
+    assert.equal(fs.existsSync(legacyIcon), true);
+    assert.equal(fs.existsSync(fixture.callsPath), false);
   } finally {
     fs.rmSync(fixture.tempDir, { recursive: true, force: true });
   }
@@ -547,6 +560,118 @@ test("prelaunch cleanup preserves symlinked and customized launcher artifacts", 
     } finally {
       fs.rmSync(fixture.tempDir, { recursive: true, force: true });
     }
+  }
+});
+
+test("sync and cleanup preserve user edits to a previously managed launcher", () => {
+  for (const field of ["Name", "Exec", "Actions"]) {
+    const fixture = createDesktopSyncFixture();
+    const appDir = path.join(fixture.tempDir, "app");
+    try {
+      fs.mkdirSync(appDir, { recursive: true });
+      assert.equal(runDesktopSync("chatgpt", fixture.firstIcon, fixture.env).status, 0);
+      const original = fs.readFileSync(fixture.managedDesktop, "utf8");
+      const customized = original.replace(
+        new RegExp(`^${field}=.*$`, "m"),
+        `${field}=User customized ${field}`,
+      );
+      const customizedWithField = customized === original
+        ? `${original}${field}=User customized ${field}\n`
+        : customized;
+      fs.writeFileSync(fixture.managedDesktop, customizedWithField);
+
+      const sync = runDesktopSync("codex-dark", fixture.secondIcon, fixture.env);
+      assert.equal(sync.status, 0, `${field}: ${sync.stderr}`);
+      assert.equal(fs.readFileSync(fixture.managedDesktop, "utf8"), customizedWithField, field);
+      assert.equal(fs.existsSync(fixture.managedIcon("codex-dark")), false, field);
+
+      const cleanup = runDesktopCleanup(appDir, fixture.env);
+      assert.equal(cleanup.status, 0, `${field}: ${cleanup.stderr}`);
+      assert.equal(fs.readFileSync(fixture.managedDesktop, "utf8"), customizedWithField, field);
+      assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), "first-icon");
+    } finally {
+      fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("AppImage synchronization writes persistent launch commands for the app and action", () => {
+  const fixture = createDesktopSyncFixture();
+  try {
+    const sourceDir = path.join(fixture.tempDir, "mounted AppDir");
+    const sourceDesktop = path.join(sourceDir, "codex-desktop.desktop");
+    const appImage = path.join(fixture.tempDir, 'ChatGPT $Community "nightly" 100%.AppImage');
+    fs.mkdirSync(sourceDir, { recursive: true });
+    fs.writeFileSync(appImage, "appimage");
+    fs.chmodSync(appImage, 0o755);
+    fs.writeFileSync(
+      sourceDesktop,
+      fs.readFileSync(path.resolve(__dirname, "../../packaging/appimage/codex-desktop.desktop"), "utf8")
+        .replaceAll("__PACKAGE_NAME__", "codex-desktop")
+        .replaceAll("__PACKAGE_DISPLAY_NAME__", "ChatGPT Community")
+        .replaceAll("__PACKAGE_COMMENT__", "Community package")
+        .replaceAll("__VERSION__", "test"),
+    );
+    fixture.env.APPIMAGE = appImage;
+    fixture.env.CODEX_LINUX_DESKTOP_FILE_SOURCE = sourceDesktop;
+
+    const result = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
+    assert.equal(result.status, 0, result.stderr);
+    const managed = fs.readFileSync(fixture.managedDesktop, "utf8");
+    const desktopAppImage = appImage
+      .replaceAll("\\", "\\\\")
+      .replaceAll('"', '\\"')
+      .replaceAll("`", "\\`")
+      .replaceAll("$", "\\$")
+      .replaceAll("%", "%%");
+    assert.doesNotMatch(managed, /\bAppRun\b/);
+    assert.equal(
+      managed.includes(`Exec="${desktopAppImage}" --show %u\n`),
+      true,
+    );
+    assert.equal(
+      managed.includes(
+        `Exec=env CHROME_DESKTOP=codex-desktop.desktop CODEX_MULTI_LAUNCH=1 "${desktopAppImage}" --new-instance\n`,
+      ),
+      true,
+    );
+    const validation = childProcess.spawnSync("desktop-file-validate", [fixture.managedDesktop], {
+      encoding: "utf8",
+    });
+    if (validation.error?.code !== "ENOENT") {
+      assert.equal(validation.status, 0, validation.stderr);
+    }
+    fs.rmSync(sourceDir, { recursive: true, force: true });
+    assert.equal(fs.readFileSync(fixture.managedDesktop, "utf8"), managed);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test("AppImage synchronization refuses to persist a launcher without a usable AppImage path", () => {
+  const fixture = createDesktopSyncFixture();
+  try {
+    const sourceDir = path.join(fixture.tempDir, "mounted-AppDir");
+    const sourceDesktop = path.join(sourceDir, "codex-desktop.desktop");
+    fs.mkdirSync(sourceDir, { recursive: true });
+    fs.writeFileSync(
+      sourceDesktop,
+      fs.readFileSync(path.resolve(__dirname, "../../packaging/appimage/codex-desktop.desktop"), "utf8")
+        .replaceAll("__PACKAGE_NAME__", "codex-desktop")
+        .replaceAll("__PACKAGE_DISPLAY_NAME__", "ChatGPT Community")
+        .replaceAll("__PACKAGE_COMMENT__", "Community package")
+        .replaceAll("__VERSION__", "test"),
+    );
+    delete fixture.env.APPIMAGE;
+    fixture.env.CODEX_LINUX_DESKTOP_FILE_SOURCE = sourceDesktop;
+
+    const result = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stderr, /has no persistent AppImage path/);
+    assert.equal(fs.existsSync(fixture.managedDesktop), false);
+    assert.equal(fs.existsSync(fixture.managedIcon("chatgpt")), false);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
   }
 });
 
@@ -597,7 +722,10 @@ test("desktop synchronization discovers side-by-side launchers after an incompat
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt", appId), "utf8"), "first-icon");
-    assert.match(fs.readFileSync(managedDesktop, "utf8"), /^X-Codex-Linux-Dock-Icon=1$/m);
+    assert.match(
+      fs.readFileSync(managedDesktop, "utf8"),
+      /^X-Codex-Linux-Dock-Icon-SHA256=[0-9a-f]{64}$/m,
+    );
   } finally {
     fs.rmSync(fixture.tempDir, { recursive: true, force: true });
   }

--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -388,6 +388,15 @@ function createDesktopSyncFixture() {
         "apps",
         `${appId}-dock-${selection}.png`,
       ),
+    managedIconOwnership: (selection, appId = "codex-desktop") =>
+      `${path.join(
+        dataHome,
+        "icons",
+        "hicolor",
+        "256x256",
+        "apps",
+        `${appId}-dock-${selection}.png`,
+      )}.codex-linux-sha256`,
     secondIcon,
     tempDir,
   };
@@ -422,6 +431,10 @@ test("desktop synchronization updates a managed KDE launcher atomically", () => 
     const first = runDesktopSync("chatgpt", fixture.firstIcon, fixture.env);
     assert.equal(first.status, 0, first.stderr);
     assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), "first-icon");
+    assert.match(
+      fs.readFileSync(fixture.managedIconOwnership("chatgpt"), "utf8"),
+      /^[0-9a-f]{64}\n$/,
+    );
     assert.match(
       fs.readFileSync(fixture.managedDesktop, "utf8"),
       /^X-Codex-Linux-Dock-Icon-SHA256=[0-9a-f]{64}$/m,
@@ -496,6 +509,8 @@ test("prelaunch cleanup removes only marker-owned Dock launcher artifacts", () =
     assert.equal(fs.existsSync(fixture.managedDesktop), false);
     assert.equal(fs.existsSync(fixture.managedIcon("chatgpt")), false);
     assert.equal(fs.existsSync(fixture.managedIcon("codex-dark")), false);
+    assert.equal(fs.existsSync(fixture.managedIconOwnership("chatgpt")), false);
+    assert.equal(fs.existsSync(fixture.managedIconOwnership("codex-dark")), false);
   } finally {
     fs.rmSync(fixture.tempDir, { recursive: true, force: true });
   }
@@ -589,6 +604,35 @@ test("sync and cleanup preserve user edits to a previously managed launcher", ()
       assert.equal(cleanup.status, 0, `${field}: ${cleanup.stderr}`);
       assert.equal(fs.readFileSync(fixture.managedDesktop, "utf8"), customizedWithField, field);
       assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), "first-icon");
+    } finally {
+      fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("sync and cleanup preserve pre-existing and modified icon resources", () => {
+  for (const kind of ["pre-existing", "modified"]) {
+    const fixture = createDesktopSyncFixture();
+    const appDir = path.join(fixture.tempDir, "app");
+    try {
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.mkdirSync(path.dirname(fixture.managedIcon("chatgpt")), { recursive: true });
+      if (kind === "pre-existing") {
+        fs.writeFileSync(fixture.managedIcon("chatgpt"), "user-icon");
+      } else {
+        assert.equal(runDesktopSync("chatgpt", fixture.firstIcon, fixture.env).status, 0);
+        fs.writeFileSync(fixture.managedIcon("chatgpt"), "user-modified-icon");
+      }
+
+      const before = fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8");
+      const sync = runDesktopSync("chatgpt", fixture.secondIcon, fixture.env);
+      assert.equal(sync.status, 0, `${kind}: ${sync.stderr}`);
+      assert.match(sync.stderr, /not an unchanged managed resource/);
+      assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), before, kind);
+
+      const cleanup = runDesktopCleanup(appDir, fixture.env);
+      assert.equal(cleanup.status, 0, `${kind}: ${cleanup.stderr}`);
+      assert.equal(fs.readFileSync(fixture.managedIcon("chatgpt"), "utf8"), before, kind);
     } finally {
       fs.rmSync(fixture.tempDir, { recursive: true, force: true });
     }

--- a/linux-features/ui-tweaks/feature.json
+++ b/linux-features/ui-tweaks/feature.json
@@ -4,9 +4,22 @@
   "description": "Optional UI customization patches for ChatGPT Community.",
   "defaultEnabled": false,
   "entrypoints": {
-    "patchDescriptors": "./patch.js"
+    "patchDescriptors": "./patch.js",
+    "stageHook": "./stage.sh"
+  },
+  "runtimeHooks": {
+    "prelaunch": {
+      "source": "sync-desktop-icon.sh",
+      "name": "dock-icon-cleanup.sh",
+      "mode": "0755"
+    }
   },
   "tweaks": {
+    "appearance": {
+      "dockIcon": {
+        "enabled": false
+      }
+    },
     "home": {
       "suggestedPrompts": {
         "enabled": false

--- a/linux-features/ui-tweaks/patch.js
+++ b/linux-features/ui-tweaks/patch.js
@@ -3,6 +3,7 @@
 const sidebarProjectName = require("./patches/sidebar-project-name.js");
 const modelPickerModelList = require("./patches/model-picker-model-list.js");
 const reasoningEffortLabels = require("./patches/reasoning-effort-labels.js");
+const dockIcon = require("./patches/dock-icon.js");
 const suggestedPrompts = require("./patches/suggested-prompts.js");
 
 function patchesFrom(...modules) {
@@ -16,6 +17,7 @@ module.exports = {
     sidebarProjectName,
     modelPickerModelList,
     reasoningEffortLabels,
+    dockIcon,
     suggestedPrompts,
   ),
 };

--- a/linux-features/ui-tweaks/patches/dock-icon.js
+++ b/linux-features/ui-tweaks/patches/dock-icon.js
@@ -1,0 +1,161 @@
+"use strict";
+
+const currentPreviewGate = "if(process.platform!==`darwin`||t==null)return null";
+const patchedPreviewGate =
+  "if(process.platform!==`darwin`&&process.platform!==`linux`||t==null)return null";
+const currentAppInfoResource =
+  "function PS(e){if(e==null)return null;let t=l.app.isPackaged?(0,p.join)(process.resourcesPath,e):null";
+const patchedAppInfoResource =
+  "function codexLinuxDockIconResourcePath(e){return process.platform===`linux`?(0,p.join)(process.resourcesPath,`dock-icon`,e):(0,p.join)(process.resourcesPath,e)}function PS(e){if(e==null)return null;let t=l.app.isPackaged||process.platform===`linux`?codexLinuxDockIconResourcePath(e):null";
+const currentWindowResource =
+  "E=e=>{if(!l.app.isPackaged)return null;let t=(0,p.join)(process.resourcesPath,e);return(0,_.existsSync)(t)?t:null}";
+const patchedWindowResource =
+  "E=e=>{if(!l.app.isPackaged&&process.platform!==`linux`)return null;let t=codexLinuxDockIconResourcePath(e);return(0,_.existsSync)(t)?t:null}";
+const currentApplyIcon =
+  "P=t=>{if(t===`app-default`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.Sc.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)}";
+const patchedApplyIcon =
+  "P=function codexLinuxApplyDockIcon(t){if(t===`app-default`&&process.platform!==`linux`&&i!==a.a.Dev&&(l.app.isPackaged||e===n.Sc.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let r=t===`codex-system`?N():null,o=(r==null?null:O(r))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);if(s.isEmpty())return;if(process.platform===`linux`){let codexLinuxIconSelection=t===`codex-system`?(l.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?`codex-dark`:`codex-light`):`chatgpt`;globalThis.codexLinuxDockIconImage=s;for(let e of l.BrowserWindow.getAllWindows())e.isDestroyed()||e.setIcon(s);V9!=null&&!V9.tray.isDestroyed()&&V9.tray.setImage(s);let codexLinuxSyncScript=codexLinuxDockIconResourcePath(`sync-desktop-icon.sh`);if(_.existsSync(codexLinuxSyncScript))try{let e=require(`node:child_process`).spawn(codexLinuxSyncScript,[codexLinuxIconSelection],{detached:!0,stdio:[`pipe`,`ignore`,`ignore`]});e.on(`error`,()=>{}),e.stdin.on(`error`,()=>{}),e.stdin.end(s.toPNG()),e.unref()}catch(e){}return}l.app.dock?.setIcon(s)}";
+const currentUpdateGate =
+  "F=()=>{if(!v)return;let e=k();P(e),dle({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})}";
+const patchedUpdateGate =
+  "F=()=>{if(!v&&process.platform!==`linux`)return;let e=k();P(e),dle({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})}";
+const currentThemeGate =
+  "if(v){F();let e=()=>{let e=k();e===`codex-system`&&P(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}";
+const patchedThemeGate =
+  "if(v||process.platform===`linux`){F();let e=()=>{let e=k();e===`codex-system`&&P(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}";
+const currentWindowRegistration =
+  "onWindowRegistered:e=>{I?.registerWindow(e),C?.(e)}";
+const patchedWindowRegistration =
+  "onWindowRegistered:e=>{I?.registerWindow(e),C?.(e),process.platform===`linux`&&setImmediate(F)}";
+const currentTrayRegistration =
+  "n=new l.Tray(t.defaultIcon,process.platform===`win32`&&l.app.isPackaged?dEe(e.buildFlavor):void 0);if(!W9)return";
+const patchedTrayRegistration =
+  "n=new l.Tray(process.platform===`linux`&&globalThis.codexLinuxDockIconImage&&!globalThis.codexLinuxDockIconImage.isEmpty()?globalThis.codexLinuxDockIconImage:t.defaultIcon,process.platform===`win32`&&l.app.isPackaged?dEe(e.buildFlavor):void 0);if(!W9)return";
+
+const currentMainContracts = [
+  currentPreviewGate,
+  currentAppInfoResource,
+  currentWindowResource,
+  currentApplyIcon,
+  currentUpdateGate,
+  currentThemeGate,
+  currentWindowRegistration,
+  currentTrayRegistration,
+];
+const patchedMainContracts = [
+  patchedPreviewGate,
+  patchedAppInfoResource,
+  patchedWindowResource,
+  patchedApplyIcon,
+  patchedUpdateGate,
+  patchedThemeGate,
+  patchedWindowRegistration,
+  patchedTrayRegistration,
+];
+
+function countOccurrences(source, needle) {
+  return typeof source === "string" ? source.split(needle).length - 1 : 0;
+}
+
+function dockIconConfig(context) {
+  const defaults = context?.feature?.manifest?.tweaks?.appearance?.dockIcon;
+  const settings = context?.feature?.settings?.tweaks?.appearance?.dockIcon;
+  return {
+    ...(defaults != null && typeof defaults === "object" && !Array.isArray(defaults) ? defaults : {}),
+    ...(settings != null && typeof settings === "object" && !Array.isArray(settings) ? settings : {}),
+  };
+}
+
+function dockIconEnabled(context) {
+  return dockIconConfig(context).enabled === true;
+}
+
+function applyDockIconMainPatch(source) {
+  const currentCounts = currentMainContracts.map((needle) => countOccurrences(source, needle));
+  const patchedCounts = patchedMainContracts.map((needle) => countOccurrences(source, needle));
+  if (currentCounts.every((count) => count === 0) && patchedCounts.every((count) => count === 1)) {
+    return source;
+  }
+  if (!currentCounts.every((count) => count === 1) || !patchedCounts.every((count) => count === 0)) {
+    console.warn(
+      "WARN: Could not find the complete current Dock icon main-process contract - skipping Dock icon main patch",
+    );
+    return source;
+  }
+  return currentMainContracts.reduce(
+    (patchedSource, needle, index) => patchedSource.replace(needle, patchedMainContracts[index]),
+    source,
+  );
+}
+
+const currentSettingsGatePattern =
+  /if\(([A-Za-z_$][\w$]*)!==`macOS`\|\|([A-Za-z_$][\w$]*)\.ChatGPT!==`chatgpt`\|\|([A-Za-z_$][\w$]*)\.Agent===`prod`\)return null/g;
+const patchedSettingsGatePattern =
+  /if\(([A-Za-z_$][\w$]*)!==`macOS`&&\1!==`linux`\|\|([A-Za-z_$][\w$]*)\.ChatGPT!==`chatgpt`\|\|([A-Za-z_$][\w$]*)\.Agent===`prod`\)return null/g;
+const settingsRowAnchorPattern = /\.dockIconPreviews\b/g;
+
+function matches(source, pattern) {
+  if (typeof source !== "string") return [];
+  pattern.lastIndex = 0;
+  return [...source.matchAll(pattern)];
+}
+
+function dockIconSettingsContract(source) {
+  const currentMatches = matches(source, currentSettingsGatePattern);
+  const patchedMatches = matches(source, patchedSettingsGatePattern);
+  const rowAnchors = matches(source, settingsRowAnchorPattern);
+  if (rowAnchors.length === 1 && currentMatches.length === 1 && patchedMatches.length === 0) {
+    return "current";
+  }
+  if (rowAnchors.length === 1 && currentMatches.length === 0 && patchedMatches.length === 1) {
+    return "patched";
+  }
+  return "drifted";
+}
+
+function applyDockIconSettingsPatch(source) {
+  const contract = dockIconSettingsContract(source);
+  if (contract === "patched") return source;
+  if (contract !== "current") {
+    console.warn(
+      "WARN: Could not find the current Dock icon settings contract - skipping Dock icon settings patch",
+    );
+    return source;
+  }
+  return source.replace(
+    currentSettingsGatePattern,
+    (_match, platformAlias, brandAlias, buildFlavorAlias) =>
+      `if(${platformAlias}!==\`macOS\`&&${platformAlias}!==\`linux\`||${brandAlias}.ChatGPT!==\`chatgpt\`||${buildFlavorAlias}.Agent===\`prod\`)return null`,
+  );
+}
+
+const descriptors = [
+  {
+    id: "appearance-dock-icon-main-process",
+    phase: "main-bundle",
+    order: 20_940,
+    ciPolicy: "optional",
+    enabled: dockIconEnabled,
+    apply: applyDockIconMainPatch,
+  },
+  {
+    id: "appearance-dock-icon-settings-row",
+    phase: "webview-asset",
+    order: 20_950,
+    ciPolicy: "optional",
+    pattern: /^general-settings-[A-Za-z0-9_-]+\.js$/,
+    assetMatch: (source) => dockIconSettingsContract(source) !== "drifted",
+    missingDescription: "official Linux General settings Dock icon bundle",
+    skipDescription: "Dock icon settings row patch",
+    enabled: dockIconEnabled,
+    apply: applyDockIconSettingsPatch,
+  },
+];
+
+module.exports = {
+  applyDockIconMainPatch,
+  applyDockIconSettingsPatch,
+  descriptors,
+  dockIconConfig,
+  dockIconEnabled,
+};

--- a/linux-features/ui-tweaks/stage.sh
+++ b/linux-features/ui-tweaks/stage.sh
@@ -43,16 +43,16 @@ if [ ! -f "$official_icon" ] || [ -L "$official_icon" ] ||
    ! grep -qxF 'Name=ChatGPT' "$official_desktop" ||
    ! grep -qxF 'Exec=chatgpt %U' "$official_desktop" ||
    ! grep -qxF 'Icon=chatgpt' "$official_desktop"; then
-    echo "WARN: Official Linux Dock icon resource or desktop metadata drifted; skipping Dock icon resources" >&2
+    echo "ERROR: Official Linux Dock icon resource or desktop metadata drifted; refusing incomplete Dock icon payload" >&2
     remove_dock_icon_payload
-    exit 0
+    exit 1
 fi
 
 for source in "$community_icon" "$helper_source"; do
     if [ ! -f "$source" ] || [ -L "$source" ]; then
-        echo "WARN: Dock icon feature resource is unavailable; skipping Dock icon resources: $source" >&2
+        echo "ERROR: Dock icon feature resource is unavailable; refusing incomplete Dock icon payload: $source" >&2
         remove_dock_icon_payload
-        exit 0
+        exit 1
     fi
 done
 

--- a/linux-features/ui-tweaks/stage.sh
+++ b/linux-features/ui-tweaks/stage.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+app_dir="${CODEX_UPSTREAM_APP_DIR:?CODEX_UPSTREAM_APP_DIR is required}"
+install_dir="${INSTALL_DIR:?INSTALL_DIR is required}"
+official_icon="$app_dir/resources/icon-chatgpt.png"
+official_desktop="$install_dir/.codex-linux/upstream-package/chatgpt.desktop"
+community_icon="$SCRIPT_DIR/assets/codex-linux.png"
+resources_dir="$install_dir/resources"
+target_dir="$resources_dir/dock-icon"
+temp_dir="$resources_dir/.dock-icon.tmp.$$"
+helper_source="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sync-desktop-icon.sh"
+
+remove_dock_icon_payload() {
+    rm -rf -- "$temp_dir"
+    if [ -L "$target_dir" ]; then
+        rm -f -- "$target_dir"
+    else
+        rm -rf -- "$target_dir"
+    fi
+}
+
+dock_icon_enabled="$(node - "$SCRIPT_DIR" <<'NODE'
+const path = require("node:path");
+const scriptDir = process.argv[2];
+const { loadEnabledLinuxFeatures } = require(path.join(scriptDir, "scripts/lib/linux-features.js"));
+const { dockIconEnabled } = require(path.join(
+  scriptDir,
+  "linux-features/ui-tweaks/patches/dock-icon.js",
+));
+const feature = loadEnabledLinuxFeatures().find(({ id }) => id === "ui-tweaks");
+process.stdout.write(feature != null && dockIconEnabled({ feature }) ? "true" : "false");
+NODE
+)"
+
+if [ "$dock_icon_enabled" != "true" ]; then
+    remove_dock_icon_payload
+    exit 0
+fi
+
+if [ ! -f "$official_icon" ] || [ -L "$official_icon" ] ||
+   [ ! -f "$official_desktop" ] || [ -L "$official_desktop" ] ||
+   ! grep -qxF 'Name=ChatGPT' "$official_desktop" ||
+   ! grep -qxF 'Exec=chatgpt %U' "$official_desktop" ||
+   ! grep -qxF 'Icon=chatgpt' "$official_desktop"; then
+    echo "WARN: Official Linux Dock icon resource or desktop metadata drifted; skipping Dock icon resources" >&2
+    remove_dock_icon_payload
+    exit 0
+fi
+
+for source in "$community_icon" "$helper_source"; do
+    if [ ! -f "$source" ] || [ -L "$source" ]; then
+        echo "WARN: Dock icon feature resource is unavailable; skipping Dock icon resources: $source" >&2
+        remove_dock_icon_payload
+        exit 0
+    fi
+done
+
+mkdir -p "$resources_dir"
+rm -rf -- "$temp_dir"
+mkdir -m 0755 "$temp_dir"
+trap 'rm -rf -- "$temp_dir"' EXIT
+install -m 0644 "$official_icon" "$temp_dir/icon-chatgpt.png"
+install -m 0644 "$community_icon" "$temp_dir/icon-codex-dark-color.png"
+install -m 0644 "$community_icon" "$temp_dir/icon-codex-light.png"
+install -m 0755 "$helper_source" "$temp_dir/sync-desktop-icon.sh"
+if [ -L "$target_dir" ]; then
+    rm -f -- "$target_dir"
+else
+    rm -rf -- "$target_dir"
+fi
+mv "$temp_dir" "$target_dir"
+trap - EXIT

--- a/linux-features/ui-tweaks/sync-desktop-icon.sh
+++ b/linux-features/ui-tweaks/sync-desktop-icon.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+set -f
+
+home_dir="${HOME:-}"
+[ -n "$home_dir" ] || exit 0
+
+app_id="${CODEX_LINUX_APP_ID:-${CODEX_APP_ID:-codex-desktop}}"
+case "$app_id" in
+    *[!A-Za-z0-9._-]*|'') exit 0 ;;
+esac
+
+data_home="${XDG_DATA_HOME:-$home_dir/.local/share}"
+applications_dir="$data_home/applications"
+icons_dir="$data_home/icons/hicolor/256x256/apps"
+desktop_target="$applications_dir/$app_id.desktop"
+legacy_icon_target="$icons_dir/$app_id-dock-selection.png"
+marker="X-Codex-Linux-Dock-Icon=1"
+managed_icons=(
+    "$icons_dir/$app_id-dock-chatgpt.png"
+    "$icons_dir/$app_id-dock-codex-dark.png"
+    "$icons_dir/$app_id-dock-codex-light.png"
+    "$legacy_icon_target"
+)
+
+refresh_desktop_database() {
+    if [[ "${XDG_CURRENT_DESKTOP:-}" == *KDE* ]]; then
+        command -v kbuildsycoca6 >/dev/null 2>&1 && kbuildsycoca6 >/dev/null 2>&1 || true
+    fi
+}
+
+managed_desktop_is_owned() {
+    local icon_value
+    [ -f "$desktop_target" ] && [ ! -L "$desktop_target" ] || return 1
+    grep -qxF "$marker" "$desktop_target" || return 1
+    icon_value="$(awk '/^Icon=/{sub(/^Icon=/, ""); print; exit}' "$desktop_target")"
+    case "$icon_value" in
+        "$icons_dir/$app_id-dock-chatgpt.png"|"$icons_dir/$app_id-dock-codex-dark.png"|"$icons_dir/$app_id-dock-codex-light.png") ;;
+        *) return 1 ;;
+    esac
+}
+
+cleanup_managed_desktop() {
+    local icon
+    local changed=0
+    managed_desktop_is_owned || return 0
+    if rm -f -- "$desktop_target"; then
+        changed=1
+    else
+        echo "WARN: Could not remove managed Dock icon desktop entry: $desktop_target" >&2
+        return 0
+    fi
+    for icon in "${managed_icons[@]}"; do
+        if [ -f "$icon" ] && [ ! -L "$icon" ]; then
+            rm -f -- "$icon" || echo "WARN: Could not remove managed Dock icon resource: $icon" >&2
+        fi
+    done
+    [ "$changed" -eq 0 ] || refresh_desktop_database
+}
+
+if [ "${CODEX_LINUX_FEATURE_HOOK_PHASE:-}" = "prelaunch" ]; then
+    app_dir="${CODEX_LINUX_APP_DIR:-${1:-}}"
+    [ -n "$app_dir" ] && [ -d "$app_dir" ] || exit 0
+    payload_helper="$app_dir/resources/dock-icon/sync-desktop-icon.sh"
+    if [ -f "$payload_helper" ] && [ ! -L "$payload_helper" ]; then
+        exit 0
+    fi
+    cleanup_managed_desktop
+    exit 0
+fi
+
+selection="${1:-}"
+case "$selection" in
+    chatgpt|codex-dark|codex-light) ;;
+    *) exit 0 ;;
+esac
+icon_target="$icons_dir/$app_id-dock-$selection.png"
+
+desktop_source_matches_identity() {
+    local source="$1"
+    local line
+    local token
+    local value
+    [ "$(basename -- "$source")" = "$app_id.desktop" ] || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            StartupWMClass=*) [ "${line#*=}" = "$app_id" ] || return 1 ;;
+            X-GNOME-WMClass=*) [ "${line#*=}" = "$app_id" ] || return 1 ;;
+            Exec=*)
+                if [ "$app_id" != "codex-desktop" ] && [[ "$line" != *"$app_id"* ]]; then
+                    return 1
+                fi
+                ;;
+        esac
+        for token in $line; do
+            case "$token" in
+                CHROME_DESKTOP=*) [ "${token#*=}" = "$app_id.desktop" ] || return 1 ;;
+                BAMF_DESKTOP_FILE_HINT=*)
+                    value="${token#*=}"
+                    [ "$(basename -- "$value")" = "$app_id.desktop" ] || return 1
+                    ;;
+                CODEX_APP_ID=*|CODEX_LINUX_APP_ID=*) [ "${token#*=}" = "$app_id" ] || return 1 ;;
+            esac
+        done
+    done < "$source"
+}
+
+if [ -e "$desktop_target" ] || [ -L "$desktop_target" ]; then
+    [ -f "$desktop_target" ] && [ ! -L "$desktop_target" ] || exit 0
+    grep -qxF "$marker" "$desktop_target" || exit 0
+fi
+
+desktop_source="${CODEX_LINUX_DESKTOP_FILE_SOURCE:-}"
+if [ -z "$desktop_source" ]; then
+    data_dirs="${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+    IFS=: read -r -a data_dirs_array <<< "$data_dirs"
+    candidates=("${BAMF_DESKTOP_FILE_HINT:-}")
+    for data_dir in "${data_dirs_array[@]}"; do
+        [ -n "$data_dir" ] && candidates+=("$data_dir/applications/$app_id.desktop")
+    done
+    for candidate in "${candidates[@]}"; do
+        if [ -n "$candidate" ] && [ "$candidate" != "$desktop_target" ] && [ -f "$candidate" ] && [ ! -L "$candidate" ] && desktop_source_matches_identity "$candidate"; then
+            desktop_source="$candidate"
+            break
+        fi
+    done
+fi
+[ -n "$desktop_source" ] && [ -f "$desktop_source" ] && [ ! -L "$desktop_source" ] || exit 0
+grep -q '^Icon=' "$desktop_source" || exit 0
+if ! desktop_source_matches_identity "$desktop_source"; then
+    echo "WARN: Dock icon desktop source identity does not match app id '$app_id'; leaving launchers unchanged" >&2
+    exit 0
+fi
+
+mkdir -p "$applications_dir" "$icons_dir"
+desktop_tmp="$(mktemp "$applications_dir/.$app_id.desktop.XXXXXX")"
+icon_tmp="$(mktemp "$icons_dir/.$app_id-dock-selection.XXXXXX")"
+trap 'rm -f -- "$desktop_tmp" "$icon_tmp"' EXIT
+cat > "$icon_tmp"
+[ -s "$icon_tmp" ] || exit 0
+chmod 0644 "$icon_tmp"
+awk -v icon="$icon_target" -v marker="$marker" '
+    $0 == marker { next }
+    /^Icon=/ && !icon_written { print "Icon=" icon; icon_written=1; next }
+    /^\[/ && $0 != "[Desktop Entry]" && !marker_written { print marker; marker_written=1 }
+    { print }
+    END { if (icon_written && !marker_written) print marker }
+' "$desktop_source" > "$desktop_tmp"
+chmod 0644 "$desktop_tmp"
+
+changed=0
+if [ ! -f "$icon_target" ] || ! cmp -s "$icon_tmp" "$icon_target"; then
+    mv -f -- "$icon_tmp" "$icon_target"
+    changed=1
+fi
+if [ ! -f "$desktop_target" ] || ! cmp -s "$desktop_tmp" "$desktop_target"; then
+    mv -f -- "$desktop_tmp" "$desktop_target"
+    changed=1
+fi
+if [ -f "$legacy_icon_target" ] && [ ! -L "$legacy_icon_target" ]; then
+    rm -f -- "$legacy_icon_target"
+fi
+[ "$changed" -eq 0 ] || refresh_desktop_database

--- a/linux-features/ui-tweaks/sync-desktop-icon.sh
+++ b/linux-features/ui-tweaks/sync-desktop-icon.sh
@@ -37,6 +37,32 @@ managed_icon_is_owned() {
     [ "$actual_digest" = "$expected_digest" ]
 }
 
+acquire_app_lock() {
+    mkdir -p "$applications_dir"
+    exec 9< "$applications_dir"
+    if ! flock 9; then
+        echo "WARN: Could not lock Dock icon launcher state: $applications_dir" >&2
+        exit 0
+    fi
+}
+
+cleanup_owned_icon_orphans() {
+    local keep="${1:-}"
+    local icon
+    [ -d "$icons_dir" ] || return 0
+    while IFS= read -r -d '' icon; do
+        [ "$icon" = "$keep" ] && continue
+        managed_icon_is_owned "$icon" || continue
+        rm -f -- "$icon" || echo "WARN: Could not remove stale managed Dock icon resource: $icon" >&2
+    done < <(
+        find "$icons_dir" -maxdepth 1 -type f \
+            \( -name "$app_id-dock-chatgpt-*.png" \
+               -o -name "$app_id-dock-codex-dark-*.png" \
+               -o -name "$app_id-dock-codex-light-*.png" \) \
+            -print0
+    )
+}
+
 refresh_desktop_database() {
     if [[ "${XDG_CURRENT_DESKTOP:-}" == *KDE* ]]; then
         command -v kbuildsycoca6 >/dev/null 2>&1 && kbuildsycoca6 >/dev/null 2>&1 || true
@@ -77,7 +103,12 @@ managed_desktop_is_owned() {
 
 cleanup_managed_desktop() {
     local icon_value
-    managed_desktop_content_is_owned || return 0
+    if ! managed_desktop_content_is_owned; then
+        if [ ! -e "$desktop_target" ] && [ ! -L "$desktop_target" ]; then
+            cleanup_owned_icon_orphans
+        fi
+        return 0
+    fi
     icon_value="$(awk '/^Icon=/{sub(/^Icon=/, ""); print; exit}' "$desktop_target")"
     if [ -e "$icon_value" ] || [ -L "$icon_value" ]; then
         managed_icon_is_owned "$icon_value" || return 0
@@ -90,6 +121,7 @@ cleanup_managed_desktop() {
         echo "WARN: Could not remove managed Dock icon desktop entry: $desktop_target" >&2
         return 0
     fi
+    cleanup_owned_icon_orphans
     refresh_desktop_database
 }
 
@@ -100,6 +132,7 @@ if [ "${CODEX_LINUX_FEATURE_HOOK_PHASE:-}" = "prelaunch" ]; then
     if [ -f "$payload_helper" ] && [ ! -L "$payload_helper" ]; then
         exit 0
     fi
+    acquire_app_lock
     cleanup_managed_desktop
     exit 0
 fi
@@ -109,6 +142,8 @@ case "$selection" in
     chatgpt|codex-dark|codex-light) ;;
     *) exit 0 ;;
 esac
+
+acquire_app_lock
 
 desktop_source_matches_identity() {
     local source="$1"
@@ -255,4 +290,5 @@ fi
 if [ -n "$previous_icon" ] && [ "$previous_icon" != "$icon_target" ] && managed_icon_is_owned "$previous_icon"; then
     rm -f -- "$previous_icon" || true
 fi
+cleanup_owned_icon_orphans "$icon_target"
 [ "$changed" -eq 0 ] || refresh_desktop_database

--- a/linux-features/ui-tweaks/sync-desktop-icon.sh
+++ b/linux-features/ui-tweaks/sync-desktop-icon.sh
@@ -24,6 +24,28 @@ managed_icons=(
     "$legacy_icon_target"
 )
 
+icon_ownership_path() {
+    printf '%s.codex-linux-sha256\n' "$1"
+}
+
+managed_icon_is_owned() {
+    local icon="$1"
+    local actual_digest
+    local expected_digest
+    local ownership
+    ownership="$(icon_ownership_path "$icon")"
+    [ -f "$icon" ] && [ ! -L "$icon" ] || return 1
+    [ -f "$ownership" ] && [ ! -L "$ownership" ] || return 1
+    IFS= read -r expected_digest < "$ownership" || return 1
+    case "$expected_digest" in
+        *[!0-9a-f]*|'') return 1 ;;
+    esac
+    [ "${#expected_digest}" -eq 64 ] || return 1
+    [ "$(wc -l < "$ownership")" -eq 1 ] || return 1
+    actual_digest="$(sha256sum "$icon" | awk '{print $1}')"
+    [ "$actual_digest" = "$expected_digest" ]
+}
+
 refresh_desktop_database() {
     if [[ "${XDG_CURRENT_DESKTOP:-}" == *KDE* ]]; then
         command -v kbuildsycoca6 >/dev/null 2>&1 && kbuildsycoca6 >/dev/null 2>&1 || true
@@ -57,6 +79,7 @@ managed_desktop_is_owned() {
 
 cleanup_managed_desktop() {
     local icon
+    local ownership
     local changed=0
     managed_desktop_is_owned || return 0
     if rm -f -- "$desktop_target"; then
@@ -66,8 +89,13 @@ cleanup_managed_desktop() {
         return 0
     fi
     for icon in "${managed_icons[@]}"; do
-        if [ -f "$icon" ] && [ ! -L "$icon" ]; then
-            rm -f -- "$icon" || echo "WARN: Could not remove managed Dock icon resource: $icon" >&2
+        ownership="$(icon_ownership_path "$icon")"
+        if managed_icon_is_owned "$icon"; then
+            if rm -f -- "$icon" "$ownership"; then
+                :
+            else
+                echo "WARN: Could not remove managed Dock icon resource: $icon" >&2
+            fi
         fi
     done
     [ "$changed" -eq 0 ] || refresh_desktop_database
@@ -90,6 +118,7 @@ case "$selection" in
     *) exit 0 ;;
 esac
 icon_target="$icons_dir/$app_id-dock-$selection.png"
+icon_ownership_target="$(icon_ownership_path "$icon_target")"
 
 desktop_source_matches_identity() {
     local source="$1"
@@ -175,13 +204,23 @@ if grep -Eq '^Exec=(AppRun|.*[[:space:]]AppRun)([[:space:]]|$)' "$desktop_source
 fi
 
 mkdir -p "$applications_dir" "$icons_dir"
+if [ -e "$icon_target" ] || [ -L "$icon_target" ] ||
+   [ -e "$icon_ownership_target" ] || [ -L "$icon_ownership_target" ]; then
+    if ! managed_icon_is_owned "$icon_target"; then
+        echo "WARN: Dock icon target is not an unchanged managed resource; leaving launchers unchanged: $icon_target" >&2
+        exit 0
+    fi
+fi
 desktop_content_tmp="$(mktemp "$applications_dir/.$app_id.desktop-content.XXXXXX")"
 desktop_tmp="$(mktemp "$applications_dir/.$app_id.desktop.XXXXXX")"
 icon_tmp="$(mktemp "$icons_dir/.$app_id-dock-selection.XXXXXX")"
-trap 'rm -f -- "$desktop_content_tmp" "$desktop_tmp" "$icon_tmp"' EXIT
+icon_ownership_tmp="$(mktemp "$icons_dir/.$app_id-dock-selection-sha256.XXXXXX")"
+trap 'rm -f -- "$desktop_content_tmp" "$desktop_tmp" "$icon_tmp" "$icon_ownership_tmp"' EXIT
 cat > "$icon_tmp"
 [ -s "$icon_tmp" ] || exit 0
 chmod 0644 "$icon_tmp"
+sha256sum "$icon_tmp" | awk '{print $1}' > "$icon_ownership_tmp"
+chmod 0600 "$icon_ownership_tmp"
 CODEX_DOCK_APPIMAGE_EXEC="$appimage_exec" awk -v icon="$icon_target" \
     -v legacy_marker="$legacy_marker" -v marker_prefix="$marker_prefix" '
     BEGIN { appimage_exec = ENVIRON["CODEX_DOCK_APPIMAGE_EXEC"] }
@@ -209,13 +248,17 @@ chmod 0644 "$desktop_tmp"
 changed=0
 if [ ! -f "$icon_target" ] || ! cmp -s "$icon_tmp" "$icon_target"; then
     mv -f -- "$icon_tmp" "$icon_target"
+    mv -f -- "$icon_ownership_tmp" "$icon_ownership_target"
     changed=1
+else
+    rm -f -- "$icon_tmp"
+    rm -f -- "$icon_ownership_tmp"
 fi
 if [ ! -f "$desktop_target" ] || ! cmp -s "$desktop_tmp" "$desktop_target"; then
     mv -f -- "$desktop_tmp" "$desktop_target"
     changed=1
 fi
-if [ -f "$legacy_icon_target" ] && [ ! -L "$legacy_icon_target" ]; then
-    rm -f -- "$legacy_icon_target"
+if managed_icon_is_owned "$legacy_icon_target"; then
+    rm -f -- "$legacy_icon_target" "$(icon_ownership_path "$legacy_icon_target")"
 fi
 [ "$changed" -eq 0 ] || refresh_desktop_database

--- a/linux-features/ui-tweaks/sync-desktop-icon.sh
+++ b/linux-features/ui-tweaks/sync-desktop-icon.sh
@@ -15,7 +15,8 @@ applications_dir="$data_home/applications"
 icons_dir="$data_home/icons/hicolor/256x256/apps"
 desktop_target="$applications_dir/$app_id.desktop"
 legacy_icon_target="$icons_dir/$app_id-dock-selection.png"
-marker="X-Codex-Linux-Dock-Icon=1"
+legacy_marker="X-Codex-Linux-Dock-Icon=1"
+marker_prefix="X-Codex-Linux-Dock-Icon-SHA256="
 managed_icons=(
     "$icons_dir/$app_id-dock-chatgpt.png"
     "$icons_dir/$app_id-dock-codex-dark.png"
@@ -30,9 +31,23 @@ refresh_desktop_database() {
 }
 
 managed_desktop_is_owned() {
+    local actual_digest
+    local expected_digest
     local icon_value
     [ -f "$desktop_target" ] && [ ! -L "$desktop_target" ] || return 1
-    grep -qxF "$marker" "$desktop_target" || return 1
+    expected_digest="$(awk -v prefix="$marker_prefix" '
+        index($0, prefix) == 1 { count += 1; digest = substr($0, length(prefix) + 1) }
+        END { if (count == 1) print digest }
+    ' "$desktop_target")"
+    case "$expected_digest" in
+        *[!0-9a-f]*|'') return 1 ;;
+    esac
+    [ "${#expected_digest}" -eq 64 ] || return 1
+    actual_digest="$(
+        awk -v prefix="$marker_prefix" 'index($0, prefix) != 1 { print }' "$desktop_target" |
+            sha256sum | awk '{print $1}'
+    )"
+    [ "$actual_digest" = "$expected_digest" ] || return 1
     icon_value="$(awk '/^Icon=/{sub(/^Icon=/, ""); print; exit}' "$desktop_target")"
     case "$icon_value" in
         "$icons_dir/$app_id-dock-chatgpt.png"|"$icons_dir/$app_id-dock-codex-dark.png"|"$icons_dir/$app_id-dock-codex-light.png"|"$legacy_icon_target") ;;
@@ -105,9 +120,19 @@ desktop_source_matches_identity() {
     done < "$source"
 }
 
+desktop_exec_quote() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//\`/\\\`}"
+    value="${value//\$/\\\$}"
+    value="${value//%/%%}"
+    printf '"%s"' "$value"
+}
+
 if [ -e "$desktop_target" ] || [ -L "$desktop_target" ]; then
     [ -f "$desktop_target" ] && [ ! -L "$desktop_target" ] || exit 0
-    grep -qxF "$marker" "$desktop_target" || exit 0
+    managed_desktop_is_owned || exit 0
 fi
 
 desktop_source="${CODEX_LINUX_DESKTOP_FILE_SOURCE:-}"
@@ -132,20 +157,53 @@ if ! desktop_source_matches_identity "$desktop_source"; then
     exit 0
 fi
 
+appimage_exec=""
+if grep -Eq '^Exec=(AppRun|.*[[:space:]]AppRun)([[:space:]]|$)' "$desktop_source"; then
+    appimage_path="${APPIMAGE:-}"
+    case "$appimage_path" in
+        /*) ;;
+        *)
+            echo "WARN: Dock icon AppImage desktop source has no persistent AppImage path; leaving launchers unchanged" >&2
+            exit 0
+            ;;
+    esac
+    if [ ! -f "$appimage_path" ] || [ ! -x "$appimage_path" ]; then
+        echo "WARN: Dock icon AppImage path is not an executable file; leaving launchers unchanged: $appimage_path" >&2
+        exit 0
+    fi
+    appimage_exec="$(desktop_exec_quote "$appimage_path")"
+fi
+
 mkdir -p "$applications_dir" "$icons_dir"
+desktop_content_tmp="$(mktemp "$applications_dir/.$app_id.desktop-content.XXXXXX")"
 desktop_tmp="$(mktemp "$applications_dir/.$app_id.desktop.XXXXXX")"
 icon_tmp="$(mktemp "$icons_dir/.$app_id-dock-selection.XXXXXX")"
-trap 'rm -f -- "$desktop_tmp" "$icon_tmp"' EXIT
+trap 'rm -f -- "$desktop_content_tmp" "$desktop_tmp" "$icon_tmp"' EXIT
 cat > "$icon_tmp"
 [ -s "$icon_tmp" ] || exit 0
 chmod 0644 "$icon_tmp"
-awk -v icon="$icon_target" -v marker="$marker" '
-    $0 == marker { next }
+CODEX_DOCK_APPIMAGE_EXEC="$appimage_exec" awk -v icon="$icon_target" \
+    -v legacy_marker="$legacy_marker" -v marker_prefix="$marker_prefix" '
+    BEGIN { appimage_exec = ENVIRON["CODEX_DOCK_APPIMAGE_EXEC"] }
+    function replace_literal(value, needle, replacement, output, position) {
+        output = ""
+        while ((position = index(value, needle)) != 0) {
+            output = output substr(value, 1, position - 1) replacement
+            value = substr(value, position + length(needle))
+        }
+        return output value
+    }
+    $0 == legacy_marker || index($0, marker_prefix) == 1 { next }
+    /^Exec=/ && appimage_exec != "" { $0 = replace_literal($0, "AppRun", appimage_exec) }
     /^Icon=/ && !icon_written { print "Icon=" icon; icon_written=1; next }
+    { print }
+' "$desktop_source" > "$desktop_content_tmp"
+desktop_digest="$(sha256sum "$desktop_content_tmp" | awk '{print $1}')"
+awk -v marker="$marker_prefix$desktop_digest" '
     /^\[/ && $0 != "[Desktop Entry]" && !marker_written { print marker; marker_written=1 }
     { print }
-    END { if (icon_written && !marker_written) print marker }
-' "$desktop_source" > "$desktop_tmp"
+    END { if (!marker_written) print marker }
+' "$desktop_content_tmp" > "$desktop_tmp"
 chmod 0644 "$desktop_tmp"
 
 changed=0

--- a/linux-features/ui-tweaks/sync-desktop-icon.sh
+++ b/linux-features/ui-tweaks/sync-desktop-icon.sh
@@ -14,34 +14,25 @@ data_home="${XDG_DATA_HOME:-$home_dir/.local/share}"
 applications_dir="$data_home/applications"
 icons_dir="$data_home/icons/hicolor/256x256/apps"
 desktop_target="$applications_dir/$app_id.desktop"
-legacy_icon_target="$icons_dir/$app_id-dock-selection.png"
 legacy_marker="X-Codex-Linux-Dock-Icon=1"
 marker_prefix="X-Codex-Linux-Dock-Icon-SHA256="
-managed_icons=(
-    "$icons_dir/$app_id-dock-chatgpt.png"
-    "$icons_dir/$app_id-dock-codex-dark.png"
-    "$icons_dir/$app_id-dock-codex-light.png"
-    "$legacy_icon_target"
-)
-
-icon_ownership_path() {
-    printf '%s.codex-linux-sha256\n' "$1"
-}
 
 managed_icon_is_owned() {
     local icon="$1"
     local actual_digest
     local expected_digest
-    local ownership
-    ownership="$(icon_ownership_path "$icon")"
     [ -f "$icon" ] && [ ! -L "$icon" ] || return 1
-    [ -f "$ownership" ] && [ ! -L "$ownership" ] || return 1
-    IFS= read -r expected_digest < "$ownership" || return 1
+    case "$icon" in
+        "$icons_dir/$app_id-dock-chatgpt-"*.png) expected_digest="${icon#"$icons_dir/$app_id-dock-chatgpt-"}" ;;
+        "$icons_dir/$app_id-dock-codex-dark-"*.png) expected_digest="${icon#"$icons_dir/$app_id-dock-codex-dark-"}" ;;
+        "$icons_dir/$app_id-dock-codex-light-"*.png) expected_digest="${icon#"$icons_dir/$app_id-dock-codex-light-"}" ;;
+        *) return 1 ;;
+    esac
+    expected_digest="${expected_digest%.png}"
     case "$expected_digest" in
         *[!0-9a-f]*|'') return 1 ;;
     esac
     [ "${#expected_digest}" -eq 64 ] || return 1
-    [ "$(wc -l < "$ownership")" -eq 1 ] || return 1
     actual_digest="$(sha256sum "$icon" | awk '{print $1}')"
     [ "$actual_digest" = "$expected_digest" ]
 }
@@ -52,7 +43,7 @@ refresh_desktop_database() {
     fi
 }
 
-managed_desktop_is_owned() {
+managed_desktop_content_is_owned() {
     local actual_digest
     local expected_digest
     local icon_value
@@ -72,33 +63,34 @@ managed_desktop_is_owned() {
     [ "$actual_digest" = "$expected_digest" ] || return 1
     icon_value="$(awk '/^Icon=/{sub(/^Icon=/, ""); print; exit}' "$desktop_target")"
     case "$icon_value" in
-        "$icons_dir/$app_id-dock-chatgpt.png"|"$icons_dir/$app_id-dock-codex-dark.png"|"$icons_dir/$app_id-dock-codex-light.png"|"$legacy_icon_target") ;;
+        "$icons_dir/$app_id-dock-chatgpt-"*.png|"$icons_dir/$app_id-dock-codex-dark-"*.png|"$icons_dir/$app_id-dock-codex-light-"*.png) ;;
         *) return 1 ;;
     esac
 }
 
+managed_desktop_is_owned() {
+    local icon_value
+    managed_desktop_content_is_owned || return 1
+    icon_value="$(awk '/^Icon=/{sub(/^Icon=/, ""); print; exit}' "$desktop_target")"
+    managed_icon_is_owned "$icon_value"
+}
+
 cleanup_managed_desktop() {
-    local icon
-    local ownership
-    local changed=0
-    managed_desktop_is_owned || return 0
-    if rm -f -- "$desktop_target"; then
-        changed=1
-    else
+    local icon_value
+    managed_desktop_content_is_owned || return 0
+    icon_value="$(awk '/^Icon=/{sub(/^Icon=/, ""); print; exit}' "$desktop_target")"
+    if [ -e "$icon_value" ] || [ -L "$icon_value" ]; then
+        managed_icon_is_owned "$icon_value" || return 0
+        if ! rm -f -- "$icon_value"; then
+            echo "WARN: Could not remove managed Dock icon resource: $icon_value" >&2
+            return 0
+        fi
+    fi
+    if ! rm -f -- "$desktop_target"; then
         echo "WARN: Could not remove managed Dock icon desktop entry: $desktop_target" >&2
         return 0
     fi
-    for icon in "${managed_icons[@]}"; do
-        ownership="$(icon_ownership_path "$icon")"
-        if managed_icon_is_owned "$icon"; then
-            if rm -f -- "$icon" "$ownership"; then
-                :
-            else
-                echo "WARN: Could not remove managed Dock icon resource: $icon" >&2
-            fi
-        fi
-    done
-    [ "$changed" -eq 0 ] || refresh_desktop_database
+    refresh_desktop_database
 }
 
 if [ "${CODEX_LINUX_FEATURE_HOOK_PHASE:-}" = "prelaunch" ]; then
@@ -117,8 +109,6 @@ case "$selection" in
     chatgpt|codex-dark|codex-light) ;;
     *) exit 0 ;;
 esac
-icon_target="$icons_dir/$app_id-dock-$selection.png"
-icon_ownership_target="$(icon_ownership_path "$icon_target")"
 
 desktop_source_matches_identity() {
     local source="$1"
@@ -161,7 +151,11 @@ desktop_exec_quote() {
 
 if [ -e "$desktop_target" ] || [ -L "$desktop_target" ]; then
     [ -f "$desktop_target" ] && [ ! -L "$desktop_target" ] || exit 0
-    managed_desktop_is_owned || exit 0
+    managed_desktop_content_is_owned || exit 0
+    current_icon="$(awk '/^Icon=/{sub(/^Icon=/, ""); print; exit}' "$desktop_target")"
+    if [ -e "$current_icon" ] || [ -L "$current_icon" ]; then
+        managed_icon_is_owned "$current_icon" || exit 0
+    fi
 fi
 
 desktop_source="${CODEX_LINUX_DESKTOP_FILE_SOURCE:-}"
@@ -204,23 +198,21 @@ if grep -Eq '^Exec=(AppRun|.*[[:space:]]AppRun)([[:space:]]|$)' "$desktop_source
 fi
 
 mkdir -p "$applications_dir" "$icons_dir"
-if [ -e "$icon_target" ] || [ -L "$icon_target" ] ||
-   [ -e "$icon_ownership_target" ] || [ -L "$icon_ownership_target" ]; then
+desktop_content_tmp="$(mktemp "$applications_dir/.$app_id.desktop-content.XXXXXX")"
+desktop_tmp="$(mktemp "$applications_dir/.$app_id.desktop.XXXXXX")"
+icon_tmp="$(mktemp "$icons_dir/.$app_id-dock-selection.XXXXXX")"
+trap 'rm -f -- "$desktop_content_tmp" "$desktop_tmp" "$icon_tmp"' EXIT
+cat > "$icon_tmp"
+[ -s "$icon_tmp" ] || exit 0
+chmod 0644 "$icon_tmp"
+icon_digest="$(sha256sum "$icon_tmp" | awk '{print $1}')"
+icon_target="$icons_dir/$app_id-dock-$selection-$icon_digest.png"
+if [ -e "$icon_target" ] || [ -L "$icon_target" ]; then
     if ! managed_icon_is_owned "$icon_target"; then
         echo "WARN: Dock icon target is not an unchanged managed resource; leaving launchers unchanged: $icon_target" >&2
         exit 0
     fi
 fi
-desktop_content_tmp="$(mktemp "$applications_dir/.$app_id.desktop-content.XXXXXX")"
-desktop_tmp="$(mktemp "$applications_dir/.$app_id.desktop.XXXXXX")"
-icon_tmp="$(mktemp "$icons_dir/.$app_id-dock-selection.XXXXXX")"
-icon_ownership_tmp="$(mktemp "$icons_dir/.$app_id-dock-selection-sha256.XXXXXX")"
-trap 'rm -f -- "$desktop_content_tmp" "$desktop_tmp" "$icon_tmp" "$icon_ownership_tmp"' EXIT
-cat > "$icon_tmp"
-[ -s "$icon_tmp" ] || exit 0
-chmod 0644 "$icon_tmp"
-sha256sum "$icon_tmp" | awk '{print $1}' > "$icon_ownership_tmp"
-chmod 0600 "$icon_ownership_tmp"
 CODEX_DOCK_APPIMAGE_EXEC="$appimage_exec" awk -v icon="$icon_target" \
     -v legacy_marker="$legacy_marker" -v marker_prefix="$marker_prefix" '
     BEGIN { appimage_exec = ENVIRON["CODEX_DOCK_APPIMAGE_EXEC"] }
@@ -246,19 +238,21 @@ awk -v marker="$marker_prefix$desktop_digest" '
 chmod 0644 "$desktop_tmp"
 
 changed=0
-if [ ! -f "$icon_target" ] || ! cmp -s "$icon_tmp" "$icon_target"; then
+if [ ! -f "$icon_target" ]; then
     mv -f -- "$icon_tmp" "$icon_target"
-    mv -f -- "$icon_ownership_tmp" "$icon_ownership_target"
     changed=1
 else
     rm -f -- "$icon_tmp"
-    rm -f -- "$icon_ownership_tmp"
+fi
+previous_icon=""
+if managed_desktop_is_owned; then
+    previous_icon="$(awk '/^Icon=/{sub(/^Icon=/, ""); print; exit}' "$desktop_target")"
 fi
 if [ ! -f "$desktop_target" ] || ! cmp -s "$desktop_tmp" "$desktop_target"; then
     mv -f -- "$desktop_tmp" "$desktop_target"
     changed=1
 fi
-if managed_icon_is_owned "$legacy_icon_target"; then
-    rm -f -- "$legacy_icon_target" "$(icon_ownership_path "$legacy_icon_target")"
+if [ -n "$previous_icon" ] && [ "$previous_icon" != "$icon_target" ] && managed_icon_is_owned "$previous_icon"; then
+    rm -f -- "$previous_icon" || true
 fi
 [ "$changed" -eq 0 ] || refresh_desktop_database

--- a/linux-features/ui-tweaks/sync-desktop-icon.sh
+++ b/linux-features/ui-tweaks/sync-desktop-icon.sh
@@ -40,10 +40,15 @@ managed_icon_is_owned() {
 acquire_app_lock() {
     mkdir -p "$applications_dir"
     exec 9< "$applications_dir"
-    if ! flock 9; then
+    if ! flock -w 5 9; then
         echo "WARN: Could not lock Dock icon launcher state: $applications_dir" >&2
         exit 0
     fi
+}
+
+release_app_lock() {
+    flock -u 9 || true
+    exec 9<&-
 }
 
 cleanup_owned_icon_orphans() {
@@ -122,6 +127,7 @@ cleanup_managed_desktop() {
         return 0
     fi
     cleanup_owned_icon_orphans
+    release_app_lock
     refresh_desktop_database
 }
 
@@ -291,4 +297,5 @@ if [ -n "$previous_icon" ] && [ "$previous_icon" != "$icon_target" ] && managed_
     rm -f -- "$previous_icon" || true
 fi
 cleanup_owned_icon_orphans "$icon_target"
+release_app_lock
 [ "$changed" -eq 0 ] || refresh_desktop_database

--- a/linux-features/ui-tweaks/sync-desktop-icon.sh
+++ b/linux-features/ui-tweaks/sync-desktop-icon.sh
@@ -35,7 +35,7 @@ managed_desktop_is_owned() {
     grep -qxF "$marker" "$desktop_target" || return 1
     icon_value="$(awk '/^Icon=/{sub(/^Icon=/, ""); print; exit}' "$desktop_target")"
     case "$icon_value" in
-        "$icons_dir/$app_id-dock-chatgpt.png"|"$icons_dir/$app_id-dock-codex-dark.png"|"$icons_dir/$app_id-dock-codex-light.png") ;;
+        "$icons_dir/$app_id-dock-chatgpt.png"|"$icons_dir/$app_id-dock-codex-dark.png"|"$icons_dir/$app_id-dock-codex-light.png"|"$legacy_icon_target") ;;
         *) return 1 ;;
     esac
 }

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -8,6 +8,7 @@ const path = require("node:path");
 const test = require("node:test");
 
 require("./suggested-prompts.test.js");
+require("./dock-icon.test.js");
 
 const {
   discoverLinuxFeatureManifests,
@@ -180,6 +181,8 @@ test("ui-tweaks is discoverable and disabled until listed in features.json", () 
           "optional",
         ],
         ["feature:ui-tweaks:reasoning-effort-labels-english", "webview-asset", "optional"],
+        ["feature:ui-tweaks:appearance-dock-icon-main-process", "main-bundle", "optional"],
+        ["feature:ui-tweaks:appearance-dock-icon-settings-row", "webview-asset", "optional"],
         ["feature:ui-tweaks:home-suggested-prompts-main-process", "main-bundle", "optional"],
         ["feature:ui-tweaks:home-suggested-prompts-app-page", "webview-asset", "optional"],
         ["feature:ui-tweaks:home-suggested-prompts-settings-row", "webview-asset", "optional"],

--- a/scripts/ci/github-actions-workflows.test.js
+++ b/scripts/ci/github-actions-workflows.test.js
@@ -40,6 +40,25 @@ test("official Linux validation runs fully on every pull request but not hourly"
   assert.match(packageMatrix, /\.\/scripts\/build-rpm\.sh/);
   assert.match(packageMatrix, /\.\/scripts\/build-pacman\.sh/);
   assert.match(packageMatrix, /\.\/scripts\/build-appimage\.sh/);
+
+  const dockFeatureAlone = job(workflow, "dock-icon-feature-alone");
+  assert.match(
+    dockFeatureAlone,
+    /ref: \$\{\{ github\.event_name == 'pull_request' && github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/,
+  );
+  assert.match(dockFeatureAlone, /"enabled": \["ui-tweaks"\]/);
+  assert.match(dockFeatureAlone, /"dockIcon": \{ "enabled": true \}/);
+  assert.match(
+    dockFeatureAlone,
+    /--require-applied feature:ui-tweaks:appearance-dock-icon-main-process/,
+  );
+  assert.match(
+    dockFeatureAlone,
+    /--require-applied feature:ui-tweaks:appearance-dock-icon-settings-row/,
+  );
+  assert.match(dockFeatureAlone, /Expected Dock descriptors 2\/2 applied/);
+  assert.match(dockFeatureAlone, /resources\/dock-icon/);
+  assert.match(dockFeatureAlone, /ui-tweaks-dock-icon-cleanup\.sh/);
 });
 
 test("official Linux metadata expires after seven days", () => {
@@ -54,12 +73,13 @@ test("official Linux gate fails closed unless every dependency succeeds", () => 
   const gate = job(workflow, "official-linux-gate");
   assert.match(
     gate,
-    /^  official-linux-gate:\n    if: \$\{\{ always\(\) \}\}\n    needs:\n      - signed-baseline\n      - package-matrix\n      - watchdog\n    runs-on:/,
+    /^  official-linux-gate:\n    if: \$\{\{ always\(\) \}\}\n    needs:\n      - signed-baseline\n      - package-matrix\n      - dock-icon-feature-alone\n      - watchdog\n    runs-on:/,
   );
 
   for (const [dependency, resultVariable] of [
     ["signed-baseline", "SIGNED_BASELINE_RESULT"],
     ["package-matrix", "PACKAGE_MATRIX_RESULT"],
+    ["dock-icon-feature-alone", "DOCK_ICON_FEATURE_ALONE_RESULT"],
     ["watchdog", "WATCHDOG_RESULT"],
   ]) {
     assert.match(

--- a/scripts/ci/github-actions-workflows.test.js
+++ b/scripts/ci/github-actions-workflows.test.js
@@ -57,8 +57,30 @@ test("official Linux validation runs fully on every pull request but not hourly"
     /--require-applied feature:ui-tweaks:appearance-dock-icon-settings-row/,
   );
   assert.match(dockFeatureAlone, /Expected Dock descriptors 2\/2 applied/);
-  assert.match(dockFeatureAlone, /resources\/dock-icon/);
+  assert.match(dockFeatureAlone, /scripts\/lib\/upstream-linux-package\.js/);
+  assert.match(
+    dockFeatureAlone,
+    /--key-base64 assets\/openai-codex-linux-repository-key\.gpg\.base64/,
+  );
+  assert.match(dockFeatureAlone, /\.\/install\.sh "\$package"/);
+  assert.match(
+    dockFeatureAlone,
+    /find "\$payload" -mindepth 1 -maxdepth 1 -printf '%f\\n'/,
+  );
+  assert.doesNotMatch(dockFeatureAlone, /find "\$payload"[^\n]+-type f/);
+  assert.match(dockFeatureAlone, /test ! -L "\$payload\/\$resource"/);
+  for (const sourceComparison of [
+    /cmp "\$upstream_root\/usr\/lib\/chatgpt\/resources\/icon-chatgpt\.png" "\$payload\/icon-chatgpt\.png"/,
+    /cmp assets\/codex-linux\.png "\$payload\/icon-codex-dark-color\.png"/,
+    /cmp assets\/codex-linux\.png "\$payload\/icon-codex-light\.png"/,
+    /cmp linux-features\/ui-tweaks\/sync-desktop-icon\.sh "\$payload\/sync-desktop-icon\.sh"/,
+    /cmp linux-features\/ui-tweaks\/sync-desktop-icon\.sh "\$hook"/,
+  ]) {
+    assert.match(dockFeatureAlone, sourceComparison);
+  }
+  assert.match(dockFeatureAlone, /test -x "\$payload\/sync-desktop-icon\.sh"/);
   assert.match(dockFeatureAlone, /ui-tweaks-dock-icon-cleanup\.sh/);
+  assert.match(dockFeatureAlone, /test -x "\$hook"/);
 });
 
 test("official Linux metadata expires after seven days", () => {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -41,6 +41,7 @@ assert_absent Makefile "compgen -G \"\$\$1\" | sort -V"
 assert_absent launcher/start.sh.template 'local content server'
 assert_contains packaging/linux/control 'official Linux runtime'
 assert_contains packaging/linux/codex-desktop.spec 'official runtime'
+assert_contains flake.nix 'systemd util-linux xdg-utils'
 assert_contains packaging/linux/codex-packaged-runtime.sh 'codex-update-manager check-now'
 assert_absent packaging/linux/codex-packaged-runtime.sh '--if-stale'
 


### PR DESCRIPTION
## Summary

Restore the disabled-by-default Dock icon tweak after the move to OpenAI's signed official Linux package.

The official-package migration removed the DMG-specific Dock implementation. This retarget keeps the behavior inside `ui-tweaks`, sources the ChatGPT icon and desktop metadata from the signed Linux package, and continues using the existing ChatGPT Community icon for the alternate selection.

## Behavior

- exposes the upstream Dock icon row on Linux only when `ui-tweaks` and `tweaks.appearance.dockIcon.enabled` are enabled;
- updates existing and newly registered windows plus the official Linux tray immediately;
- writes a marker-owned user-local desktop override only after validating the launcher identity;
- preserves unmanaged, customized, symlinked, and side-by-side launchers;
- removes only marker-owned launcher artifacts after the nested tweak is disabled;
- rejects mixed, duplicate, or drifted patch contracts byte-identically.

The implementation is current-package-only. It does not restore DMG resources, alternate Electron behavior, or legacy bundle shapes.

## Maintenance

This follows the feature-maintenance coordination in #1038 and the maintainer's approval for focused PRs in [this comment](https://github.com/ilysenko/codex-desktop-linux/issues/1038#issuecomment-5010933211). As committed there, I will continue supervising and maintaining both Dock Icon and Suggested Prompts as upstream packages change. Suggested Prompts already targets the official package and is intentionally unchanged here.

Related history: #1078, #1101, #1164, #1193, #1235, #1299, and the official-package migration in #1317.

## Current upstream identity

- base: `bc13db63`
- package: `chatgpt 26.803.81509` (`amd64`)
- size: `349937362` bytes
- SHA-256: `a9bf91a368f9f7c4eea38082a9fb8fb46b8d005b719a6d7715d2e5a1982c38eb`
- environment: Ubuntu 25.10, KDE Plasma, Wayland

## Validation

Exact head `b44cb25c`:

- `node --test linux-features/ui-tweaks/test.js` - 52/52
- `node --test linux-features/ui-tweaks/dock-icon.test.js` - 19/19
- patcher and feature framework tests - 32/32
- `bash tests/scripts_smoke.sh` - 42/42
- `bash -n` for both Dock shell helpers
- `node --check` for the modified active main and General Settings assets
- `git diff --check`
- isolated official-package candidate accepted with all nine selected features composed
- first pass: 46 `applied`, 1 `already-applied`, 3 deliberately `skipped-disabled`
- Dock: 2/2 `applied`; Suggested Prompts: 4/4 `applied`
- second pass: 47 `already-applied`, 3 `skipped-disabled`; extracted tree digest unchanged
- staged official icon, Community icons, helper mode, prelaunch hook, source provenance, and signed package identity verified

## Runtime

The isolated candidate was exercised side by side on KDE Wayland before the final rebase. `git range-diff` confirms the five PR commits are code-identical after rebasing onto `bc13db63`; an exact-head accepted candidate was then rebuilt at `b44cb25c`.

Observed behavior:

- Suggested Prompts remained visible under General Settings;
- Dock icon appeared under Appearance;
- switching ChatGPT -> Codex changed the StatusNotifier icon immediately;
- switching back restored the Codex icon immediately;
- the Codex selection and tray image persisted across a cold restart;
- closing to tray kept the process and tray alive, and activating the tray item restored the window.

The upstream isolated session did not expose a second-window action, and raw DBus menu invocation is not equivalent to a desktop-shell tray Quit. Those registration and cleanup paths are covered by the focused lifecycle tests. No daily-driver package was changed by this PR validation.