### PR TITLE
Align packaged window class with desktop identity

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -192,7 +192,7 @@ case "${1:-}" in
 esac
 [ -x "$CHATGPT_BINARY" ] || { printf 'ChatGPT executable is missing: %s\n' "$CHATGPT_BINARY" >&2; exit 1; }
 
-ELECTRON_ARGS=()
+ELECTRON_ARGS=("--class=$CODEX_LINUX_APP_ID")
 load_environment_hooks
 refresh_legacy_bundled_plugin_caches
 load_user_electron_args

--- a/launcher/start.test.js
+++ b/launcher/start.test.js
@@ -62,6 +62,7 @@ test("launcher composes declarative hooks and forwards arguments", (t) => {
     "from-launcher",
   ]);
   assert.deepEqual(fs.readFileSync(path.join(root, "arguments"), "utf8").trim().split("\n"), [
+    "--class=codex-desktop",
     "--feature-arg=one two",
     "--launcher-arg=value",
     "codex://thread/123",

--- a/launcher/start.test.js
+++ b/launcher/start.test.js
@@ -105,6 +105,7 @@ test("launcher loads global and app-specific Electron flags", (t) => {
 
   assert.equal(result.status, 7);
   assert.deepEqual(fs.readFileSync(path.join(root, "arguments"), "utf8").trim().split("\n"), [
+    "--class=codex-desktop",
     "--ozone-platform=wayland",
     "--enable-features=WaylandWindowDecorations",
     "--ozone-platform=x11",
@@ -113,6 +114,7 @@ test("launcher loads global and app-specific Electron flags", (t) => {
   assert.deepEqual(
     fs.readFileSync(path.join(root, "launcher-hook-arguments"), "utf8").trim().split("\n"),
     [
+      "--class=codex-desktop",
       "--ozone-platform=wayland",
       "--enable-features=WaylandWindowDecorations",
       "--ozone-platform=x11",
@@ -146,7 +148,10 @@ test("launcher uses the HOME config fallback and ignores non-file flag paths", (
 
   assert.equal(result.status, 7);
   assert.equal(result.stderr, "");
-  assert.equal(fs.readFileSync(path.join(root, "arguments"), "utf8"), "--ozone-platform=wayland\n");
+  assert.equal(
+    fs.readFileSync(path.join(root, "arguments"), "utf8"),
+    "--class=codex-desktop\n--ozone-platform=wayland\n",
+  );
 });
 
 test("diagnose validates the official runtime without starting it", (t) => {


### PR DESCRIPTION
## Summary
- pass the packaged application ID to the official Electron runtime as its window class
- keep the runtime identity aligned with the shipped `StartupWMClass` across native packages, AppImage, and Nix
- cover the launcher argument contract, persistent Electron flags, and launcher-hook argv with regression assertions

## Problem
After the official Linux package migration, launching ChatGPT Community from its pinned `codex-desktop.desktop` entry opened a second taskbar item. The launcher declared `StartupWMClass=codex-desktop`, while the running official window reported `app_id=Chatgpt` and `wm_class=Chatgpt` under KWin.

This also made the optional Dock icon appear split: the pinned launcher used the selected icon, while the running window was grouped under the official runtime identity.

## Fix
Initialize the shared launcher's Electron arguments with `--class=$CODEX_LINUX_APP_ID`. All supported package entrypoints execute this launcher, and later user, feature, hook, and explicit CLI arguments retain their existing precedence.

## Reproduction and runtime evidence
Environment:
- Ubuntu 25.10, KDE Plasma, Wayland session with the app running through XWayland
- official `chatgpt` package `26.803.81509` (`amd64`)
- package SHA-256 `a9bf91a368f9f7c4eea38082a9fb8fb46b8d005b719a6d7715d2e5a1982c38eb`
- package size `349937362` bytes
- repository base `bf7c98089a2c35951a7c4dffa736e27219559753`

Observed through the packaged Computer Use KWin window inventory:

```text
without --class: app_id=Chatgpt, wm_class=Chatgpt
with --class=codex-desktop: app_id=codex-desktop, wm_class=codex-desktop
```

The latter matches both the packaged and user Dock launcher `StartupWMClass=codex-desktop` values.

## Validation
- regression assertion failed on the test-only commit because the launcher omitted `--class=codex-desktop`
- `node --test launcher/start.test.js linux-features/authenticated-proxy/test.js` (17 passed)
- `bash -n launcher/start.sh.template`
- `bash tests/scripts_smoke.sh` (46 passed)
- `git diff --check origin/main...HEAD`
- two complete updated base-to-head code-review passes; Standards and Spec reported no blockers

Fresh repository CI covers the complete package matrix after the rebase.

## Scope
No ASAR patch, Dock icon behavior, persisted state, package metadata, or generated output is changed. Native Wayland behavior was not separately exercised; the reproduced KDE Wayland installation currently runs the official Electron window through XWayland.
