### PR TITLE
nix: respect NIXOS_OZONE_WL

### DIFF
--- a/docs/nix.md
+++ b/docs/nix.md
@@ -100,6 +100,10 @@ The NixOS module uses the same option namespace:
 }
 ```
 
+The Nix package follows the standard `NIXOS_OZONE_WL` convention. When both
+`NIXOS_OZONE_WL` and `WAYLAND_DISPLAY` are set, its wrapper starts Electron with
+native Wayland rendering and text-input-v3 IME support.
+
 When `codex-micro` is selected, the module also exposes its packaged udev
 rules. Optional declarative remote-control service options live under
 `programs.codexDesktopLinux.remoteControl` and are independent of the desktop

--- a/flake.nix
+++ b/flake.nix
@@ -152,7 +152,8 @@
                 --replace-fail "/usr/share/applications/codex-desktop.desktop" "$out/share/applications/codex-desktop.desktop"
               makeWrapper "$app/start.sh" "$out/bin/codex-desktop" \
                 --prefix PATH : "${runtimePath}" \
-                --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}"
+                --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}" \
+                --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-wayland-ime=true --wayland-text-input-version=3}}"
               runHook postInstall
             '';
             passthru = {


### PR DESCRIPTION
## Summary

- make the Nix package wrapper honor the existing `NIXOS_OZONE_WL` convention
- enable native Wayland rendering and text-input-v3 IME support only when both `NIXOS_OZONE_WL` and `WAYLAND_DISPLAY` are non-empty
- document the behavior alongside the NixOS module

The current signed Linux package bundles Electron 42.3.0. For this Electron generation, native Wayland selection uses `--ozone-platform=wayland`; the wrapper also passes `--enable-wayland-ime=true --wayland-text-input-version=3` so native Wayland sessions can use modern IME protocols.

This is scoped to the Nix package wrapper. It adds no module option and does not change native deb/RPM/pacman/AppImage launch behavior.

## Validation

- `nix flake check`
- `nix build --no-link --print-out-paths .#codex-desktop`
- inspected the built wrapper and confirmed the nested environment expansion is preserved in its final `exec` line
- `git diff --check`

The package was built and tested on `x86_64-linux`; the incompatible `aarch64-linux` output was evaluated but not built locally.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest signed stable OpenAI Linux package and removes obsolete fallback code and tests. (Not applicable: this changes only the Nix wrapper.)
- [ ] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
