### PR TITLE
Restore pre-migration hover scrollbars on official Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- An opt-in `hover-scrollbars` feature restores the pre-migration overlay-style
+  hover hide on official Linux overflow scrollers. Classic Chromium thumbs stay
+  transparent until hover on the project sidebar, chat thread, and other
+  `overflow-*-auto` surfaces, and reserved `scrollbar-gutter: stable` space is
+  dropped. The default clean build still preserves `resources/app.asar`.
 - A disabled-by-default `deferred-update-build` Linux feature adds a **Build
   updates automatically** setting. Turning it off keeps notification and DMG
   verification active while deferring local package builds until an explicit

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ requirements, known limitations, configuration, and tests.
 | `directory-only-working-tree-watch` | Bounded Watchbound working-tree watching | [Docs](linux-features/directory-only-working-tree-watch/README.md) |
 | `frameless-titlebar` | Hide official Linux overlay buttons for compositor-managed decorations | [Docs](linux-features/frameless-titlebar/README.md) |
 | `global-dictation` | X11 and XDG portal global dictation hotkeys | [Docs](linux-features/global-dictation/README.md) |
+| `hover-scrollbars` | Restore pre-migration overlay-style hover scrollbars on official Linux | [Docs](linux-features/hover-scrollbars/README.md) |
 | `linux-performance-workarounds` | Measured renderer workarounds for affected systems | [Docs](linux-features/linux-performance-workarounds/README.md) |
 | `mcp-helper-reaper` | Reap orphaned MCP helpers without touching live sessions | [Docs](linux-features/mcp-helper-reaper/README.md) |
 | `node-repl-reaper` | Reap Browser Use `node_repl` helpers leaked after owner exit | [Docs](linux-features/node-repl-reaper/README.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -193,6 +193,7 @@ Nix 用户应从 profile、Home Manager 配置或 NixOS module 中删除该包�
 | `directory-only-working-tree-watch` | 有界 Watchbound 工作树监听 | [文档](linux-features/directory-only-working-tree-watch/README.md) |
 | `frameless-titlebar` | 隐藏官方 Linux overlay 按钮，改由 compositor 管理窗口装饰 | [文档](linux-features/frameless-titlebar/README.md) |
 | `global-dictation` | X11 / XDG portal 全局听写快捷键 | [文档](linux-features/global-dictation/README.md) |
+| `hover-scrollbars` | 恢复迁移前官方 Linux 的 hover overlay 滚动条 | [文档](linux-features/hover-scrollbars/README.md) |
 | `linux-performance-workarounds` | 针对受影响系统的 renderer workaround | [文档](linux-features/linux-performance-workarounds/README.md) |
 | `mcp-helper-reaper` | 安全清理孤立 MCP helper | [文档](linux-features/mcp-helper-reaper/README.md) |
 | `node-repl-reaper` | 清理 owner 退出后泄漏的 Browser Use `node_repl` | [文档](linux-features/node-repl-reaper/README.md) |

--- a/linux-features/hover-scrollbars/README.md
+++ b/linux-features/hover-scrollbars/README.md
@@ -1,0 +1,31 @@
+# Hover Scrollbars
+
+Official Linux Chromium uses classic scrollbars. The same
+`overflow-y-auto` surfaces overlay-hide on macOS, including the project
+sidebar and chat thread. After the official Linux package migration those
+scrollers stay visible because official CSS sets `scrollbar-color` on every
+overflow class.
+
+This feature restores the previous hover-hide behaviour. It injects official
+`scrollbar-on-hover` rules onto all `overflow-auto` / `overflow-y-auto` /
+`overflow-x-auto` scrollers and drops reserved `scrollbar-gutter: stable`
+space so Linux does not keep an empty track.
+
+The repository leaves it disabled by default so a clean build still preserves
+`resources/app.asar`. Enable it to restore the pre-migration look:
+
+```json
+{
+  "enabled": ["hover-scrollbars"]
+}
+```
+
+Then rebuild with `./install.sh` or `make install-native`. A reload is not
+enough.
+
+If the official app-initial bundle drifts, the contracts fail closed and the
+candidate is left unchanged.
+
+```bash
+node --test linux-features/hover-scrollbars/test.js
+```

--- a/linux-features/hover-scrollbars/feature.json
+++ b/linux-features/hover-scrollbars/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "hover-scrollbars",
+  "title": "Hover Scrollbars",
+  "description": "Restore pre-migration overlay-style hover scrollbars on official Linux overflow scrollers.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/hover-scrollbars/patch.js
+++ b/linux-features/hover-scrollbars/patch.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const APP_INITIAL_ASSET_PATTERN = /^app-initial-[A-Za-z0-9_-]+\.js$/;
+const STYLE_ID = "codex-linux-hover-scrollbars-style";
+const RUNTIME_MARKER = "codexLinuxHoverScrollbarsRuntime";
+const SIDEBAR_MARKER = "data-app-action-sidebar-scroll";
+
+const HOVER_SCROLLBAR_CSS = [
+  ".overflow-auto,.overflow-scroll,.overflow-x-auto,.overflow-y-auto,.overflow-x-scroll,.overflow-y-scroll{",
+  "transition:scrollbar-color var(--transition-duration-basic,150ms) ease;",
+  "scrollbar-color:transparent transparent!important",
+  "}",
+  ".overflow-auto:hover,.overflow-scroll:hover,.overflow-x-auto:hover,.overflow-y-auto:hover,.overflow-x-scroll:hover,.overflow-y-scroll:hover{",
+  "scrollbar-color:var(--color-token-scrollbar-slider-hover-background) transparent!important",
+  "}",
+  ".overflow-auto::-webkit-scrollbar-thumb,.overflow-scroll::-webkit-scrollbar-thumb,.overflow-x-auto::-webkit-scrollbar-thumb,.overflow-y-auto::-webkit-scrollbar-thumb,.overflow-x-scroll::-webkit-scrollbar-thumb,.overflow-y-scroll::-webkit-scrollbar-thumb{",
+  "background-color:#0000",
+  "}",
+  ".overflow-auto:hover::-webkit-scrollbar-thumb,.overflow-scroll:hover::-webkit-scrollbar-thumb,.overflow-x-auto:hover::-webkit-scrollbar-thumb,.overflow-y-auto:hover::-webkit-scrollbar-thumb,.overflow-x-scroll:hover::-webkit-scrollbar-thumb,.overflow-y-scroll:hover::-webkit-scrollbar-thumb{",
+  "background-color:var(--color-token-scrollbar-slider-hover-background)",
+  "}",
+  ".overflow-auto::-webkit-scrollbar-track,.overflow-scroll::-webkit-scrollbar-track,.overflow-x-auto::-webkit-scrollbar-track,.overflow-y-auto::-webkit-scrollbar-track,.overflow-x-scroll::-webkit-scrollbar-track,.overflow-y-scroll::-webkit-scrollbar-track{",
+  "background-color:#0000",
+  "}",
+  '[class*="scrollbar-gutter:stable"],.scrollbar-stable{scrollbar-gutter:auto}',
+].join("");
+
+function warn() {
+  console.warn(
+    "WARN: Could not find the complete current hover-scrollbars app-initial contract - skipping hover-scrollbars patch",
+  );
+}
+
+function looksLikeAppInitialBundle(source) {
+  return typeof source === "string" &&
+    source.includes(SIDEBAR_MARKER) &&
+    source.includes("overflow-y-auto") &&
+    source.includes("thread-scroll-container") === false;
+}
+
+function hoverScrollbarsContract(source) {
+  if (typeof source !== "string") return "drifted";
+  const hasMarker = source.includes(RUNTIME_MARKER) && source.includes(STYLE_ID);
+  if (hasMarker && looksLikeAppInitialBundle(source)) return "patched";
+  if (!hasMarker && looksLikeAppInitialBundle(source)) return "current";
+  return "drifted";
+}
+
+function hoverScrollbarsRuntimeSource() {
+  return [
+    `;(()=>{const ${RUNTIME_MARKER}=true;`,
+    `const STYLE_ID=${JSON.stringify(STYLE_ID)};`,
+    `const CSS=${JSON.stringify(HOVER_SCROLLBAR_CSS)};`,
+    `function install(){if(typeof document==="undefined")return;const target=document.head||document.documentElement;if(!target)return;let style=document.getElementById(STYLE_ID);if(style){style.textContent!==CSS&&(style.textContent=CSS);return}style=document.createElement("style");style.id=STYLE_ID;style.textContent=CSS;target.appendChild(style)}`,
+    `document.readyState==="loading"&&document.addEventListener("DOMContentLoaded",install,{once:true});install();})();`,
+  ].join("");
+}
+
+function applyHoverScrollbarsPatch(source) {
+  const contract = hoverScrollbarsContract(source);
+  if (contract === "patched") return source;
+  if (contract !== "current") {
+    warn();
+    return source;
+  }
+
+  const patched = `${source}\n${hoverScrollbarsRuntimeSource()}`;
+  if (hoverScrollbarsContract(patched) !== "patched") {
+    warn();
+    return source;
+  }
+  return patched;
+}
+
+module.exports = {
+  APP_INITIAL_ASSET_PATTERN,
+  HOVER_SCROLLBAR_CSS,
+  RUNTIME_MARKER,
+  SIDEBAR_MARKER,
+  STYLE_ID,
+  applyHoverScrollbarsPatch,
+  descriptors: [
+    {
+      id: "app-initial-style",
+      phase: "webview-asset",
+      order: 21_200,
+      ciPolicy: "optional",
+      pattern: APP_INITIAL_ASSET_PATTERN,
+      assetMatch: (source) => hoverScrollbarsContract(source) !== "drifted",
+      missingDescription: "official Linux app-initial bundle",
+      skipDescription: "hover-scrollbars patch",
+      apply: applyHoverScrollbarsPatch,
+    },
+  ],
+  hoverScrollbarsContract,
+  hoverScrollbarsRuntimeSource,
+};

--- a/linux-features/hover-scrollbars/test.js
+++ b/linux-features/hover-scrollbars/test.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const { loadLinuxFeaturePatchDescriptors } = require("../../scripts/lib/linux-features.js");
+const { patchUniqueAssetFile } = require("../../scripts/patches/lib/assets.js");
+const {
+  APP_INITIAL_ASSET_PATTERN,
+  HOVER_SCROLLBAR_CSS,
+  RUNTIME_MARKER,
+  STYLE_ID,
+  applyHoverScrollbarsPatch,
+  descriptors,
+  hoverScrollbarsContract,
+} = require("./patch.js");
+
+function captureWarnings(callback) {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.map(String).join(" "));
+  try {
+    return { value: callback(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+function fixture() {
+  return [
+    "const ids={sidebarScroll:`data-app-action-sidebar-scroll`};",
+    "className:`vertical-scroll-fade-mask overflow-y-auto`",
+  ].join("");
+}
+
+test("hover-scrollbars is disabled by default and exposes a standalone descriptor", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "hover-scrollbars-"));
+  try {
+    const config = path.join(temp, "features.json");
+    fs.writeFileSync(config, '{"enabled":[]}\n');
+    assert.deepEqual(
+      loadLinuxFeaturePatchDescriptors({
+        featuresRoot: path.join(__dirname, ".."),
+        featuresConfigPath: config,
+      }),
+      [],
+    );
+    fs.writeFileSync(config, '{"enabled":["hover-scrollbars"]}\n');
+    const loaded = loadLinuxFeaturePatchDescriptors({
+      featuresRoot: path.join(__dirname, ".."),
+      featuresConfigPath: config,
+    });
+    assert.deepEqual(
+      loaded.map(({ id, phase, ciPolicy }) => [id, phase, ciPolicy]),
+      [["feature:hover-scrollbars:app-initial-style", "webview-asset", "optional"]],
+    );
+    assert.deepEqual(
+      descriptors.map(({ id, phase }) => [id, phase]),
+      [["app-initial-style", "webview-asset"]],
+    );
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test("injects hover scrollbar CSS once and is idempotent", () => {
+  const source = fixture();
+  assert.equal(hoverScrollbarsContract(source), "current");
+  const patched = applyHoverScrollbarsPatch(source);
+  assert.notEqual(patched, source);
+  assert.match(patched, new RegExp(STYLE_ID));
+  assert.match(patched, new RegExp(RUNTIME_MARKER));
+  assert.ok(patched.includes(JSON.stringify(HOVER_SCROLLBAR_CSS)));
+  assert.match(patched, /scrollbar-color:transparent transparent!important/);
+  assert.match(patched, /scrollbar-gutter:auto/);
+  assert.equal(hoverScrollbarsContract(patched), "patched");
+  assert.equal(applyHoverScrollbarsPatch(patched), patched);
+});
+
+test("rejects unrecognized contracts byte-identically", () => {
+  for (const source of ["export{app}", "overflow-y-auto only"]) {
+    const result = captureWarnings(() => applyHoverScrollbarsPatch(source));
+    assert.equal(result.value, source);
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /current hover-scrollbars app-initial contract/);
+  }
+});
+
+test("descriptor selects the current official app-initial bundle", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "hover-scrollbars-assets-"));
+  try {
+    const assetsDir = path.join(temp, "webview", "assets");
+    fs.mkdirSync(assetsDir, { recursive: true });
+    fs.writeFileSync(path.join(assetsDir, "app-initial-iMhn6nFd.js"), fixture());
+    fs.writeFileSync(path.join(assetsDir, "chatgpt-conversation-page-ChLif5-T.js"), fixture());
+    const result = patchUniqueAssetFile(
+      temp,
+      APP_INITIAL_ASSET_PATTERN,
+      descriptors[0].assetMatch,
+      applyHoverScrollbarsPatch,
+      "missing",
+      "ambiguous",
+    );
+    const patched = fs.readFileSync(path.join(assetsDir, "app-initial-iMhn6nFd.js"), "utf8");
+    const skipped = fs.readFileSync(path.join(assetsDir, "chatgpt-conversation-page-ChLif5-T.js"), "utf8");
+    assert.deepEqual(result, { matched: 1, changed: 1, assetName: "app-initial-iMhn6nFd.js" });
+    assert.match(patched, new RegExp(STYLE_ID));
+    assert.equal(skipped, fixture());
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Official Linux paints classic Chromium thumbs on every `overflow-*-auto` scroller. macOS overlay-hid these before the Linux package migration.

This restores that hover-hide on the project sidebar, chat thread, and other overflow surfaces.

Shipped as a disabled-by-default feature so a clean build still preserves `app.asar`. If maintainers prefer, keep it opt-in rather than a default fix.

## Validation

- `node --test linux-features/hover-scrollbars/test.js`
- Official `26.810.41047` `app-initial-iMhn6nFd.js` applies once and is idempotent
- Feature/smoke/updater tests from the earlier review pass
- Manual: hover hide on the project sidebar after rebuild

## Checklist

- [x] Ready for review
- [x] Focused source change, no generated output
- [x] Latest official Linux package; no obsolete fallbacks
- [x] Tests added and run
- [x] Reviewed the final diff