### PR TITLE
Fix Computer Use feature marketplace registration

### DIFF
--- a/linux-features/computer-use-linux/stage.sh
+++ b/linux-features/computer-use-linux/stage.sh
@@ -5,6 +5,41 @@ backend="${CODEX_COMPUTER_USE_BINARY_SOURCE:-$SCRIPT_DIR/target/release/codex-co
 cosmic="${CODEX_COMPUTER_USE_COSMIC_BINARY_SOURCE:-$SCRIPT_DIR/target/release/codex-computer-use-cosmic}"
 template="$SCRIPT_DIR/plugins/openai-bundled/plugins/computer-use"
 target="$INSTALL_DIR/resources/plugins/openai-bundled/plugins/computer-use"
+marketplace="$INSTALL_DIR/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
+
+write_computer_use_marketplace_entry() {
+    local marketplace_path="$1"
+    node - "$marketplace_path" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const marketplacePath = process.argv[2];
+let marketplace = { plugins: [] };
+try {
+  marketplace = JSON.parse(fs.readFileSync(marketplacePath, "utf8"));
+} catch (_error) {
+  marketplace = { plugins: [] };
+}
+if (!Array.isArray(marketplace.plugins)) {
+  marketplace.plugins = [];
+}
+marketplace.plugins = marketplace.plugins.filter((plugin) => plugin?.name !== "computer-use");
+marketplace.plugins.push({
+  name: "computer-use",
+  source: {
+    source: "local",
+    path: "./plugins/computer-use",
+  },
+  policy: {
+    installation: "AVAILABLE",
+    authentication: "ON_INSTALL",
+  },
+  category: "Productivity",
+});
+fs.mkdirSync(path.dirname(marketplacePath), { recursive: true });
+fs.writeFileSync(marketplacePath, `${JSON.stringify(marketplace, null, 2)}\n`);
+NODE
+}
 
 [ -x "$backend" ] || {
     echo "Linux Computer Use is enabled but its release binary is missing: $backend" >&2
@@ -26,3 +61,5 @@ mkdir -p "$target/bin"
 cp "$backend" "$target/bin/codex-computer-use-linux"
 cp "$cosmic" "$target/bin/codex-computer-use-cosmic"
 chmod 0755 "$target/bin/codex-computer-use-linux" "$target/bin/codex-computer-use-cosmic"
+find "$target" \( -name '*:com.apple.*' -o -name '.gitkeep' \) -delete
+write_computer_use_marketplace_entry "$marketplace"

--- a/linux-features/computer-use-linux/test.js
+++ b/linux-features/computer-use-linux/test.js
@@ -1,7 +1,9 @@
 "use strict";
 
 const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 
@@ -28,4 +30,65 @@ test("computer-use-linux staging consumes release artifacts without invoking Car
   const stage = fs.readFileSync(path.join(__dirname, "stage.sh"), "utf8");
   assert.doesNotMatch(stage, /cargo\s+(?:build|install)/);
   assert.match(stage, /target\/release\/codex-computer-use-linux/);
+});
+
+test("computer-use-linux staging registers the bundled plugin idempotently", (t) => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "computer-use-linux-stage-"));
+  t.after(() => fs.rmSync(workspace, { recursive: true, force: true }));
+
+  const installDir = path.join(workspace, "app");
+  const releaseDir = path.join(workspace, "target", "release");
+  const marketplacePath = path.join(
+    installDir,
+    "resources/plugins/openai-bundled/.agents/plugins/marketplace.json",
+  );
+  fs.mkdirSync(path.dirname(marketplacePath), { recursive: true });
+  fs.writeFileSync(
+    marketplacePath,
+    `${JSON.stringify({ plugins: [{ name: "browser", source: { source: "local", path: "./plugins/browser" } }] })}\n`,
+  );
+  fs.mkdirSync(releaseDir, { recursive: true });
+  for (const binary of ["codex-computer-use-linux", "codex-computer-use-cosmic"]) {
+    const binaryPath = path.join(releaseDir, binary);
+    fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  }
+
+  const env = {
+    ...process.env,
+    SCRIPT_DIR: workspace,
+    INSTALL_DIR: installDir,
+    CODEX_COMPUTER_USE_BINARY_SOURCE: path.join(releaseDir, "codex-computer-use-linux"),
+    CODEX_COMPUTER_USE_COSMIC_BINARY_SOURCE: path.join(releaseDir, "codex-computer-use-cosmic"),
+  };
+  fs.mkdirSync(path.join(workspace, "plugins/openai-bundled/plugins"), { recursive: true });
+  fs.cpSync(
+    path.resolve(__dirname, "../../plugins/openai-bundled/plugins/computer-use"),
+    path.join(workspace, "plugins/openai-bundled/plugins/computer-use"),
+    { recursive: true },
+  );
+
+  execFileSync("bash", [path.join(__dirname, "stage.sh")], { env });
+  execFileSync("bash", [path.join(__dirname, "stage.sh")], { env });
+
+  const marketplace = JSON.parse(fs.readFileSync(marketplacePath, "utf8"));
+  assert.equal(marketplace.plugins.filter(({ name }) => name === "computer-use").length, 1);
+  assert.ok(marketplace.plugins.some(({ name }) => name === "browser"));
+  assert.deepEqual(
+    marketplace.plugins.find(({ name }) => name === "computer-use"),
+    {
+      name: "computer-use",
+      source: { source: "local", path: "./plugins/computer-use" },
+      policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" },
+      category: "Productivity",
+    },
+  );
+  assert.equal(
+    fs.existsSync(
+      path.join(
+        installDir,
+        "resources/plugins/openai-bundled/plugins/computer-use/bin/codex-computer-use-linux",
+      ),
+    ),
+    true,
+  );
 });


### PR DESCRIPTION
## Summary

Closes #1329.

The opt-in `computer-use-linux` stage hook copied the native plugin and both release binaries into `openai-bundled`, but it did not add `computer-use` to that marketplace's manifest. As a result, the Computer Use settings surface and backend could work while the plugin detail route reported that `computer-use` was not found in `openai-bundled`.

This change registers the staged plugin with the same local marketplace shape used by other repository-owned bundled plugin features. It preserves existing entries, replaces any prior `computer-use` entry, and remains idempotent across repeated rebuilds. It also removes template placeholder files from the staged plugin payload.

The regression test runs the stage hook twice against a temporary marketplace, verifies that an existing Browser entry is preserved, asserts that exactly one Computer Use entry is present, and confirms the native backend is staged.

User-visible result: **Plugins > Computer Use** resolves its detail page and lists the packaged MCP server after enabling and installing `computer-use-linux`.

Affected scope:

- opt-in `computer-use-linux` feature only
- shared staged app payload for package formats that enable the feature
- amd64 validated manually; no architecture-specific code changed

## Validation

- `git diff --check`
- `bash -n linux-features/computer-use-linux/stage.sh`
- `node --test linux-features/computer-use-linux/test.js`
- `node --test linux-features/computer-use-linux/test.js linux-features/record-and-replay/test.js linux-features/read-aloud-mcp/test.js scripts/lib/package-common.test.js` (57 passed)
- `node --test scripts/lib/linux-features.test.js scripts/patch-linux-window-ui.test.js` (32 passed)
- built and inspected `codex-desktop-2026.08.12.220752-1-x86_64.pkg.tar.zst`; the packaged marketplace contained exactly one local `computer-use` entry and both native binaries
- manually installed and verified on Arch Linux x86_64, Hyprland/Wayland, upstream ChatGPT `26.803.81509`
- `codex-computer-use-linux doctor`: no blockers; AT-SPI, Hyprland targeting, `ydotoold`, `/dev/uinput`, and MCP registration ready
- manual task verified plugin registration, window queries/focus, and AT-SPI tree extraction without clicks, text input, or screenshots

Not tested manually: deb, RPM, AppImage, Nix, arm64, GNOME, KDE, COSMIC, X11.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] Upstream-drift checklist item is not applicable: this fixes a repository feature-stage regression and adds no compatibility fallback.
- [ ] I added or updated relevant tests and ran the validation listed above; required GitHub CI checks are still running.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
