### PR TITLE
Fix persistent Electron flag loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ output layout, parallelism, and payload inspection.
 | Browser/Chrome extension cannot connect after migration | Exit ChatGPT and Chrome completely, then follow the narrow cache repair in [Troubleshooting](docs/troubleshooting.md#browser-or-chrome-plugin-is-visible-but-cannot-connect) |
 | Signature or package verification fails | Do not bypass it; check time, network, `gpgv`, architecture, and disk space |
 | App does not launch | Run `/opt/codex-desktop/start.sh --diagnose` |
+| App uses XWayland or needs persistent Electron flags | Put one flag per line in `~/.config/codex-desktop/electron-flags.conf`; for example, `--ozone-platform=wayland` |
 | AppImage reports a sandbox error | Enable user namespaces or install a native package; `--no-sandbox` is not added automatically |
 | Enabled feature drifts after an upstream release | Disable that feature to confirm the clean baseline and attach its patch report to an issue |
 | Updater waits for application exit | Close official and Community processes, then inspect `codex-update-manager status --json` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -308,6 +308,7 @@ make appimage
 | 迁移后 Browser/Chrome extension 无法连接 | 完全退出 ChatGPT 与 Chrome，再按[故障排除](docs/troubleshooting.md#browser-or-chrome-plugin-is-visible-but-cannot-connect)执行窄范围 cache repair |
 | 签名或软件包验证失败 | 不要绕过；检查系统时间、网络、`gpgv`、architecture 和磁盘空间 |
 | 应用无法启动 | 运行 `/opt/codex-desktop/start.sh --diagnose` |
+| 应用使用 XWayland，或需要持久化 Electron 参数 | 在 `~/.config/codex-desktop/electron-flags.conf` 中每行写一个参数，例如 `--ozone-platform=wayland` |
 | AppImage 报 sandbox 错误 | 启用 user namespaces 或安装原生包；不会自动添加 `--no-sandbox` |
 | 上游更新后启用扩展发生 drift | 禁用该扩展确认 clean baseline，并在 issue 中附上 patch report |
 | updater 等待应用退出 | 关闭官方与 Community 进程，检查 `codex-update-manager status --json` |

--- a/docs/linux-features-architecture.md
+++ b/docs/linux-features-architecture.md
@@ -158,9 +158,11 @@ a feature removes framework-owned files on the next rebuild.
 - `coldStart`: background hook at launch.
 - `afterExit`: requires the wrapper to wait, then runs after process exit.
 
-Hooks receive the original launcher arguments and feature/app directory
-environment. Keep them bounded; the compact launcher does not supervise helper
-processes or provide a second application lifecycle.
+Launcher hooks receive the Electron arguments already loaded from user and
+feature configuration followed by the original launcher arguments. Other
+executable hooks receive the original arguments. All hooks receive the
+feature/app directory environment. Keep them bounded; the compact launcher
+does not supervise helper processes or provide a second application lifecycle.
 
 ## Native package extensions
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -37,6 +37,29 @@ Do not start the underlying `ChatGPT` binary directly for normal use. The
 `codex-desktop` wrapper supplies the correct desktop identity and enabled
 feature hooks.
 
+## Persistent Electron flags and native Wayland
+
+The launcher reads shared Electron flags from
+`${XDG_CONFIG_HOME:-$HOME/.config}/electron-flags.conf` and Community-specific
+flags from
+`${XDG_CONFIG_HOME:-$HOME/.config}/codex-desktop/electron-flags.conf`, in that
+order. Put one complete argument on each line; blank lines and lines beginning
+with `#` are ignored. App-specific flags are followed by enabled feature flags
+and explicit command-line arguments, so a later explicit argument can override
+an earlier setting.
+
+To force native Wayland rendering without editing a generated desktop entry:
+
+```bash
+mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/codex-desktop"
+printf '%s\n' '--ozone-platform=wayland' > \
+  "${XDG_CONFIG_HOME:-$HOME/.config}/codex-desktop/electron-flags.conf"
+```
+
+Restart every running official and Community process after changing the file.
+The launcher does not evaluate shell quoting or split a line into multiple
+arguments.
+
 ## Chromium sandbox or AppArmor
 
 Prefer a native package, which installs an AppArmor profile adapted to

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -133,6 +133,31 @@ load_electron_args() {
     done < <(find "$HOOK_ROOT/electron-args.d" -maxdepth 1 -type f -print0 | sort -z)
 }
 
+load_user_electron_args_file() {
+    local file="$1"
+    local line
+    local leading_space
+    local trailing_space
+
+    [ -f "$file" ] && [ -r "$file" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        leading_space="${line%%[![:space:]]*}"
+        line="${line#"$leading_space"}"
+        trailing_space="${line##*[![:space:]]}"
+        line="${line%"$trailing_space"}"
+        case "$line" in ""|\#*) continue ;; esac
+        ELECTRON_ARGS+=("$line")
+    done < "$file"
+}
+
+load_user_electron_args() {
+    local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+
+    load_user_electron_args_file "$config_home/electron-flags.conf"
+    load_user_electron_args_file "$config_home/$CODEX_LINUX_APP_ID/electron-flags.conf"
+}
+
 run_launcher_hooks() {
     local hook
     local output
@@ -141,7 +166,7 @@ run_launcher_hooks() {
     local name
     [ -d "$HOOK_ROOT/launcher.d" ] || return 0
     while IFS= read -r -d '' hook; do
-        output="$(CODEX_LINUX_FEATURE_HOOK_PHASE=launcher "$hook" "${ORIGINAL_ARGS[@]}")"
+        output="$(CODEX_LINUX_FEATURE_HOOK_PHASE=launcher "$hook" "$@")"
         while IFS=' ' read -r kind payload; do
             [ -n "${kind:-}" ] || continue
             case "$kind" in
@@ -170,9 +195,10 @@ esac
 ELECTRON_ARGS=()
 load_environment_hooks
 refresh_legacy_bundled_plugin_caches
+load_user_electron_args
 load_electron_args
 run_hook_directory "$HOOK_ROOT/prelaunch.d" prelaunch
-run_launcher_hooks
+run_launcher_hooks "${ELECTRON_ARGS[@]}" "${ORIGINAL_ARGS[@]}"
 
 if [ -f "$HOOK_ROOT/codex-packaged-runtime.sh" ]; then
     # shellcheck disable=SC1091

--- a/launcher/start.test.js
+++ b/launcher/start.test.js
@@ -49,6 +49,7 @@ test("launcher composes declarative hooks and forwards arguments", (t) => {
     env: {
       ...process.env,
       CODEX_HOME: path.join(root, "codex-home"),
+      XDG_CONFIG_HOME: path.join(root, "config"),
       TEST_ROOT: root,
     },
     encoding: "utf8",
@@ -70,10 +71,87 @@ test("launcher composes declarative hooks and forwards arguments", (t) => {
   assert.equal(fs.readFileSync(path.join(root, "after-exit"), "utf8"), "after-exit");
 });
 
+test("launcher loads global and app-specific Electron flags", (t) => {
+  const root = createApp(t);
+  const configHome = path.join(root, "config");
+  fs.mkdirSync(path.join(configHome, "codex-desktop"), { recursive: true });
+  fs.writeFileSync(
+    path.join(configHome, "electron-flags.conf"),
+    "# Shared Electron flags\n  --ozone-platform=wayland  \r\n\n",
+  );
+  fs.writeFileSync(
+    path.join(configHome, "codex-desktop", "electron-flags.conf"),
+    "  # Community-only flags\n--enable-features=WaylandWindowDecorations\n",
+  );
+  writeExecutable(
+    path.join(root, ".codex-linux", "launcher.d", "capture-args.sh"),
+    "#!/bin/bash\nprintf '%s\\n' \"$@\" > \"$TEST_ROOT/launcher-hook-arguments\"\n",
+  );
+
+  const result = childProcess.spawnSync(
+    path.join(root, "start.sh"),
+    ["--ozone-platform=x11", "codex://thread/123"],
+    {
+      env: {
+        ...process.env,
+        CODEX_HOME: path.join(root, "codex-home"),
+        XDG_CONFIG_HOME: configHome,
+        TEST_ROOT: root,
+      },
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(result.status, 7);
+  assert.deepEqual(fs.readFileSync(path.join(root, "arguments"), "utf8").trim().split("\n"), [
+    "--ozone-platform=wayland",
+    "--enable-features=WaylandWindowDecorations",
+    "--ozone-platform=x11",
+    "codex://thread/123",
+  ]);
+  assert.deepEqual(
+    fs.readFileSync(path.join(root, "launcher-hook-arguments"), "utf8").trim().split("\n"),
+    [
+      "--ozone-platform=wayland",
+      "--enable-features=WaylandWindowDecorations",
+      "--ozone-platform=x11",
+      "codex://thread/123",
+    ],
+  );
+});
+
+test("launcher uses the HOME config fallback and ignores non-file flag paths", (t) => {
+  const root = createApp(t);
+  const home = path.join(root, "home");
+  const configHome = path.join(home, ".config");
+  fs.mkdirSync(path.join(configHome, "electron-flags.conf"), { recursive: true });
+  fs.mkdirSync(path.join(configHome, "codex-desktop"), { recursive: true });
+  fs.writeFileSync(
+    path.join(configHome, "codex-desktop", "electron-flags.conf"),
+    "--ozone-platform=wayland\n",
+  );
+  const env = {
+    ...process.env,
+    CODEX_HOME: path.join(root, "codex-home"),
+    HOME: home,
+    TEST_ROOT: root,
+  };
+  delete env.XDG_CONFIG_HOME;
+
+  const result = childProcess.spawnSync(path.join(root, "start.sh"), [], {
+    env,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 7);
+  assert.equal(result.stderr, "");
+  assert.equal(fs.readFileSync(path.join(root, "arguments"), "utf8"), "--ozone-platform=wayland\n");
+});
+
 test("diagnose validates the official runtime without starting it", (t) => {
   const root = createApp(t);
   const result = childProcess.spawnSync(path.join(root, "start.sh"), ["--diagnose"], {
-    env: { ...process.env, TEST_ROOT: root }, encoding: "utf8",
+    env: { ...process.env, XDG_CONFIG_HOME: path.join(root, "config"), TEST_ROOT: root }, encoding: "utf8",
   });
   assert.equal(result.status, 0);
   assert.match(result.stdout, /ok: .*\/ChatGPT/);
@@ -161,7 +239,12 @@ test("launcher replaces only matching retired Browser and Chrome plugin caches",
   fs.chmodSync(pluginAppserver, 0o775);
 
   const result = childProcess.spawnSync(path.join(root, "start.sh"), [], {
-    env: { ...process.env, CODEX_HOME: codexHome, TEST_ROOT: root },
+    env: {
+      ...process.env,
+      CODEX_HOME: codexHome,
+      XDG_CONFIG_HOME: path.join(root, "config"),
+      TEST_ROOT: root,
+    },
     encoding: "utf8",
   });
   assert.equal(result.status, 7);

--- a/linux-features/authenticated-proxy/README.md
+++ b/linux-features/authenticated-proxy/README.md
@@ -57,9 +57,11 @@ flatpak override --user \
 
 If a `--proxy-server` flag is already present in the merged Electron argument
 list, this feature does not add another proxy server or authentication target.
-There is no special parser for `electron-flags.conf`; persistent launch flags,
-feature-provided Electron args, and command-line passthrough arguments are all
-loaded into the same Electron argument list before this feature hook runs.
+Persistent launch flags, feature-provided Electron args, and command-line
+passthrough arguments are loaded into the same Electron argument list before
+this feature hook runs.
+See the top-level troubleshooting guide for the supported
+`electron-flags.conf` locations and format.
 
 Validate the launcher and Electron bridge behavior with:
 


### PR DESCRIPTION
## Summary

- load shared and Community-specific `electron-flags.conf` files through the common launcher
- preserve global, app-specific, feature, and explicit CLI argument precedence
- expose the merged argument list to launcher hooks and document the supported format
- ignore non-regular config paths and cover XDG/HOME fallbacks

Fixes #1326

## Tests/checks

- `bash -n launcher/start.sh.template`
- `node --test launcher/start.test.js linux-features/authenticated-proxy/test.js`
- `bash tests/scripts_smoke.sh`
- `git diff --check`
- `./scripts/ci-local.sh pr` (core suite plus deb, RPM, and pacman package builds)
- two complete-diff review passes; no remaining blockers or actionable findings

## Notes

Each non-comment line is one complete Electron argument. The launcher does not evaluate shell syntax or split a line into multiple arguments.