### PR TITLE
Fix shared app-server startup without explicit CLI path

### DIFF
--- a/linux-features/shared-app-server-socket/README.md
+++ b/linux-features/shared-app-server-socket/README.md
@@ -17,6 +17,10 @@ PATH` byte tunnel and its existing WebSocket transport. Other local clients use
 the same stock proxy command to attach to the Unix socket and receive the normal
 WebSocket `/rpc` byte stream. Closing Desktop stops the authority.
 
+The launcher uses the official CLI bundled in `resources/codex` by default.
+An explicit `CODEX_CLI_PATH` remains supported and is preserved by the feature
+hook.
+
 The default socket is scoped by Linux app id under `XDG_RUNTIME_DIR`, preventing
 side-by-side Desktop instances from sharing an authority accidentally. Override
 it with `CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET` when a stable path is required.

--- a/linux-features/shared-app-server-socket/socket-env.sh
+++ b/linux-features/shared-app-server-socket/socket-env.sh
@@ -23,5 +23,7 @@ if [ -n "$node_bin" ] && [ -f "$reaper_path" ]; then
 fi
 
 if [ "${CODEX_LINUX_FEATURE_HOOK_PHASE:-launcher}" = "launcher" ]; then
+    cli_path="${CODEX_CLI_PATH:-${CODEX_LINUX_APP_DIR:?}/resources/codex}"
     printf 'env CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET=%s\n' "$socket_path"
+    printf 'env CODEX_CLI_PATH=%s\n' "$cli_path"
 fi

--- a/linux-features/shared-app-server-socket/test.js
+++ b/linux-features/shared-app-server-socket/test.js
@@ -584,8 +584,38 @@ test("descriptor is optional and targets the main bundle", () => {
 
 test("socket hook exports an instance-scoped path without starting a process", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "shared-app-server-socket-runtime-"));
+  const appDir = path.join(tempDir, "app");
   const env = {
     ...process.env,
+    CODEX_LINUX_APP_DIR: appDir,
+    CODEX_LINUX_APP_ID: "codex-bridge-test",
+    CODEX_LINUX_APP_STATE_DIR: path.join(tempDir, "state"),
+    XDG_RUNTIME_DIR: tempDir,
+  };
+  delete env.CODEX_CLI_PATH;
+  delete env.CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET;
+  try {
+    const result = spawnSync(socketEnvHook, [], { encoding: "utf8", env });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      result.stdout.trim(),
+      [
+        `env CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET=${tempDir}/codex-bridge-test/app-server-bridge/app-server.sock`,
+        `env CODEX_CLI_PATH=${appDir}/resources/codex`,
+      ].join("\n"),
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("socket hook preserves an explicit real Codex CLI path", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "shared-app-server-explicit-cli-"));
+  const explicitCli = path.join(tempDir, "real codex");
+  const env = {
+    ...process.env,
+    CODEX_CLI_PATH: explicitCli,
+    CODEX_LINUX_APP_DIR: path.join(tempDir, "app"),
     CODEX_LINUX_APP_ID: "codex-bridge-test",
     CODEX_LINUX_APP_STATE_DIR: path.join(tempDir, "state"),
     XDG_RUNTIME_DIR: tempDir,
@@ -595,8 +625,8 @@ test("socket hook exports an instance-scoped path without starting a process", (
     const result = spawnSync(socketEnvHook, [], { encoding: "utf8", env });
     assert.equal(result.status, 0, result.stderr);
     assert.equal(
-      result.stdout.trim(),
-      `env CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET=${tempDir}/codex-bridge-test/app-server-bridge/app-server.sock`,
+      result.stdout.trim().split("\n").at(-1),
+      `env CODEX_CLI_PATH=${explicitCli}`,
     );
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Enabling `shared-app-server-socket` patched Desktop to require
`CODEX_CLI_PATH`, but the feature's launcher hook exported only the shared
socket path. Fresh native-package launches therefore stopped before the main
window with `shared app-server socket requires CODEX_CLI_PATH`.

The hook now defaults `CODEX_CLI_PATH` to the official bundled
`resources/codex` executable while preserving an explicit override. Regression
coverage exercises both cases, and the feature documentation records the
launcher-owned default.

User-visible result: installations with this disabled-by-default feature
enabled start normally without requiring a manual environment override.

The declarative hook is shared by deb, RPM, pacman, AppImage, and Nix feature
staging. Manual package/install proof was performed on Arch x86_64; the other
formats and arm64 were not manually built in this change.

## Validation

- `CODEX_CLI_PATH=/opt/codex-desktop/resources/codex node --test linux-features/shared-app-server-socket/test.js` (41 passed, including the real authority/proxy lifecycle)
- `bash tests/scripts_smoke.sh` (46 passed)
- `git diff --check`
- Feature-only build from the latest signed stable OpenAI Linux package with only `shared-app-server-socket` enabled (one feature patch applied, hook staged, runtime diagnosis passed)
- `make pacman`, inspected the packaged hook, and installed `codex-desktop 2026.08.13.101330-1`
- Plain installed launch with caller `CODEX_CLI_PATH` unset: Codex CLI handshake succeeded, the window reached `ready-to-show`, and the owner-only shared socket was listening with mode `0600`

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] Upstream drift handling is not applicable; this fixes the launcher contract of one disabled-by-default Linux feature.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
