### PR TITLE
Fix directory-only-working-tree-watch SIGILL from Watchbound libc detection

### DIFF
--- a/linux-features/directory-only-working-tree-watch/README.md
+++ b/linux-features/directory-only-working-tree-watch/README.md
@@ -89,6 +89,17 @@ resolution, and `support.currentRuntime.targetCompatible`. It requires
 established physical root still matches that qualification snapshot. It does
 not recreate Watchbound's target or root decision from host strings.
 
+Watchbound's wrapper and loader detect libc through `process.report.getReport()`.
+Inside the packaged Electron binary that call is fatal — an internal CHECK
+aborts the process with SIGILL (the openai/codex#38123 git-watcher crash
+class) — so the adapter replaces `process.report` in the worker with a shim
+before any Watchbound code loads. The shim serves the same libc facts from
+probes that stay in JavaScript: the ELF interpreter of `/proc/self/exe`,
+`/usr/bin/ldd` content, and a `getconf GNU_LIBC_VERSION` subprocess. It stays
+installed for the worker's lifetime so later capability reads remain safe.
+When every probe fails, the shim reports an empty header, which Watchbound
+treats as an unsupported runtime and refuses instead of crashing.
+
 Build-time runtime qualification does not execute the upstream Electron
 binary. The extracted app's pinned Electron dependency must match the exact
 Electron/Node pair in the checked-in Watchbound artifact manifest; a mismatch

--- a/linux-features/directory-only-working-tree-watch/README.md
+++ b/linux-features/directory-only-working-tree-watch/README.md
@@ -95,7 +95,10 @@ aborts the process with SIGILL (the openai/codex#38123 git-watcher crash
 class) — so the adapter replaces `process.report` in the worker with a shim
 before any Watchbound code loads. The shim serves the same libc facts from
 probes that stay in JavaScript: the ELF interpreter of `/proc/self/exe`,
-`/usr/bin/ldd` content, and a `getconf GNU_LIBC_VERSION` subprocess. It stays
+`/usr/bin/ldd` content, and a `getconf GNU_LIBC_VERSION` subprocess. A Nix
+store interpreter names its exact glibc, so closure-only Nix launches (no
+`/usr/bin/ldd`, no `getconf` on the runtime `PATH`) take the version straight
+from the `PT_INTERP` path. The shim stays
 installed for the worker's lifetime so later capability reads remain safe.
 When every probe fails, the shim reports an empty header, which Watchbound
 treats as an unsupported runtime and refuses instead of crashing.

--- a/linux-features/directory-only-working-tree-watch/README.md
+++ b/linux-features/directory-only-working-tree-watch/README.md
@@ -92,16 +92,21 @@ not recreate Watchbound's target or root decision from host strings.
 Watchbound's wrapper and loader detect libc through `process.report.getReport()`.
 Inside the packaged Electron binary that call is fatal — an internal CHECK
 aborts the process with SIGILL (the openai/codex#38123 git-watcher crash
-class) — so the adapter replaces `process.report` in the worker with a shim
-before any Watchbound code loads. The shim serves the same libc facts from
+class) — so the adapter replaces `process.report` in both patched bundles
+(the worker and the main-process src bundle) with a shim that keeps the
+original report members and overrides only `getReport`, before any Watchbound
+code loads. The shim serves the same libc facts from
 probes that stay in JavaScript: the ELF interpreter of `/proc/self/exe`,
 `/usr/bin/ldd` content, and a `getconf GNU_LIBC_VERSION` subprocess. A Nix
 store interpreter names its exact glibc, so closure-only Nix launches (no
 `/usr/bin/ldd`, no `getconf` on the runtime `PATH`) take the version straight
-from the `PT_INTERP` path. The shim stays
-installed for the worker's lifetime so later capability reads remain safe.
-When every probe fails, the shim reports an empty header, which Watchbound
-treats as an unsupported runtime and refuses instead of crashing.
+from the `PT_INTERP` path — readable because the Nix build relocates
+`PT_INTERP` into the scanned range (#1332). The shim stays
+installed for the process's lifetime so later capability reads remain safe.
+When every probe fails, the shim reports an empty header; Watchbound then
+refuses at load, the adapter catches the refused import, and the request
+degrades to the preserved Parcel route (worker) or the original local watch
+(src bundle) instead of crashing.
 
 Build-time runtime qualification does not execute the upstream Electron
 binary. The extracted app's pinned Electron dependency must match the exact

--- a/linux-features/directory-only-working-tree-watch/patch.js
+++ b/linux-features/directory-only-working-tree-watch/patch.js
@@ -103,6 +103,8 @@ const PARCEL_FALLBACK_SYMBOL_KEY =
   "codex-linux.directory-only-working-tree-watch.parcel-fallback";
 const QUALIFICATION_WARNINGS_SYMBOL_KEY =
   "codex-linux.directory-only-working-tree-watch.qualification-warnings";
+const REPORT_SHIM_SYMBOL_KEY =
+  "codex-linux.directory-only-working-tree-watch.process-report-shim";
 const WATCHBOUND_RESULT_NAME = "codexLinuxWatchboundWatcher";
 const WATCHBOUND_VERSION = "2.1.1";
 const DEFAULT_MAX_WATCHES = 8192;
@@ -197,6 +199,92 @@ function codexLinuxStartDirectoryOnlyWorkingTreeWatch(
       "codex-linux.directory-only-working-tree-watch.test-module",
     );
     const moduleOverride = globalThis[moduleOverrideKey];
+    // process.report.getReport() dies in a fatal CHECK trap inside the official
+    // Electron binary (SIGILL; the openai/codex#38123 crash class), and both
+    // watchbound/capabilities.js and @gadicc/watchbound-node/load-native.cjs
+    // call it for libc detection. Replace it with the same facts from probes
+    // that stay in JavaScript before any Watchbound code can run.
+    const reportShimMarker = Symbol.for(
+      "codex-linux.directory-only-working-tree-watch.process-report-shim",
+    );
+    if (process.report?.[reportShimMarker] !== true) {
+      const elfInterpreterPath = (image) => {
+        if (image.length < 64 || image.readUInt32LE(0) !== 0x464c457f) return null;
+        if (image[4] !== 2 || image[5] !== 1) return null;
+        const tableOffset = Number(image.readBigUInt64LE(32));
+        const entrySize = image.readUInt16LE(54);
+        const entryCount = image.readUInt16LE(56);
+        for (let index = 0; index < entryCount; index += 1) {
+          const entry = tableOffset + index * entrySize;
+          if (entry + 40 > image.length) break;
+          if (image.readUInt32LE(entry) !== 3) continue;
+          const interpOffset = Number(image.readBigUInt64LE(entry + 8));
+          const interpSize = Number(image.readBigUInt64LE(entry + 32));
+          if (interpSize < 2 || interpOffset + interpSize > image.length) return null;
+          return image.toString("utf8", interpOffset, interpOffset + interpSize - 1);
+        }
+        return null;
+      };
+      const readLeadingBytes = (filePath, length) => {
+        const descriptor = fs.openSync(filePath, "r");
+        try {
+          const buffer = Buffer.alloc(length);
+          return buffer.subarray(0, fs.readSync(descriptor, buffer, 0, length, 0));
+        } finally {
+          fs.closeSync(descriptor);
+        }
+      };
+      let family = null;
+      let glibcVersion = null;
+      let muslInterpreter = null;
+      try {
+        const interpreter = elfInterpreterPath(readLeadingBytes("/proc/self/exe", 4096));
+        if (interpreter?.includes("/ld-musl-")) {
+          family = "musl";
+          muslInterpreter = interpreter;
+        } else if (interpreter?.includes("/ld-linux-")) {
+          family = "glibc";
+        }
+      } catch {}
+      try {
+        const ldd = fs.readFileSync("/usr/bin/ldd", "latin1");
+        if (family == null) {
+          if (ldd.includes("musl")) family = "musl";
+          else if (ldd.includes("GNU C Library")) family = "glibc";
+        }
+        if (family === "glibc") {
+          glibcVersion = ldd.match(/LIBC[a-z0-9 \-).]*?(\d+\.\d+)/iu)?.[1] ?? null;
+        }
+      } catch {}
+      if (family === "glibc" && glibcVersion == null) {
+        try {
+          glibcVersion = childProcess
+            .execSync("getconf GNU_LIBC_VERSION", {
+              encoding: "utf8",
+              timeout: 1000,
+              stdio: ["ignore", "pipe", "ignore"],
+            })
+            .match(/(\d+\.\d+(?:\.\d+)?)/u)?.[1] ?? null;
+        } catch {}
+      }
+      const reportHeader = family === "glibc" && glibcVersion != null
+        ? { glibcVersionRuntime: glibcVersion }
+        : {};
+      const reportSharedObjects = family === "musl" && muslInterpreter != null
+        ? [muslInterpreter]
+        : [];
+      Object.defineProperty(process, "report", {
+        configurable: true,
+        enumerable: true,
+        value: {
+          [reportShimMarker]: true,
+          getReport: () => ({
+            header: { ...reportHeader },
+            sharedObjects: [...reportSharedObjects],
+          }),
+        },
+      });
+    }
     const watchbound = moduleOverride ?? await import("watchbound");
     if (
       watchbound.capabilities?.schemaVersion !== 9 ||
@@ -1904,6 +1992,7 @@ module.exports = {
   PARCEL_WATCH_MARKER,
   PARCEL_WORKING_TREE_WATCH,
   QUALIFICATION_WARNINGS_SYMBOL_KEY,
+  REPORT_SHIM_SYMBOL_KEY,
   WATCHBOUND_VERSION,
   codexLinuxStartDirectoryOnlyWorkingTreeWatch,
   descriptors,

--- a/linux-features/directory-only-working-tree-watch/patch.js
+++ b/linux-features/directory-only-working-tree-watch/patch.js
@@ -234,16 +234,22 @@ function codexLinuxStartDirectoryOnlyWorkingTreeWatch(
           fs.closeSync(descriptor);
         }
       };
+      const probeExecutable =
+        moduleOverride != null && typeof moduleOverride.reportProbeExecutable === "string"
+          ? moduleOverride.reportProbeExecutable
+          : "/proc/self/exe";
       let family = null;
       let glibcVersion = null;
-      let muslInterpreter = null;
+      let interpreter = null;
       try {
-        const interpreter = elfInterpreterPath(readLeadingBytes("/proc/self/exe", 4096));
+        interpreter = elfInterpreterPath(readLeadingBytes(probeExecutable, 4096));
         if (interpreter?.includes("/ld-musl-")) {
           family = "musl";
-          muslInterpreter = interpreter;
         } else if (interpreter?.includes("/ld-linux-")) {
           family = "glibc";
+          // Closure-only Nix launches have no /usr/bin/ldd and no getconf on
+          // PATH, but the store path in PT_INTERP names the exact glibc.
+          glibcVersion = interpreter.match(/-glibc-(\d+\.\d+(?:\.\d+)?)/u)?.[1] ?? null;
         }
       } catch {}
       try {
@@ -252,7 +258,7 @@ function codexLinuxStartDirectoryOnlyWorkingTreeWatch(
           if (ldd.includes("musl")) family = "musl";
           else if (ldd.includes("GNU C Library")) family = "glibc";
         }
-        if (family === "glibc") {
+        if (family === "glibc" && glibcVersion == null) {
           glibcVersion = ldd.match(/LIBC[a-z0-9 \-).]*?(\d+\.\d+)/iu)?.[1] ?? null;
         }
       } catch {}
@@ -270,8 +276,8 @@ function codexLinuxStartDirectoryOnlyWorkingTreeWatch(
       const reportHeader = family === "glibc" && glibcVersion != null
         ? { glibcVersionRuntime: glibcVersion }
         : {};
-      const reportSharedObjects = family === "musl" && muslInterpreter != null
-        ? [muslInterpreter]
+      const reportSharedObjects = family === "musl" && interpreter != null
+        ? [interpreter]
         : [];
       Object.defineProperty(process, "report", {
         configurable: true,

--- a/linux-features/directory-only-working-tree-watch/patch.js
+++ b/linux-features/directory-only-working-tree-watch/patch.js
@@ -203,7 +203,8 @@ function codexLinuxStartDirectoryOnlyWorkingTreeWatch(
     // Electron binary (SIGILL; the openai/codex#38123 crash class), and both
     // watchbound/capabilities.js and @gadicc/watchbound-node/load-native.cjs
     // call it for libc detection. Replace it with the same facts from probes
-    // that stay in JavaScript before any Watchbound code can run.
+    // that stay in JavaScript before any Watchbound code can run. Probe order
+    // and matchers follow detect-libc (Apache-2.0, Lovell Fuller and others).
     const reportShimMarker = Symbol.for(
       "codex-linux.directory-only-working-tree-watch.process-report-shim",
     );
@@ -214,6 +215,7 @@ function codexLinuxStartDirectoryOnlyWorkingTreeWatch(
         const tableOffset = Number(image.readBigUInt64LE(32));
         const entrySize = image.readUInt16LE(54);
         const entryCount = image.readUInt16LE(56);
+        if (entrySize < 56) return null;
         for (let index = 0; index < entryCount; index += 1) {
           const entry = tableOffset + index * entrySize;
           if (entry + 40 > image.length) break;
@@ -221,7 +223,9 @@ function codexLinuxStartDirectoryOnlyWorkingTreeWatch(
           const interpOffset = Number(image.readBigUInt64LE(entry + 8));
           const interpSize = Number(image.readBigUInt64LE(entry + 32));
           if (interpSize < 2 || interpOffset + interpSize > image.length) return null;
-          return image.toString("utf8", interpOffset, interpOffset + interpSize - 1);
+          const segment = image.subarray(interpOffset, interpOffset + interpSize);
+          const terminator = segment.indexOf(0);
+          return segment.toString("utf8", 0, terminator === -1 ? segment.length : terminator);
         }
         return null;
       };
@@ -265,7 +269,7 @@ function codexLinuxStartDirectoryOnlyWorkingTreeWatch(
       if (family === "glibc" && glibcVersion == null) {
         try {
           glibcVersion = childProcess
-            .execSync("getconf GNU_LIBC_VERSION", {
+            .execFileSync("getconf", ["GNU_LIBC_VERSION"], {
               encoding: "utf8",
               timeout: 1000,
               stdio: ["ignore", "pipe", "ignore"],
@@ -282,7 +286,9 @@ function codexLinuxStartDirectoryOnlyWorkingTreeWatch(
       Object.defineProperty(process, "report", {
         configurable: true,
         enumerable: true,
+        writable: true,
         value: {
+          ...(process.report ?? {}),
           [reportShimMarker]: true,
           getReport: () => ({
             header: { ...reportHeader },
@@ -291,7 +297,16 @@ function codexLinuxStartDirectoryOnlyWorkingTreeWatch(
         },
       });
     }
-    const watchbound = moduleOverride ?? await import("watchbound");
+    let watchbound = moduleOverride;
+    if (watchbound == null) {
+      try {
+        watchbound = await import("watchbound");
+      } catch {
+        // A refused loader (unsupported libc, missing package) must degrade to
+        // the preserved route, not reject the caller's file watch.
+        return typeof fallback === "function" ? fallback() : null;
+      }
+    }
     if (
       watchbound.capabilities?.schemaVersion !== 9 ||
       watchbound.capabilities?.versions?.wrapper !== WATCHBOUND_VERSION ||

--- a/linux-features/directory-only-working-tree-watch/patch.js
+++ b/linux-features/directory-only-working-tree-watch/patch.js
@@ -283,18 +283,24 @@ function codexLinuxStartDirectoryOnlyWorkingTreeWatch(
       const reportSharedObjects = family === "musl" && interpreter != null
         ? [interpreter]
         : [];
+      // The native report object stays as the prototype so every other
+      // member keeps its accessor-backed behavior; only getReport is shadowed.
       Object.defineProperty(process, "report", {
         configurable: true,
         enumerable: true,
         writable: true,
-        value: {
-          ...(process.report ?? {}),
-          [reportShimMarker]: true,
-          getReport: () => ({
-            header: { ...reportHeader },
-            sharedObjects: [...reportSharedObjects],
-          }),
-        },
+        value: Object.create(process.report ?? null, {
+          [reportShimMarker]: { value: true },
+          getReport: {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: () => ({
+              header: { ...reportHeader },
+              sharedObjects: [...reportSharedObjects],
+            }),
+          },
+        }),
       });
     }
     let watchbound = moduleOverride;

--- a/linux-features/directory-only-working-tree-watch/test.js
+++ b/linux-features/directory-only-working-tree-watch/test.js
@@ -25,6 +25,7 @@ const {
   PARCEL_WATCH_MARKER,
   PARCEL_WORKING_TREE_WATCH,
   QUALIFICATION_WARNINGS_SYMBOL_KEY,
+  REPORT_SHIM_SYMBOL_KEY,
   WATCHBOUND_VERSION,
   codexLinuxStartDirectoryOnlyWorkingTreeWatch,
   descriptors,
@@ -3339,6 +3340,66 @@ test("the adapter fails closed on every Watchbound 2.1.1 contract mismatch", asy
     );
     assert.equal(fake.subscriptions.length, 0);
   }
+});
+
+test("the adapter replaces process.report before any Watchbound code runs", async (t) => {
+  const originalReport = Object.getOwnPropertyDescriptor(process, "report");
+  let poisonedCalls = 0;
+  Object.defineProperty(process, "report", {
+    configurable: true,
+    enumerable: true,
+    value: {
+      getReport() {
+        poisonedCalls += 1;
+        throw new Error("getReport is fatal inside the packaged Electron binary");
+      },
+    },
+  });
+  const fake = fakeWatchbound();
+  fake.capabilities.schemaVersion = 0;
+  globalThis[MODULE_OVERRIDE_KEY] = fake;
+  delete globalThis[ENGINE_KEY];
+  t.after(() => {
+    delete globalThis[MODULE_OVERRIDE_KEY];
+    delete globalThis[ENGINE_KEY];
+    Object.defineProperty(process, "report", originalReport);
+  });
+
+  const start = () => codexLinuxStartDirectoryOnlyWorkingTreeWatch(
+    {
+      getFileSystemPath: () => "/qualified/root",
+      platformPath: async () => path.posix,
+    },
+    {
+      path: "/logical/root",
+      recursive: true,
+      renameEventHandling: "changed-path-with-parent-directory",
+      onChange() {},
+    },
+    {
+      maxWatches: 64,
+      honorGitIgnore: false,
+      ignoredDirectoryNames: [],
+    },
+  );
+  await assert.rejects(start(), /requires watchbound 2\.1\.1/u);
+
+  assert.equal(poisonedCalls, 0);
+  const shim = process.report;
+  assert.equal(shim[Symbol.for(REPORT_SHIM_SYMBOL_KEY)], true);
+  const report = shim.getReport();
+  assert.equal(typeof report.header, "object");
+  assert.ok(Array.isArray(report.sharedObjects));
+  let expectGlibc = false;
+  try {
+    expectGlibc = fs.readFileSync("/usr/bin/ldd", "latin1").includes("GNU C Library");
+  } catch {}
+  if (expectGlibc) {
+    assert.match(report.header.glibcVersionRuntime, /^\d+\.\d+/u);
+  }
+
+  await assert.rejects(start(), /requires watchbound 2\.1\.1/u);
+  assert.equal(process.report, shim);
 });
 
 test("the adapter preserves Codex policy around the Watchbound engine", async (t) => {

--- a/linux-features/directory-only-working-tree-watch/test.js
+++ b/linux-features/directory-only-working-tree-watch/test.js
@@ -3277,7 +3277,9 @@ async function waitFor(predicate, label, timeout = 3000) {
 }
 
 test("the adapter fails closed on every Watchbound 2.1.1 contract mismatch", async (t) => {
+  const originalReport = Object.getOwnPropertyDescriptor(process, "report");
   t.after(() => {
+    Object.defineProperty(process, "report", originalReport);
     delete globalThis[MODULE_OVERRIDE_KEY];
     delete globalThis[ENGINE_KEY];
   });
@@ -3465,6 +3467,55 @@ test("the report shim reads the glibc version from a Nix store interpreter", asy
   const report = process.report.getReport();
   assert.equal(report.header.glibcVersionRuntime, "2.40");
   assert.deepEqual(report.sharedObjects, []);
+});
+
+test("a failed Watchbound import degrades to the preserved fallback", async (t) => {
+  const originalReport = Object.getOwnPropertyDescriptor(process, "report");
+  let poisonedCalls = 0;
+  Object.defineProperty(process, "report", {
+    configurable: true,
+    enumerable: true,
+    value: {
+      getReport() {
+        poisonedCalls += 1;
+        throw new Error("getReport is fatal inside the packaged Electron binary");
+      },
+    },
+  });
+  delete globalThis[MODULE_OVERRIDE_KEY];
+  delete globalThis[ENGINE_KEY];
+  t.after(() => {
+    Object.defineProperty(process, "report", originalReport);
+  });
+
+  let fallbackCalls = 0;
+  const preserved = { dispose() {} };
+  const result = await codexLinuxStartDirectoryOnlyWorkingTreeWatch(
+    {
+      getFileSystemPath: () => "/qualified/root",
+      platformPath: async () => path.posix,
+    },
+    {
+      path: "/logical/root",
+      recursive: true,
+      renameEventHandling: "changed-path-with-parent-directory",
+      onChange() {},
+    },
+    {
+      maxWatches: 64,
+      honorGitIgnore: false,
+      ignoredDirectoryNames: [],
+    },
+    () => {
+      fallbackCalls += 1;
+      return preserved;
+    },
+  );
+
+  assert.equal(fallbackCalls, 1);
+  assert.equal(result, preserved);
+  assert.equal(poisonedCalls, 0);
+  assert.equal(process.report[Symbol.for(REPORT_SHIM_SYMBOL_KEY)], true);
 });
 
 test("the adapter preserves Codex policy around the Watchbound engine", async (t) => {

--- a/linux-features/directory-only-working-tree-watch/test.js
+++ b/linux-features/directory-only-working-tree-watch/test.js
@@ -3402,6 +3402,71 @@ test("the adapter replaces process.report before any Watchbound code runs", asyn
   assert.equal(process.report, shim);
 });
 
+test("the report shim reads the glibc version from a Nix store interpreter", async (t) => {
+  const interpreterPath =
+    "/nix/store/6q3xi2h1a7lb0k5cm9dr8v4y5zj0wf2s-glibc-2.40-66/lib64/ld-linux-x86-64.so.2";
+  const interpreterBytes = Buffer.from(`${interpreterPath}\0`, "utf8");
+  const image = Buffer.alloc(512);
+  image.writeUInt32LE(0x464c457f, 0);
+  image[4] = 2;
+  image[5] = 1;
+  image.writeBigUInt64LE(64n, 32);
+  image.writeUInt16LE(56, 54);
+  image.writeUInt16LE(1, 56);
+  image.writeUInt32LE(3, 64);
+  image.writeBigUInt64LE(256n, 64 + 8);
+  image.writeBigUInt64LE(BigInt(interpreterBytes.length), 64 + 32);
+  interpreterBytes.copy(image, 256);
+  const executable = path.join(tempDirectory(t, "watchbound-nix-elf-"), "electron");
+  fs.writeFileSync(executable, image);
+
+  const originalReport = Object.getOwnPropertyDescriptor(process, "report");
+  Object.defineProperty(process, "report", {
+    configurable: true,
+    enumerable: true,
+    value: {
+      getReport() {
+        throw new Error("getReport is fatal inside the packaged Electron binary");
+      },
+    },
+  });
+  const fake = fakeWatchbound();
+  fake.capabilities.schemaVersion = 0;
+  fake.reportProbeExecutable = executable;
+  globalThis[MODULE_OVERRIDE_KEY] = fake;
+  delete globalThis[ENGINE_KEY];
+  t.after(() => {
+    delete globalThis[MODULE_OVERRIDE_KEY];
+    delete globalThis[ENGINE_KEY];
+    Object.defineProperty(process, "report", originalReport);
+  });
+
+  await assert.rejects(
+    codexLinuxStartDirectoryOnlyWorkingTreeWatch(
+      {
+        getFileSystemPath: () => "/qualified/root",
+        platformPath: async () => path.posix,
+      },
+      {
+        path: "/logical/root",
+        recursive: true,
+        renameEventHandling: "changed-path-with-parent-directory",
+        onChange() {},
+      },
+      {
+        maxWatches: 64,
+        honorGitIgnore: false,
+        ignoredDirectoryNames: [],
+      },
+    ),
+    /requires watchbound 2\.1\.1/u,
+  );
+
+  const report = process.report.getReport();
+  assert.equal(report.header.glibcVersionRuntime, "2.40");
+  assert.deepEqual(report.sharedObjects, []);
+});
+
 test("the adapter preserves Codex policy around the Watchbound engine", async (t) => {
   const root = tempDirectory(t, "watchbound-adapter-git-");
   git(root, ["init", "-q"]);


### PR DESCRIPTION
# Fix directory-only-working-tree-watch SIGILL from Watchbound libc detection

## Problem

With `directory-only-working-tree-watch` enabled, upstream `26.803.81509` crashes with SIGILL about 5 seconds after every launch, right after `[git-repo-watcher] Starting git repo watcher`. Coredumps place the crashing worker thread inside the node-report machinery (`node::GetNodeReport` / `TriggerNodeReport` region). The faulting instruction is a `ud1` CHECK trap preceded by `abort@plt` calls, a deliberate abort rather than corruption.

The trigger is Watchbound's runtime libc detection. `watchbound/capabilities.js` (`runtimeFacts()`) and `@gadicc/watchbound-node/load-native.cjs` (`detectLibc()`) both call `process.report.getReport()`. Inside the official Electron binary any `getReport()` call dies in a fatal internal CHECK. This is the crash class documented in openai/codex#38123 and NixOS/nixpkgs#551713. The surrounding `try/catch` never runs because the process takes SIGILL at the instruction level.

Earlier upstream builds failed the worker's `await import('@parcel/watcher')` with a non-fatal `ERR_MODULE_NOT_FOUND`, and the feature's rerouted path never engaged. `26.803.81509` resolves that import, which is why the crash only appeared now.

## Environment (found, replicated, and fixed on)

- Fedora Linux 43 (KDE Plasma Desktop Edition), Wayland session, x86_64
- Kernel 7.1.3-100.fc43.x86_64, Intel Core Ultra 7 258V, glibc 2.42
- First hit on the installed community package `codex-desktop-2026.08.13.085619-1.fc43` (12 enabled features, built by the update manager from a repo state that already included #1332); reproduced on 6+ consecutive launches there before the bisect
- Upstream package throughout: official `chatgpt-26.803.81509-amd64.deb` (sha256 `a9bf91a368f9f7c4eea38082a9fb8fb46b8d005b719a6d7715d2e5a1982c38eb`)
- Bisect and fix verification: clean clone of current `main`, `CODEX_INSTALL_DIR` build from that same deb

Feature bisect results:

| Build | Result |
| --- | --- |
| 0 features | survives |
| only `directory-only-working-tree-watch` | SIGILL about 5 s after launch, every launch |
| 12-feature set without this feature | survives |
| only `directory-only-working-tree-watch`, with this fix | survives (60 s, watcher started 4 times, no fallback diagnostics) |
| 12-feature set with this fix | survives |

## Fix

The pinned Watchbound packages stay byte-identical. The feature's serialized adapter (`codexLinuxStartDirectoryOnlyWorkingTreeWatch`, injected into both the worker and the main-process src bundle) now replaces `process.report` with a shim before any Watchbound code loads. The shim keeps the original report members, overrides only `getReport`, and produces the same libc answer from probes that stay in JavaScript, following detect-libc's probe order (Apache-2.0, attributed in the code):

1. ELF `PT_INTERP` of `/proc/self/exe` (bounded 4 KiB read): family, and on Nix the glibc version straight from the store path (readable because the flake build relocates `PT_INTERP` into range, #1332)
2. `/usr/bin/ldd` content: family and glibc version
3. `getconf GNU_LIBC_VERSION` subprocess: version fallback

`load-native.cjs` receives the shim through its normal `process.report` default. `capabilities.js` reads it directly. The shim carries the marker `Symbol.for("codex-linux.directory-only-working-tree-watch.process-report-shim")` and installs once per process. It reports musl only with a real `ld-musl` interpreter path and glibc only with a probed version. When every probe fails it reports an empty header, Watchbound refuses the runtime at load, and the adapter catches the refused import and hands the request to the preserved Parcel route (worker) or lets the original local watch run (src bundle). No crash, and every path keeps exactly one watcher owner.

## Testing

- `node --test linux-features/directory-only-working-tree-watch/test.js`: 118 pass, 0 fail. Three new tests: one replaces `process.report.getReport` with a function that throws and asserts the adapter never lets it run; one feeds a fixture ELF with a Nix store interpreter through the probe override and asserts the derived version; one runs the adapter with no module override so the real `import("watchbound")` fails, and asserts the preserved fallback is called exactly once, the poisoned `getReport` stays uncalled, and the shim is installed before the import.
- `bash -n`, `tests/scripts_smoke.sh`, and the full `node --test` line from CONTRIBUTING: 733 pass, 0 fail, 1 pre-existing skip. `./scripts/ci-local.sh pr` passed (core, deb, rpm, pacman) on the first commit.
- Live builds from the official deb on Fedora 43, listed in the table above. The configuration that crashed on every launch now survives. The full 12-feature configuration survives with it.

Not exercised live: arm64, musl, and a running Nix installation. Those lanes are covered by reasoning and unit fixtures only; on all of them a probe failure now degrades to the preserved route instead of rejecting the watch.

#1332 covered the Nix-specific `PT_INTERP` displacement inside detect-libc. This change covers the feature's own direct `getReport()` path, which affects every distro.

## Disclosure

This contribution was AI-assisted. I drove the work on my machine: hitting the crash, deciding what to investigate, running the feature bisect and the live build checks, and reviewing the diff and this description before submitting. An AI coding agent helped with the coredump analysis, the patch, and the write-up. Review feedback lands with me and I will handle it.
