### PR TITLE
Fix Nix git watcher SIGILL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,4 @@ jobs:
           node-version: 24
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
       - run: scripts/ci/validate-nix-pins.sh
+      - run: nix build .#checks.x86_64-linux.nix-runtime --no-link

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y dpkg-dev gnupg
+          sudo apt-get install -y dpkg-dev gnupg patchelf
       - name: Resolve signed package
         id: upstream
         run: |
@@ -115,6 +115,23 @@ jobs:
           cmp "$upstream_root/usr/lib/chatgpt/resources/app.asar" "$CODEX_INSTALL_DIR/resources/app.asar"
           test -x "$CODEX_INSTALL_DIR/ChatGPT"
           test -x "$CODEX_INSTALL_DIR/resources/codex"
+      - name: Validate Nix ELF workaround against the official executable
+        env:
+          CODEX_INSTALL_DIR: ${{ github.workspace }}/codex-app-${{ matrix.architecture }}
+        run: |
+          set -euo pipefail
+          executable_copy="$(mktemp)"
+          cp "$CODEX_INSTALL_DIR/ChatGPT" "$executable_copy"
+          if [ "${{ matrix.architecture }}" = amd64 ]; then
+            dynamic_linker=/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-glibc/lib/ld-linux-x86-64.so.2
+          else
+            dynamic_linker=/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-glibc/lib/ld-linux-aarch64.so.1
+          fi
+          patchelf --set-interpreter "$dynamic_linker" \
+            --add-rpath /nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-runtime/lib \
+            "$executable_copy"
+          node nix/relocate-elf-interpreter.cjs relocate "$executable_copy" "$dynamic_linker"
+          node nix/relocate-elf-interpreter.cjs check "$executable_copy" "$dynamic_linker"
       - name: Audit every ASAR feature against the official bundle
         if: matrix.architecture == 'amd64'
         run: |

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -6,6 +6,12 @@ ELF payload, and wraps it with the required Nix libraries.
 
 These inputs are official Linux `.deb` files. Nix wraps the official runtime
 directly instead of replacing Electron or rebuilding upstream native modules.
+`patchelf` normally moves Electron's interpreter metadata beyond the first
+2 KiB of the executable, where the bundled libc detector can no longer see it.
+The derivation relocates that metadata into verified `patchelf` padding so the
+detector selects glibc without using Electron's unsafe report fallback. This
+ELF-only compatibility fix is checked against both official architectures and
+keeps `resources/app.asar` byte-for-byte identical to upstream.
 
 ```bash
 nix run github:ilysenko/codex-desktop-linux

--- a/flake.nix
+++ b/flake.nix
@@ -133,11 +133,16 @@
               bash "$source_dir/install.sh" "${upstreamDeb}"
 
               app="$out/opt/codex-desktop"
+              dynamic_linker="$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)"
               for executable in "$app/ChatGPT" "$app/chrome_crashpad_handler"; do
                 test ! -f "$executable" || patchelf \
-                  --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
+                  --set-interpreter "$dynamic_linker" \
                   --add-rpath "${runtimeLibraryPath}" "$executable"
               done
+              # patchelf moves Electron's PT_INTERP beyond detect-libc's 2 KiB
+              # scan, whose process.report fallback trips Electron's CFI.
+              node "$source_dir/nix/relocate-elf-interpreter.cjs" relocate \
+                "$app/ChatGPT" "$dynamic_linker"
               find "$app" -type f \( -name '*.so' -o -name '*.so.*' -o -name '*.node' \) -print0 | \
                 while IFS= read -r -d "" library; do
                   patchelf --add-rpath "${runtimeLibraryPath}" "$library" 2>/dev/null || true
@@ -197,6 +202,16 @@
         checks.official-linux-package = pkgs.runCommand "official-linux-package-check" { nativeBuildInputs = [ pkgs.dpkg ]; } ''
           test "$(dpkg-deb -f ${upstreamDeb} Package)" = chatgpt
           test "$(dpkg-deb -f ${upstreamDeb} Architecture)" = ${officialPackage.architecture}
+          touch "$out"
+        '';
+        checks.nix-runtime = pkgs.runCommand "nix-runtime-check" { nativeBuildInputs = [ pkgs.dpkg pkgs.nodejs ]; } ''
+          dynamic_linker="$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)"
+          node ${sourceRoot}/nix/relocate-elf-interpreter.cjs check \
+            ${codexDesktop}/opt/codex-desktop/ChatGPT "$dynamic_linker"
+          upstream_root="$(mktemp -d)"
+          dpkg-deb -x ${upstreamDeb} "$upstream_root"
+          cmp "$upstream_root/usr/lib/chatgpt/resources/app.asar" \
+            ${codexDesktop}/opt/codex-desktop/resources/app.asar
           touch "$out"
         '';
         devShells.default = pkgs.mkShell { packages = [ pkgs.nodejs pkgs.python3 pkgs.dpkg pkgs.gnupg ]; };

--- a/nix/relocate-elf-interpreter.cjs
+++ b/nix/relocate-elf-interpreter.cjs
@@ -7,7 +7,7 @@ const ELF_HEADER_SIZE = 64;
 const PROGRAM_HEADER_SIZE = 56;
 const SECTION_HEADER_SIZE = 64;
 const DETECT_LIBC_SCAN_SIZE = 2048;
-const PATCHELF_FILL_BYTES = new Set([0x00, 0x5a]);
+const PATCHELF_FILL_BYTES = new Set([0x00, 0x58, 0x5a]);
 const PT_LOAD = 1;
 const PT_INTERP = 3;
 const SHT_PROGBITS = 1;
@@ -249,61 +249,65 @@ function relocateBuffer(buffer, expectedInterpreter) {
     fail("PT_INTERP is already inside detect-libc scan range");
   }
 
-  const targetOffset = alignUp(parsed.programEnd, parsed.alignment);
-  checkedRange(
-    targetOffset,
-    expectedBytes.length,
-    buffer.length,
-    "relocated PT_INTERP",
-  );
-  if (targetOffset + expectedBytes.length > DETECT_LIBC_SCAN_SIZE) {
-    fail("no room for PT_INTERP inside detect-libc scan range");
-  }
-  const relocationSlot = buffer.subarray(
-    targetOffset,
-    targetOffset + expectedBytes.length,
-  );
-  if (!relocationSlot.every((byte) => PATCHELF_FILL_BYTES.has(byte))) {
-    fail("relocation slot is not patchelf padding");
-  }
+  const firstCandidate = alignUp(parsed.programEnd, parsed.alignment);
+  const lastCandidate =
+    Math.min(buffer.length, DETECT_LIBC_SCAN_SIZE) - expectedBytes.length;
+  let targetOffset;
+  let load;
+  for (
+    let candidate = firstCandidate;
+    candidate <= lastCandidate;
+    candidate += parsed.alignment
+  ) {
+    const relocationSlot = buffer.subarray(
+      candidate,
+      candidate + expectedBytes.length,
+    );
+    if (!relocationSlot.every((byte) => PATCHELF_FILL_BYTES.has(byte)))
+      continue;
 
-  const loads = programs.filter(
-    ({ type, offset, fileSize }) =>
-      type === PT_LOAD &&
-      targetOffset >= offset &&
-      targetOffset + expectedBytes.length <= offset + fileSize,
-  );
-  if (loads.length !== 1)
-    fail(`expected one PT_LOAD for relocation slot, found ${loads.length}`);
-  const load = loads[0];
+    const loads = programs.filter(
+      ({ type, offset, fileSize }) =>
+        type === PT_LOAD &&
+        candidate >= offset &&
+        candidate + expectedBytes.length <= offset + fileSize,
+    );
+    if (loads.length !== 1) continue;
 
-  for (const program of programs) {
-    if (
-      program.type !== PT_LOAD &&
-      program !== interpreter &&
-      rangesOverlap(
-        targetOffset,
-        expectedBytes.length,
-        program.offset,
-        program.fileSize,
-      )
-    ) {
-      fail("relocation slot overlaps a non-LOAD segment");
-    }
+    const overlapsProgram = programs.some(
+      (program) =>
+        program.type !== PT_LOAD &&
+        program !== interpreter &&
+        rangesOverlap(
+          candidate,
+          expectedBytes.length,
+          program.offset,
+          program.fileSize,
+        ),
+    );
+    if (overlapsProgram) continue;
+
+    const overlapsSection = sections.some(
+      (section) =>
+        section.type !== SHT_NOBITS &&
+        section !== interpreterSection &&
+        rangesOverlap(
+          candidate,
+          expectedBytes.length,
+          section.offset,
+          section.size,
+        ),
+    );
+    if (overlapsSection) continue;
+
+    targetOffset = candidate;
+    load = loads[0];
+    break;
   }
-  for (const section of sections) {
-    if (
-      section.type !== SHT_NOBITS &&
-      section !== interpreterSection &&
-      rangesOverlap(
-        targetOffset,
-        expectedBytes.length,
-        section.offset,
-        section.size,
-      )
-    ) {
-      fail(`relocation slot overlaps section ${section.name || "<unnamed>"}`);
-    }
+  if (targetOffset === undefined || load === undefined) {
+    fail(
+      "no safe patchelf padding for PT_INTERP inside detect-libc scan range",
+    );
   }
 
   const delta = BigInt(targetOffset - load.offset);

--- a/nix/relocate-elf-interpreter.cjs
+++ b/nix/relocate-elf-interpreter.cjs
@@ -7,7 +7,7 @@ const ELF_HEADER_SIZE = 64;
 const PROGRAM_HEADER_SIZE = 56;
 const SECTION_HEADER_SIZE = 64;
 const DETECT_LIBC_SCAN_SIZE = 2048;
-const PATCHELF_FILL_BYTE = 0x5a;
+const PATCHELF_FILL_BYTES = new Set([0x00, 0x5a]);
 const PT_LOAD = 1;
 const PT_INTERP = 3;
 const SHT_PROGBITS = 1;
@@ -259,10 +259,13 @@ function relocateBuffer(buffer, expectedInterpreter) {
   if (targetOffset + expectedBytes.length > DETECT_LIBC_SCAN_SIZE) {
     fail("no room for PT_INTERP inside detect-libc scan range");
   }
+  const relocationSlot = buffer.subarray(
+    targetOffset,
+    targetOffset + expectedBytes.length,
+  );
   if (
-    !buffer
-      .subarray(targetOffset, targetOffset + expectedBytes.length)
-      .every((byte) => byte === PATCHELF_FILL_BYTE)
+    !PATCHELF_FILL_BYTES.has(relocationSlot[0]) ||
+    !relocationSlot.every((byte) => byte === relocationSlot[0])
   ) {
     fail("relocation slot is not patchelf padding");
   }

--- a/nix/relocate-elf-interpreter.cjs
+++ b/nix/relocate-elf-interpreter.cjs
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+
+const ELF_HEADER_SIZE = 64;
+const PROGRAM_HEADER_SIZE = 56;
+const SECTION_HEADER_SIZE = 64;
+const DETECT_LIBC_SCAN_SIZE = 2048;
+const PATCHELF_FILL_BYTE = 0x5a;
+const PT_LOAD = 1;
+const PT_INTERP = 3;
+const SHT_PROGBITS = 1;
+const SHT_NOBITS = 8;
+const SHF_ALLOC = 2n;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function checkedNumber(value, label) {
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    fail(`${label} exceeds JavaScript's safe integer range`);
+  }
+  return Number(value);
+}
+
+function checkedRange(offset, size, bufferLength, label) {
+  if (
+    !Number.isSafeInteger(offset) ||
+    !Number.isSafeInteger(size) ||
+    offset < 0 ||
+    size < 0 ||
+    offset > bufferLength - size
+  ) {
+    fail(`${label} is outside the ELF file`);
+  }
+}
+
+function rangesOverlap(startA, sizeA, startB, sizeB) {
+  return (
+    sizeA > 0 && sizeB > 0 && startA < startB + sizeB && startB < startA + sizeA
+  );
+}
+
+function alignUp(value, alignment) {
+  return Math.ceil(value / alignment) * alignment;
+}
+
+function readCString(buffer, offset, limit, label) {
+  if (offset < 0 || offset >= limit) {
+    fail(`${label} starts outside its string table`);
+  }
+  const end = buffer.indexOf(0, offset);
+  if (end === -1 || end >= limit) {
+    fail(`${label} is not NUL-terminated inside its string table`);
+  }
+  return buffer.toString("utf8", offset, end);
+}
+
+function parseElf(buffer, expectedInterpreter) {
+  checkedRange(0, ELF_HEADER_SIZE, buffer.length, "ELF header");
+  if (buffer.readUInt32BE(0) !== 0x7f454c46) fail("not an ELF file");
+  if (buffer[4] !== 2) fail("expected a 64-bit ELF file");
+  if (buffer[5] !== 1) fail("expected a little-endian ELF file");
+
+  const machine = buffer.readUInt16LE(18);
+  if (machine !== 62 && machine !== 183)
+    fail(`unsupported ELF machine: ${machine}`);
+  if (buffer.readUInt16LE(52) !== ELF_HEADER_SIZE)
+    fail("unexpected ELF header size");
+
+  const programOffset = checkedNumber(
+    buffer.readBigUInt64LE(32),
+    "program header offset",
+  );
+  const programEntrySize = buffer.readUInt16LE(54);
+  const programCount = buffer.readUInt16LE(56);
+  if (
+    programEntrySize !== PROGRAM_HEADER_SIZE ||
+    programCount === 0 ||
+    programCount === 0xffff
+  ) {
+    fail("unsupported program header table");
+  }
+  const programSize = programEntrySize * programCount;
+  checkedRange(
+    programOffset,
+    programSize,
+    buffer.length,
+    "program header table",
+  );
+
+  const sectionOffset = checkedNumber(
+    buffer.readBigUInt64LE(40),
+    "section header offset",
+  );
+  const sectionEntrySize = buffer.readUInt16LE(58);
+  const sectionCount = buffer.readUInt16LE(60);
+  const sectionNamesIndex = buffer.readUInt16LE(62);
+  if (
+    sectionEntrySize !== SECTION_HEADER_SIZE ||
+    sectionCount === 0 ||
+    sectionCount === 0xffff ||
+    sectionNamesIndex >= sectionCount ||
+    sectionNamesIndex === 0xffff
+  ) {
+    fail("unsupported section header table");
+  }
+  checkedRange(
+    sectionOffset,
+    sectionEntrySize * sectionCount,
+    buffer.length,
+    "section header table",
+  );
+
+  const programs = [];
+  for (let index = 0; index < programCount; index += 1) {
+    const header = programOffset + index * programEntrySize;
+    const item = {
+      header,
+      type: buffer.readUInt32LE(header),
+      offset: checkedNumber(
+        buffer.readBigUInt64LE(header + 8),
+        `program ${index} offset`,
+      ),
+      vaddr: buffer.readBigUInt64LE(header + 16),
+      paddr: buffer.readBigUInt64LE(header + 24),
+      fileSize: checkedNumber(
+        buffer.readBigUInt64LE(header + 32),
+        `program ${index} file size`,
+      ),
+      memorySize: checkedNumber(
+        buffer.readBigUInt64LE(header + 40),
+        `program ${index} memory size`,
+      ),
+    };
+    checkedRange(item.offset, item.fileSize, buffer.length, `program ${index}`);
+    programs.push(item);
+  }
+
+  const interpreters = programs.filter(({ type }) => type === PT_INTERP);
+  if (interpreters.length !== 1)
+    fail(`expected one PT_INTERP, found ${interpreters.length}`);
+  const interpreter = interpreters[0];
+  if (
+    interpreter.fileSize !== interpreter.memorySize ||
+    interpreter.fileSize === 0
+  ) {
+    fail("PT_INTERP has inconsistent size");
+  }
+  const expectedBytes = Buffer.from(`${expectedInterpreter}\0`);
+  if (
+    !buffer
+      .subarray(interpreter.offset, interpreter.offset + interpreter.fileSize)
+      .equals(expectedBytes)
+  ) {
+    fail("PT_INTERP does not contain the expected dynamic linker");
+  }
+
+  const rawSections = [];
+  for (let index = 0; index < sectionCount; index += 1) {
+    const header = sectionOffset + index * sectionEntrySize;
+    const item = {
+      header,
+      nameOffset: buffer.readUInt32LE(header),
+      type: buffer.readUInt32LE(header + 4),
+      flags: buffer.readBigUInt64LE(header + 8),
+      address: buffer.readBigUInt64LE(header + 16),
+      offset: checkedNumber(
+        buffer.readBigUInt64LE(header + 24),
+        `section ${index} offset`,
+      ),
+      size: checkedNumber(
+        buffer.readBigUInt64LE(header + 32),
+        `section ${index} size`,
+      ),
+      alignment: checkedNumber(
+        buffer.readBigUInt64LE(header + 48),
+        `section ${index} alignment`,
+      ),
+    };
+    if (item.type !== SHT_NOBITS)
+      checkedRange(item.offset, item.size, buffer.length, `section ${index}`);
+    rawSections.push(item);
+  }
+
+  const names = rawSections[sectionNamesIndex];
+  if (names.type !== 3 || names.size === 0)
+    fail("invalid section-name string table");
+  const namesLimit = names.offset + names.size;
+  const sections = rawSections.map((section, index) => ({
+    ...section,
+    name: readCString(
+      buffer,
+      names.offset + section.nameOffset,
+      namesLimit,
+      `section ${index} name`,
+    ),
+  }));
+  const interpreterSections = sections.filter(({ name }) => name === ".interp");
+  if (interpreterSections.length !== 1) {
+    fail(`expected one .interp section, found ${interpreterSections.length}`);
+  }
+  const interpreterSection = interpreterSections[0];
+  if (
+    interpreterSection.type !== SHT_PROGBITS ||
+    !(interpreterSection.flags & SHF_ALLOC) ||
+    interpreterSection.offset !== interpreter.offset ||
+    interpreterSection.address !== interpreter.vaddr ||
+    interpreterSection.size !== interpreter.fileSize
+  ) {
+    fail(".interp does not match PT_INTERP");
+  }
+  const alignment = interpreterSection.alignment;
+  if (
+    alignment === 0 ||
+    alignment > DETECT_LIBC_SCAN_SIZE ||
+    (alignment & (alignment - 1)) !== 0
+  ) {
+    fail(`unsupported .interp alignment: ${alignment}`);
+  }
+
+  return {
+    expectedBytes,
+    interpreter,
+    interpreterSection,
+    programs,
+    sections,
+    programEnd: programOffset + programSize,
+    alignment,
+  };
+}
+
+function inspectInterpreter(buffer, expectedInterpreter) {
+  const parsed = parseElf(buffer, expectedInterpreter);
+  return {
+    offset: parsed.interpreter.offset,
+    size: parsed.interpreter.fileSize,
+    path: expectedInterpreter,
+  };
+}
+
+function relocateBuffer(buffer, expectedInterpreter) {
+  const parsed = parseElf(buffer, expectedInterpreter);
+  const { expectedBytes, interpreter, interpreterSection, programs, sections } =
+    parsed;
+  if (interpreter.offset + interpreter.fileSize <= DETECT_LIBC_SCAN_SIZE) {
+    fail("PT_INTERP is already inside detect-libc scan range");
+  }
+
+  const targetOffset = alignUp(parsed.programEnd, parsed.alignment);
+  checkedRange(
+    targetOffset,
+    expectedBytes.length,
+    buffer.length,
+    "relocated PT_INTERP",
+  );
+  if (targetOffset + expectedBytes.length > DETECT_LIBC_SCAN_SIZE) {
+    fail("no room for PT_INTERP inside detect-libc scan range");
+  }
+  if (
+    !buffer
+      .subarray(targetOffset, targetOffset + expectedBytes.length)
+      .every((byte) => byte === PATCHELF_FILL_BYTE)
+  ) {
+    fail("relocation slot is not patchelf padding");
+  }
+
+  const loads = programs.filter(
+    ({ type, offset, fileSize }) =>
+      type === PT_LOAD &&
+      targetOffset >= offset &&
+      targetOffset + expectedBytes.length <= offset + fileSize,
+  );
+  if (loads.length !== 1)
+    fail(`expected one PT_LOAD for relocation slot, found ${loads.length}`);
+  const load = loads[0];
+
+  for (const program of programs) {
+    if (
+      program.type !== PT_LOAD &&
+      program !== interpreter &&
+      rangesOverlap(
+        targetOffset,
+        expectedBytes.length,
+        program.offset,
+        program.fileSize,
+      )
+    ) {
+      fail("relocation slot overlaps a non-LOAD segment");
+    }
+  }
+  for (const section of sections) {
+    if (
+      section.type !== SHT_NOBITS &&
+      section !== interpreterSection &&
+      rangesOverlap(
+        targetOffset,
+        expectedBytes.length,
+        section.offset,
+        section.size,
+      )
+    ) {
+      fail(`relocation slot overlaps section ${section.name || "<unnamed>"}`);
+    }
+  }
+
+  const delta = BigInt(targetOffset - load.offset);
+  const targetAddress = load.vaddr + delta;
+  const targetPhysicalAddress = load.paddr + delta;
+  const patched = Buffer.from(buffer);
+  expectedBytes.copy(patched, targetOffset);
+  patched.writeBigUInt64LE(BigInt(targetOffset), interpreter.header + 8);
+  patched.writeBigUInt64LE(targetAddress, interpreter.header + 16);
+  patched.writeBigUInt64LE(targetPhysicalAddress, interpreter.header + 24);
+  patched.writeBigUInt64LE(
+    BigInt(expectedBytes.length),
+    interpreter.header + 32,
+  );
+  patched.writeBigUInt64LE(
+    BigInt(expectedBytes.length),
+    interpreter.header + 40,
+  );
+  patched.writeBigUInt64LE(targetAddress, interpreterSection.header + 16);
+  patched.writeBigUInt64LE(
+    BigInt(targetOffset),
+    interpreterSection.header + 24,
+  );
+  patched.writeBigUInt64LE(
+    BigInt(expectedBytes.length),
+    interpreterSection.header + 32,
+  );
+
+  const verified = parseElf(patched, expectedInterpreter);
+  if (
+    verified.interpreter.offset !== targetOffset ||
+    targetOffset + verified.interpreter.fileSize > DETECT_LIBC_SCAN_SIZE ||
+    patched.length !== buffer.length
+  ) {
+    fail("relocated PT_INTERP verification failed");
+  }
+  return patched;
+}
+
+function relocateFile(elfPath, expectedInterpreter) {
+  const original = fs.readFileSync(elfPath);
+  const patched = relocateBuffer(original, expectedInterpreter);
+  const temporaryPath = `${elfPath}.codex-desktop-${process.pid}.tmp`;
+  const mode = fs.statSync(elfPath).mode;
+  try {
+    fs.writeFileSync(temporaryPath, patched, { mode });
+    fs.renameSync(temporaryPath, elfPath);
+  } catch (error) {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch {}
+    throw error;
+  }
+}
+
+function checkFile(elfPath, expectedInterpreter) {
+  const result = inspectInterpreter(
+    fs.readFileSync(elfPath),
+    expectedInterpreter,
+  );
+  if (result.offset + result.size > DETECT_LIBC_SCAN_SIZE) {
+    fail("PT_INTERP is outside detect-libc scan range");
+  }
+  return result;
+}
+
+function main(argv) {
+  const [command, elfPath, expectedInterpreter] = argv;
+  if (
+    !["relocate", "check"].includes(command) ||
+    !elfPath ||
+    !expectedInterpreter
+  ) {
+    fail(
+      "usage: relocate-elf-interpreter.cjs <relocate|check> <elf> <expected-dynamic-linker>",
+    );
+  }
+  if (command === "relocate") {
+    relocateFile(elfPath, expectedInterpreter);
+  } else {
+    checkFile(elfPath, expectedInterpreter);
+  }
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(`[relocate-elf-interpreter] ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  DETECT_LIBC_SCAN_SIZE,
+  checkFile,
+  inspectInterpreter,
+  relocateBuffer,
+  relocateFile,
+};

--- a/nix/relocate-elf-interpreter.cjs
+++ b/nix/relocate-elf-interpreter.cjs
@@ -263,10 +263,7 @@ function relocateBuffer(buffer, expectedInterpreter) {
     targetOffset,
     targetOffset + expectedBytes.length,
   );
-  if (
-    !PATCHELF_FILL_BYTES.has(relocationSlot[0]) ||
-    !relocationSlot.every((byte) => byte === relocationSlot[0])
-  ) {
+  if (!relocationSlot.every((byte) => PATCHELF_FILL_BYTES.has(byte))) {
     fail("relocation slot is not patchelf padding");
   }
 

--- a/scripts/ci/github-actions-workflows.test.js
+++ b/scripts/ci/github-actions-workflows.test.js
@@ -24,6 +24,7 @@ function job(workflow, jobName) {
 test("CI runs the complete workflow regression suite", () => {
   const workflow = read(".github/workflows/ci.yml");
   assert.match(workflow, /node --test scripts\/ci\/\*\.test\.js/);
+  assert.match(workflow, /nix build \.#checks\.x86_64-linux\.nix-runtime --no-link/);
 });
 
 test("official Linux validation runs fully on every pull request but not hourly", () => {
@@ -31,7 +32,12 @@ test("official Linux validation runs fully on every pull request but not hourly"
   assert.doesNotMatch(workflow, /^  schedule:/m);
   assert.match(workflow, /^  pull_request:\s*\n  push:/m);
   assert.match(workflow, /^      - \.github\/workflows\/upstream-build-app\.yml$/m);
-  assert.match(job(workflow, "signed-baseline"), /architecture: \[amd64, arm64\]/);
+  const signedBaseline = job(workflow, "signed-baseline");
+  assert.match(signedBaseline, /architecture: \[amd64, arm64\]/);
+  assert.match(
+    signedBaseline,
+    /name: Validate Nix ELF workaround[\s\S]*?env:\n          CODEX_INSTALL_DIR:.*matrix\.architecture[\s\S]*?relocate-elf-interpreter\.cjs relocate/,
+  );
 
   const packageMatrix = job(workflow, "package-matrix");
   assert.match(packageMatrix, /architecture: amd64/);

--- a/scripts/ci/relocate-elf-interpreter.test.js
+++ b/scripts/ci/relocate-elf-interpreter.test.js
@@ -1,0 +1,229 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  DETECT_LIBC_SCAN_SIZE,
+  inspectInterpreter,
+  relocateBuffer,
+  relocateFile,
+} = require("../../nix/relocate-elf-interpreter.cjs");
+
+const PH_OFFSET = 64;
+const PH_SIZE = 56;
+const PH_COUNT = 4;
+const SLOT_OFFSET = PH_OFFSET + PH_SIZE * PH_COUNT;
+const INTERP_PH = PH_OFFSET + 2 * PH_SIZE;
+const SECTION_OFFSET = 0xc00;
+const INTERP_SH = SECTION_OFFSET + 64;
+
+function writeProgram(buffer, index, type, offset, size, address = offset) {
+  const header = PH_OFFSET + index * PH_SIZE;
+  buffer.writeUInt32LE(type, header);
+  buffer.writeUInt32LE(4, header + 4);
+  buffer.writeBigUInt64LE(BigInt(offset), header + 8);
+  buffer.writeBigUInt64LE(BigInt(address), header + 16);
+  buffer.writeBigUInt64LE(BigInt(address), header + 24);
+  buffer.writeBigUInt64LE(BigInt(size), header + 32);
+  buffer.writeBigUInt64LE(BigInt(size), header + 40);
+  buffer.writeBigUInt64LE(8n, header + 48);
+}
+
+function writeSection(
+  buffer,
+  index,
+  name,
+  type,
+  flags,
+  address,
+  offset,
+  size,
+  alignment,
+) {
+  const header = SECTION_OFFSET + index * 64;
+  buffer.writeUInt32LE(name, header);
+  buffer.writeUInt32LE(type, header + 4);
+  buffer.writeBigUInt64LE(BigInt(flags), header + 8);
+  buffer.writeBigUInt64LE(BigInt(address), header + 16);
+  buffer.writeBigUInt64LE(BigInt(offset), header + 24);
+  buffer.writeBigUInt64LE(BigInt(size), header + 32);
+  buffer.writeBigUInt64LE(BigInt(alignment), header + 48);
+}
+
+function elfFixture(machine, interpreter, interpreterOffset = 0x900) {
+  const buffer = Buffer.alloc(4096);
+  buffer.writeUInt32BE(0x7f454c46, 0);
+  buffer[4] = 2;
+  buffer[5] = 1;
+  buffer[6] = 1;
+  buffer.writeUInt16LE(3, 16);
+  buffer.writeUInt16LE(machine, 18);
+  buffer.writeUInt32LE(1, 20);
+  buffer.writeBigUInt64LE(BigInt(PH_OFFSET), 32);
+  buffer.writeBigUInt64LE(BigInt(SECTION_OFFSET), 40);
+  buffer.writeUInt16LE(64, 52);
+  buffer.writeUInt16LE(PH_SIZE, 54);
+  buffer.writeUInt16LE(PH_COUNT, 56);
+  buffer.writeUInt16LE(64, 58);
+  buffer.writeUInt16LE(3, 60);
+  buffer.writeUInt16LE(2, 62);
+
+  const interpreterBytes = Buffer.from(`${interpreter}\0`);
+  writeProgram(buffer, 0, 6, PH_OFFSET, PH_SIZE * PH_COUNT);
+  writeProgram(buffer, 1, 1, 0, buffer.length);
+  writeProgram(buffer, 2, 3, interpreterOffset, interpreterBytes.length);
+  writeProgram(buffer, 3, 4, 0xb00, 16);
+  buffer.fill(0x5a, SLOT_OFFSET, DETECT_LIBC_SCAN_SIZE);
+  interpreterBytes.copy(buffer, interpreterOffset);
+
+  const sectionNames = Buffer.from("\0.interp\0.shstrtab\0");
+  sectionNames.copy(buffer, 0xa00);
+  writeSection(
+    buffer,
+    1,
+    1,
+    1,
+    2,
+    interpreterOffset,
+    interpreterOffset,
+    interpreterBytes.length,
+    8,
+  );
+  writeSection(buffer, 2, 9, 3, 0, 0, 0xa00, sectionNames.length, 1);
+  return buffer;
+}
+
+function interpreterFromFirstTwoKiB(buffer) {
+  const scan = buffer.subarray(0, DETECT_LIBC_SCAN_SIZE);
+  const programOffset = Number(scan.readBigUInt64LE(32));
+  const entrySize = scan.readUInt16LE(54);
+  const count = scan.readUInt16LE(56);
+  for (let index = 0; index < count; index += 1) {
+    const header = programOffset + index * entrySize;
+    if (scan.readUInt32LE(header) === 3) {
+      const offset = Number(scan.readBigUInt64LE(header + 8));
+      const size = Number(scan.readBigUInt64LE(header + 32));
+      return scan
+        .subarray(offset, offset + size)
+        .toString()
+        .replace(/\0.*$/s, "");
+    }
+  }
+  return null;
+}
+
+for (const [name, machine, interpreter] of [
+  [
+    "x86_64",
+    62,
+    "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-glibc/lib/ld-linux-x86-64.so.2",
+  ],
+  [
+    "aarch64",
+    183,
+    "/nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-glibc/lib/ld-linux-aarch64.so.1",
+  ],
+]) {
+  test(`relocates ${name} PT_INTERP into detect-libc scan range`, () => {
+    const original = elfFixture(machine, interpreter);
+    const patched = relocateBuffer(original, interpreter);
+    const inspected = inspectInterpreter(patched, interpreter);
+
+    assert.equal(patched.length, original.length);
+    assert.equal(inspected.offset, SLOT_OFFSET);
+    assert.ok(inspected.offset + inspected.size <= DETECT_LIBC_SCAN_SIZE);
+    assert.equal(interpreterFromFirstTwoKiB(patched), interpreter);
+    assert.equal(Number(patched.readBigUInt64LE(INTERP_SH + 24)), SLOT_OFFSET);
+    assert.equal(
+      patched.subarray(0x900, 0x900 + interpreter.length + 1).toString(),
+      `${interpreter}\0`,
+    );
+
+    const allowed = new Set();
+    for (
+      let index = SLOT_OFFSET;
+      index < SLOT_OFFSET + interpreter.length + 1;
+      index += 1
+    )
+      allowed.add(index);
+    for (const [start, size] of [
+      [INTERP_PH + 8, 40],
+      [INTERP_SH + 16, 24],
+    ]) {
+      for (let index = start; index < start + size; index += 1)
+        allowed.add(index);
+    }
+    for (let index = 0; index < original.length; index += 1) {
+      if (!allowed.has(index))
+        assert.equal(
+          patched[index],
+          original[index],
+          `unexpected change at ${index}`,
+        );
+    }
+  });
+}
+
+test("relocateFile preserves executable mode", () => {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "relocate-elf-interpreter-"),
+  );
+  const elfPath = path.join(directory, "ChatGPT");
+  const interpreter =
+    "/nix/store/cccccccccccccccccccccccccccccccc-glibc/lib/ld-linux-x86-64.so.2";
+  try {
+    fs.writeFileSync(elfPath, elfFixture(62, interpreter), { mode: 0o755 });
+    relocateFile(elfPath, interpreter);
+    assert.equal(fs.statSync(elfPath).mode & 0o777, 0o755);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+for (const [name, mutate, pattern] of [
+  [
+    "an unsupported machine",
+    (buffer) => buffer.writeUInt16LE(40, 18),
+    /unsupported ELF machine/,
+  ],
+  [
+    "duplicate PT_INTERP",
+    (buffer) => buffer.writeUInt32LE(3, PH_OFFSET + 3 * PH_SIZE),
+    /expected one PT_INTERP/,
+  ],
+  [
+    "non-padding bytes",
+    (buffer) => {
+      buffer[SLOT_OFFSET] = 0;
+    },
+    /not patchelf padding/,
+  ],
+  [
+    "an already visible interpreter",
+    null,
+    /already inside detect-libc scan range/,
+  ],
+  [
+    "mismatched .interp metadata",
+    (buffer) => buffer.writeBigUInt64LE(0x901n, INTERP_SH + 24),
+    /\.interp does not match/,
+  ],
+]) {
+  test(`fails closed for ${name}`, () => {
+    const interpreter =
+      "/nix/store/dddddddddddddddddddddddddddddddd-glibc/lib/ld-linux-x86-64.so.2";
+    const original = elfFixture(
+      62,
+      interpreter,
+      name === "an already visible interpreter" ? 0x700 : 0x900,
+    );
+    if (mutate) mutate(original);
+    const snapshot = Buffer.from(original);
+    assert.throws(() => relocateBuffer(original, interpreter), pattern);
+    assert.deepEqual(original, snapshot);
+  });
+}

--- a/scripts/ci/relocate-elf-interpreter.test.js
+++ b/scripts/ci/relocate-elf-interpreter.test.js
@@ -54,7 +54,12 @@ function writeSection(
   buffer.writeBigUInt64LE(BigInt(alignment), header + 48);
 }
 
-function elfFixture(machine, interpreter, interpreterOffset = 0x900) {
+function elfFixture(
+  machine,
+  interpreter,
+  interpreterOffset = 0x900,
+  paddingByte = 0x5a,
+) {
   const buffer = Buffer.alloc(4096);
   buffer.writeUInt32BE(0x7f454c46, 0);
   buffer[4] = 2;
@@ -77,7 +82,7 @@ function elfFixture(machine, interpreter, interpreterOffset = 0x900) {
   writeProgram(buffer, 1, 1, 0, buffer.length);
   writeProgram(buffer, 2, 3, interpreterOffset, interpreterBytes.length);
   writeProgram(buffer, 3, 4, 0xb00, 16);
-  buffer.fill(0x5a, SLOT_OFFSET, DETECT_LIBC_SCAN_SIZE);
+  buffer.fill(paddingByte, SLOT_OFFSET, DETECT_LIBC_SCAN_SIZE);
   interpreterBytes.copy(buffer, interpreterOffset);
 
   const sectionNames = Buffer.from("\0.interp\0.shstrtab\0");
@@ -96,6 +101,16 @@ function elfFixture(machine, interpreter, interpreterOffset = 0x900) {
   writeSection(buffer, 2, 9, 3, 0, 0, 0xa00, sectionNames.length, 1);
   return buffer;
 }
+
+test("accepts zero-filled patchelf padding", () => {
+  const interpreter =
+    "/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-glibc/lib/ld-linux-x86-64.so.2";
+  const patched = relocateBuffer(
+    elfFixture(62, interpreter, 0x900, 0),
+    interpreter,
+  );
+  assert.equal(inspectInterpreter(patched, interpreter).offset, SLOT_OFFSET);
+});
 
 function interpreterFromFirstTwoKiB(buffer) {
   const scan = buffer.subarray(0, DETECT_LIBC_SCAN_SIZE);

--- a/scripts/ci/relocate-elf-interpreter.test.js
+++ b/scripts/ci/relocate-elf-interpreter.test.js
@@ -112,6 +112,16 @@ test("accepts zero-filled patchelf padding", () => {
   assert.equal(inspectInterpreter(patched, interpreter).offset, SLOT_OFFSET);
 });
 
+test("accepts 0x58 padding from the pinned Nix patchelf", () => {
+  const interpreter =
+    "/nix/store/12121212121212121212121212121212-glibc/lib/ld-linux-x86-64.so.2";
+  const patched = relocateBuffer(
+    elfFixture(62, interpreter, 0x900, 0x58),
+    interpreter,
+  );
+  assert.equal(inspectInterpreter(patched, interpreter).offset, SLOT_OFFSET);
+});
+
 test("accepts mixed zero and 0x5a patchelf padding", () => {
   const interpreter =
     "/nix/store/ffffffffffffffffffffffffffffffff-glibc/lib/ld-linux-x86-64.so.2";
@@ -121,6 +131,18 @@ test("accepts mixed zero and 0x5a patchelf padding", () => {
   }
   const patched = relocateBuffer(fixture, interpreter);
   assert.equal(inspectInterpreter(patched, interpreter).offset, SLOT_OFFSET);
+});
+
+test("skips occupied bytes before safe patchelf padding", () => {
+  const interpreter =
+    "/nix/store/11111111111111111111111111111111-glibc/lib/ld-linux-x86-64.so.2";
+  const fixture = elfFixture(62, interpreter);
+  fixture.fill(1, SLOT_OFFSET, SLOT_OFFSET + 16);
+  const patched = relocateBuffer(fixture, interpreter);
+  assert.equal(
+    inspectInterpreter(patched, interpreter).offset,
+    SLOT_OFFSET + 16,
+  );
 });
 
 function interpreterFromFirstTwoKiB(buffer) {
@@ -224,9 +246,9 @@ for (const [name, mutate, pattern] of [
   [
     "non-padding bytes",
     (buffer) => {
-      buffer[SLOT_OFFSET] = 1;
+      buffer.fill(1, SLOT_OFFSET, DETECT_LIBC_SCAN_SIZE);
     },
-    /not patchelf padding/,
+    /no safe patchelf padding/,
   ],
   [
     "an already visible interpreter",

--- a/scripts/ci/relocate-elf-interpreter.test.js
+++ b/scripts/ci/relocate-elf-interpreter.test.js
@@ -112,6 +112,17 @@ test("accepts zero-filled patchelf padding", () => {
   assert.equal(inspectInterpreter(patched, interpreter).offset, SLOT_OFFSET);
 });
 
+test("accepts mixed zero and 0x5a patchelf padding", () => {
+  const interpreter =
+    "/nix/store/ffffffffffffffffffffffffffffffff-glibc/lib/ld-linux-x86-64.so.2";
+  const fixture = elfFixture(62, interpreter);
+  for (let index = SLOT_OFFSET; index < DETECT_LIBC_SCAN_SIZE; index += 2) {
+    fixture[index] = 0;
+  }
+  const patched = relocateBuffer(fixture, interpreter);
+  assert.equal(inspectInterpreter(patched, interpreter).offset, SLOT_OFFSET);
+});
+
 function interpreterFromFirstTwoKiB(buffer) {
   const scan = buffer.subarray(0, DETECT_LIBC_SCAN_SIZE);
   const programOffset = Number(scan.readBigUInt64LE(32));
@@ -213,7 +224,7 @@ for (const [name, mutate, pattern] of [
   [
     "non-padding bytes",
     (buffer) => {
-      buffer[SLOT_OFFSET] = 0;
+      buffer[SLOT_OFFSET] = 1;
     },
     /not patchelf padding/,
   ],


### PR DESCRIPTION
## Summary
- relocate the patchelf-generated Electron `PT_INTERP` metadata into verified padding within detect-libc's 2 KiB scan range
- preserve the official `app.asar` byte-for-byte instead of patching the bundled watcher
- add fail-closed x86_64/aarch64 ELF tests and current-official-package CI coverage

Fixes #1331

## Tests
- `node --test scripts/ci/*.test.js`
- `bash tests/scripts_smoke.sh`
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template`
- `git diff --check`
- actual current official amd64 and arm64 Electron ELF relocation/check

## Notes
- the helper intentionally fails if upstream or patchelf no longer produces the expected out-of-range layout, so the workaround is reviewed and removed instead of silently retained