### PR TITLE
Fix bundled marketplace staging permission loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
           node --test scripts/lib/package-common.test.js
           node --check scripts/ci/verify-official-linux-features.js
           node --test scripts/automation/upstream-linux-package-watchdog/test.js
-          node --test scripts/patch-linux-window-ui.test.js scripts/lib/linux-features.test.js linux-features/*/test.js
+          node --test scripts/patch-linux-window-ui.test.js scripts/patches/descriptor.test.js \
+            scripts/lib/linux-features.test.js linux-features/*/test.js
       - name: Smoke tests
         run: bash tests/scripts_smoke.sh
 
@@ -71,6 +72,8 @@ jobs:
         run: nix build ".#checks.${{ matrix.system }}.modules" --no-link
       - name: Build audited default runtime
         run: nix build ".#checks.${{ matrix.system }}.nix-runtime" --no-link
+      - name: Build audited Computer Use runtime
+        run: nix build ".#checks.${{ matrix.system }}.nix-runtime-computer-use" --no-link
       - name: Build audited directory-watch feature profile
         run: nix build ".#checks.${{ matrix.system }}.nix-runtime-maximal-directory-watch" --no-link
       - name: Build audited shallow-watch feature profile

--- a/docs/linux-features-architecture.md
+++ b/docs/linux-features-architecture.md
@@ -59,6 +59,7 @@ Manifest fields:
 | `id` | Stable configuration ID matching the directory name |
 | `title`, `description` | User-facing wizard and documentation text |
 | `defaultEnabled` | Must be `false` for every repository and local feature |
+| `internal` | Optional boolean for build-owned plumbing hidden from public feature selection |
 | `entrypoints.patchDescriptors` | Optional ASAR descriptor module |
 | `entrypoints.stageHook` | Last-resort app staging script |
 | `resources` | Declarative files copied into the app tree |

--- a/flake.nix
+++ b/flake.nix
@@ -282,16 +282,20 @@
           enableComputerUseUi ? false,
         }:
           let
-            normalizedFeatureIds = nixLinuxFeatures.normalize (
+            userFeatureIds = nixLinuxFeatures.normalize (
               linuxFeatureIds ++ lib.optional enableComputerUseUi "computer-use-linux"
             );
-            workspaceHelpers = mkWorkspaceHelpers normalizedFeatureIds;
-            watchboundEnabled = lib.elem "directory-only-working-tree-watch" normalizedFeatureIds;
-            codexMicroEnabled = lib.elem "codex-micro" normalizedFeatureIds;
+            internalNixFeatureIds = [ "nix-store-bundled-marketplace-permissions" ];
+            effectiveFeatureIds = nixLinuxFeatures.normalize (
+              userFeatureIds ++ internalNixFeatureIds
+            );
+            workspaceHelpers = mkWorkspaceHelpers effectiveFeatureIds;
+            watchboundEnabled = lib.elem "directory-only-working-tree-watch" effectiveFeatureIds;
+            codexMicroEnabled = lib.elem "codex-micro" effectiveFeatureIds;
             featuresConfig = pkgs.writeText "codex-linux-features.json" (builtins.toJSON {
-              enabled = normalizedFeatureIds;
+              enabled = effectiveFeatureIds;
             });
-            suffix = if normalizedFeatureIds == [ ] then "" else "-${lib.concatStringsSep "-" normalizedFeatureIds}";
+            suffix = if userFeatureIds == [ ] then "" else "-${lib.concatStringsSep "-" userFeatureIds}";
           in
           pkgs.stdenv.mkDerivation {
             pname = "codex-desktop${suffix}";
@@ -332,20 +336,20 @@
               export CODEX_LINUX_SOURCE_COMMIT="${flakeSourceCommit}"
               export CODEX_LINUX_SOURCE_REMOTE="${flakeSourceRemote}"
               ''}
-              ${lib.optionalString (lib.elem "computer-use-linux" normalizedFeatureIds) ''
+              ${lib.optionalString (lib.elem "computer-use-linux" effectiveFeatureIds) ''
               export CODEX_COMPUTER_USE_BINARY_SOURCE="${workspaceHelpers}/bin/codex-computer-use-linux"
               export CODEX_COMPUTER_USE_COSMIC_BINARY_SOURCE="${workspaceHelpers}/bin/codex-computer-use-cosmic"
               ''}
-              ${lib.optionalString (lib.elem "read-aloud-mcp" normalizedFeatureIds) ''
+              ${lib.optionalString (lib.elem "read-aloud-mcp" effectiveFeatureIds) ''
               export CODEX_LINUX_READ_ALOUD_MCP_SOURCE="${workspaceHelpers}/bin/codex-read-aloud-linux"
               ''}
-              ${lib.optionalString (lib.elem "record-and-replay" normalizedFeatureIds) ''
+              ${lib.optionalString (lib.elem "record-and-replay" effectiveFeatureIds) ''
               export CODEX_RECORD_REPLAY_LINUX_SOURCE="${workspaceHelpers}/bin/codex-record-replay-linux"
               ''}
-              ${lib.optionalString (lib.elem "global-dictation" normalizedFeatureIds) ''
+              ${lib.optionalString (lib.elem "global-dictation" effectiveFeatureIds) ''
               export CODEX_GLOBAL_DICTATION_LINUX_SOURCE="${globalDictationHelper}/bin/codex-global-dictation-linux"
               ''}
-              ${lib.optionalString (lib.elem "mcp-helper-reaper" normalizedFeatureIds) ''
+              ${lib.optionalString (lib.elem "mcp-helper-reaper" effectiveFeatureIds) ''
               export CODEX_MCP_HELPER_REAPER_SOURCE="${mcpReaperHelper}/bin/codex-mcp-helper-reaper"
               ''}
               ${lib.optionalString watchboundEnabled ''
@@ -355,6 +359,11 @@
               bash "$source_dir/install.sh" "${upstreamDeb}"
 
               app="$out/opt/codex-desktop"
+              test -d "$app"
+              node "$source_dir/scripts/ci/validate-patch-report.js" \
+                "$app/.codex-linux/patch-report.json" \
+                --require-enabled-feature nix-store-bundled-marketplace-permissions \
+                --require-applied feature:nix-store-bundled-marketplace-permissions:bundled-marketplace-staging-copy-permissions
               dynamic_linker="$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)"
               node "$source_dir/nix/elf-runtime.cjs" fix \
                 --root "$app" \
@@ -387,7 +396,7 @@
                 --replace-fail "/usr/bin/codex-desktop" "$out/bin/codex-desktop" \
                 --replace-fail "/usr/share/applications/codex-desktop.desktop" "$out/share/applications/codex-desktop.desktop"
               makeWrapper "$app/start.sh" "$out/bin/codex-desktop" \
-                --prefix PATH : "${runtimePathFor normalizedFeatureIds}" \
+                --prefix PATH : "${runtimePathFor effectiveFeatureIds}" \
                 --set-default ALSA_PLUGIN_DIR "${pkgs.pipewire}/lib/alsa-lib" \
                 --run 'export XDG_DATA_DIRS="''${XDG_DATA_DIRS:-${xdgDefaultDataDirs}}"' \
                 --prefix XDG_DATA_DIRS : "${gsettingsSchemaDataDirs}" \
@@ -405,7 +414,9 @@
               runHook postInstall
             '';
             passthru = {
-              inherit linuxFeatureIds upstreamDeb;
+              linuxFeatureIds = userFeatureIds;
+              effectiveLinuxFeatureIds = effectiveFeatureIds;
+              inherit upstreamDeb;
               upstreamVersion = codexVersion;
               upstreamArchitecture = officialPackage.architecture;
             };
@@ -714,7 +725,7 @@
             ${package}/bin/codex-desktop --diagnose
           ${pkgs.gnugrep}/bin/grep -Fx 'alsa=x:' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'xdg=x:${gsettingsSchemaDataDirs}:${xdgDefaultDataDirs}' "$capture"
-          ${pkgs.gnugrep}/bin/grep -Fx 'path=${runtimePathFor package.passthru.linuxFeatureIds}:/caller/bin' "$capture"
+          ${pkgs.gnugrep}/bin/grep -Fx 'path=${runtimePathFor package.passthru.effectiveLinuxFeatureIds}:/caller/bin' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'ld=x:/caller/lib' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx \
             'args=<--ozone-platform=wayland><--enable-wayland-ime=true><--wayland-text-input-version=3><--diagnose>' \
@@ -728,7 +739,7 @@
           ${pkgs.gnugrep}/bin/grep -Fx 'ld=x:' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'bamf=/caller/desktop' "$capture"
         '';
-        mkRuntimeCheck = name: package: verifyCleanAsar: verifyWatchbound:
+        mkRuntimeCheck = name: package: verifyBundledMarketplacePermissions: verifyWatchbound:
           pkgs.runCommand name {
             nativeBuildInputs = [ pkgs.coreutils pkgs.dpkg pkgs.nodejs pkgs.patchelf ];
           } ''
@@ -785,10 +796,11 @@
             fs.rmSync(root, { recursive: true, force: true });
             NODE
             ''}
-            ${lib.optionalString verifyCleanAsar ''
-            upstream_root="$(mktemp -d)"
-            dpkg-deb -x ${upstreamDeb} "$upstream_root"
-            cmp "$upstream_root/usr/lib/chatgpt/resources/app.asar" "$app/resources/app.asar"
+            ${lib.optionalString verifyBundledMarketplacePermissions ''
+            node ${sourceRoot}/scripts/ci/validate-patch-report.js \
+              "$app/.codex-linux/patch-report.json" \
+              --require-enabled-feature nix-store-bundled-marketplace-permissions \
+              --require-applied feature:nix-store-bundled-marketplace-permissions:bundled-marketplace-staging-copy-permissions
             ''}
             test -x ${pkgs.pipewire}/lib/alsa-lib/libasound_module_pcm_pipewire.so
             ! grep -q 'LD_LIBRARY_PATH=' ${package}/bin/codex-desktop

--- a/flake.nix
+++ b/flake.nix
@@ -286,7 +286,7 @@
               linuxFeatureIds ++ lib.optional enableComputerUseUi "computer-use-linux"
             );
             internalNixFeatureIds = [ "nix-store-bundled-marketplace-permissions" ];
-            effectiveFeatureIds = nixLinuxFeatures.normalize (
+            effectiveFeatureIds = nixLinuxFeatures.normalizeAll (
               userFeatureIds ++ internalNixFeatureIds
             );
             workspaceHelpers = mkWorkspaceHelpers effectiveFeatureIds;
@@ -332,6 +332,7 @@
               export CODEX_INSTALL_TRANSACTION_ACTIVE=1
               export CODEX_INSTALL_DIR="$out/opt/codex-desktop"
               export CODEX_LINUX_FEATURES_CONFIG="${featuresConfig}"
+              export CODEX_INTERNAL_LINUX_FEATURE_IDS="${lib.concatStringsSep "," internalNixFeatureIds}"
               ${lib.optionalString (flakeSourceCommit != "") ''
               export CODEX_LINUX_SOURCE_COMMIT="${flakeSourceCommit}"
               export CODEX_LINUX_SOURCE_REMOTE="${flakeSourceRemote}"

--- a/flake.nix
+++ b/flake.nix
@@ -362,8 +362,7 @@
               test -d "$app"
               node "$source_dir/scripts/ci/validate-patch-report.js" \
                 "$app/.codex-linux/patch-report.json" \
-                --require-enabled-feature nix-store-bundled-marketplace-permissions \
-                --require-applied feature:nix-store-bundled-marketplace-permissions:bundled-marketplace-staging-copy-permissions
+                --require-enabled-feature nix-store-bundled-marketplace-permissions
               dynamic_linker="$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)"
               node "$source_dir/nix/elf-runtime.cjs" fix \
                 --root "$app" \
@@ -890,10 +889,12 @@
         '';
         checks.modules = import ./nix/modules-test.nix { inherit pkgs self system; };
         checks.nix-runtime = mkRuntimeCheck "nix-runtime-check" codexDesktop true false;
+        checks.nix-runtime-computer-use =
+          mkRuntimeCheck "nix-runtime-computer-use" computerUse true false;
         checks.nix-runtime-maximal-directory-watch =
-          mkRuntimeCheck "nix-runtime-maximal-directory-watch" maximalDirectory false true;
+          mkRuntimeCheck "nix-runtime-maximal-directory-watch" maximalDirectory true true;
         checks.nix-runtime-maximal-shallow-watch =
-          mkRuntimeCheck "nix-runtime-maximal-shallow-watch" maximalShallow false false;
+          mkRuntimeCheck "nix-runtime-maximal-shallow-watch" maximalShallow true false;
         checks.nix-installer = pkgs.runCommand "nix-installer-check" {
           nativeBuildInputs = [ installer pkgs.nodejs pkgs.patchelf ];
         } ''

--- a/linux-features/README.md
+++ b/linux-features/README.md
@@ -94,6 +94,11 @@ Each feature directory must include:
 - optional `stage.sh` — legacy install/build staging hook
 - optional `test.js` — self-contained tests for the feature
 
+Repository-owned build plumbing may set `"internal": true` in `feature.json`.
+Internal features are hidden from the setup wizard and public feature summary,
+cannot be selected through native `features.json`, and must be explicitly
+allowlisted by the owning build integration.
+
 `stage.sh` hooks run with `SCRIPT_DIR`, `INSTALL_DIR`, `WORK_DIR`, `ARCH`, and
 `CODEX_UPSTREAM_APP_DIR` in the environment.
 

--- a/linux-features/computer-use-linux/README.md
+++ b/linux-features/computer-use-linux/README.md
@@ -1,15 +1,10 @@
 # Linux Computer Use
 
 Disabled-by-default Linux Computer Use integration. It owns the seven ASAR
-descriptors that used to be unconditional core port glue, the Nix staging
-permission repair, and the native MCP plugin staged only when explicitly
-enabled.
-
-The feature also repairs owner-write permissions on the app's fresh bundled
-marketplace staging copy. Nix store inputs are `0555`/`0444`, and Electron's
-recursive copy preserves those modes before it rewrites plugin metadata. The
-repair is scoped to the newly copied tree, does not follow symlinks, and leaves
-the default feature-free ASAR unchanged.
+descriptors that used to be unconditional core port glue and the native MCP
+plugin staged only when explicitly enabled. Immutable Nix packages receive
+their bundled-marketplace staging permission repair from the separate internal
+`nix-store-bundled-marketplace-permissions` feature.
 
 Enable it in `linux-features/features.json`:
 
@@ -23,8 +18,7 @@ Enable it in `linux-features/features.json`:
 `CODEX_COMPUTER_USE_BINARY_SOURCE` and `CODEX_COMPUTER_USE_COSMIC_BINARY_SOURCE`.
 Updater rebuilds reuse the packaged artifacts and never invoke Cargo.
 
-Validate descriptor ownership, Nix staging permissions, and artifact-only
-staging with:
+Validate descriptor ownership and artifact-only staging with:
 
 ```bash
 node --test linux-features/computer-use-linux/test.js

--- a/linux-features/computer-use-linux/patch.js
+++ b/linux-features/computer-use-linux/patch.js
@@ -13,68 +13,6 @@ const {
   matchesLinuxComputerUseInstallFlowContract,
 } = require("../../scripts/patches/impl/computer-use.js");
 
-const NIX_STAGING_PERMISSIONS_MARKER = "codex-linux-computer-use-nix-staging-permissions-v1";
-const IDENT = "[A-Za-z_$][\\w$]*";
-
-const NIX_STAGING_PERMISSIONS_HELPER = `/* ${NIX_STAGING_PERMISSIONS_MARKER} */
-async function codexLinuxComputerUseMakeStagingCopyWritable(fs,destination){
-  let stat;
-  try{stat=await fs.lstat(destination)}catch(error){if(error?.code===\`ENOENT\`)return;throw error}
-  if(stat.isSymbolicLink()||(!stat.isDirectory()&&!stat.isFile()))return;
-  if((stat.mode&0o200)===0)await fs.chmod(destination,stat.mode|0o200);
-  if(!stat.isDirectory())return;
-  for(const entry of await fs.readdir(destination)){
-    await codexLinuxComputerUseMakeStagingCopyWritable(fs,\`\${destination}/\${entry}\`);
-  }
-}
-`;
-
-function applyLinuxComputerUseNixStagingPermissionsPatch(source) {
-  if (source.includes(NIX_STAGING_PERMISSIONS_MARKER)) return source;
-  if (!source.includes(".staging-${")) {
-    throw new Error("Linux Computer Use Nix staging patch could not find the bundled marketplace staging contract");
-  }
-
-  const copyPattern = new RegExp(
-    `await (${IDENT})\\.default\\.cp\\((${IDENT}),(${IDENT}),\\{recursive:!0,verbatimSymlinks:!0\\}\\)` +
-      "(?=;return\\}let\\{copyDirectoryAllowDecryptedDestinationOnEncryptionFailure:)",
-    "g",
-  );
-  const matches = [...source.matchAll(copyPattern)].filter((match) => {
-    const prefix = source.slice(Math.max(0, match.index - 160), match.index);
-    const suffix = source.slice(match.index + match[0].length, match.index + match[0].length + 420);
-    return prefix.includes("platform!==`win32`") && suffix.includes("windows-file-copy-");
-  });
-  if (matches.length !== 1) {
-    throw new Error(`Linux Computer Use Nix staging copy contract matched ${matches.length} times`);
-  }
-
-  const match = matches[0];
-  const [, fsName] = match;
-  const copyFunctionPrefix = source.slice(0, match.index);
-  const copyFunctionMatch = [...copyFunctionPrefix.matchAll(new RegExp(`async function (${IDENT})\\([^)]*\\)\\{`, "g"))].at(-1);
-  if (copyFunctionMatch == null) {
-    throw new Error("Linux Computer Use Nix staging patch could not resolve the copy helper name");
-  }
-  const copyFunctionName = copyFunctionMatch[1];
-  const stagingCalls = [...source.matchAll(new RegExp(`await ${copyFunctionName}\\((${IDENT}),(${IDENT})\\)`, "g"))]
-    .filter((call) => {
-      const prefix = source.slice(Math.max(0, call.index - 3_000), call.index);
-      const suffix = source.slice(call.index + call[0].length, call.index + call[0].length + 1_200);
-      return prefix.includes(".staging-${") && suffix.includes(`pluginRoot:${call[2]}`);
-    });
-  if (stagingCalls.length !== 1) {
-    throw new Error(`Linux Computer Use bundled marketplace staging call matched ${stagingCalls.length} times`);
-  }
-
-  const stagingCall = stagingCalls[0];
-  const stagingDestinationName = stagingCall[2];
-  const replacement =
-    `try{${stagingCall[0]}}finally{` +
-    `await codexLinuxComputerUseMakeStagingCopyWritable(${fsName}.default,${stagingDestinationName})}`;
-  return `${NIX_STAGING_PERMISSIONS_HELPER}${source.slice(0, stagingCall.index)}${replacement}${source.slice(stagingCall.index + stagingCall[0].length)}`;
-}
-
 module.exports = [
   mainBundlePatch({
     id: "avatar-cursor",
@@ -135,12 +73,5 @@ module.exports = [
     missingDescription: "current Computer Use install flow app-initial contract",
     skipDescription: "Linux Computer Use install flow patch",
     apply: applyLinuxComputerUseInstallFlowPatch,
-  }),
-  mainBundlePatch({
-    id: "nix-staging-permissions",
-    phase: "main-bundle",
-    order: 20_170,
-    ciPolicy: "optional",
-    apply: applyLinuxComputerUseNixStagingPermissionsPatch,
   }),
 ];

--- a/linux-features/computer-use-linux/test.js
+++ b/linux-features/computer-use-linux/test.js
@@ -10,7 +10,7 @@ const test = require("node:test");
 const manifest = require("./feature.json");
 const descriptors = require("./patch.js");
 
-test("computer-use-linux is opt-in and owns the eight Linux descriptors", () => {
+test("computer-use-linux is opt-in and owns the seven Linux descriptors", () => {
   assert.equal(manifest.defaultEnabled, false);
   assert.deepEqual(
     descriptors.map(({ id }) => id),
@@ -22,159 +22,8 @@ test("computer-use-linux is opt-in and owns the eight Linux descriptors", () => 
       "ui-availability",
       "host-platform",
       "install-flow",
-      "nix-staging-permissions",
     ],
   );
-});
-
-const STAGING_COPY_FIXTURE = `async function Mne(source,destination){if(S.default.platform===\`darwin\`){await ditto(\`ditto\`,[source,destination]);return}if(S.default.platform!==\`win32\`){await y.default.cp(source,destination,{recursive:!0,verbatimSymlinks:!0});return}let{copyDirectoryAllowDecryptedDestinationOnEncryptionFailure:copy}=await Promise.resolve().then(()=>require("./windows-file-copy-Bw9CB6bJ.js"));await copy({copy:()=>y.default.cp(source,destination,{recursive:!0,verbatimSymlinks:!0}),destination,source})}
-async function copyPlugins(source,destination){const staging=\`openai-bundled.staging-\${randomUUID()}\`;await Mne(source,destination);await transform({pluginRoot:destination});return staging}`;
-
-function stagingFs({ copyError = null, writable = false } = {}) {
-  const nodes = new Map([
-    ["destination", { kind: "directory", mode: writable ? 0o755 : 0o555, entries: ["nested", "manifest", "link", "socket"] }],
-    ["destination/nested", { kind: "directory", mode: writable ? 0o755 : 0o555, entries: [] }],
-    ["destination/manifest", { kind: "file", mode: writable ? 0o644 : 0o444 }],
-    ["destination/link", { kind: "symlink", mode: 0o777 }],
-    ["destination/socket", { kind: "special", mode: 0o600 }],
-  ]);
-  const chmodCalls = [];
-  return {
-    chmodCalls,
-    nodes,
-    fs: {
-      async cp() {
-        if (copyError != null) throw copyError;
-      },
-      async lstat(target) {
-        const node = nodes.get(target);
-        if (node == null) {
-          const error = new Error("missing");
-          error.code = "ENOENT";
-          throw error;
-        }
-        return {
-          mode: node.mode,
-          isDirectory: () => node.kind === "directory",
-          isFile: () => node.kind === "file",
-          isSymbolicLink: () => node.kind === "symlink",
-        };
-      },
-      async chmod(target, mode) {
-        chmodCalls.push(target);
-        nodes.get(target).mode = mode;
-      },
-      async readdir(target) {
-        return [...nodes.get(target).entries];
-      },
-    },
-  };
-}
-
-function materializeStagingCopy(source, fsApi) {
-  const context = {
-    randomUUID: () => "uuid",
-    S: { default: { platform: "linux" } },
-    transform: async () => {},
-    y: { default: fsApi },
-  };
-  require("node:vm").runInNewContext(`${source};globalThis.copy=copyPlugins;`, context);
-  return context.copy;
-}
-
-test("computer-use-linux makes copied Nix staging nodes owner-writable", async () => {
-  const descriptor = descriptors.find(({ id }) => id === "nix-staging-permissions");
-  assert.ok(descriptor);
-  const patched = descriptor.apply(STAGING_COPY_FIXTURE);
-  const { fs: fsApi, nodes } = stagingFs();
-
-  await materializeStagingCopy(patched, fsApi)("source", "destination");
-
-  assert.equal(nodes.get("destination").mode, 0o755);
-  assert.equal(nodes.get("destination/nested").mode, 0o755);
-  assert.equal(nodes.get("destination/manifest").mode, 0o644);
-  assert.equal(nodes.get("destination/link").mode, 0o777);
-  assert.equal(nodes.get("destination/socket").mode, 0o600);
-});
-
-test("computer-use-linux repairs partial Nix staging copies for cleanup", async () => {
-  const descriptor = descriptors.find(({ id }) => id === "nix-staging-permissions");
-  const patched = descriptor.apply(STAGING_COPY_FIXTURE);
-  const copyError = new Error("copy failed");
-  const { fs: fsApi, nodes } = stagingFs({ copyError });
-
-  await assert.rejects(materializeStagingCopy(patched, fsApi)("source", "destination"), copyError);
-  assert.equal(nodes.get("destination").mode, 0o755);
-  assert.equal(nodes.get("destination/nested").mode, 0o755);
-  assert.equal(nodes.get("destination/manifest").mode, 0o644);
-});
-
-test("computer-use-linux leaves already-writable staging nodes unchanged", async () => {
-  const descriptor = descriptors.find(({ id }) => id === "nix-staging-permissions");
-  const patched = descriptor.apply(STAGING_COPY_FIXTURE);
-  const { chmodCalls, fs: fsApi } = stagingFs({ writable: true });
-
-  await materializeStagingCopy(patched, fsApi)("source", "destination");
-
-  assert.deepEqual(chmodCalls, []);
-});
-
-test("computer-use-linux Nix staging patch is unique, fail-closed, and idempotent", () => {
-  const descriptor = descriptors.find(({ id }) => id === "nix-staging-permissions");
-  const patched = descriptor.apply(STAGING_COPY_FIXTURE);
-
-  assert.equal(descriptor.apply(patched), patched);
-  assert.throws(
-    () => descriptor.apply(STAGING_COPY_FIXTURE.replace("platform!==`win32`", "platform===`linux`")),
-    /matched 0 times/,
-  );
-  assert.throws(
-    () => descriptor.apply(`${STAGING_COPY_FIXTURE}\n${STAGING_COPY_FIXTURE}`),
-    /matched 2 times/,
-  );
-  assert.throws(
-    () => descriptor.apply(STAGING_COPY_FIXTURE.replace("await Mne(source,destination)", "await otherCopy(source,destination)")),
-    /staging call matched 0 times/,
-  );
-
-  const withUnrelatedCaller = `${STAGING_COPY_FIXTURE}\nasync function unrelated(source,destination){await Mne(source,destination)}`;
-  const narrowlyPatched = descriptor.apply(withUnrelatedCaller);
-  assert.match(narrowlyPatched, /try\{await Mne\(source,destination\)\}finally/);
-  assert.match(narrowlyPatched, /async function unrelated\(source,destination\)\{await Mne\(source,destination\)\}/);
-  assert.match(
-    narrowlyPatched,
-    /platform!==`win32`\)\{await y\.default\.cp\(source,destination,\{recursive:!0,verbatimSymlinks:!0\}\);return}/,
-  );
-});
-
-test("computer-use-linux repairs real fs.cp modes before plugin metadata rewriting", async (t) => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "computer-use-linux-nix-copy-"));
-  const source = path.join(root, "source");
-  const destination = path.join(root, "destination");
-  const sourceMetadata = path.join(source, ".codex-plugin");
-  const destinationManifest = path.join(destination, ".codex-plugin", "plugin.json");
-  t.after(() => {
-    for (const directory of [sourceMetadata, source]) {
-      if (fs.existsSync(directory)) fs.chmodSync(directory, 0o755);
-    }
-    fs.rmSync(root, { recursive: true, force: true });
-  });
-
-  fs.mkdirSync(sourceMetadata, { recursive: true });
-  fs.writeFileSync(path.join(sourceMetadata, "plugin.json"), "{}\n");
-  fs.chmodSync(path.join(sourceMetadata, "plugin.json"), 0o444);
-  fs.chmodSync(sourceMetadata, 0o555);
-  fs.chmodSync(source, 0o555);
-
-  const descriptor = descriptors.find(({ id }) => id === "nix-staging-permissions");
-  const patched = descriptor.apply(STAGING_COPY_FIXTURE);
-  await materializeStagingCopy(patched, fs.promises)(source, destination);
-
-  assert.equal(fs.statSync(destination).mode & 0o777, 0o755);
-  assert.equal(fs.statSync(path.dirname(destinationManifest)).mode & 0o777, 0o755);
-  assert.equal(fs.statSync(destinationManifest).mode & 0o777, 0o644);
-  await fs.promises.writeFile(destinationManifest, '{"rewritten":true}\n');
-  assert.deepEqual(JSON.parse(fs.readFileSync(destinationManifest, "utf8")), { rewritten: true });
 });
 
 test("computer-use-linux staging consumes release artifacts without invoking Cargo", () => {

--- a/linux-features/global-dictation/test.js
+++ b/linux-features/global-dictation/test.js
@@ -607,6 +607,7 @@ test("main patch reports a missing release watcher sentinel as an optional skip"
       phase: "main-bundle",
       targetSummary: "all-linux",
       ciPolicy: "optional",
+      enforceWhenEnabled: true,
       sourceKind: "feature",
       featureId: "global-dictation",
       warnings: ["WARN: release watcher sentinel was not found - skipping Linux global dictation patch"],

--- a/linux-features/nix-store-bundled-marketplace-permissions/README.md
+++ b/linux-features/nix-store-bundled-marketplace-permissions/README.md
@@ -18,6 +18,11 @@ harmless, and lets chmod errors propagate. It neither changes source-store
 permissions nor scans/removes old staging directories or runtime marketplace
 data. Existing leaked staging data must be cleaned up manually.
 
+Upstream-contract drift is best-effort for package consumers: the patch report
+records `skipped-optional`, the build warns, and an otherwise unchanged ASAR is
+preserved byte-for-byte. Repository CI still requires the descriptor to apply
+to the current signed official package so drift is repaired before release.
+
 Run the adjacent regression test with:
 
 ```bash

--- a/linux-features/nix-store-bundled-marketplace-permissions/README.md
+++ b/linux-features/nix-store-bundled-marketplace-permissions/README.md
@@ -1,0 +1,25 @@
+# Nix bundled marketplace staging permissions
+
+This feature is disabled by default and is enabled internally only by the Nix
+`mkCodexDesktop` package. Native packages and `.#installer` keep the ordinary
+descriptor-free build and do not enable it.
+
+The Nix store supplies the bundled marketplace source with read-only `0444`
+files and `0555` directories. When the signed app copies a bundled plugin into
+a staging directory, an interrupted or failed materialization can preserve
+those modes. Upstream cleanup then cannot remove the staging UUID and later
+focus/startup reconciliation can accumulate more staging trees.
+
+The descriptor attaches a `finally` to the unique bundled-marketplace copy
+path. After either copy success or failure, it recursively adds owner write
+permission to real directories and regular files in that copied destination.
+It skips symlinks and every other node type, treats a missing destination as
+harmless, and lets chmod errors propagate. It neither changes source-store
+permissions nor scans/removes old staging directories or runtime marketplace
+data. Existing leaked staging data must be cleaned up manually.
+
+Run the adjacent regression test with:
+
+```bash
+node --test linux-features/nix-store-bundled-marketplace-permissions/test.js
+```

--- a/linux-features/nix-store-bundled-marketplace-permissions/feature.json
+++ b/linux-features/nix-store-bundled-marketplace-permissions/feature.json
@@ -3,6 +3,7 @@
   "title": "Nix bundled marketplace staging permissions",
   "description": "Nix-only repair for read-only bundled marketplace staging copies.",
   "defaultEnabled": false,
+  "internal": true,
   "entrypoints": {
     "patchDescriptors": "./patch.js"
   }

--- a/linux-features/nix-store-bundled-marketplace-permissions/feature.json
+++ b/linux-features/nix-store-bundled-marketplace-permissions/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "nix-store-bundled-marketplace-permissions",
+  "title": "Nix bundled marketplace staging permissions",
+  "description": "Nix-only repair for read-only bundled marketplace staging copies.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/nix-store-bundled-marketplace-permissions/patch.js
+++ b/linux-features/nix-store-bundled-marketplace-permissions/patch.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const { mainBundlePatch } = require("../../scripts/patches/descriptor.js");
+
+const PATCH_MARKER = "codex-linux-bundled-marketplace-staging-copy-permissions-v1";
+const IDENT = "[A-Za-z_$][\\w$]*";
+
+const HELPER_SOURCE = `/* ${PATCH_MARKER} */
+async function codexLinuxMakeBundledPluginStageNodesWritable(fs,destination){
+  let stat;
+  try{stat=await fs.lstat(destination)}catch(error){if(error?.code==="ENOENT")return;throw error}
+  if(stat.isSymbolicLink()||(!stat.isDirectory()&&!stat.isFile()))return;
+  await fs.chmod(destination,stat.mode|0o200);
+  if(!stat.isDirectory())return;
+  for(const entry of await fs.readdir(destination)){
+    await codexLinuxMakeBundledPluginStageNodesWritable(fs,\`\${destination}/\${entry}\`);
+  }
+}
+`;
+
+function functionContaining(source, index) {
+  const prefix = source.slice(0, index);
+  const starts = [...prefix.matchAll(new RegExp(`async function (${IDENT})\\(([^)]*)\\)\\{`, "g"))];
+  const start = starts.at(-1);
+  if (start == null) return null;
+  let depth = 1;
+  let cursor = start.index + start[0].length;
+  for (; cursor < source.length && depth > 0; cursor += 1) {
+    if (source[cursor] === "{") depth += 1;
+    if (source[cursor] === "}") depth -= 1;
+  }
+  return depth === 0 ? {
+    name: start[1],
+    start: start.index,
+    end: cursor,
+    source: source.slice(start.index, cursor),
+  } : null;
+}
+
+function stagingCopyContracts(source) {
+  const cpPattern = new RegExp(
+    `await (${IDENT})\\.default\\.cp\\((${IDENT}),(${IDENT}),\\{recursive:!0,verbatimSymlinks:!0\\}\\)`,
+    "g",
+  );
+  const contracts = [];
+  for (const match of source.matchAll(cpPattern)) {
+    const fn = functionContaining(source, match.index);
+    if (fn == null || !fn.source.includes("ditto") || !fn.source.includes("windows-file-copy")) continue;
+    const callPattern = new RegExp(`await ${fn.name}\\(${IDENT},${IDENT}\\)`, "g");
+    const calls = [...source.matchAll(callPattern)];
+    if (calls.length !== 1 || !/staging-\$\{[^}]*randomUUID/.test(source)) continue;
+    contracts.push({ match, fn });
+  }
+  return contracts;
+}
+
+function applyBundledMarketplaceStagingCopyPermissions(source) {
+  if (source.includes(PATCH_MARKER)) return source;
+  const contracts = stagingCopyContracts(source);
+  if (contracts.length !== 1) {
+    throw new Error(`bundled marketplace staging copy contract matched ${contracts.length} times`);
+  }
+  const { match } = contracts[0];
+  const [, fsName, , destinationName] = match;
+  const replacement = `try{${match[0]}}finally{await codexLinuxMakeBundledPluginStageNodesWritable(${fsName}.default,${destinationName})}`;
+  const patched = `${source.slice(0, match.index)}${replacement}${source.slice(match.index + match[0].length)}`;
+  return `${HELPER_SOURCE}${patched}`;
+}
+
+module.exports = {
+  PATCH_MARKER,
+  applyBundledMarketplaceStagingCopyPermissions,
+  descriptors: [mainBundlePatch({
+    id: "bundled-marketplace-staging-copy-permissions",
+    ciPolicy: "optional",
+    apply: applyBundledMarketplaceStagingCopyPermissions,
+  })],
+};

--- a/linux-features/nix-store-bundled-marketplace-permissions/patch.js
+++ b/linux-features/nix-store-bundled-marketplace-permissions/patch.js
@@ -73,6 +73,8 @@ module.exports = {
   descriptors: [mainBundlePatch({
     id: "bundled-marketplace-staging-copy-permissions",
     ciPolicy: "optional",
+    enforceWhenEnabled: false,
+    order: 20_170,
     apply: applyBundledMarketplaceStagingCopyPermissions,
   })],
 };

--- a/linux-features/nix-store-bundled-marketplace-permissions/test.js
+++ b/linux-features/nix-store-bundled-marketplace-permissions/test.js
@@ -10,6 +10,13 @@ const {
   loadLinuxFeaturePatchDescriptors,
 } = require("../../scripts/lib/linux-features.js");
 const {
+  createPatchReport,
+  enabledFeatureFailuresFromReport,
+  optionalDriftFromReport,
+  reportHasPatchChanges,
+} = require("../../scripts/lib/patch-report.js");
+const { patchExtractedApp } = require("../../scripts/patches/runner.js");
+const {
   PATCH_MARKER,
   applyBundledMarketplaceStagingCopyPermissions,
 } = require("./patch.js");
@@ -83,15 +90,53 @@ test("feature loads only when enabled with its prefixed optional descriptor", ()
   assert.equal(descriptor.sourceKind, "feature");
   assert.equal(descriptor.featureId, FEATURE_ID);
   assert.equal(descriptor.ciPolicy, "optional");
+  assert.equal(descriptor.enforceWhenEnabled, false);
+  assert.equal(descriptor.order, 20_170);
 });
 
-test("required descriptor anchor is unique and patching is idempotent", () => {
+test("descriptor anchor is unique and patching is idempotent", () => {
   const patched = applyBundledMarketplaceStagingCopyPermissions(FIXTURE);
   assert.match(patched, new RegExp(PATCH_MARKER));
   assert.match(patched, /try\{await y\.default\.cp/);
   assert.equal(applyBundledMarketplaceStagingCopyPermissions(patched), patched);
   assert.throws(() => applyBundledMarketplaceStagingCopyPermissions(FIXTURE.replaceAll("ditto", "other")), /matched 0 times/);
   assert.throws(() => applyBundledMarketplaceStagingCopyPermissions(`${FIXTURE}${FIXTURE.replaceAll("Mne", "Nne")}`), /matched 2 times/);
+});
+
+test("Computer Use composition has one Nix staging permission owner", () => {
+  const descriptors = descriptorsFor(["computer-use-linux", FEATURE_ID]);
+  const stagingDescriptors = descriptors.filter(({ id }) =>
+    id.includes("staging") && id.includes("permission"));
+  assert.deepEqual(stagingDescriptors.map(({ id }) => id), [DESCRIPTOR_ID]);
+  assert.match(stagingDescriptors[0].apply(FIXTURE), new RegExp(PATCH_MARKER));
+});
+
+test("upstream drift is reported but does not fail enabled-feature acceptance", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nix-marketplace-drift-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const buildDir = path.join(root, ".vite", "build");
+  fs.mkdirSync(buildDir, { recursive: true });
+  const mainPath = path.join(buildDir, "main-fixture.js");
+  const drifted = FIXTURE.replaceAll("ditto", "other");
+  fs.writeFileSync(mainPath, drifted);
+  const configPath = path.join(root, "features.json");
+  fs.writeFileSync(configPath, JSON.stringify({ enabled: [FEATURE_ID] }));
+
+  const report = createPatchReport();
+  patchExtractedApp(root, {
+    report,
+    featuresConfigPath: configPath,
+    featuresRoot: path.resolve(__dirname, ".."),
+  });
+
+  const [entry] = report.patches;
+  assert.equal(entry.name, DESCRIPTOR_ID);
+  assert.equal(entry.status, "skipped-optional");
+  assert.equal(entry.enforceWhenEnabled, false);
+  assert.deepEqual(enabledFeatureFailuresFromReport(report), []);
+  assert.equal(optionalDriftFromReport(report).length, 1);
+  assert.equal(reportHasPatchChanges(report), false);
+  assert.equal(fs.readFileSync(mainPath, "utf8"), drifted);
 });
 
 test("finally repairs copied real files and directories, including after copy failure", async () => {

--- a/linux-features/nix-store-bundled-marketplace-permissions/test.js
+++ b/linux-features/nix-store-bundled-marketplace-permissions/test.js
@@ -7,6 +7,7 @@ const path = require("node:path");
 const test = require("node:test");
 const vm = require("node:vm");
 const {
+  featuresJsonSummary,
   loadLinuxFeaturePatchDescriptors,
 } = require("../../scripts/lib/linux-features.js");
 const {
@@ -77,6 +78,7 @@ function descriptorsFor(enabled) {
     return loadLinuxFeaturePatchDescriptors({
       featuresRoot: path.resolve(__dirname, ".."),
       featuresConfigPath: configPath,
+      internalFeatureIds: enabled.includes(FEATURE_ID) ? [FEATURE_ID] : [],
     });
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
@@ -92,6 +94,20 @@ test("feature loads only when enabled with its prefixed optional descriptor", ()
   assert.equal(descriptor.ciPolicy, "optional");
   assert.equal(descriptor.enforceWhenEnabled, false);
   assert.equal(descriptor.order, 20_170);
+});
+
+test("feature stays hidden from public configuration", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nix-marketplace-public-config-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const configPath = path.join(root, "features.json");
+  fs.writeFileSync(configPath, JSON.stringify({ enabled: [FEATURE_ID] }));
+  const featuresRoot = path.resolve(__dirname, "..");
+
+  assert.throws(
+    () => loadLinuxFeaturePatchDescriptors({ featuresRoot, featuresConfigPath: configPath }),
+    /is internal and cannot be enabled through public feature configuration/,
+  );
+  assert.equal(featuresJsonSummary({ featuresRoot }).some(({ id }) => id === FEATURE_ID), false);
 });
 
 test("descriptor anchor is unique and patching is idempotent", () => {
@@ -127,6 +143,7 @@ test("upstream drift is reported but does not fail enabled-feature acceptance", 
     report,
     featuresConfigPath: configPath,
     featuresRoot: path.resolve(__dirname, ".."),
+    internalFeatureIds: [FEATURE_ID],
   });
 
   const [entry] = report.patches;
@@ -137,6 +154,28 @@ test("upstream drift is reported but does not fail enabled-feature acceptance", 
   assert.equal(optionalDriftFromReport(report).length, 1);
   assert.equal(reportHasPatchChanges(report), false);
   assert.equal(fs.readFileSync(mainPath, "utf8"), drifted);
+});
+
+test("missing main bundle is reported as best-effort drift", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nix-marketplace-missing-main-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const configPath = path.join(root, "features.json");
+  fs.writeFileSync(configPath, JSON.stringify({ enabled: [FEATURE_ID] }));
+  const report = createPatchReport();
+
+  patchExtractedApp(root, {
+    report,
+    featuresConfigPath: configPath,
+    featuresRoot: path.resolve(__dirname, ".."),
+    internalFeatureIds: [FEATURE_ID],
+  });
+
+  assert.equal(report.patches[0].name, DESCRIPTOR_ID);
+  assert.equal(report.patches[0].status, "skipped-optional");
+  assert.equal(report.patches[0].unavailable, true);
+  assert.deepEqual(enabledFeatureFailuresFromReport(report), []);
+  assert.equal(optionalDriftFromReport(report).length, 1);
+  assert.equal(reportHasPatchChanges(report), false);
 });
 
 test("finally repairs copied real files and directories, including after copy failure", async () => {

--- a/linux-features/nix-store-bundled-marketplace-permissions/test.js
+++ b/linux-features/nix-store-bundled-marketplace-permissions/test.js
@@ -1,0 +1,116 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+const {
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const {
+  PATCH_MARKER,
+  applyBundledMarketplaceStagingCopyPermissions,
+} = require("./patch.js");
+
+const FEATURE_ID = "nix-store-bundled-marketplace-permissions";
+const DESCRIPTOR_ID = `feature:${FEATURE_ID}:bundled-marketplace-staging-copy-permissions`;
+const FIXTURE = `async function Mne(source,destination){if(S.default.platform===\`darwin\`){await ditto(\`ditto\`,[source,destination]);return}if(S.default.platform!==\`win32\`){await y.default.cp(source,destination,{recursive:!0,verbatimSymlinks:!0});return}let{copyDirectoryAllowDecryptedDestinationOnEncryptionFailure:copy}=await Promise.resolve().then(()=>require("./windows-file-copy-Bw9CB6bJ.js"));await copy({copy:()=>y.default.cp(source,destination,{recursive:!0,verbatimSymlinks:!0}),destination,source})}
+async function copyPlugins(source,destination){const staging=\`openai-bundled.staging-\${randomUUID()}\`;const target=\`\${staging}/plugin\`;await Mne(source,target);return destination}`;
+
+function fakeFs({ cpError = null, chmodError = null, missing = false } = {}) {
+  const nodes = new Map([
+    ["destination", { kind: "directory", mode: 0o555, entries: ["nested", "file", "link", "special"] }],
+    ["destination/nested", { kind: "directory", mode: 0o555, entries: [] }],
+    ["destination/file", { kind: "file", mode: 0o444 }],
+    ["destination/link", { kind: "symlink", mode: 0o777 }],
+    ["destination/special", { kind: "special", mode: 0o600 }],
+  ]);
+  const fsPromises = {
+    async cp() { if (cpError) throw cpError; },
+    async lstat(target) {
+      const node = missing ? null : nodes.get(target);
+      if (node == null) {
+        const error = new Error("missing");
+        error.code = "ENOENT";
+        throw error;
+      }
+      return {
+        mode: node.mode,
+        isDirectory: () => node.kind === "directory",
+        isFile: () => node.kind === "file",
+        isSymbolicLink: () => node.kind === "symlink",
+      };
+    },
+    async chmod(target, mode) {
+      if (chmodError) throw chmodError;
+      nodes.get(target).mode = mode;
+    },
+    async readdir(target) { return [...nodes.get(target).entries]; },
+  };
+  return { fs: fsPromises, nodes };
+}
+
+function materialize(source, fsPromises) {
+  const context = {
+    S: { default: { platform: "linux" } },
+    y: { default: fsPromises },
+    randomUUID: () => "uuid",
+  };
+  vm.runInNewContext(`${source};globalThis.materialize=Mne;`, context);
+  return context.materialize;
+}
+
+function descriptorsFor(enabled) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nix-marketplace-feature-"));
+  const configPath = path.join(tempDir, "features.json");
+  fs.writeFileSync(configPath, JSON.stringify({ enabled }));
+  try {
+    return loadLinuxFeaturePatchDescriptors({
+      featuresRoot: path.resolve(__dirname, ".."),
+      featuresConfigPath: configPath,
+    });
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("feature loads only when enabled with its prefixed optional descriptor", () => {
+  assert.deepEqual(descriptorsFor([]), []);
+  const [descriptor] = descriptorsFor([FEATURE_ID]);
+  assert.equal(descriptor.id, DESCRIPTOR_ID);
+  assert.equal(descriptor.sourceKind, "feature");
+  assert.equal(descriptor.featureId, FEATURE_ID);
+  assert.equal(descriptor.ciPolicy, "optional");
+});
+
+test("required descriptor anchor is unique and patching is idempotent", () => {
+  const patched = applyBundledMarketplaceStagingCopyPermissions(FIXTURE);
+  assert.match(patched, new RegExp(PATCH_MARKER));
+  assert.match(patched, /try\{await y\.default\.cp/);
+  assert.equal(applyBundledMarketplaceStagingCopyPermissions(patched), patched);
+  assert.throws(() => applyBundledMarketplaceStagingCopyPermissions(FIXTURE.replaceAll("ditto", "other")), /matched 0 times/);
+  assert.throws(() => applyBundledMarketplaceStagingCopyPermissions(`${FIXTURE}${FIXTURE.replaceAll("Mne", "Nne")}`), /matched 2 times/);
+});
+
+test("finally repairs copied real files and directories, including after copy failure", async () => {
+  const patched = applyBundledMarketplaceStagingCopyPermissions(FIXTURE);
+  const copyError = new Error("copy failed");
+  const { fs: fsPromises, nodes } = fakeFs({ cpError: copyError });
+  await assert.rejects(materialize(patched, fsPromises)("source", "destination"), copyError);
+  assert.equal(nodes.get("destination").mode, 0o755);
+  assert.equal(nodes.get("destination/nested").mode, 0o755);
+  assert.equal(nodes.get("destination/file").mode, 0o644);
+  assert.equal(nodes.get("destination/link").mode, 0o777);
+  assert.equal(nodes.get("destination/special").mode, 0o600);
+});
+
+test("missing copied destination is harmless and repair errors propagate", async () => {
+  const patched = applyBundledMarketplaceStagingCopyPermissions(FIXTURE);
+  const missing = fakeFs({ missing: true });
+  await materialize(patched, missing.fs)("source", "destination");
+  const repairError = new Error("chmod failed");
+  const failing = fakeFs({ chmodError: repairError });
+  await assert.rejects(materialize(patched, failing.fs)("source", "destination"), repairError);
+});

--- a/nix/linux-features.nix
+++ b/nix/linux-features.nix
@@ -13,9 +13,13 @@ let
       else throw "Linux feature directory '${name}' contains mismatched id '${manifest.id}'")
     featureDirectories;
   manifestIds = map (manifest: manifest.id) manifests;
+  internalFeatureIds = lib.sort builtins.lessThan (
+    map (manifest: manifest.id) (lib.filter (manifest: manifest.internal or false) manifests)
+  );
   supportedFeatureIds =
     if builtins.length manifestIds == builtins.length (lib.unique manifestIds)
-    then lib.sort builtins.lessThan manifestIds
+    then lib.filter (featureId: !(lib.elem featureId internalFeatureIds))
+      (lib.sort builtins.lessThan manifestIds)
     else throw "Duplicate Linux feature IDs were discovered";
   manifestById = lib.listToAttrs (map (manifest: {
     name = manifest.id;
@@ -55,9 +59,26 @@ let
         throw "Invalid Nix Linux feature selection: ${lib.concatStringsSep "; " dependencyErrors}"
       else
         normalized;
+  normalizeAll = featureIds:
+    if !builtins.isList featureIds then
+      throw "Nix Linux feature IDs must be provided as a list"
+    else if !(lib.all builtins.isString featureIds) then
+      throw "Nix Linux feature IDs must all be strings"
+    else
+      let
+        canonical = map (featureId: aliases.${featureId} or featureId) featureIds;
+        normalized = sortAndDeduplicate (lib.filter
+          (featureId: !(lib.elem featureId retiredFeatureIds))
+          canonical);
+        unsupported = lib.filter (featureId: !(lib.elem featureId manifestIds)) normalized;
+      in
+      if unsupported != [ ] then
+        throw "Unsupported internal Nix Linux feature IDs: ${lib.concatStringsSep ", " unsupported}"
+      else
+        normalized;
 in
 {
-  inherit normalize retiredFeatureIds supportedFeatureIds;
+  inherit internalFeatureIds normalize normalizeAll retiredFeatureIds supportedFeatureIds;
 
   # Keep explicitly retired IDs valid while rejecting arbitrary unknown IDs
   # and dependency conflicts during option checking, even for custom packages.

--- a/scripts/bootstrap-wizard.sh
+++ b/scripts/bootstrap-wizard.sh
@@ -699,6 +699,10 @@ def discover_features(root):
             die(f"Linux feature '{feature_id}' must include README.md next to feature.json")
         if data.get("defaultEnabled") is True:
             die(f"Linux feature '{feature_id}' must be disabled by default; defaultEnabled true is not allowed")
+        if "internal" in data and not isinstance(data["internal"], bool):
+            die(f"Linux feature '{feature_id}' internal must be a boolean")
+        if data.get("internal") is True:
+            continue
         if feature_id in features:
             die(f"Duplicate Linux feature id '{feature_id}' in {manifest_path} and {features[feature_id]['manifest_path']}")
         title = data.get("title") or data.get("name") or feature_id

--- a/scripts/ci/github-actions-workflows.test.js
+++ b/scripts/ci/github-actions-workflows.test.js
@@ -29,6 +29,7 @@ test("CI runs the complete workflow regression suite", () => {
   assert.match(nixBuild, /system: aarch64-linux/);
   assert.match(nixBuild, /runner: ubuntu-24\.04-arm/);
   assert.match(nixBuild, /checks\.\$\{\{ matrix\.system \}\}\.modules/);
+  assert.match(nixBuild, /nix-runtime-computer-use/);
   assert.match(nixBuild, /nix-runtime-maximal-directory-watch/);
   assert.match(nixBuild, /nix-runtime-maximal-shallow-watch/);
   assert.match(nixBuild, /nix-installer/);

--- a/scripts/ci/verify-official-linux-features.js
+++ b/scripts/ci/verify-official-linux-features.js
@@ -35,15 +35,25 @@ try {
       enabled.push(id);
     };
     addWithRequirements(feature.id);
+    const internalFeatureIds = enabled.filter((id) => featureMap.get(id)?.manifest.internal === true);
     const config = path.join(work, `${feature.id}.json`);
     fs.writeFileSync(config, `${JSON.stringify({ enabled })}\n`);
-    const descriptors = loadLinuxFeaturePatchDescriptors({ featuresRoot, featuresConfigPath: config });
+    const descriptors = loadLinuxFeaturePatchDescriptors({
+      featuresRoot,
+      featuresConfigPath: config,
+      internalFeatureIds,
+    });
     if (!descriptors.some((descriptor) => descriptor.featureId === feature.id)) continue;
 
     const app = path.join(work, feature.id);
     fs.cpSync(source, app, { recursive: true, verbatimSymlinks: true });
     const report = createPatchReport();
-    patchExtractedApp(app, { report, featuresRoot, featuresConfigPath: config });
+    patchExtractedApp(app, {
+      report,
+      featuresRoot,
+      featuresConfigPath: config,
+      internalFeatureIds,
+    });
     const featureFailures = enabledFeatureFailuresFromReport(report);
     audited += 1;
     if (featureFailures.length > 0) {

--- a/scripts/lib/asar-patch.sh
+++ b/scripts/lib/asar-patch.sh
@@ -17,6 +17,32 @@ console.error(`[INFO] feature patch summary: ${summary}`);
 NODE
 }
 
+patch_report_has_changes() {
+    local patch_report="$1"
+    node - "$patch_report" "$SCRIPT_DIR/scripts/lib/patch-report.js" <<'NODE'
+const fs = require("node:fs");
+const [reportPath, helperPath] = process.argv.slice(2);
+const { reportHasPatchChanges } = require(helperPath);
+const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+process.exit(reportHasPatchChanges(report) ? 0 : 1);
+NODE
+}
+
+record_patch_report_asar_hashes() {
+    local patch_report="$1"
+    local upstream_sha="$2"
+    local output_sha="$3"
+    local preserved_byte_for_byte="$4"
+    node - "$patch_report" "$upstream_sha" "$output_sha" "$preserved_byte_for_byte" <<'NODE'
+const fs = require("node:fs");
+const [reportPath, upstreamSha, outputSha, preserved] = process.argv.slice(2);
+const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+report.upstreamAppAsar = { sha256: upstreamSha, preservedByteForByte: preserved === "true" };
+report.outputAppAsar = { sha256: outputSha };
+fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+NODE
+}
+
 write_empty_feature_patch_report() {
     local report_path="$1"
     local app_asar="$2"
@@ -67,6 +93,13 @@ patch_asar() {
         "$WORK_DIR/app-extracted"
     print_patch_report_summary "$patch_report_json"
 
+    if ! patch_report_has_changes "$patch_report_json"; then
+        info "No ASAR descriptor changed the current bundle; preserving official app.asar byte-for-byte"
+        record_patch_report_asar_hashes "$patch_report_json" "$upstream_sha" "$upstream_sha" true
+        CODEX_PATCH_REPORT_RESOLVED="$patch_report_json"
+        return 0
+    fi
+
     (cd "$WORK_DIR/app-extracted" && find . -type f -printf '%P\n' | LC_ALL=C sort) > "$WORK_DIR/app.asar.ordering"
     npx --yes @electron/asar pack \
         "$WORK_DIR/app-extracted" \
@@ -79,14 +112,7 @@ patch_asar() {
         mv "$WORK_DIR/app.asar.unpacked" "$resources_dir/app.asar.unpacked"
     fi
     patched_sha="$(sha256sum "$app_asar" | awk '{print $1}')"
-    node - "$patch_report_json" "$upstream_sha" "$patched_sha" <<'NODE'
-const fs = require("node:fs");
-const [reportPath, upstreamSha, patchedSha] = process.argv.slice(2);
-const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
-report.upstreamAppAsar = { sha256: upstreamSha, preservedByteForByte: false };
-report.outputAppAsar = { sha256: patchedSha };
-fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
-NODE
+    record_patch_report_asar_hashes "$patch_report_json" "$upstream_sha" "$patched_sha" false
     CODEX_PATCH_REPORT_RESOLVED="$patch_report_json"
 }
 

--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -314,6 +314,9 @@ function normalizeLinuxFeatureManifest(featuresRoot, candidate) {
   if (manifest.defaultEnabled === true) {
     throw new Error(`Linux feature '${id}' must be disabled by default; defaultEnabled true is not allowed`);
   }
+  if (manifest.internal != null && typeof manifest.internal !== "boolean") {
+    throw new Error(`Linux feature '${id}' internal must be a boolean`);
+  }
 
   const relativeDir = path.relative(featuresRoot, candidate.dir);
   return {
@@ -327,10 +330,23 @@ function normalizeLinuxFeatureManifest(featuresRoot, candidate) {
     manifest: {
       ...manifest,
       defaultEnabled: false,
+      internal: manifest.internal === true,
       requires: normalizeFeatureIdList(manifest.requires, "requires", id),
       conflicts: normalizeFeatureIdList(manifest.conflicts, "conflicts", id),
     },
   };
+}
+
+function allowedInternalFeatureIds(options = {}) {
+  const configured = options.internalFeatureIds ??
+    String(process.env.CODEX_INTERNAL_LINUX_FEATURE_IDS ?? "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+  if (!Array.isArray(configured)) {
+    throw new Error("internalFeatureIds must be an array");
+  }
+  return new Set(configured.map((id) => assertFeatureId(id, "Internal Linux feature id")));
 }
 
 function discoverLinuxFeatureManifests(options = {}) {
@@ -387,10 +403,15 @@ function loadEnabledLinuxFeatures(options = {}) {
   const enabled = options.enabledFeatureIds ?? config.enabled;
   const features = [];
   const missing = [];
+  const allowedInternal = allowedInternalFeatureIds(options);
   for (const id of enabled) {
     const feature = available.get(id);
     if (feature == null) {
       missing.push(id);
+    } else if (feature.manifest.internal && !allowedInternal.has(id)) {
+      throw new Error(
+        `Linux feature '${id}' is internal and cannot be enabled through public feature configuration`,
+      );
     } else {
       features.push({ ...feature, settings: config.settings[id] ?? {} });
     }
@@ -471,7 +492,7 @@ function resolveFeatureRelativePath(feature, relativePath, label, { mustExist = 
   return resolved;
 }
 
-function resolveFeatureEntrypoint(feature, key) {
+function resolveFeatureEntrypoint(feature, key, options = {}) {
   const relativePath = feature.manifest.entrypoints?.[key];
   if (relativePath == null) {
     return null;
@@ -479,13 +500,16 @@ function resolveFeatureEntrypoint(feature, key) {
   try {
     return resolveFeatureRelativePath(feature, relativePath, `${key} entrypoint`);
   } catch (error) {
+    if (options.strict === true) {
+      throw error;
+    }
     console.warn(`WARN: ${error.message}`);
     return null;
   }
 }
 
-function loadFeatureEntrypointModule(feature, key) {
-  const entrypoint = resolveFeatureEntrypoint(feature, key);
+function loadFeatureEntrypointModule(feature, key, options = {}) {
+  const entrypoint = resolveFeatureEntrypoint(feature, key, options);
   if (entrypoint == null) {
     return null;
   }
@@ -496,6 +520,11 @@ function loadFeatureEntrypointModule(feature, key) {
       moduleExports: require(entrypoint),
     };
   } catch (error) {
+    if (options.strict === true) {
+      throw new Error(`Could not load Linux feature '${feature.id}' ${key}: ${error.message}`, {
+        cause: error,
+      });
+    }
     console.warn(`WARN: Could not load Linux feature '${feature.id}' ${key}: ${error.message}`);
     return null;
   }
@@ -580,7 +609,7 @@ function featurePatchDescriptorListFromExports(feature, moduleExports, sourcePat
 function loadLinuxFeaturePatchDescriptors(options = {}) {
   const descriptors = [];
   for (const [featureIndex, feature] of loadEnabledLinuxFeatures(options).entries()) {
-    const loaded = loadFeatureEntrypointModule(feature, "patchDescriptors");
+    const loaded = loadFeatureEntrypointModule(feature, "patchDescriptors", { strict: true });
     if (loaded == null) {
       continue;
     }
@@ -1313,7 +1342,9 @@ function restoreEnabledLinuxFeaturePackageResourcePermissions(packageRoot, optio
 }
 
 function featuresJsonSummary(options = {}) {
-  return discoverLinuxFeatureManifests(options).map((feature) => ({
+  return discoverLinuxFeatureManifests(options)
+    .filter((feature) => !feature.manifest.internal)
+    .map((feature) => ({
     id: feature.id,
     title: feature.manifest.title ?? feature.manifest.name ?? feature.id,
     name: feature.manifest.name ?? feature.manifest.title ?? feature.id,
@@ -1326,7 +1357,7 @@ function featuresJsonSummary(options = {}) {
     defaultEnabled: false,
     setup: feature.manifest.setup ?? null,
     cleanup: feature.manifest.cleanup ?? null,
-  }));
+    }));
 }
 
 function main() {

--- a/scripts/lib/linux-features.test.js
+++ b/scripts/lib/linux-features.test.js
@@ -137,6 +137,35 @@ test("Linux feature asset matchers receive feature settings", (t) => {
   assert.equal(descriptor.assetMatch("current-contract", "app-current.js", {}), true);
 });
 
+test("enabled patch descriptor load errors are fatal", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-invalid-descriptor-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const { featureDir, featuresRoot } = makeFeatureRoot(root, {
+    id: "unsafe-link",
+    title: "Unsafe Link",
+    entrypoints: { patchDescriptors: "./patch.js" },
+  });
+  const descriptorModule = path.join(__dirname, "..", "patches", "descriptor.js");
+  fs.writeFileSync(
+    path.join(featureDir, "patch.js"),
+    [
+      `const { mainBundlePatch } = require(${JSON.stringify(descriptorModule)});`,
+      "module.exports = mainBundlePatch({",
+      "  id: 'invalid-required-bypass',",
+      "  ciPolicy: 'required-upstream',",
+      "  enforceWhenEnabled: false,",
+      "  apply: (source) => source,",
+      "});",
+      "",
+    ].join("\n"),
+  );
+
+  assert.throws(
+    () => loadLinuxFeaturePatchDescriptors({ featuresRoot }),
+    /Could not load Linux feature 'unsafe-link' patchDescriptors:.*only with ciPolicy 'optional'/,
+  );
+});
+
 test("Linux feature staging rejects duplicate resource targets", (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-duplicate-resource-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));

--- a/scripts/lib/patch-report.js
+++ b/scripts/lib/patch-report.js
@@ -14,6 +14,7 @@ const PATCH_STATUS_SKIPPED_OPTIONAL = "skipped-optional";
 const PATCH_STATUS_SKIPPED_TARGET = "skipped-target";
 
 const SUCCESS_STATUSES = new Set([PATCH_STATUS_APPLIED, PATCH_STATUS_ALREADY_APPLIED]);
+const CHANGED_STATUSES = new Set([PATCH_STATUS_APPLIED, PATCH_STATUS_APPLIED_WITH_WARNINGS]);
 // Statuses meaning "not applicable here" rather than "failed": the patch was
 // skipped because of platform targeting or an explicit enable gate.
 const NOT_APPLICABLE_STATUSES = new Set([PATCH_STATUS_SKIPPED_TARGET, PATCH_STATUS_SKIPPED_DISABLED]);
@@ -58,8 +59,13 @@ function enabledFeatureFailuresFromReport(report) {
   const enabledFeatures = new Set(Array.isArray(report?.enabledFeatures) ? report.enabledFeatures : []);
   return (report?.patches ?? [])
     .filter((patch) => patch.sourceKind === "feature" && enabledFeatures.has(patch.featureId))
+    .filter((patch) => patch.enforceWhenEnabled !== false)
     .filter((patch) => !SUCCESS_STATUSES.has(patch.status) && !NOT_APPLICABLE_STATUSES.has(patch.status))
     .map((patch) => ({ ...reportEntryFailure(patch), featureId: patch.featureId }));
+}
+
+function reportHasPatchChanges(report) {
+  return (report?.patches ?? []).some((patch) => CHANGED_STATUSES.has(patch.status));
 }
 
 function createPatchReport() {
@@ -167,6 +173,7 @@ function summarizePatchReport(report) {
 
 module.exports = {
   CRITICAL_CI_POLICY,
+  CHANGED_STATUSES,
   NOT_APPLICABLE_STATUSES,
   PATCH_STATUS_ALREADY_APPLIED,
   PATCH_STATUS_APPLIED,
@@ -186,6 +193,7 @@ module.exports = {
   optionalDriftFromReport,
   patchStatusFromChange,
   recordPatch,
+  reportHasPatchChanges,
   summarizePatchReport,
   writePatchReport,
 };

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -13,7 +13,40 @@ const {
   featurePatchDescriptors,
   patchExtractedApp,
 } = require("./patches/runner.js");
-const { createPatchReport } = require("./lib/patch-report.js");
+const {
+  createPatchReport,
+  enabledFeatureFailuresFromReport,
+  reportHasPatchChanges,
+} = require("./lib/patch-report.js");
+
+test("best-effort feature drift stays non-fatal without hiding changed outputs", () => {
+  const report = createPatchReport();
+  report.enabledFeatures = ["best-effort", "strict"];
+  report.patches = [
+    {
+      name: "feature:best-effort:repair",
+      status: "skipped-optional",
+      ciPolicy: "optional",
+      sourceKind: "feature",
+      featureId: "best-effort",
+      enforceWhenEnabled: false,
+    },
+  ];
+  assert.deepEqual(enabledFeatureFailuresFromReport(report), []);
+  assert.equal(reportHasPatchChanges(report), false);
+
+  report.patches[0].status = "applied-with-warnings";
+  assert.equal(reportHasPatchChanges(report), true);
+
+  report.patches[0] = {
+    ...report.patches[0],
+    name: "feature:strict:repair",
+    status: "skipped-optional",
+    featureId: "strict",
+    enforceWhenEnabled: true,
+  };
+  assert.equal(enabledFeatureFailuresFromReport(report).length, 1);
+});
 
 test("official Linux baseline has an empty core patch registry", () => {
   assert.deepEqual(corePatchDescriptors(), []);

--- a/scripts/patches/descriptor.js
+++ b/scripts/patches/descriptor.js
@@ -47,6 +47,14 @@ function assertDescriptorBase(descriptor, phase) {
   if (!CI_POLICIES.has(ciPolicy)) {
     throw new Error(`Patch descriptor '${id}' has unsupported ciPolicy '${ciPolicy}'`);
   }
+  if (descriptor.enforceWhenEnabled != null && typeof descriptor.enforceWhenEnabled !== "boolean") {
+    throw new Error(`Patch descriptor '${id}' enforceWhenEnabled must be a boolean`);
+  }
+  if (descriptor.enforceWhenEnabled === false && ciPolicy !== CI_POLICY_OPTIONAL) {
+    throw new Error(
+      `Patch descriptor '${id}' can disable enabled-feature enforcement only with ciPolicy 'optional'`,
+    );
+  }
   if (descriptor.composesPatches != null) {
     throw new Error(`Patch descriptor '${id}' uses removed composesPatches support`);
   }
@@ -64,6 +72,7 @@ function patchDescriptor(phase, descriptor) {
     name: descriptor.name ?? id,
     phase,
     ciPolicy: descriptor.ciPolicy ?? CI_POLICY_OPTIONAL,
+    enforceWhenEnabled: descriptor.enforceWhenEnabled ?? true,
   };
 }
 

--- a/scripts/patches/descriptor.test.js
+++ b/scripts/patches/descriptor.test.js
@@ -1,5 +1,9 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
+const {
+  createPatchReport,
+  criticalFailuresFromReport,
+} = require("../lib/patch-report.js");
 
 const {
   CI_POLICY_OPTIONAL,
@@ -11,7 +15,10 @@ const {
   mainBundlePatch,
   webviewAssetPatch,
 } = require("./descriptor.js");
-const { normalizePatchDescriptors } = require("./engine.js");
+const {
+  normalizePatchDescriptors,
+  recordUnavailablePhasePatchDescriptors,
+} = require("./engine.js");
 
 test("descriptor factories stamp explicit patch phases", () => {
   assert.equal(
@@ -122,4 +129,25 @@ test("descriptor factories validate the fresh descriptor contract", () => {
     }]),
     /only with ciPolicy 'optional'/,
   );
+});
+
+test("missing required phase remains fail-closed", () => {
+  const [descriptor] = normalizePatchDescriptors([mainBundlePatch({
+    id: "required-main",
+    ciPolicy: "required-upstream",
+    apply: (source) => source,
+  })]);
+  const report = createPatchReport();
+
+  recordUnavailablePhasePatchDescriptors(
+    [descriptor],
+    PHASE_MAIN_BUNDLE,
+    {},
+    report,
+    "main bundle unavailable",
+  );
+
+  assert.equal(report.patches[0].status, "failed-required");
+  assert.equal(report.patches[0].unavailable, true);
+  assert.equal(criticalFailuresFromReport(report).length, 1);
 });

--- a/scripts/patches/descriptor.test.js
+++ b/scripts/patches/descriptor.test.js
@@ -11,6 +11,7 @@ const {
   mainBundlePatch,
   webviewAssetPatch,
 } = require("./descriptor.js");
+const { normalizePatchDescriptors } = require("./engine.js");
 
 test("descriptor factories stamp explicit patch phases", () => {
   assert.equal(
@@ -57,6 +58,22 @@ test("descriptor factories validate the fresh descriptor contract", () => {
     }).ciPolicy,
     CI_POLICY_OPTIONAL,
   );
+  assert.equal(
+    mainBundlePatch({
+      id: "default-enforcement",
+      apply: (source) => source,
+    }).enforceWhenEnabled,
+    true,
+  );
+  assert.equal(
+    mainBundlePatch({
+      id: "best-effort",
+      ciPolicy: "optional",
+      enforceWhenEnabled: false,
+      apply: (source) => source,
+    }).enforceWhenEnabled,
+    false,
+  );
 
   assert.throws(
     () => webviewAssetPatch({ id: "missing-pattern", apply: (source) => source }),
@@ -82,5 +99,27 @@ test("descriptor factories validate the fresh descriptor contract", () => {
   assert.throws(
     () => mainBundlePatch({ id: "bad-composition", composesPatches: "linux-owner", apply: (source) => source }),
     /removed composesPatches support/,
+  );
+  assert.throws(
+    () => mainBundlePatch({ id: "bad-enforcement", enforceWhenEnabled: "no", apply: (source) => source }),
+    /enforceWhenEnabled must be a boolean/,
+  );
+  assert.throws(
+    () => mainBundlePatch({
+      id: "required-bypass",
+      ciPolicy: "required-upstream",
+      enforceWhenEnabled: false,
+      apply: (source) => source,
+    }),
+    /only with ciPolicy 'optional'/,
+  );
+  assert.throws(
+    () => normalizePatchDescriptors([{
+      id: "raw-required-bypass",
+      ciPolicy: "required-upstream",
+      enforceWhenEnabled: false,
+      apply: (source) => source,
+    }]),
+    /only with ciPolicy 'optional'/,
   );
 });

--- a/scripts/patches/engine.js
+++ b/scripts/patches/engine.js
@@ -257,6 +257,27 @@ function recordDescriptorError(report, descriptor, error, context, strategies = 
   );
 }
 
+function recordUnavailablePhasePatchDescriptors(descriptors, phase, context, report, reason) {
+  for (const descriptor of descriptors.filter((patch) => patch.phase === phase)) {
+    if (!descriptorAppliesTo(descriptor, context)) {
+      recordDescriptorPatch(report, descriptor, PATCH_STATUS_SKIPPED_TARGET, null, context);
+      continue;
+    }
+    if (!descriptorEnabled(descriptor, context)) {
+      recordDescriptorPatch(report, descriptor, PATCH_STATUS_SKIPPED_DISABLED, null, context);
+      continue;
+    }
+    recordDescriptorPatch(
+      report,
+      descriptor,
+      descriptorFailureStatus(descriptor),
+      reason,
+      context,
+      { unavailable: true },
+    );
+  }
+}
+
 function rethrowPatchIntegrityError(error) {
   if (isPatchIntegrityError(error)) {
     throw error;
@@ -470,5 +491,6 @@ module.exports = {
   normalizeDescriptor,
   normalizePatchDescriptors,
   patchTargetSummary,
+  recordUnavailablePhasePatchDescriptors,
   sortPatchDescriptors,
 };

--- a/scripts/patches/engine.js
+++ b/scripts/patches/engine.js
@@ -64,9 +64,20 @@ function normalizeDescriptor(descriptor, sourcePath = null, index = 0) {
       `Patch descriptor '${id}' has unsupported ciPolicy '${ciPolicy}' in ${sourcePath ?? "inline descriptor"}`,
     );
   }
+  if (descriptor.enforceWhenEnabled != null && typeof descriptor.enforceWhenEnabled !== "boolean") {
+    throw new Error(
+      `Patch descriptor '${id}' enforceWhenEnabled must be a boolean in ${sourcePath ?? "inline descriptor"}`,
+    );
+  }
+  if (descriptor.enforceWhenEnabled === false && ciPolicy !== OPTIONAL) {
+    throw new Error(
+      `Patch descriptor '${id}' can disable enabled-feature enforcement only with ciPolicy 'optional'`,
+    );
+  }
   const normalized = {
     ...descriptor,
     ciPolicy,
+    enforceWhenEnabled: descriptor.enforceWhenEnabled ?? true,
     id,
     name: descriptor.name ?? id,
     phase: descriptor.phase ?? PHASE_MAIN_BUNDLE,
@@ -221,6 +232,9 @@ function recordDescriptorPatch(report, descriptor, status, reason, context, extr
     ciPolicy: descriptor.ciPolicy ?? "optional",
     sourceKind: descriptor.sourceKind ?? "core",
     ...(descriptor.featureId != null ? { featureId: descriptor.featureId } : {}),
+    ...(descriptor.sourceKind === "feature"
+      ? { enforceWhenEnabled: descriptor.enforceWhenEnabled !== false }
+      : {}),
     ...(extraMetadata ?? {}),
     ...warnings,
   });

--- a/scripts/patches/runner.js
+++ b/scripts/patches/runner.js
@@ -21,6 +21,7 @@ const {
   applyMainBundlePatchDescriptors,
   applyWebviewAssetPatchDescriptors,
   normalizePatchDescriptors,
+  recordUnavailablePhasePatchDescriptors,
 } = require("./engine.js");
 const {
   PHASE_EXTRACTED_APP_POST_WEBVIEW,
@@ -52,6 +53,7 @@ function featurePatchOptions(options = {}) {
   return {
     ...(options.featuresRoot != null ? { featuresRoot: options.featuresRoot } : {}),
     ...(options.featuresConfigPath != null ? { featuresConfigPath: options.featuresConfigPath } : {}),
+    ...(options.internalFeatureIds != null ? { internalFeatureIds: options.internalFeatureIds } : {}),
   };
 }
 
@@ -128,6 +130,13 @@ function patchExtractedApp(extractedDir, options = {}) {
   if (main == null && patchDescriptors.some((descriptor) => descriptor.phase === PHASE_MAIN_BUNDLE)) {
     const reason = `Could not find main bundle in ${path.join(extractedDir, ".vite", "build")}`;
     console.warn(`WARN: ${reason} — skipping enabled main-bundle feature patches`);
+    recordUnavailablePhasePatchDescriptors(
+      patchDescriptors,
+      PHASE_MAIN_BUNDLE,
+      baseContext,
+      report,
+      reason,
+    );
   }
 
   const iconAsset = null;

--- a/scripts/patches/runner.test.js
+++ b/scripts/patches/runner.test.js
@@ -5,7 +5,10 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
-const { createPatchReport } = require("../lib/patch-report.js");
+const {
+  createPatchReport,
+  enabledFeatureFailuresFromReport,
+} = require("../lib/patch-report.js");
 const {
   allPatchPolicies,
   corePatchDescriptors,
@@ -53,4 +56,24 @@ test("empty feature set leaves official extracted files byte-identical", () => {
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("missing main bundle records enabled feature drift", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "runner-missing-main-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const config = path.join(root, "features.json");
+  fs.writeFileSync(config, '{"enabled":["frameless-titlebar"]}\n');
+  const report = createPatchReport();
+
+  patchExtractedApp(root, { report, featuresConfigPath: config });
+
+  const [entry] = report.patches;
+  assert.equal(entry.name, "feature:frameless-titlebar:main-process");
+  assert.equal(entry.status, "skipped-optional");
+  assert.equal(entry.enforceWhenEnabled, true);
+  assert.equal(entry.unavailable, true);
+  assert.equal(
+    enabledFeatureFailuresFromReport(report).some((failure) => failure.name === entry.name),
+    true,
+  );
 });

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -55,6 +55,36 @@ selected_package="$(scripts/select-latest-package.sh "$selector_fixture/codex-de
 [ "$selected_package" = "$selector_fixture/codex-desktop_2026.08.12.100000_amd64.deb" ] ||
     fail "package selector did not choose the newest artifact: $selected_package"
 
+SCRIPT_DIR="$REPO_DIR"
+. scripts/lib/asar-patch.sh
+asar_report="$selector_fixture/patch-report.json"
+node - "$asar_report" <<'NODE'
+const fs = require("node:fs");
+const reportPath = process.argv[2];
+fs.writeFileSync(reportPath, `${JSON.stringify({
+  patches: [{ status: "skipped-optional" }],
+}, null, 2)}\n`);
+NODE
+if patch_report_has_changes "$asar_report"; then
+    fail "skipped optional ASAR descriptors must preserve the official archive"
+fi
+node - "$asar_report" <<'NODE'
+const fs = require("node:fs");
+const reportPath = process.argv[2];
+const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+report.patches[0].status = "applied";
+fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+NODE
+patch_report_has_changes "$asar_report" || fail "applied ASAR descriptors must be packed"
+record_patch_report_asar_hashes "$asar_report" upstream-sha output-sha true
+node - "$asar_report" <<'NODE'
+const fs = require("node:fs");
+const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+if (!report.upstreamAppAsar.preservedByteForByte) throw new Error("missing byte-preserved report state");
+if (report.upstreamAppAsar.sha256 !== "upstream-sha") throw new Error("bad upstream hash");
+if (report.outputAppAsar.sha256 !== "output-sha") throw new Error("bad output hash");
+NODE
+
 if find scripts/patches/core -name patch.js -print -quit | grep -q .; then
     fail "official baseline core registry must remain empty"
 fi


### PR DESCRIPTION
## Summary

Nix store sources give bundled marketplace plugin files read-only modes. The signed app copies those modes into `openai-bundled.staging-*`, then fails when it writes plugin metadata or removes an interrupted staging tree. Repeated reconciliation can therefore leave additional full staging copies behind.

This PR adds one internal Nix-only ASAR repair. It wraps the current bundled-marketplace copy contract in `try/finally` and recursively adds owner-write permission to real directories and regular files in the copied destination. Symlinks and special nodes are skipped, a missing destination is harmless, and real `chmod` failures still propagate.

The repair is injected only by `mkCodexDesktop`. It is hidden from public Linux feature selection and replaces the narrower Computer Use-owned patch, so default, Computer Use, and maximal Nix profiles compose exactly one staging-permission descriptor. Native deb/RPM/pacman/AppImage builds, the updater, and public `.#installer` remain descriptor-free and preserve the official ASAR byte-for-byte.

## Drift policy

User Nix package builds treat this repair as best-effort. If the current upstream main-bundle contract cannot be found or the optional patch otherwise drifts, the report records `skipped-optional`, emits a warning, and preserves an unchanged official ASAR byte-for-byte. Required-upstream descriptors, integrity failures, and all other enabled features remain fail-closed.

Repository CI is deliberately stricter: runtime checks for default, Computer Use, and both maximal profiles require this exact descriptor to be `applied` on the current signed official ASAR on amd64 and arm64.

This change does not scan or remove staging directories that already accumulated. Existing leaked data still requires manual cleanup.

## Validation

- Full CI-equivalent Node suite: 849 passed, 1 pre-existing skip, 0 failed
- Shell smoke suite: 50/50 passed
- Shell syntax checks and `git diff --check`
- Three independent blocker reviews of the final base-to-head diff: no findings
- All GitHub checks passed, including real Nix builds and strict runtime audits on x86_64 and aarch64

## Checklist

- [x] Synchronized by merging current `main` without force-push
- [x] Current-DMG-only contract; no legacy fallback path
- [x] Optional consumer drift and strict repository validation are tested separately
- [x] Native package/updater/public-installer isolation is preserved
- [x] Final diff was independently reviewed until no blockers remained
