### PR TITLE
Restore full Linux package watchdog lifecycle

### DIFF
--- a/.github/workflows/update-official-linux-pins.yml
+++ b/.github/workflows/update-official-linux-pins.yml
@@ -1,61 +1,209 @@
 name: Update official Linux package pins
+run-name: Linux pin refresh ${{ inputs.release_id }} at ${{ inputs.expected_main_sha }}
 
 on:
-  schedule:
-    - cron: '15 * * * *'
   workflow_dispatch:
+    inputs:
+      release_id:
+        description: Exact signed Linux package campaign identity
+        required: true
+        type: string
+      expected_main_sha:
+        description: Accepted main commit selected by the watchdog
+        required: true
+        type: string
+      version:
+        description: Signed stable package version
+        required: true
+        type: string
+      amd64_repository_path:
+        description: Signed amd64 repository path
+        required: true
+        type: string
+      amd64_sha256:
+        description: Signed amd64 package SHA-256
+        required: true
+        type: string
+      arm64_repository_path:
+        description: Signed arm64 repository path
+        required: true
+        type: string
+      arm64_sha256:
+        description: Signed arm64 package SHA-256
+        required: true
+        type: string
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
 concurrency:
-  group: update-official-linux-package-pins
+  group: update-official-linux-package-pins-${{ inputs.release_id }}
   cancel-in-progress: false
 
 jobs:
   refresh:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
+    env:
+      RELEASE_ID: ${{ inputs.release_id }}
+      EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+      EXPECTED_VERSION: ${{ inputs.version }}
+      EXPECTED_AMD64_PATH: ${{ inputs.amd64_repository_path }}
+      EXPECTED_AMD64_SHA256: ${{ inputs.amd64_sha256 }}
+      EXPECTED_ARM64_PATH: ${{ inputs.arm64_repository_path }}
+      EXPECTED_ARM64_SHA256: ${{ inputs.arm64_sha256 }}
     steps:
+      - name: Require the accepted commit to be current main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_MAIN_SHA" =~ ^[0-9a-f]{40}$ ]]
+          current_main="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)"
+          test "$current_main" = "$EXPECTED_MAIN_SHA"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.expected_main_sha }}
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
-      - name: Refresh pins through signed metadata
+
+      - name: Refresh and bind pins to the signed campaign
         id: pins
         run: |
           set -euo pipefail
-          result="$(node scripts/automation/upstream-linux-package-watchdog/watchdog.js --write --json)"
-          printf '%s\n' "$result"
-          changed="$(node -e 'const value=JSON.parse(process.argv[1]); process.stdout.write(String(value.changed))' "$result")"
-          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          result_file="$RUNNER_TEMP/signed-linux-release.json"
+          node scripts/automation/upstream-linux-package-watchdog/watchdog.js --write --json > "$result_file"
+          cat "$result_file"
+          node - "$result_file" <<'NODE'
+          const fs = require("node:fs");
+          const value = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const expected = {
+            releaseId: process.env.RELEASE_ID,
+            version: process.env.EXPECTED_VERSION,
+            amd64Path: process.env.EXPECTED_AMD64_PATH,
+            amd64Sha: process.env.EXPECTED_AMD64_SHA256,
+            arm64Path: process.env.EXPECTED_ARM64_PATH,
+            arm64Sha: process.env.EXPECTED_ARM64_SHA256,
+          };
+          const actual = value.release;
+          if (!actual || actual.releaseId !== expected.releaseId || actual.version !== expected.version
+              || actual.packages?.amd64?.repositoryPath !== expected.amd64Path
+              || actual.packages?.amd64?.sha256 !== expected.amd64Sha
+              || actual.packages?.arm64?.repositoryPath !== expected.arm64Path
+              || actual.packages?.arm64?.sha256 !== expected.arm64Sha) {
+            throw new Error("signed metadata no longer matches the dispatched watchdog campaign");
+          }
+          NODE
+          if git diff --quiet -- nix/upstream-linux-packages.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Evaluate and build Nix baseline
         if: steps.pins.outputs.changed == 'true'
         run: |
+          set -euo pipefail
+          test "$(git diff --name-only | sort)" = "nix/upstream-linux-packages.json"
           nix flake check --no-build
           nix build .#codex-desktop
-      - name: Open or update refresh pull request
+
+      - name: Open or update campaign pin pull request
         if: steps.pins.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          BRANCH: codex/official-linux-package-pins
         run: |
           set -euo pipefail
-          git diff --quiet -- nix/upstream-linux-packages.json && exit 0
-          version="$(node -p 'require("./nix/upstream-linux-packages.json").version')"
+          current_main="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)"
+          test "$current_main" = "$EXPECTED_MAIN_SHA"
+          branch="codex/official-linux-pins-${RELEASE_ID:0:12}"
           git config user.name codex-linux-package-bot
           git config user.email actions@github.com
-          git checkout -B "$BRANCH"
+          git checkout -B "$branch"
           git add nix/upstream-linux-packages.json
-          git commit -m "fix(nix): refresh official Linux package pins for $version"
-          git push --force-with-lease origin "$BRANCH"
-          pr="$(gh pr list --head "$BRANCH" --base main --state open --json url --jq '.[0].url // ""')"
-          if [ -z "$pr" ]; then
-            gh pr create --head "$BRANCH" --base main \
-              --title "fix(nix): refresh official Linux package pins for $version" \
-              --body $'## Summary\n- refresh amd64 and arm64 pins from OpenAI signed APT metadata\n\n## Checks\n- nix flake check --no-build\n- nix build .#codex-desktop'
+          desired_tree="$(git write-tree)"
+          remote_record="$(git ls-remote --heads origin "refs/heads/$branch")"
+          remote_head="${remote_record%%[[:space:]]*}"
+          reuse_remote=false
+          if [ -n "$remote_head" ]; then
+            git fetch origin "$branch"
+            remote_message="$(git log -1 --format=%B FETCH_HEAD)"
+            grep -Fqx "Official-Linux-Release-ID: $RELEASE_ID" <<< "$remote_message"
+            if [ "$(git rev-parse FETCH_HEAD^)" = "$EXPECTED_MAIN_SHA" ] \
+                && [ "$(git rev-parse 'FETCH_HEAD^{tree}')" = "$desired_tree" ] \
+                && grep -Fqx "Source-Main-SHA: $EXPECTED_MAIN_SHA" <<< "$remote_message"; then
+              git reset --hard FETCH_HEAD
+              reuse_remote=true
+            fi
           fi
+          if [ "$reuse_remote" = false ]; then
+            git commit \
+              -m "fix(nix): refresh official Linux package pins for $EXPECTED_VERSION" \
+              -m "Source-Main-SHA: $EXPECTED_MAIN_SHA" \
+              -m "Official-Linux-Release-ID: $RELEASE_ID"
+            gh auth setup-git
+            git push \
+              "--force-with-lease=refs/heads/$branch:$remote_head" \
+              origin "HEAD:$branch"
+          fi
+
+          body_file="$RUNNER_TEMP/nix-refresh-pr.md"
+          {
+            echo "<!-- official-linux-release:$RELEASE_ID -->"
+            echo
+            echo "## Summary"
+            echo "- refresh amd64 and arm64 pins from OpenAI signed APT metadata"
+            echo "- bind the refresh to accepted main \`$EXPECTED_MAIN_SHA\`"
+            echo
+            echo "## Checks"
+            echo "- nix flake check --no-build"
+            echo "- nix build .#codex-desktop"
+          } > "$body_file"
+          pr="$(gh pr list --head "$GITHUB_REPOSITORY_OWNER:$branch" --base main --state open \
+            --json url,author,headRepositoryOwner,headRefOid,baseRefName \
+            --jq 'if length == 0 then "" elif length == 1 then .[0] else error("multiple campaign PRs") end')"
+          if [ -z "$pr" ]; then
+            pr="$(gh pr create --head "$branch" --base main \
+              --title "fix(nix): refresh official Linux package pins for $EXPECTED_VERSION" \
+              --body-file "$body_file")"
+          else
+            test "$(jq -r .headRepositoryOwner.login <<< "$pr")" = "$GITHUB_REPOSITORY_OWNER"
+            case "$(jq -r .author.login <<< "$pr")" in
+              github-actions|github-actions\[bot\]|"$GITHUB_ACTOR") ;;
+              *) echo "unexpected campaign PR author" >&2; exit 1 ;;
+            esac
+            test "$(jq -r .headRefOid <<< "$pr")" = "$(git rev-parse HEAD)"
+            test "$(jq -r .baseRefName <<< "$pr")" = main
+            pr_url="$(jq -r .url <<< "$pr")"
+            gh pr edit "$pr_url" \
+              --title "fix(nix): refresh official Linux package pins for $EXPECTED_VERSION" \
+              --body-file "$body_file"
+            pr="$pr_url"
+          fi
+          echo "Nix refresh PR: $pr"
+
+          head_sha="$(git rev-parse HEAD)"
+          dispatch_if_missing() {
+            local workflow="$1"
+            shift
+            count="$(gh run list --workflow "$workflow" --branch "$branch" --event workflow_dispatch \
+              --limit 20 --json headSha --jq "[.[] | select(.headSha == \"$head_sha\")] | length")"
+            if [ "$count" -eq 0 ]; then
+              gh workflow run "$workflow" --ref "$branch" "$@"
+            fi
+          }
+          dispatch_if_missing ci.yml
+          dispatch_if_missing upstream-build-app.yml \
+            -f "release_id=$RELEASE_ID" \
+            -f "version=$EXPECTED_VERSION" \
+            -f "amd64_repository_path=$EXPECTED_AMD64_PATH" \
+            -f "amd64_sha256=$EXPECTED_AMD64_SHA256" \
+            -f "arm64_repository_path=$EXPECTED_ARM64_PATH" \
+            -f "arm64_sha256=$EXPECTED_ARM64_SHA256"

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -1,7 +1,33 @@
 name: Official Linux package build
+run-name: ${{ inputs.release_id && format('Official Linux campaign {0}', inputs.release_id) || format('Official Linux {0}', github.event_name) }}
 
 on:
   workflow_dispatch:
+    inputs:
+      release_id:
+        description: Exact signed release identity selected by watchdog
+        required: true
+        type: string
+      version:
+        description: Expected signed package version
+        required: true
+        type: string
+      amd64_repository_path:
+        description: Expected signed amd64 repository path
+        required: true
+        type: string
+      amd64_sha256:
+        description: Expected signed amd64 SHA-256
+        required: true
+        type: string
+      arm64_repository_path:
+        description: Expected signed arm64 repository path
+        required: true
+        type: string
+      arm64_sha256:
+        description: Expected signed arm64 SHA-256
+        required: true
+        type: string
   pull_request:
   push:
     branches: [main]
@@ -57,6 +83,26 @@ jobs:
             --key-base64 assets/openai-codex-linux-repository-key.gpg.base64 \
             --arch ${{ matrix.architecture }})"
           echo "package=$package" >> "$GITHUB_OUTPUT"
+      - name: Require the dispatched signed campaign
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          EXPECTED_RELEASE_ID: ${{ inputs.release_id }}
+          EXPECTED_VERSION: ${{ inputs.version }}
+          EXPECTED_REPOSITORY_PATH: ${{ matrix.architecture == 'amd64' && inputs.amd64_repository_path || inputs.arm64_repository_path }}
+          EXPECTED_SHA256: ${{ matrix.architecture == 'amd64' && inputs.amd64_sha256 || inputs.arm64_sha256 }}
+        run: |
+          node - "upstream/${{ matrix.architecture }}.json" <<'NODE'
+          const fs = require("node:fs");
+          const metadata = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          if (metadata.version !== process.env.EXPECTED_VERSION
+              || metadata.repositoryPath !== process.env.EXPECTED_REPOSITORY_PATH
+              || metadata.sha256 !== process.env.EXPECTED_SHA256) {
+            throw new Error("resolved signed package does not match the dispatched campaign");
+          }
+          if (!/^[0-9a-f]{64}$/.test(process.env.EXPECTED_RELEASE_ID)) {
+            throw new Error("invalid dispatched release identity");
+          }
+          NODE
       - name: Build byte-identical clean baseline
         env:
           CODEX_TARGET_ARCH: ${{ matrix.architecture }}
@@ -103,15 +149,43 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dpkg-dev gnupg rpm
+      - name: Resolve exact package matrix input
+        id: upstream
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
+          EXPECTED_REPOSITORY_PATH: ${{ matrix.architecture == 'amd64' && inputs.amd64_repository_path || inputs.arm64_repository_path }}
+          EXPECTED_SHA256: ${{ matrix.architecture == 'amd64' && inputs.amd64_sha256 || inputs.arm64_sha256 }}
+        run: |
+          set -euo pipefail
+          mkdir -p upstream
+          package="$(node scripts/lib/upstream-linux-package.js \
+            --output-dir upstream/${{ matrix.architecture }} \
+            --metadata upstream/${{ matrix.architecture }}.json \
+            --key-base64 assets/openai-codex-linux-repository-key.gpg.base64 \
+            --arch ${{ matrix.architecture }})"
+          echo "package=$package" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = workflow_dispatch ]; then
+            node - "upstream/${{ matrix.architecture }}.json" <<'NODE'
+            const fs = require("node:fs");
+            const metadata = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+            if (metadata.version !== process.env.EXPECTED_VERSION
+                || metadata.repositoryPath !== process.env.EXPECTED_REPOSITORY_PATH
+                || metadata.sha256 !== process.env.EXPECTED_SHA256) {
+              throw new Error("package matrix input does not match the dispatched campaign");
+            }
+            NODE
+          fi
       - name: Build baseline and package formats
         env:
           CODEX_LINUX_FEATURES_CONFIG: ${{ github.workspace }}/linux-features/features.example.json
           CODEX_TARGET_ARCH: ${{ matrix.architecture }}
           PACKAGE_WITH_UPDATER: '0'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y dpkg-dev gnupg rpm
-          ./install.sh
+          ./install.sh "${{ steps.upstream.outputs.package }}"
           ./scripts/build-deb.sh
           ./scripts/build-rpm.sh
           PACMAN_STAGE_ONLY=1 ./scripts/build-pacman.sh
@@ -124,7 +198,34 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
-      - run: node scripts/automation/upstream-linux-package-watchdog/watchdog.js --json
+      - name: Resolve and bind the two-architecture campaign
+        env:
+          EXPECTED_RELEASE_ID: ${{ inputs.release_id }}
+          EXPECTED_VERSION: ${{ inputs.version }}
+          EXPECTED_AMD64_PATH: ${{ inputs.amd64_repository_path }}
+          EXPECTED_AMD64_SHA256: ${{ inputs.amd64_sha256 }}
+          EXPECTED_ARM64_PATH: ${{ inputs.arm64_repository_path }}
+          EXPECTED_ARM64_SHA256: ${{ inputs.arm64_sha256 }}
+        run: |
+          set -euo pipefail
+          result="$RUNNER_TEMP/official-linux-release.json"
+          node scripts/automation/upstream-linux-package-watchdog/watchdog.js --json > "$result"
+          cat "$result"
+          if [ "${{ github.event_name }}" = workflow_dispatch ]; then
+            node - "$result" <<'NODE'
+            const fs = require("node:fs");
+            const actual = JSON.parse(fs.readFileSync(process.argv[2], "utf8")).release;
+            const expected = process.env;
+            if (!actual || actual.releaseId !== expected.EXPECTED_RELEASE_ID
+                || actual.version !== expected.EXPECTED_VERSION
+                || actual.packages?.amd64?.repositoryPath !== expected.EXPECTED_AMD64_PATH
+                || actual.packages?.amd64?.sha256 !== expected.EXPECTED_AMD64_SHA256
+                || actual.packages?.arm64?.repositoryPath !== expected.EXPECTED_ARM64_PATH
+                || actual.packages?.arm64?.sha256 !== expected.EXPECTED_ARM64_SHA256) {
+              throw new Error("two-architecture signed release does not match dispatched campaign");
+            }
+            NODE
+          fi
 
   official-linux-gate:
     if: ${{ always() }}

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -168,17 +168,16 @@ jobs:
             --key-base64 assets/openai-codex-linux-repository-key.gpg.base64 \
             --arch ${{ matrix.architecture }})"
           echo "package=$package" >> "$GITHUB_OUTPUT"
-          if [ "${{ github.event_name }}" = workflow_dispatch ]; then
-            node - "upstream/${{ matrix.architecture }}.json" <<'NODE'
-            const fs = require("node:fs");
-            const metadata = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-            if (metadata.version !== process.env.EXPECTED_VERSION
+          node - "upstream/${{ matrix.architecture }}.json" <<'NODE'
+          const fs = require("node:fs");
+          const metadata = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          if (process.env.GITHUB_EVENT_NAME === "workflow_dispatch"
+              && (metadata.version !== process.env.EXPECTED_VERSION
                 || metadata.repositoryPath !== process.env.EXPECTED_REPOSITORY_PATH
-                || metadata.sha256 !== process.env.EXPECTED_SHA256) {
-              throw new Error("package matrix input does not match the dispatched campaign");
-            }
-            NODE
-          fi
+                || metadata.sha256 !== process.env.EXPECTED_SHA256)) {
+            throw new Error("package matrix input does not match the dispatched campaign");
+          }
+          NODE
       - name: Build baseline and package formats
         env:
           CODEX_LINUX_FEATURES_CONFIG: ${{ github.workspace }}/linux-features/features.example.json
@@ -211,21 +210,20 @@ jobs:
           result="$RUNNER_TEMP/official-linux-release.json"
           node scripts/automation/upstream-linux-package-watchdog/watchdog.js --json > "$result"
           cat "$result"
-          if [ "${{ github.event_name }}" = workflow_dispatch ]; then
-            node - "$result" <<'NODE'
-            const fs = require("node:fs");
-            const actual = JSON.parse(fs.readFileSync(process.argv[2], "utf8")).release;
-            const expected = process.env;
-            if (!actual || actual.releaseId !== expected.EXPECTED_RELEASE_ID
+          node - "$result" <<'NODE'
+          const fs = require("node:fs");
+          const actual = JSON.parse(fs.readFileSync(process.argv[2], "utf8")).release;
+          const expected = process.env;
+          if (process.env.GITHUB_EVENT_NAME === "workflow_dispatch"
+              && (!actual || actual.releaseId !== expected.EXPECTED_RELEASE_ID
                 || actual.version !== expected.EXPECTED_VERSION
                 || actual.packages?.amd64?.repositoryPath !== expected.EXPECTED_AMD64_PATH
                 || actual.packages?.amd64?.sha256 !== expected.EXPECTED_AMD64_SHA256
                 || actual.packages?.arm64?.repositoryPath !== expected.EXPECTED_ARM64_PATH
-                || actual.packages?.arm64?.sha256 !== expected.EXPECTED_ARM64_SHA256) {
-              throw new Error("two-architecture signed release does not match dispatched campaign");
-            }
-            NODE
-          fi
+                || actual.packages?.arm64?.sha256 !== expected.EXPECTED_ARM64_SHA256)) {
+            throw new Error("two-architecture signed release does not match dispatched campaign");
+          }
+          NODE
 
   official-linux-gate:
     if: ${{ always() }}

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -135,6 +135,13 @@ scripts/ci/update-official-linux-pins.sh
 ```
 
 The automation checks both architectures. Do not hand-invent or bypass hashes.
+The production pin workflow is dispatched by the standalone signed-package
+watchdog only after the matching source revision has passed acceptance and any
+required source repair has merged. It is not an independent timer: the
+workflow binds its checkout, both package records, branch, pull request, and
+explicit exact-head CI runs to one release campaign. The watchdog reviews and
+merges that pull request only after the repository's required checks pass.
+
 Validate changes with:
 
 ```bash

--- a/scripts/automation/upstream-linux-package-watchdog/README.md
+++ b/scripts/automation/upstream-linux-package-watchdog/README.md
@@ -10,6 +10,12 @@ node scripts/automation/upstream-linux-package-watchdog/watchdog.js --json
 node scripts/automation/upstream-linux-package-watchdog/watchdog.js --write
 ```
 
+This JavaScript command is the small signed-metadata and pin-file helper used
+by CI. The standalone `upstream-linux-package-watchdog-v2` owns release
+campaigns, source repair, internal review, pull requests, guarded merges, and
+the ordered Nix refresh. The Nix workflow is dispatched only after accepted
+source reaches `main`; it no longer polls independently.
+
 CI follows a changed pin with clean baseline builds for both architectures and
-the package matrix. Enabled-feature drift remains a build failure; disabled
-features are not probed.
+the package matrix. Repository features are audited against the exact official
+bundle before an automated repair can be published.

--- a/scripts/automation/upstream-linux-package-watchdog/test.js
+++ b/scripts/automation/upstream-linux-package-watchdog/test.js
@@ -4,7 +4,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const test = require("node:test");
-const { pinsFromMetadata, sha256Sri } = require("./watchdog.js");
+const { pinsFromMetadata, releaseFromMetadata, sha256Sri } = require("./watchdog.js");
 
 test("watchdog creates architecture pins from a single signed stable version", () => {
   const amdSha = "a".repeat(64);
@@ -25,12 +25,32 @@ test("watchdog rejects a split stable version", () => {
   ]), /versions differ/);
 });
 
+test("release identity binds both signed package records", () => {
+  const entries = [
+    { version: "26.1", architecture: "amd64", repositoryPath: "pool/amd.deb", sha256: "a".repeat(64), size: 10 },
+    { version: "26.1", architecture: "arm64", repositoryPath: "pool/arm.deb", sha256: "b".repeat(64), size: 20 },
+  ];
+  const first = releaseFromMetadata(entries, "https://example.invalid/deb/");
+  const second = releaseFromMetadata([...entries].reverse(), "https://example.invalid/deb");
+  assert.match(first.release.releaseId, /^[0-9a-f]{64}$/);
+  assert.equal(first.release.releaseId, second.release.releaseId);
+  assert.equal(first.release.releaseId, "44962ae3f86bfa3a6db2df452e9f51faa9797f44036d8845397cb92bd93d7b7b");
+  assert.equal(first.release.packages.arm64.size, 20);
+});
+
+test("release identity rejects duplicate or extra architecture records", () => {
+  const amd64 = { version: "26.1", architecture: "amd64", repositoryPath: "pool/amd.deb", sha256: "a".repeat(64), size: 10 };
+  const arm64 = { version: "26.1", architecture: "arm64", repositoryPath: "pool/arm.deb", sha256: "b".repeat(64), size: 20 };
+  assert.throws(() => releaseFromMetadata([amd64, amd64], "https://example.invalid/deb"), /exactly amd64 and arm64/);
+  assert.throws(() => releaseFromMetadata([amd64, arm64, { ...arm64, architecture: "riscv64" }], "https://example.invalid/deb"), /exactly amd64 and arm64/);
+});
+
 test("pin refresh automation polls signed metadata and gates builds on changes", () => {
   const workflow = fs.readFileSync(
     path.resolve(__dirname, "../../../.github/workflows/update-official-linux-pins.yml"),
     "utf8",
   );
-  assert.match(workflow, /schedule:\s*\n\s*- cron:/);
   assert.match(workflow, /watchdog\.js --write --json/);
-  assert.match(workflow, /if: steps\.pins\.outputs\.changed == 'true'/);
+  assert.match(workflow, /expected_main_sha:/);
+  assert.doesNotMatch(workflow, /schedule:/);
 });

--- a/scripts/automation/upstream-linux-package-watchdog/watchdog.js
+++ b/scripts/automation/upstream-linux-package-watchdog/watchdog.js
@@ -11,16 +11,48 @@ const {
 const REPO_ROOT = path.resolve(__dirname, "../../..");
 const PINS_PATH = path.join(REPO_ROOT, "nix/upstream-linux-packages.json");
 
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
 function sha256Sri(hex) {
   if (!/^[0-9a-f]{64}$/i.test(hex)) throw new Error("invalid SHA256");
   return `sha256-${Buffer.from(hex, "hex").toString("base64")}`;
 }
 
-function pinsFromMetadata(entries) {
-  const versions = new Set(entries.map((entry) => entry.version));
-  if (versions.size !== 1) throw new Error("amd64 and arm64 stable versions differ");
-  const pins = { version: entries[0].version };
+function normalizeMetadata(entries) {
+  if (!Array.isArray(entries) || entries.length !== 2) {
+    throw new Error("signed release must contain exactly amd64 and arm64 packages");
+  }
+  const normalized = new Map();
   for (const entry of entries) {
+    if (!entry || !["amd64", "arm64"].includes(entry.architecture)
+        || normalized.has(entry.architecture)) {
+      throw new Error("signed release must contain exactly amd64 and arm64 packages");
+    }
+    if (typeof entry.version !== "string" || entry.version === ""
+        || typeof entry.repositoryPath !== "string" || entry.repositoryPath === ""
+        || !/^[0-9a-f]{64}$/.test(entry.sha256)) {
+      throw new Error(`invalid signed package metadata for ${entry.architecture}`);
+    }
+    normalized.set(entry.architecture, entry);
+  }
+  if (normalized.size !== 2) {
+    throw new Error("signed release must contain exactly amd64 and arm64 packages");
+  }
+  return [normalized.get("amd64"), normalized.get("arm64")];
+}
+
+function pinsFromMetadata(entries) {
+  const normalized = normalizeMetadata(entries);
+  const versions = new Set(normalized.map((entry) => entry.version));
+  if (versions.size !== 1) throw new Error("amd64 and arm64 stable versions differ");
+  const pins = { version: normalized[0].version };
+  for (const entry of normalized) {
     pins[entry.architecture] = {
       repositoryPath: entry.repositoryPath,
       sha256: entry.sha256,
@@ -28,6 +60,43 @@ function pinsFromMetadata(entries) {
     };
   }
   return pins;
+}
+
+function releaseFromMetadata(entries, repository) {
+  const normalized = normalizeMetadata(entries);
+  const pins = pinsFromMetadata(normalized);
+  const packages = {};
+  for (const entry of normalized) {
+    const architecture = entry.architecture;
+    if (!Number.isSafeInteger(Number(entry.size)) || Number(entry.size) <= 0) {
+      throw new Error(`missing signed package metadata for ${architecture}`);
+    }
+    packages[architecture] = {
+      architecture,
+      version: entry.version,
+      repositoryPath: entry.repositoryPath,
+      sha256: entry.sha256,
+      size: Number(entry.size),
+    };
+  }
+  const identity = {
+    repository: repository.replace(/\/+$/, ""),
+    version: pins.version,
+    packages,
+  };
+  const releaseManifest = {
+    version: identity.version,
+    packages: Object.fromEntries(["amd64", "arm64"].map((architecture) => [architecture, {
+      repositoryPath: packages[architecture].repositoryPath,
+      sha256: packages[architecture].sha256,
+      size: packages[architecture].size,
+    }])),
+  };
+  identity.releaseId = require("node:crypto")
+    .createHash("sha256")
+    .update(canonicalJson(releaseManifest))
+    .digest("hex");
+  return { pins, release: identity };
 }
 
 async function probe(repository) {
@@ -45,7 +114,7 @@ async function probe(repository) {
         metadataOnly: true,
       }));
     }
-    return pinsFromMetadata(entries);
+    return releaseFromMetadata(entries, repository);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -56,12 +125,13 @@ async function main() {
   const repository = process.env.CODEX_UPSTREAM_LINUX_REPOSITORY
     ?? "https://persistent.oaistatic.com/codex-app-prod/linux/deb";
   const current = JSON.parse(fs.readFileSync(PINS_PATH, "utf8"));
-  const latest = await probe(repository);
+  const observed = await probe(repository);
+  const latest = observed.pins;
   const changed = JSON.stringify(current) !== JSON.stringify(latest);
   if (args.has("--write")) {
     fs.writeFileSync(PINS_PATH, `${JSON.stringify(latest, null, 2)}\n`);
   }
-  const result = { changed, current, latest, wrote: args.has("--write") };
+  const result = { changed, current, latest, release: observed.release, wrote: args.has("--write") };
   if (args.has("--json")) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   else process.stdout.write(`${changed ? "changed" : "unchanged"}: ${latest.version}\n`);
 }
@@ -73,4 +143,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { pinsFromMetadata, sha256Sri };
+module.exports = { canonicalJson, pinsFromMetadata, releaseFromMetadata, sha256Sri };

--- a/scripts/ci/github-actions-workflows.test.js
+++ b/scripts/ci/github-actions-workflows.test.js
@@ -75,3 +75,48 @@ test("official Linux gate fails closed unless every dependency succeeds", () => 
     );
   }
 });
+
+test("Nix pin refresh is watchdog-dispatched and campaign-bound", () => {
+  const workflow = read(".github/workflows/update-official-linux-pins.yml");
+  assert.doesNotMatch(workflow, /^  schedule:/m);
+  for (const input of [
+    "release_id",
+    "expected_main_sha",
+    "version",
+    "amd64_repository_path",
+    "amd64_sha256",
+    "arm64_repository_path",
+    "arm64_sha256",
+  ]) {
+    assert.match(workflow, new RegExp(`^      ${input}:$`, "m"));
+  }
+  assert.match(workflow, /^  actions: write$/m);
+  assert.match(workflow, /Require the accepted commit to be current main/);
+  assert.match(workflow, /persist-credentials: false/);
+  assert.match(workflow, /gh api "repos\/\$GITHUB_REPOSITORY\/commits\/main" --jq \.sha/);
+  assert.match(workflow, /ref: \$\{\{ inputs\.expected_main_sha \}\}/);
+  assert.match(workflow, /codex\/official-linux-pins-\$\{RELEASE_ID:0:12\}/);
+  assert.match(workflow, /dispatch_if_missing ci\.yml/);
+  assert.match(workflow, /dispatch_if_missing upstream-build-app\.yml/);
+  assert.match(workflow, /Official-Linux-Release-ID:/);
+  assert.match(workflow, /--force-with-lease=refs\/heads\/\$branch:\$remote_head/);
+  assert.match(workflow, /git rev-parse 'FETCH_HEAD\^\{tree\}'/);
+  assert.match(workflow, /--head "\$GITHUB_REPOSITORY_OWNER:\$branch"/);
+});
+
+test("manual official Linux validation accepts an exact campaign", () => {
+  const workflow = read(".github/workflows/upstream-build-app.yml");
+  assert.match(workflow, /run-name:.*Official Linux campaign.*inputs\.release_id/);
+  for (const input of ["release_id", "version", "amd64_sha256", "arm64_sha256"]) {
+    assert.match(workflow, new RegExp(`^      ${input}:$`, "m"));
+  }
+  assert.equal((workflow.match(/^        required: true$/gm) || []).length, 6);
+  assert.match(workflow, /Require the dispatched signed campaign/);
+  assert.match(workflow, /resolved signed package does not match the dispatched campaign/);
+  assert.match(workflow, /Resolve and bind the two-architecture campaign/);
+  assert.match(workflow, /actual\.releaseId !== expected\.EXPECTED_RELEASE_ID/);
+  const packageMatrix = job(workflow, "package-matrix");
+  assert.match(packageMatrix, /Resolve exact package matrix input/);
+  assert.match(packageMatrix, /package matrix input does not match the dispatched campaign/);
+  assert.match(packageMatrix, /\.\/install\.sh "\$\{\{ steps\.upstream\.outputs\.package \}\}"/);
+});


### PR DESCRIPTION
## Summary
- bind Linux release validation to exact signed amd64/arm64 campaign metadata
- make source repair and Nix refresh sequential, recoverable, and exact-head gated
- harden privileged Nix refresh, managed branch adoption, and workflow dispatch evidence
- remove the independent hourly Nix refresh

## Checks
- node --test scripts/ci/*.test.js
- node --test scripts/automation/upstream-linux-package-watchdog/test.js
- scripts/ci/validate-nix-pins.sh
- bash tests/scripts_smoke.sh
- standalone watchdog: 50 Python tests and Ruff
- independent final review: no P0-P3 findings

## Notes
- standalone watchdog-v2 remains a separate nested repository and is not tracked by this parent PR
- this is the one-time Actions bootstrap required before unattended mutation mode can run