### PR TITLE
Fix Nix remote-control CLI compatibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -960,13 +960,15 @@
                 package = codexDesktop;
                 remoteControl = {
                   enable = true;
-                  target = "never.target";
                   environment = { CODEX_NIX_VM = true; NULL_VALUE = null; };
                 };
               };
+              users.manageLingering = true;
               users.users.tester = {
                 isNormalUser = true;
                 uid = 1000;
+                createHome = true;
+                linger = true;
               };
               services.dbus.enable = true;
               environment.systemPackages = [ pkgs.xvfb pkgs.dbus ];
@@ -978,6 +980,16 @@
               machine.succeed("grep -q 'CODEX_NIX_VM=true' /etc/systemd/user/codex-remote-control.service")
               machine.succeed("grep -q 'After=network.target' /etc/systemd/user/codex-remote-control.service")
               machine.succeed("grep -q 'CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED' /etc/set-environment")
+              machine.succeed("grep -Fq 'CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET=\"$HOME/.codex/app-server-control/app-server-control.sock\"' /etc/set-environment")
+              machine.wait_for_unit("user@1000.service")
+              machine.wait_until_succeeds(
+                "su - tester -c 'XDG_RUNTIME_DIR=/run/user/1000 systemctl --user is-active codex-remote-control.service'",
+                timeout=60,
+              )
+              machine.wait_until_succeeds(
+                "test -S /home/tester/.codex/app-server-control/app-server-control.sock",
+                timeout=60,
+              )
               machine.succeed("su - tester -c ${lib.escapeShellArg (toString vmSmokeScript)}")
               machine.succeed("! grep -R 'Could not start dynamically linked executable' /var/log")
             '';

--- a/nix/bundled-codex-cli.nix
+++ b/nix/bundled-codex-cli.nix
@@ -1,0 +1,10 @@
+{ pkgs, desktopPackage }:
+pkgs.runCommand "codex-desktop-bundled-cli" { } ''
+  bundled_cli=${desktopPackage}/opt/codex-desktop/resources/codex
+  if [ ! -x "$bundled_cli" ]; then
+    echo "The selected codex-desktop package does not provide an executable bundled Codex CLI at $bundled_cli" >&2
+    exit 1
+  fi
+  mkdir -p "$out/bin"
+  ln -s "$bundled_cli" "$out/bin/codex"
+''

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -17,9 +17,15 @@ let
     flakePackages = self.packages.${system};
   };
   basePackage = selection.package;
+  bundledCodexCliPackage = import ./bundled-codex-cli.nix {
+    inherit pkgs;
+    desktopPackage = basePackage;
+  };
+  remoteCodexCliPackage =
+    if remote.package == null then bundledCodexCliPackage else remote.package;
   codexCliPackage =
     if cfg.cliPackage != null then cfg.cliPackage
-    else if remote.enable then remote.package
+    else if remote.enable then remoteCodexCliPackage
     else null;
   codexCliPath = if codexCliPackage == null then null else lib.getExe' codexCliPackage "codex";
   withCodexCliPath = base:
@@ -45,6 +51,7 @@ let
     };
   desktopPackage = if codexCliPath == null then basePackage else withCodexCliPath basePackage;
   codexHome = if remote.codexHome == null then "${config.home.homeDirectory}/.codex" else remote.codexHome;
+  prepareCodexHome = lib.escapeShellArgs [ "${pkgs.coreutils}/bin/mkdir" "-p" codexHome ];
   listenIsUnixSocket =
     remote.listen == "unix://"
     || builtins.match "unix:///[^/].*" remote.listen != null;
@@ -88,7 +95,17 @@ in {
     };
     remoteControl = {
       enable = lib.mkEnableOption "a declarative Codex remote-control app-server";
-      package = lib.mkOption { type = lib.types.package; default = pkgs.codex; };
+      package = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = null;
+        example = lib.literalExpression "pkgs.codex";
+        description = ''
+          Optional Codex CLI package for the remote-control app-server.
+          When unset, the compatible CLI bundled in the selected official
+          Desktop package is used. An override must support the app-server
+          --remote-control and --listen arguments.
+        '';
+      };
       codexHome = lib.mkOption { type = lib.types.nullOr lib.types.str; default = null; };
       listen = lib.mkOption { type = lib.types.str; default = "unix://"; };
       target = lib.mkOption { type = lib.types.str; default = "default.target"; };
@@ -146,8 +163,9 @@ in {
         After = [ "network.target" ];
       };
       Service = {
+        ExecStartPre = prepareCodexHome;
         ExecStart = lib.escapeShellArgs ([
-          (lib.getExe' remote.package "codex")
+          (lib.getExe' remoteCodexCliPackage "codex")
           "app-server"
           "--remote-control"
           "--listen"

--- a/nix/modules-test.nix
+++ b/nix/modules-test.nix
@@ -47,13 +47,20 @@ let
   };
 
   fakeDesktop = pkgs.runCommand "codex-desktop-module-test" { } ''
-    mkdir -p "$out/bin" "$out/share/applications"
+    mkdir -p "$out/bin" "$out/share/applications" "$out/opt/codex-desktop/resources"
     printf '#!/bin/sh\nprintf "%%s\\n" "''${CODEX_CLI_PATH-}"\n' > "$out/bin/codex-desktop"
     chmod +x "$out/bin/codex-desktop"
+    printf '#!/bin/sh\nexit 0\n' > "$out/opt/codex-desktop/resources/codex"
+    chmod +x "$out/opt/codex-desktop/resources/codex"
     printf '[Desktop Entry]\nExec=%s/bin/codex-desktop\n' "$out" > "$out/share/applications/codex-desktop.desktop"
   '';
+  fakeBundledCli = import ./bundled-codex-cli.nix {
+    inherit pkgs;
+    desktopPackage = fakeDesktop;
+  };
   fakeCli = pkgs.writeShellScriptBin "codex" "exit 0";
   baseConfig = { enable = true; package = fakeDesktop; };
+  bundledRemoteConfig = baseConfig // { remoteControl.enable = true; };
   remoteConfig = baseConfig // {
     remoteControl = {
       enable = true;
@@ -82,8 +89,12 @@ let
   };
   home = (evalHome remoteConfig).config;
   nixos = (evalNixOS remoteConfig).config;
+  bundledHome = (evalHome bundledRemoteConfig).config;
+  bundledNixOS = (evalNixOS bundledRemoteConfig).config;
   homeService = home.systemd.user.services.codex-remote-control;
   nixosService = nixos.systemd.user.services.codex-remote-control;
+  bundledHomeService = bundledHome.systemd.user.services.codex-remote-control;
+  bundledNixOSService = bundledNixOS.systemd.user.services.codex-remote-control;
   homeDefaultPackage = builtins.head (evalHome baseConfig).config.home.packages;
   nixosDefaultPackage = builtins.head (evalNixOS baseConfig).config.environment.systemPackages;
   homeCliPackage = builtins.head (evalHome (baseConfig // { cliPackage = fakeCli; })).config.home.packages;
@@ -112,6 +123,10 @@ assert lib.assertMsg
   (homeDefaultPackage.drvPath == fakeDesktop.drvPath && nixosDefaultPackage.drvPath == fakeDesktop.drvPath)
   "the bundled CLI default unexpectedly wrapped a custom Desktop package";
 assert lib.assertMsg
+  (!((evalHome baseConfig).config.systemd.user.services ? codex-remote-control)
+    && !((evalNixOS baseConfig).config.systemd.user.services ? codex-remote-control))
+  "remote control was enabled without explicit user configuration";
+assert lib.assertMsg
   (homeCliPackage.drvPath != fakeDesktop.drvPath && nixosCliPackage.drvPath != fakeDesktop.drvPath)
   "cliPackage did not wrap the Desktop launcher";
 assert lib.assertMsg
@@ -120,6 +135,14 @@ assert lib.assertMsg
 assert lib.assertMsg
   ((builtins.head (evalNixOS remoteConfig).config.environment.systemPackages).drvPath != fakeDesktop.drvPath)
   "NixOS did not use the remote-control CLI fallback";
+assert lib.assertMsg
+  (lib.hasPrefix "${fakeBundledCli}/bin/codex " bundledHomeService.Service.ExecStart
+    && lib.hasPrefix "${fakeBundledCli}/bin/codex " bundledNixOSService.serviceConfig.ExecStart)
+  "the default remote-control service did not use the Desktop package's bundled CLI";
+assert lib.assertMsg
+  ((builtins.head bundledHome.home.packages).drvPath != fakeDesktop.drvPath
+    && (builtins.head bundledNixOS.environment.systemPackages).drvPath != fakeDesktop.drvPath)
+  "the bundled remote-control CLI was not shared with the Desktop launcher";
 assert lib.assertMsg
   ((evalNixOS (baseConfig // { linuxFeatures = [ "codex-micro" ]; })).config.services.udev.packages == [ ])
   "a custom Desktop package unexpectedly inherited codex-micro udev policy";
@@ -134,6 +157,10 @@ assert lib.assertMsg
     && nixos.environment.sessionVariables.CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED == "1")
   "launcher daemon suppression was not enabled by default";
 assert lib.assertMsg
+  (nixos.environment.sessionVariables.CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET
+    == "$HOME/.codex/app-server-control/app-server-control.sock")
+  "the NixOS session proxy socket did not use a per-user home path";
+assert lib.assertMsg
   (!((evalHome remoteAutostartConfig).config.home.sessionVariables ? CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED)
     && !((evalNixOS remoteAutostartConfig).config.environment.sessionVariables ? CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED))
   "launcher daemon suppression ignored its option";
@@ -141,6 +168,10 @@ assert lib.assertMsg
   (homeService.Unit.After == [ "network.target" ] && homeService.Service.RestartSec == 5
     && nixosService.after == [ "network.target" ] && nixosService.serviceConfig.RestartSec == 5)
   "remote-control service ordering or restart timing regressed";
+assert lib.assertMsg
+  (lib.hasSuffix "mkdir -p /home/tester/.codex" bundledHomeService.Service.ExecStartPre
+    && lib.hasSuffix "mkdir -p %h/.codex" bundledNixOSService.serviceConfig.ExecStartPre)
+  "remote-control service did not prepare the default CODEX_HOME";
 assert lib.assertMsg
   (lib.elem "BOOL=true" homeService.Service.Environment
     && lib.elem "COUNT=7" homeService.Service.Environment
@@ -166,6 +197,9 @@ assert lib.assertMsg
   (assertionsFail (evalHome contextEnvironmentFileConfig) && assertionsFail (evalNixOS contextEnvironmentFileConfig))
   "a context-bearing environmentFile was accepted";
 pkgs.runCommand "codex-desktop-module-evaluation" { } ''
+  test -x ${fakeBundledCli}/bin/codex
+  test "$(${builtins.head bundledHome.home.packages}/bin/codex-desktop)" = "${fakeBundledCli}/bin/codex"
+  test "$(${builtins.head bundledNixOS.environment.systemPackages}/bin/codex-desktop)" = "${fakeBundledCli}/bin/codex"
   test "$(${homeCliPackage}/bin/codex-desktop)" = "${fakeCli}/bin/codex"
   test "$(CODEX_CLI_PATH=/explicit/codex ${homeCliPackage}/bin/codex-desktop)" = "/explicit/codex"
   grep -F "Exec=${homeCliPackage}/bin/codex-desktop" \

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -17,12 +17,18 @@ let
     flakePackages = self.packages.${system};
   };
   basePackage = selection.package;
+  bundledCodexCliPackage = import ./bundled-codex-cli.nix {
+    inherit pkgs;
+    desktopPackage = basePackage;
+  };
+  remoteCodexCliPackage =
+    if remote.package == null then bundledCodexCliPackage else remote.package;
   codexMicroEnabled =
     cfg.package == null
     && lib.elem "codex-micro" selection.normalizedFeatureIds;
   codexCliPackage =
     if cfg.cliPackage != null then cfg.cliPackage
-    else if remote.enable then remote.package
+    else if remote.enable then remoteCodexCliPackage
     else null;
   codexCliPath = if codexCliPackage == null then null else lib.getExe' codexCliPackage "codex";
   withCodexCliPath = base:
@@ -47,15 +53,19 @@ let
       meta = base.meta or { };
     };
   desktopPackage = if codexCliPath == null then basePackage else withCodexCliPath basePackage;
-  codexHome = if remote.codexHome == null then "%h/.codex" else remote.codexHome;
+  serviceCodexHome = if remote.codexHome == null then "%h/.codex" else remote.codexHome;
+  sessionCodexHome = if remote.codexHome == null then "$HOME/.codex" else remote.codexHome;
+  prepareCodexHome = lib.escapeShellArgs [ "${pkgs.coreutils}/bin/mkdir" "-p" serviceCodexHome ];
   listenIsUnixSocket =
     remote.listen == "unix://"
     || builtins.match "unix:///[^/].*" remote.listen != null;
-  socket = if remote.listen == "unix://" then "${codexHome}/app-server-control/app-server-control.sock"
+  serviceSocket = if remote.listen == "unix://" then "${serviceCodexHome}/app-server-control/app-server-control.sock"
+    else lib.removePrefix "unix://" remote.listen;
+  sessionSocket = if remote.listen == "unix://" then "${sessionCodexHome}/app-server-control/app-server-control.sock"
     else lib.removePrefix "unix://" remote.listen;
   remotePath = lib.makeSearchPath "bin" ([ "/run/current-system/sw" ] ++ remote.extraPackages);
   remoteEnvironment = {
-    CODEX_HOME = codexHome;
+    CODEX_HOME = serviceCodexHome;
     PATH = remotePath;
   } // remote.environment;
   remoteEnvironmentList = lib.mapAttrsToList
@@ -84,7 +94,17 @@ in {
     };
     remoteControl = {
       enable = lib.mkEnableOption "a system-wide user remote-control app-server unit";
-      package = lib.mkOption { type = lib.types.package; default = pkgs.codex; };
+      package = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = null;
+        example = lib.literalExpression "pkgs.codex";
+        description = ''
+          Optional Codex CLI package for the remote-control app-server.
+          When unset, the compatible CLI bundled in the selected official
+          Desktop package is used. An override must support the app-server
+          --remote-control and --listen arguments.
+        '';
+      };
       codexHome = lib.mkOption { type = lib.types.nullOr lib.types.str; default = null; };
       listen = lib.mkOption { type = lib.types.str; default = "unix://"; };
       target = lib.mkOption { type = lib.types.str; default = "default.target"; };
@@ -137,7 +157,7 @@ in {
     services.udev.packages = lib.optionals codexMicroEnabled [ basePackage ];
     environment.sessionVariables = lib.mkIf remote.enable ({
       CODEX_REMOTE_CONTROL_APP_SERVER_MODE = "proxy";
-      CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET = socket;
+      CODEX_REMOTE_CONTROL_APP_SERVER_PROXY_SOCKET = sessionSocket;
     } // lib.optionalAttrs remote.disableLauncherAutostart {
       CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED = "1";
     });
@@ -146,8 +166,9 @@ in {
       after = [ "network.target" ];
       wantedBy = [ remote.target ];
       serviceConfig = {
+        ExecStartPre = prepareCodexHome;
         ExecStart = lib.escapeShellArgs ([
-          (lib.getExe' remote.package "codex")
+          (lib.getExe' remoteCodexCliPackage "codex")
           "app-server"
           "--remote-control"
           "--listen"


### PR DESCRIPTION
## Summary

- use the Codex CLI bundled with the selected official Desktop package for Remote Control by default
- preserve explicit `remoteControl.package` overrides while validating the bundled CLI layout at build time
- use `$HOME` rather than the systemd-only `%h` specifier for the NixOS session proxy socket
- start the opt-in Remote Control service in the NixOS VM test and verify its Unix socket

## Why

The pinned nixpkgs `pkgs.codex` is version 0.92.0 and does not support `app-server --remote-control --listen`, so enabling Remote Control produced a systemd unit that failed immediately. The current official Desktop package already carries the matching CLI.

## Checks

- `git diff --check`
- module evaluation assertions for disabled-by-default behavior, bundled CLI selection, explicit overrides, and per-user socket paths
- NixOS VM coverage now starts the service and waits for its socket

## Risk

Nix/Home Manager/NixOS only. Remote Control remains disabled by default; explicit CLI package overrides keep their existing behavior.
