### PR TITLE
Hide official Linux overlay buttons in frameless-titlebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- The opt-in `frameless-titlebar` feature again hides official Linux overlay
+  buttons. It retargets the current `titleBarOverlay` window options, zoom
+  update, and theme-sync contracts, remaps Linux webview chrome to `native`,
+  and rejects mixed, duplicate, or drifted official-package surfaces
+  byte-identically. Retired DMG inset and user-agent layout-gate rewrites are
+  omitted because official Linux already uses a 0px inset for both layouts.
 - The opt-in Dock icon tweak is restored for the signed official Linux package,
   using its ChatGPT icon and desktop metadata while preserving ChatGPT
   Community window, tray, and managed launcher synchronization.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ requirements, known limitations, configuration, and tests.
 | `computer-use-linux` | Linux desktop-control UI and native MCP backend | [Docs](linux-features/computer-use-linux/README.md) |
 | `copilot-reasoning-effort` | Persistent reasoning-effort defaults for Copilot-auth sessions | [Docs](linux-features/copilot-reasoning-effort/README.md) |
 | `directory-only-working-tree-watch` | Bounded Watchbound working-tree watching | [Docs](linux-features/directory-only-working-tree-watch/README.md) |
-| `frameless-titlebar` | Compositor-managed decorations without overlay controls | [Docs](linux-features/frameless-titlebar/README.md) |
+| `frameless-titlebar` | Hide official Linux overlay buttons for compositor-managed decorations | [Docs](linux-features/frameless-titlebar/README.md) |
 | `global-dictation` | X11 and XDG portal global dictation hotkeys | [Docs](linux-features/global-dictation/README.md) |
 | `linux-performance-workarounds` | Measured renderer workarounds for affected systems | [Docs](linux-features/linux-performance-workarounds/README.md) |
 | `mcp-helper-reaper` | Reap orphaned MCP helpers without touching live sessions | [Docs](linux-features/mcp-helper-reaper/README.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -191,7 +191,7 @@ Nix 用户应从 profile、Home Manager 配置或 NixOS module 中删除该包�
 | `computer-use-linux` | Linux desktop-control UI 与原生 MCP backend | [文档](linux-features/computer-use-linux/README.md) |
 | `copilot-reasoning-effort` | Copilot auth 的 reasoning-effort 默认值 | [文档](linux-features/copilot-reasoning-effort/README.md) |
 | `directory-only-working-tree-watch` | 有界 Watchbound 工作树监听 | [文档](linux-features/directory-only-working-tree-watch/README.md) |
-| `frameless-titlebar` | 由 compositor 管理窗口装饰 | [文档](linux-features/frameless-titlebar/README.md) |
+| `frameless-titlebar` | 隐藏官方 Linux overlay 按钮，改由 compositor 管理窗口装饰 | [文档](linux-features/frameless-titlebar/README.md) |
 | `global-dictation` | X11 / XDG portal 全局听写快捷键 | [文档](linux-features/global-dictation/README.md) |
 | `linux-performance-workarounds` | 针对受影响系统的 renderer workaround | [文档](linux-features/linux-performance-workarounds/README.md) |
 | `mcp-helper-reaper` | 安全清理孤立 MCP helper | [文档](linux-features/mcp-helper-reaper/README.md) |

--- a/linux-features/frameless-titlebar/README.md
+++ b/linux-features/frameless-titlebar/README.md
@@ -1,18 +1,23 @@
 # Frameless Titlebar
 
-This optional feature removes the app-rendered titlebar controls and menu
-chrome from the primary and Quick Chat Community windows. The official Linux
-runtime already owns native BrowserWindow decoration; this feature only changes
-the current webview layout and does not patch main-process window creation.
-It is intended for compositors or window managers where compositor-managed
-decorations already provide the expected window controls, such as Hyprland
-setups. It is also a
-useful diagnostic switch for GNOME/X11 titlebar right-click lockups, because it
-removes the Linux Window Controls Overlay path from the main window.
+This optional feature hides Electron-drawn Linux window-control overlay buttons
+and the in-app application menu on the primary and Quick Chat Community windows.
+The official Linux package still creates those windows with
+`titleBarStyle: hidden` plus `titleBarOverlay`, then reapplies the overlay from
+`setWindowZoom` and `installApplicationMenuTitleBarOverlaySync`. Official Linux
+webview chrome still maps Electron Linux to `application-menu`.
 
-The default build leaves the existing Linux titlebar overlay behavior in place.
-Enable this only when the built-in Codex titlebar/buttons visually conflict
-with your desktop environment.
+This feature keeps the hidden titlebar style so compositor-managed decorations
+remain, stops Linux from receiving the overlay, and remaps Linux webview chrome
+to `native`.
+
+Use it on compositors or window managers that already provide move, resize,
+minimize, maximize, and close, such as Hyprland. It is also a diagnostic
+switch for GNOME/X11 titlebar right-click lockups, because it removes the
+Linux Window Controls Overlay path from the main window.
+
+The default build leaves the official Linux overlay buttons in place. Enable
+this only when those built-in buttons conflict with your desktop environment.
 
 Enable it by copying `linux-features/features.example.json` to
 `linux-features/features.json` and listing the feature id:
@@ -26,7 +31,26 @@ Enable it by copying `linux-features/features.example.json` to
 ```
 
 Then rerun `./install.sh` or the native package build flow so the ASAR patches
-are regenerated with this feature enabled.
+are regenerated with this feature enabled. A reload is not enough: the overlay
+is created when the window is constructed.
+
+## What it patches
+
+| Surface | Current official contract | Result on Linux |
+|---|---|---|
+| Main window options | `win32\|\|linux` hidden titlebar plus `titleBarOverlay` | Linux keeps `titleBarStyle: hidden` and does not receive an overlay |
+| Zoom overlay | `setWindowZoom` calls `setTitleBarOverlay` on Linux | Overlay updates stay Windows-only |
+| Theme overlay sync | `installApplicationMenuTitleBarOverlaySync` runs on Linux | Theme changes do not restore Linux overlay buttons |
+| Webview chrome mapping | Electron Linux uses `application-menu` | Linux uses `native` chrome and hides the in-app menu |
+
+The official Linux webview already uses a 0px inset for both `default` and
+`application-menu` layouts. This feature does not rewrite that inset, does not
+patch the user-agent layout gate, and does not depend on retired DMG
+`codexLinuxUseWindowControlsSafeArea` markers.
+
+Missing, mixed, duplicate, or drifted contracts leave the source
+byte-identical and report optional drift. An already-patched official bundle
+is recognized as applied and is left unchanged.
 
 ## Testing
 
@@ -36,7 +60,8 @@ Run the feature's unit tests from the repository root:
 node --test linux-features/frameless-titlebar/test.js
 ```
 
-For a manual check, enable the feature as above, rebuild, and launch the app:
+For a manual check, enable the feature as above, rebuild, fully quit every
+ChatGPT Community and official ChatGPT process, then launch the app:
 
 - The primary and Quick Chat windows should show no Electron-drawn titlebar
   overlay buttons (minimize/maximize/close in the top-right corner) and no menu
@@ -47,8 +72,7 @@ For a manual check, enable the feature as above, rebuild, and launch the app:
   compositor's bindings (for example Hyprland's `bindm` mouse binds and
   `killactive`/`fullscreen` dispatchers).
 - Changing the system dark/light theme must not crash the app or repaint a
-  titlebar strip in either window; the patch removes their Linux
-  `setTitleBarOverlay` calls.
+  titlebar strip in either window.
 - On GNOME/X11, right-click the same titlebar area that previously locked input
   and verify whether clicks outside the window recover normally. If the issue
   still reproduces, disable the feature again and report the distro, GNOME

--- a/linux-features/frameless-titlebar/patch.js
+++ b/linux-features/frameless-titlebar/patch.js
@@ -1,49 +1,156 @@
 "use strict";
 
-const WEBVIEW_MARKER = "/*codexLinuxFramelessTitlebarWebviewV1*/";
+const IDENT = "[A-Za-z_$][\\w$]*";
+const APP_INITIAL_ASSET_PATTERN = /^app-initial-[A-Za-z0-9_-]+\.js$/;
+const CURRENT_CHROME_MAPPING = "case`win32`:case`linux`:return`application-menu`";
+const PATCHED_CHROME_MAPPING = "case`win32`:return`application-menu`;case`linux`:return`native`";
 
-function applyFramelessTitlebarWebviewTransforms(source) {
-  let patched = source.replace(
-    /applicationMenu:Object\.freeze\(\{left:0,right:\d+\}\)/g,
-    "applicationMenu:Object.freeze({left:0,right:0})",
+const currentWindowOptionsPattern = new RegExp(
+  `(${IDENT})===\\\`win32\\\`\\|\\|\\1===\\\`linux\\\`\\?\\{titleBarStyle:\\\`hidden\\\`,titleBarOverlay:(${IDENT})\\((${IDENT})\\),(\\.\\.\\.(${IDENT})===\\\`quickChat\\\`\\?\\{resizable:!0\\}:\\{\\})\\}`,
+  "g",
+);
+const patchedWindowOptionsPattern = new RegExp(
+  `(${IDENT})===\\\`win32\\\`\\?\\{titleBarStyle:\\\`hidden\\\`,titleBarOverlay:(${IDENT})\\((${IDENT})\\),(\\.\\.\\.(${IDENT})===\\\`quickChat\\\`\\?\\{resizable:!0\\}:\\{\\})\\}:` +
+    `\\1===\\\`linux\\\`\\?\\{titleBarStyle:\\\`hidden\\\`,\\4\\}`,
+  "g",
+);
+const currentZoomOverlayPattern = new RegExp(
+  `\\(process\\.platform===\\\`win32\\\`\\|\\|process\\.platform===\\\`linux\\\`\\)&&\\(this\\.windowZooms\\.set\\((${IDENT})\\.id,(${IDENT})\\),\\1\\.setTitleBarOverlay\\((${IDENT})\\(\\2\\)\\)\\)`,
+  "g",
+);
+const patchedZoomOverlayPattern = new RegExp(
+  `process\\.platform===\\\`win32\\\`&&\\(this\\.windowZooms\\.set\\((${IDENT})\\.id,(${IDENT})\\),\\1\\.setTitleBarOverlay\\((${IDENT})\\(\\2\\)\\)\\)`,
+  "g",
+);
+const currentOverlaySyncPattern = new RegExp(
+  `installApplicationMenuTitleBarOverlaySync\\((${IDENT}),(${IDENT})\\)\\{if\\(process\\.platform!==\\\`win32\\\`&&process\\.platform!==\\\`linux\\\`\\|\\|\\2!==\\\`primary\\\`&&\\2!==\\\`quickChat\\\`\\)return;`,
+  "g",
+);
+const patchedOverlaySyncPattern = new RegExp(
+  `installApplicationMenuTitleBarOverlaySync\\((${IDENT}),(${IDENT})\\)\\{if\\(process\\.platform!==\\\`win32\\\`\\|\\|\\2!==\\\`primary\\\`&&\\2!==\\\`quickChat\\\`\\)return;`,
+  "g",
+);
+
+const mainContracts = [
+  [currentWindowOptionsPattern, patchedWindowOptionsPattern],
+  [currentZoomOverlayPattern, patchedZoomOverlayPattern],
+  [currentOverlaySyncPattern, patchedOverlaySyncPattern],
+];
+
+function matchCount(source, pattern) {
+  if (typeof source !== "string") return 0;
+  pattern.lastIndex = 0;
+  return [...source.matchAll(pattern)].length;
+}
+
+function countOccurrences(source, needle) {
+  return typeof source === "string" ? source.split(needle).length - 1 : 0;
+}
+
+function classifyContracts(source, pairs) {
+  if (typeof source !== "string") return "drifted";
+  const currentCounts = pairs.map(([current]) => matchCount(source, current));
+  const patchedCounts = pairs.map(([, patched]) => matchCount(source, patched));
+  if (currentCounts.every((count) => count === 1) && patchedCounts.every((count) => count === 0)) {
+    return "current";
+  }
+  if (currentCounts.every((count) => count === 0) && patchedCounts.every((count) => count === 1)) {
+    return "patched";
+  }
+  return "drifted";
+}
+
+function framelessTitlebarMainContract(source) {
+  return classifyContracts(source, mainContracts);
+}
+
+function framelessTitlebarWebviewContract(source) {
+  const currentCount = countOccurrences(source, CURRENT_CHROME_MAPPING);
+  const patchedCount = countOccurrences(source, PATCHED_CHROME_MAPPING);
+  if (currentCount === 1 && patchedCount === 0) return "current";
+  if (currentCount === 0 && patchedCount === 1) return "patched";
+  return "drifted";
+}
+
+function warn(surface) {
+  console.warn(
+    `WARN: Could not find the complete current frameless-titlebar ${surface} contract - skipping frameless titlebar ${surface} patch`,
   );
-  patched = patched.replace(
-    /codexLinuxUseWindowControlsSafeArea:![A-Za-z_$][\w$]*,side:`end`/g,
-    "codexLinuxUseWindowControlsSafeArea:!1,side:`end`",
-  );
-  patched = patched.split("case`win32`:case`linux`:return`application-menu`")
-    .join("case`win32`:return`application-menu`;case`linux`:return`native`");
-  patched = patched.replace(
-    /([A-Za-z_$][\w$]*)\.includes\(`win`\)\|\|([A-Za-z_$][\w$]*)\.includes\(`windows`\)\|\|\1\.includes\(`linux`\)\?([A-Za-z_$][\w$]*)\?\?([A-Za-z_$][\w$]*)\.applicationMenu:\4\.default/g,
-    (_match, platform, ua, fallback, layout) =>
-      `${platform}.includes(\`win\`)||${ua}.includes(\`windows\`)?${fallback}??${layout}.applicationMenu:${layout}.default`,
-  );
+}
+
+function applyFramelessTitlebarMainPatch(source) {
+  const contract = framelessTitlebarMainContract(source);
+  if (contract === "patched") return source;
+  if (contract !== "current") {
+    warn("main-process");
+    return source;
+  }
+
+  const patched = source
+    .replace(
+      currentWindowOptionsPattern,
+      (_match, platform, overlayHelper, zoom, quickChatOptions) =>
+        `${platform}===\`win32\`?{titleBarStyle:\`hidden\`,titleBarOverlay:${overlayHelper}(${zoom}),${quickChatOptions}}:` +
+        `${platform}===\`linux\`?{titleBarStyle:\`hidden\`,${quickChatOptions}}`,
+    )
+    .replace(
+      currentZoomOverlayPattern,
+      (_match, windowAlias, zoomAlias, overlayHelper) =>
+        `process.platform===\`win32\`&&(this.windowZooms.set(${windowAlias}.id,${zoomAlias}),${windowAlias}.setTitleBarOverlay(${overlayHelper}(${zoomAlias})))`,
+    )
+    .replace(
+      currentOverlaySyncPattern,
+      (_match, windowAlias, windowTypeAlias) =>
+        `installApplicationMenuTitleBarOverlaySync(${windowAlias},${windowTypeAlias}){if(process.platform!==\`win32\`||${windowTypeAlias}!==\`primary\`&&${windowTypeAlias}!==\`quickChat\`)return;`,
+    );
+
+  if (framelessTitlebarMainContract(patched) !== "patched") {
+    warn("main-process");
+    return source;
+  }
   return patched;
 }
 
 function applyFramelessTitlebarWebviewPatch(source) {
-  if (source.includes(WEBVIEW_MARKER)) return source;
-  const patched = applyFramelessTitlebarWebviewTransforms(source);
-  if (patched === source) {
-    console.warn("WARN: Could not identify official frameless-titlebar webview surface");
+  const contract = framelessTitlebarWebviewContract(source);
+  if (contract === "patched") return source;
+  if (contract !== "current") {
+    warn("webview");
     return source;
   }
-  return `${WEBVIEW_MARKER}${patched}`;
+
+  const patched = source.replace(CURRENT_CHROME_MAPPING, PATCHED_CHROME_MAPPING);
+  if (framelessTitlebarWebviewContract(patched) !== "patched") {
+    warn("webview");
+    return source;
+  }
+  return patched;
 }
 
 module.exports = {
+  APP_INITIAL_ASSET_PATTERN,
   descriptors: [
     {
-      id: "webview-window-controls-layout",
+      id: "main-process",
+      phase: "main-bundle",
+      order: 20_720,
+      ciPolicy: "optional",
+      apply: applyFramelessTitlebarMainPatch,
+    },
+    {
+      id: "webview-chrome-mapping",
       phase: "webview-asset",
       order: 20_730,
       ciPolicy: "optional",
-      pattern: /^app-initial-[^.]+\.js$/,
-      missingDescription: "main app chrome bundle",
-      skipDescription: "frameless titlebar webview layout patch",
+      pattern: APP_INITIAL_ASSET_PATTERN,
+      assetMatch: (source) => framelessTitlebarWebviewContract(source) !== "drifted",
+      missingDescription: "official Linux chrome-mapping bundle",
+      skipDescription: "frameless titlebar webview chrome patch",
       apply: applyFramelessTitlebarWebviewPatch,
     },
   ],
+  applyFramelessTitlebarMainPatch,
   applyFramelessTitlebarWebviewPatch,
-  applyFramelessTitlebarWebviewTransforms,
+  framelessTitlebarMainContract,
+  framelessTitlebarWebviewContract,
 };

--- a/linux-features/frameless-titlebar/test.js
+++ b/linux-features/frameless-titlebar/test.js
@@ -7,7 +7,52 @@ const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 const { loadLinuxFeaturePatchDescriptors } = require("../../scripts/lib/linux-features.js");
-const { applyFramelessTitlebarWebviewPatch } = require("./patch.js");
+const {
+  APP_INITIAL_ASSET_PATTERN,
+  applyFramelessTitlebarMainPatch,
+  applyFramelessTitlebarWebviewPatch,
+  descriptors,
+  framelessTitlebarMainContract,
+  framelessTitlebarWebviewContract,
+} = require("./patch.js");
+
+function captureWarnings(callback) {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.map(String).join(" "));
+  try {
+    return { value: callback(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+function officialMainFixture() {
+  return [
+    "function A9(e=1){return{color:O9,symbolColor:l.nativeTheme.shouldUseDarkColors?LTe:ITe,height:Math.round(FTe*e)}}",
+    "setWindowZoom(e,t){let n=l.BrowserWindow.fromWebContents(e),r=n&&this.windowAppearances.get(n.id);",
+    "n==null||r!==`primary`&&r!==`quickChat`||(process.platform===`darwin`?n.setWindowButtonPosition(k9(t)):",
+    "(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(n.id,t),n.setTitleBarOverlay(A9(t))))}",
+    "installApplicationMenuTitleBarOverlaySync(e,t){if(process.platform!==`win32`&&process.platform!==`linux`||t!==`primary`&&t!==`quickChat`)return;",
+    "let n=()=>{e.isDestroyed()||e.setTitleBarOverlay(A9(this.windowZooms.get(e.id)))};return l.nativeTheme.on(`updated`,n),n(),()=>{l.nativeTheme.off(`updated`,n)}}",
+    "case`quickChat`:case`primary`:return n===`darwin`?{titleBarStyle:`hiddenInset`}:",
+    "n===`win32`||n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:A9(r),...e===`quickChat`?{resizable:!0}:{}}:{titleBarStyle:`default`}",
+  ].join("");
+}
+
+function aliasedMainFixture() {
+  return [
+    "setWindowZoom(contents,zoom){let window=l.BrowserWindow.fromWebContents(contents),appearance=window&&this.windowAppearances.get(window.id);",
+    "window==null||appearance!==`primary`&&appearance!==`quickChat`||(process.platform===`darwin`?window.setWindowButtonPosition(k9(zoom)):",
+    "(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(window.id,zoom),window.setTitleBarOverlay(overlay(zoom))))}",
+    "installApplicationMenuTitleBarOverlaySync(window,windowType){if(process.platform!==`win32`&&process.platform!==`linux`||windowType!==`primary`&&windowType!==`quickChat`)return;}",
+    "platform===`win32`||platform===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:overlay(zoom),...windowType===`quickChat`?{resizable:!0}:{}}:{titleBarStyle:`default`}",
+  ].join("");
+}
+
+function officialWebviewFixture() {
+  return "function h3e(e,t){if(e!==`electron`)return`native`;switch(t){case`win32`:case`linux`:return`application-menu`;case`darwin`:case`unknown`:return`native`}}";
+}
 
 test("frameless-titlebar is disabled by default and exposes standalone descriptors", () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "frameless-titlebar-"));
@@ -16,21 +61,151 @@ test("frameless-titlebar is disabled by default and exposes standalone descripto
     fs.writeFileSync(config, '{"enabled":[]}\n');
     assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot: path.join(__dirname, ".."), featuresConfigPath: config }), []);
     fs.writeFileSync(config, '{"enabled":["frameless-titlebar"]}\n');
-    const descriptors = loadLinuxFeaturePatchDescriptors({ featuresRoot: path.join(__dirname, ".."), featuresConfigPath: config });
-    assert.deepEqual(descriptors.map(({ id }) => id), [
-      "feature:frameless-titlebar:webview-window-controls-layout",
-    ]);
-    assert.ok(descriptors.every(({ composesPatches }) => composesPatches == null));
+    const loaded = loadLinuxFeaturePatchDescriptors({ featuresRoot: path.join(__dirname, ".."), featuresConfigPath: config });
+    assert.deepEqual(
+      loaded.map(({ id, phase, ciPolicy }) => [id, phase, ciPolicy]),
+      [
+        ["feature:frameless-titlebar:main-process", "main-bundle", "optional"],
+        ["feature:frameless-titlebar:webview-chrome-mapping", "webview-asset", "optional"],
+      ],
+    );
+    assert.ok(loaded.every(({ composesPatches }) => composesPatches == null));
+    assert.deepEqual(
+      descriptors.map(({ id, phase }) => [id, phase]),
+      [
+        ["main-process", "main-bundle"],
+        ["webview-chrome-mapping", "webview-asset"],
+      ],
+    );
   } finally {
     fs.rmSync(temp, { recursive: true, force: true });
   }
 });
 
-test("webview patch removes Linux application-menu insets and is idempotent", () => {
-  const source = "applicationMenu:Object.freeze({left:0,right:138});case`win32`:case`linux`:return`application-menu`;a.includes(`win`)||b.includes(`windows`)||a.includes(`linux`)?c??d.applicationMenu:d.default";
+test("main-process patch removes Linux titleBarOverlay and is idempotent", () => {
+  const source = officialMainFixture();
+  assert.equal(framelessTitlebarMainContract(source), "current");
+  const patched = applyFramelessTitlebarMainPatch(source);
+  assert.notEqual(patched, source);
+  assert.equal(framelessTitlebarMainContract(patched), "patched");
+  assert.equal(applyFramelessTitlebarMainPatch(patched), patched);
+  assert.match(patched, /n===`win32`\?\{titleBarStyle:`hidden`,titleBarOverlay:A9\(r\)/);
+  assert.match(patched, /n===`linux`\?\{titleBarStyle:`hidden`,\.\.\.e===`quickChat`\?\{resizable:!0\}:\{\}\}/);
+  assert.doesNotMatch(patched, /n===`win32`\|\|n===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay/);
+  assert.match(patched, /process\.platform===`win32`&&\(this\.windowZooms\.set\(n\.id,t\),n\.setTitleBarOverlay\(A9\(t\)\)\)/);
+  assert.doesNotMatch(patched, /process\.platform===`win32`\|\|process\.platform===`linux`\)&&\(this\.windowZooms\.set/);
+  assert.match(
+    patched,
+    /installApplicationMenuTitleBarOverlaySync\(e,t\)\{if\(process\.platform!==`win32`\|\|t!==`primary`&&t!==`quickChat`\)return;/,
+  );
+  assert.match(patched, /titleBarStyle:`hiddenInset`/);
+});
+
+test("main-process patch preserves current minified aliases", () => {
+  const source = aliasedMainFixture();
+  const patched = applyFramelessTitlebarMainPatch(source);
+  assert.notEqual(patched, source);
+  assert.match(patched, /platform===`win32`\?\{titleBarStyle:`hidden`,titleBarOverlay:overlay\(zoom\)/);
+  assert.match(patched, /platform===`linux`\?\{titleBarStyle:`hidden`,\.\.\.windowType===`quickChat`\?\{resizable:!0\}:\{\}\}/);
+  assert.match(patched, /this\.windowZooms\.set\(window\.id,zoom\),window\.setTitleBarOverlay\(overlay\(zoom\)\)/);
+  assert.match(
+    patched,
+    /installApplicationMenuTitleBarOverlaySync\(window,windowType\)\{if\(process\.platform!==`win32`\|\|windowType!==`primary`&&windowType!==`quickChat`\)return;/,
+  );
+  assert.equal(applyFramelessTitlebarMainPatch(patched), patched);
+});
+
+test("already-patched main-process contracts do not warn", () => {
+  const patched = applyFramelessTitlebarMainPatch(officialMainFixture());
+  const result = captureWarnings(() => applyFramelessTitlebarMainPatch(patched));
+  assert.equal(result.value, patched);
+  assert.deepEqual(result.warnings, []);
+});
+
+test("main-process patch rejects incomplete, duplicate, and mixed contracts byte-identically", () => {
+  const current = officialMainFixture();
+  const patched = applyFramelessTitlebarMainPatch(current);
+  const sources = [
+    current.replace("titleBarOverlay:A9(r),", ""),
+    current.replace("installApplicationMenuTitleBarOverlaySync", "installTitleBarOverlaySync"),
+    current.replace("(process.platform===`win32`||process.platform===`linux`)", "(process.platform===`win32`)"),
+    patched.replace("n===`linux`?{titleBarStyle:`hidden`", "n===`linux`?{titleBarStyle:`default`"),
+    patched.replace("process.platform===`win32`&&(this.windowZooms.set", "process.platform===`linux`&&(this.windowZooms.set"),
+    current + current,
+    patched + patched,
+    current + patched,
+    current.replace(
+      "n===`win32`||n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:A9(r),...e===`quickChat`?{resizable:!0}:{}}",
+      "n===`win32`?{titleBarStyle:`hidden`,titleBarOverlay:A9(r),...e===`quickChat`?{resizable:!0}:{}}:n===`linux`?{titleBarStyle:`hidden`,...e===`quickChat`?{resizable:!0}:{}}",
+    ),
+  ];
+
+  for (const source of sources) {
+    const result = captureWarnings(() => applyFramelessTitlebarMainPatch(source));
+    assert.equal(result.value, source);
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /current frameless-titlebar main-process contract/);
+  }
+});
+
+test("unrecognized main-process contracts warn instead of reporting false already-applied", () => {
+  const source = "function driftedMain(){return {titleBarStyle:`default`}}";
+  const result = captureWarnings(() => applyFramelessTitlebarMainPatch(source));
+  assert.equal(result.value, source);
+  assert.equal(framelessTitlebarMainContract(source), "drifted");
+  assert.match(result.warnings.join("\n"), /current frameless-titlebar main-process contract/);
+});
+
+test("webview patch remaps Linux chrome and is idempotent", () => {
+  const source = officialWebviewFixture();
+  assert.equal(framelessTitlebarWebviewContract(source), "current");
   const patched = applyFramelessTitlebarWebviewPatch(source);
+  assert.notEqual(patched, source);
+  assert.equal(framelessTitlebarWebviewContract(patched), "patched");
   assert.equal(applyFramelessTitlebarWebviewPatch(patched), patched);
-  assert.match(patched, /right:0/);
   assert.match(patched, /case`linux`:return`native`/);
-  assert.doesNotMatch(patched, /includes\(`linux`\)\?/);
+  assert.doesNotMatch(patched, /case`win32`:case`linux`:return`application-menu`/);
+});
+
+test("already-patched webview contracts do not warn", () => {
+  const patched = applyFramelessTitlebarWebviewPatch(officialWebviewFixture());
+  const result = captureWarnings(() => applyFramelessTitlebarWebviewPatch(patched));
+  assert.equal(result.value, patched);
+  assert.deepEqual(result.warnings, []);
+});
+
+test("webview patch rejects incomplete, duplicate, and mixed contracts byte-identically", () => {
+  const current = officialWebviewFixture();
+  const patched = applyFramelessTitlebarWebviewPatch(current);
+  const sources = [
+    current.replace("case`win32`:case`linux`:return`application-menu`", "case`win32`:return`application-menu`"),
+    patched.replace("case`linux`:return`native`", "case`linux`:return`application-menu`"),
+    current + current,
+    patched + patched,
+    current + patched,
+  ];
+
+  for (const source of sources) {
+    const result = captureWarnings(() => applyFramelessTitlebarWebviewPatch(source));
+    assert.equal(result.value, source);
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /current frameless-titlebar webview contract/);
+  }
+});
+
+test("unrecognized webview contracts warn instead of reporting false already-applied", () => {
+  const source = "function driftedWebview(){return `native`}";
+  const result = captureWarnings(() => applyFramelessTitlebarWebviewPatch(source));
+  assert.equal(result.value, source);
+  assert.equal(framelessTitlebarWebviewContract(source), "drifted");
+  assert.match(result.warnings.join("\n"), /current frameless-titlebar webview contract/);
+});
+
+test("webview descriptor selects current contracts across renderer hash changes", () => {
+  const descriptor = descriptors.find(({ id }) => id === "webview-chrome-mapping");
+  assert.match("app-initial-HashNext1.js", APP_INITIAL_ASSET_PATTERN);
+  assert.doesNotMatch("app-initial~app-main~page-CMpPiY3-.js", APP_INITIAL_ASSET_PATTERN);
+  assert.equal(descriptor.assetMatch(officialWebviewFixture()), true);
+  assert.equal(descriptor.assetMatch(applyFramelessTitlebarWebviewPatch(officialWebviewFixture())), true);
+  assert.equal(descriptor.assetMatch("export{chrome}"), false);
 });


### PR DESCRIPTION
**IMPORTANT: Please keep only one pull request open at a time. The default maximum is two active pull requests from the same contributor, and even that should be reserved for exceptional circumstances. Maintainers may configure a different per-contributor limit for explicit exceptions. Do not open several pull requests at once; finish or close existing work before submitting more. An automated bot will close pull requests that exceed the effective limit.**

## Summary

`frameless-titlebar` still left official Linux overlay buttons visible. Official Linux creates primary/Quick Chat windows with `titleBarOverlay` and reapplies it on zoom/theme changes.

This restores the main-process hide, remaps Linux webview chrome to `native`, and drops the retired DMG inset/layout-gate rewrites.

## Validation

- `node --test linux-features/frameless-titlebar/test.js`
- isolated official `chatgpt 26.803.81509` amd64 candidate: 2/2 applied, second pass already-applied
- Hyprland Wayland: overlay buttons gone after full quit/relaunch

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest signed stable OpenAI Linux package and removes obsolete fallback code and tests.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.