### PR TITLE
Autodetect native Wayland sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ output layout, parallelism, and payload inspection.
 | Browser/Chrome extension cannot connect after migration | Exit ChatGPT and Chrome completely, then follow the narrow cache repair in [Troubleshooting](docs/troubleshooting.md#browser-or-chrome-plugin-is-visible-but-cannot-connect) |
 | Signature or package verification fails | Do not bypass it; check time, network, `gpgv`, architecture, and disk space |
 | App does not launch | Run `/opt/codex-desktop/start.sh --diagnose` |
-| App uses XWayland or needs persistent Electron flags | Put one flag per line in `~/.config/codex-desktop/electron-flags.conf`; for example, `--ozone-platform=wayland` |
+| App uses XWayland or needs a backend override | Native Wayland is automatic for a Wayland session with a live display socket, or the explicit `NIXOS_OZONE_WL` compatibility opt-in. Use `codex-desktop --ozone-platform=x11`, or put one Electron flag per line in `~/.config/codex-desktop/electron-flags.conf` |
 | AppImage reports a sandbox error | Enable user namespaces or install a native package; `--no-sandbox` is not added automatically |
 | Enabled feature drifts after an upstream release | Disable that feature to confirm the clean baseline and attach its patch report to an issue |
 | Updater waits for application exit | Close official and Community processes, then inspect `codex-update-manager status --json` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,16 +39,33 @@ feature hooks.
 
 ## Persistent Electron flags and native Wayland
 
+The generic launcher automatically selects native Wayland when
+`XDG_SESSION_TYPE=wayland`, `WAYLAND_DISPLAY` is set, and the resolved display
+path is a live Unix socket. An absolute `WAYLAND_DISPLAY` is used directly; a
+relative value is resolved below `XDG_RUNTIME_DIR`. `DISPLAY` does not disable
+this behavior. The established NixOS `NIXOS_OZONE_WL` plus `WAYLAND_DISPLAY`
+opt-in remains supported even when that session/socket predicate is unavailable.
+
+An explicit `--ozone-platform` selection (with or without `=value`) suppresses
+the automatic defaults. The setting may come from a flag file, an enabled
+feature, or the command line. Do not rely on conflicting flags being resolved
+by argument order.
+
 The launcher reads shared Electron flags from
 `${XDG_CONFIG_HOME:-$HOME/.config}/electron-flags.conf` and Community-specific
 flags from
 `${XDG_CONFIG_HOME:-$HOME/.config}/codex-desktop/electron-flags.conf`, in that
 order. Put one complete argument on each line; blank lines and lines beginning
 with `#` are ignored. App-specific flags are followed by enabled feature flags
-and explicit command-line arguments, so a later explicit argument can override
-an earlier setting.
+and explicit command-line arguments.
 
-To force native Wayland rendering without editing a generated desktop entry:
+To choose a backend for one launch, for example to opt out to X11:
+
+```bash
+codex-desktop --ozone-platform=x11
+```
+
+To persistently choose native Wayland without editing a generated desktop entry:
 
 ```bash
 mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/codex-desktop"

--- a/flake.nix
+++ b/flake.nix
@@ -392,8 +392,7 @@
                 --run 'export XDG_DATA_DIRS="''${XDG_DATA_DIRS:-${xdgDefaultDataDirs}}"' \
                 --prefix XDG_DATA_DIRS : "${gsettingsSchemaDataDirs}" \
                 --set-default BAMF_DESKTOP_FILE_HINT "$out/share/applications/codex-desktop.desktop" \
-                --set-default CODEX_CLI_PATH "$app/resources/codex" \
-                --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-wayland-ime=true --wayland-text-input-version=3}}"
+                --set-default CODEX_CLI_PATH "$app/resources/codex"
               node "$source_dir/nix/elf-runtime.cjs" audit \
                 --root "$app" \
                 --arch ${officialPackage.architecture} \
@@ -443,15 +442,7 @@
           export XDG_DATA_DIRS="${gsettingsSchemaDataDirs}:''${XDG_DATA_DIRS:-${xdgDefaultDataDirs}}"
           export CODEX_CLI_PATH="''${CODEX_CLI_PATH:-$app_dir/resources/codex}"
           export BAMF_DESKTOP_FILE_HINT="''${BAMF_DESKTOP_FILE_HINT:-$app_dir/.codex-linux/codex-desktop.desktop}"
-          extra_flags=()
-          if [[ -n "''${NIXOS_OZONE_WL-}" && -n "''${WAYLAND_DISPLAY-}" ]]; then
-            extra_flags+=(
-              --ozone-platform=wayland
-              --enable-wayland-ime=true
-              --wayland-text-input-version=3
-            )
-          fi
-          exec "$app_dir/.start.sh-nix" "$@" "''${extra_flags[@]}"
+          exec "$app_dir/.start.sh-nix" "$@"
         '';
         installerWorkspaceHelpers = mkWorkspaceHelpers maximalDirectoryFeatureIds;
         installerRuntimeClosure = pkgs.writeText "codex-desktop-installer-runtime-closure" (
@@ -716,9 +707,7 @@
           ${pkgs.gnugrep}/bin/grep -Fx 'xdg=x:${gsettingsSchemaDataDirs}:${xdgDefaultDataDirs}' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'path=${runtimePathFor package.passthru.linuxFeatureIds}:/caller/bin' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'ld=x:/caller/lib' "$capture"
-          ${pkgs.gnugrep}/bin/grep -Fx \
-            'args=<--ozone-platform=wayland><--enable-wayland-ime=true><--wayland-text-input-version=3><--diagnose>' \
-            "$capture"
+          ${pkgs.gnugrep}/bin/grep -Fx 'args=<--diagnose>' "$capture"
           ${pkgs.coreutils}/bin/env ALSA_PLUGIN_DIR=/caller/alsa XDG_DATA_DIRS=/caller/share \
             BAMF_DESKTOP_FILE_HINT=/caller/desktop LD_LIBRARY_PATH= \
             BASH_ENV=${wrapperEnvironmentProbe} CODEX_NIX_ENV_CAPTURE="$capture" \

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -219,6 +219,79 @@ run_launcher_hooks() {
     done < <(find "$HOOK_ROOT/launcher.d" -maxdepth 1 -type f -perm -u+x -print0 | sort -z)
 }
 
+has_explicit_electron_backend() {
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            --ozone-platform|--ozone-platform=*)
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+has_live_unix_socket() {
+    local expected_path
+    local record
+    local socket_path
+
+    command -v readlink >/dev/null 2>&1 || return 1
+    expected_path="$(readlink -f -- "$1")" || return 1
+    [ -S "$expected_path" ] || return 1
+    [ -r /proc/net/unix ] || return 1
+    while IFS= read -r record; do
+        [[ "$record" =~ ^[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]+00010000[[:space:]]+0001[[:space:]]+[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]+(.*)$ ]] || continue
+        socket_path="$(readlink -f -- "${BASH_REMATCH[1]}")" || continue
+        [ "$socket_path" = "$expected_path" ] && return 0
+    done < /proc/net/unix
+    return 1
+}
+
+should_use_native_wayland() {
+    local socket_path
+
+    # Preserve the established NixOS opt-in even when session metadata is not
+    # available (for example, from a desktop launcher).
+    if [ -n "${NIXOS_OZONE_WL:-}" ] && [ -n "${WAYLAND_DISPLAY:-}" ]; then
+        return 0
+    fi
+
+    [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || return 1
+    [ -n "${WAYLAND_DISPLAY:-}" ] || return 1
+    case "$WAYLAND_DISPLAY" in
+        /*) socket_path="$WAYLAND_DISPLAY" ;;
+        *)
+            [ -n "${XDG_RUNTIME_DIR:-}" ] || return 1
+            socket_path="$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY"
+            ;;
+    esac
+    has_live_unix_socket "$socket_path"
+}
+
+has_explicit_wayland_ime_configuration() {
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            --enable-wayland-ime|--enable-wayland-ime=*|--disable-wayland-ime|--disable-wayland-ime=*|--wayland-text-input-version|--wayland-text-input-version=*)
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+prepend_native_wayland_defaults() {
+    local -a defaults=(--ozone-platform=wayland)
+    if ! has_explicit_wayland_ime_configuration "$@"; then
+        defaults+=(
+            --enable-wayland-ime=true
+            --wayland-text-input-version=3
+        )
+    fi
+    ELECTRON_ARGS=("${defaults[@]}" "${ELECTRON_ARGS[@]}")
+}
+
 ORIGINAL_ARGS=("$@")
 case "${1:-}" in
     -h|--help) usage; exit 0 ;;
@@ -233,6 +306,11 @@ load_user_electron_args
 load_electron_args
 run_hook_directory "$HOOK_ROOT/prelaunch.d" prelaunch
 run_launcher_hooks "${ELECTRON_ARGS[@]}" "${ORIGINAL_ARGS[@]}"
+
+if ! has_explicit_electron_backend "${ELECTRON_ARGS[@]}" "${ORIGINAL_ARGS[@]}" &&
+   should_use_native_wayland; then
+    prepend_native_wayland_defaults "${ELECTRON_ARGS[@]}" "${ORIGINAL_ARGS[@]}"
+fi
 
 if [ -f "$HOOK_ROOT/codex-packaged-runtime.sh" ]; then
     # shellcheck disable=SC1091

--- a/launcher/start.test.js
+++ b/launcher/start.test.js
@@ -3,6 +3,7 @@
 const assert = require("node:assert/strict");
 const childProcess = require("node:child_process");
 const fs = require("node:fs");
+const net = require("node:net");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
@@ -159,6 +160,103 @@ exit 22
   assert.equal(failing.stderr, "");
 });
 
+function launcherEnvironment(root, overrides = {}) {
+  const env = {
+    ...process.env,
+    CODEX_HOME: path.join(root, "codex-home"),
+    XDG_CONFIG_HOME: path.join(root, "config"),
+    TEST_ROOT: root,
+  };
+  for (const key of ["DISPLAY", "NIXOS_OZONE_WL", "WAYLAND_DISPLAY", "XDG_RUNTIME_DIR", "XDG_SESSION_TYPE"]) {
+    delete env[key];
+  }
+  return { ...env, ...overrides };
+}
+
+function launch(root, args = [], env = {}) {
+  return childProcess.spawnSync(path.join(root, "start.sh"), args, {
+    env: launcherEnvironment(root, env),
+    encoding: "utf8",
+  });
+}
+
+function capturedArguments(root) {
+  const output = fs.readFileSync(path.join(root, "arguments"), "utf8").trimEnd();
+  return output === "" ? [] : output.split("\n");
+}
+
+function listenUnixSocket(socketPath) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(socketPath, () => resolve(server));
+  });
+}
+
+function closeUnixSocket(server) {
+  return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+function createStaleUnixSocket(socketPath) {
+  const child = childProcess.spawn(
+    process.execPath,
+    ["-e", "require('node:net').createServer().listen(process.argv[1], () => process.stdout.write('ready'))", socketPath],
+    { stdio: ["ignore", "pipe", "inherit"] },
+  );
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => reject(new Error(`socket helper exited before ready: ${code}/${signal}`)));
+    child.stdout.once("data", (output) => {
+      if (output.toString() !== "ready") {
+        reject(new Error(`socket helper failed to start: ${output}`));
+        return;
+      }
+      child.removeAllListeners("exit");
+      child.once("exit", () => resolve());
+      child.kill("SIGKILL");
+    });
+  });
+}
+
+function createBoundUnixSocket(socketPath, socketType) {
+  const source = [
+    "import signal, socket, sys",
+    "sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM if sys.argv[1] == 'stream' else socket.SOCK_DGRAM)",
+    "sock.bind(sys.argv[2])",
+    "print('ready', flush=True)",
+    "signal.pause()",
+  ].join("\n");
+  const child = childProcess.spawn("python3", ["-c", source, socketType, socketPath], {
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => reject(new Error(`socket helper exited before ready: ${code}/${signal}`)));
+    child.stdout.once("data", (output) => {
+      if (output.toString() !== "ready\n") {
+        reject(new Error(`socket helper failed to start: ${output}`));
+        return;
+      }
+      child.removeAllListeners("exit");
+      resolve(child);
+    });
+  });
+}
+
+function stopSocketHelper(child) {
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", () => resolve());
+    child.kill("SIGTERM");
+  });
+}
+
+const nativeWaylandDefaults = [
+  "--ozone-platform=wayland",
+  "--enable-wayland-ime=true",
+  "--wayland-text-input-version=3",
+];
+
 test("launcher composes declarative hooks and forwards arguments", (t) => {
   const root = createApp(t);
   const hooks = path.join(root, ".codex-linux");
@@ -170,18 +268,10 @@ test("launcher composes declarative hooks and forwards arguments", (t) => {
   writeExecutable(path.join(hooks, "launcher.d", "fixture.sh"), "#!/bin/bash\nprintf '%s\\n' 'env LAUNCHER_ENV=from-launcher' 'electron-arg --launcher-arg=value'\n");
   writeExecutable(path.join(hooks, "after-exit.d", "fixture.sh"), "#!/bin/bash\nprintf after-exit > \"$TEST_ROOT/after-exit\"\n");
 
-  const env = {
-    ...process.env,
-    CODEX_HOME: path.join(root, "codex-home"),
-    XDG_CONFIG_HOME: path.join(root, "config"),
-    TEST_ROOT: root,
-  };
+  const env = launcherEnvironment(root);
   delete env.CHROME_DESKTOP;
   delete env.BAMF_DESKTOP_FILE_HINT;
-  const result = childProcess.spawnSync(path.join(root, "start.sh"), ["codex://thread/123", "--new-window"], {
-    env,
-    encoding: "utf8",
-  });
+  const result = childProcess.spawnSync(path.join(root, "start.sh"), ["codex://thread/123", "--new-window"], { env, encoding: "utf8" });
   assert.equal(result.status, 7);
   assert.deepEqual(fs.readFileSync(path.join(root, "environment"), "utf8").trim().split("\n"), [
     "codex-desktop.desktop",
@@ -221,12 +311,7 @@ test("launcher loads global and app-specific Electron flags", (t) => {
     path.join(root, "start.sh"),
     ["--ozone-platform=x11", "codex://thread/123"],
     {
-      env: {
-        ...process.env,
-        CODEX_HOME: path.join(root, "codex-home"),
-        XDG_CONFIG_HOME: configHome,
-        TEST_ROOT: root,
-      },
+      env: launcherEnvironment(root, { XDG_CONFIG_HOME: configHome }),
       encoding: "utf8",
     },
   );
@@ -261,12 +346,7 @@ test("launcher uses the HOME config fallback and ignores non-file flag paths", (
     path.join(configHome, "codex-desktop", "electron-flags.conf"),
     "--ozone-platform=wayland\n",
   );
-  const env = {
-    ...process.env,
-    CODEX_HOME: path.join(root, "codex-home"),
-    HOME: home,
-    TEST_ROOT: root,
-  };
+  const env = launcherEnvironment(root, { HOME: home });
   delete env.XDG_CONFIG_HOME;
 
   const result = childProcess.spawnSync(path.join(root, "start.sh"), [], {
@@ -282,10 +362,210 @@ test("launcher uses the HOME config fallback and ignores non-file flag paths", (
   );
 });
 
+test("launcher selects native Wayland from a live relative display socket", async (t) => {
+  const root = createApp(t);
+  const runtimeDir = path.join(root, "runtime");
+  const socketName = "wayland-test";
+  fs.mkdirSync(runtimeDir);
+  const server = await listenUnixSocket(path.join(runtimeDir, socketName));
+  try {
+    fs.mkdirSync(path.join(root, "config"), { recursive: true });
+    fs.writeFileSync(path.join(root, "config", "electron-flags.conf"), "--unrelated-config\n");
+    fs.mkdirSync(path.join(root, ".codex-linux", "electron-args.d"), { recursive: true });
+    fs.writeFileSync(path.join(root, ".codex-linux", "electron-args.d", "fixture.args"), "--unrelated-feature\n");
+    writeExecutable(
+      path.join(root, ".codex-linux", "launcher.d", "fixture.sh"),
+      "#!/bin/bash\nprintf '%s\\n' 'electron-arg --unrelated-launcher'\n",
+    );
+
+    const result = launch(root, ["codex://thread/123", "--new-window"], {
+      DISPLAY: ":0",
+      XDG_RUNTIME_DIR: runtimeDir,
+      XDG_SESSION_TYPE: "wayland",
+      WAYLAND_DISPLAY: socketName,
+    });
+
+    assert.equal(result.status, 7);
+    assert.deepEqual(capturedArguments(root), [
+      ...nativeWaylandDefaults,
+      "--class=codex-desktop",
+      "--unrelated-config",
+      "--unrelated-feature",
+      "--unrelated-launcher",
+      "codex://thread/123",
+      "--new-window",
+    ]);
+  } finally {
+    await closeUnixSocket(server);
+  }
+});
+
+test("launcher accepts a live absolute Wayland display socket", async (t) => {
+  const root = createApp(t);
+  const socketDir = path.join(root, "sockets");
+  const socketPath = path.join(socketDir, "absolute-wayland.sock");
+  fs.mkdirSync(socketDir);
+  const server = await listenUnixSocket(socketPath);
+  try {
+    const aliases = [
+      ["absolute", socketPath],
+      ["symlink", path.join(root, "socket-link", "absolute-wayland.sock")],
+      ["dot-dot", `${socketDir}/../sockets/absolute-wayland.sock`],
+    ];
+    fs.symlinkSync(socketDir, path.join(root, "socket-link"));
+
+    for (const [name, displayPath] of aliases) {
+      const result = launch(root, ["--absolute-socket"], {
+        XDG_SESSION_TYPE: "wayland",
+        WAYLAND_DISPLAY: displayPath,
+      });
+      assert.equal(result.status, 7, name);
+      assert.deepEqual(capturedArguments(root), [...nativeWaylandDefaults, "--class=codex-desktop", "--absolute-socket"], name);
+    }
+
+    const trailingSpaceSocket = path.join(socketDir, "trailing-space ");
+    const trailingSpaceServer = await listenUnixSocket(trailingSpaceSocket);
+    try {
+      const result = launch(root, ["--trailing-space-socket"], {
+        XDG_SESSION_TYPE: "wayland",
+        WAYLAND_DISPLAY: trailingSpaceSocket,
+      });
+      assert.equal(result.status, 7);
+      assert.deepEqual(capturedArguments(root), [...nativeWaylandDefaults, "--class=codex-desktop", "--trailing-space-socket"]);
+    } finally {
+      await closeUnixSocket(trailingSpaceServer);
+    }
+  } finally {
+    await closeUnixSocket(server);
+  }
+});
+
+test("launcher requires a live Wayland session socket for automatic defaults", async (t) => {
+  const root = createApp(t);
+  const runtimeDir = path.join(root, "runtime");
+  const socketName = "wayland-test";
+  const socketPath = path.join(runtimeDir, socketName);
+  fs.mkdirSync(runtimeDir);
+  const server = await listenUnixSocket(socketPath);
+  const staleSocket = path.join(runtimeDir, "stale-wayland");
+  await createStaleUnixSocket(staleSocket);
+  assert.equal(fs.lstatSync(staleSocket).isSocket(), true);
+  let boundStream;
+  let datagramSocket;
+  try {
+    boundStream = await createBoundUnixSocket(path.join(runtimeDir, "bound-stream"), "stream");
+    datagramSocket = await createBoundUnixSocket(path.join(runtimeDir, "datagram"), "datagram");
+    const cases = [
+      ["non-Wayland session", { XDG_RUNTIME_DIR: runtimeDir, XDG_SESSION_TYPE: "x11", WAYLAND_DISPLAY: socketName }],
+      ["missing runtime directory", { XDG_SESSION_TYPE: "wayland", WAYLAND_DISPLAY: socketName }],
+      ["stale display socket", { XDG_RUNTIME_DIR: runtimeDir, XDG_SESSION_TYPE: "wayland", WAYLAND_DISPLAY: "stale-wayland" }],
+      ["missing display socket", { XDG_RUNTIME_DIR: runtimeDir, XDG_SESSION_TYPE: "wayland", WAYLAND_DISPLAY: "missing-wayland" }],
+      ["bound non-listening stream socket", { XDG_RUNTIME_DIR: runtimeDir, XDG_SESSION_TYPE: "wayland", WAYLAND_DISPLAY: "bound-stream" }],
+      ["datagram socket", { XDG_RUNTIME_DIR: runtimeDir, XDG_SESSION_TYPE: "wayland", WAYLAND_DISPLAY: "datagram" }],
+    ];
+    const nonSocket = path.join(runtimeDir, "not-a-socket");
+    fs.writeFileSync(nonSocket, "fixture");
+    cases.push([
+      "non-socket display path",
+      { XDG_RUNTIME_DIR: runtimeDir, XDG_SESSION_TYPE: "wayland", WAYLAND_DISPLAY: "not-a-socket" },
+    ]);
+
+    for (const [name, environment] of cases) {
+      const result = launch(root, ["--probe"], environment);
+      assert.equal(result.status, 7, name);
+      assert.deepEqual(capturedArguments(root), ["--class=codex-desktop", "--probe"], name);
+    }
+  } finally {
+    if (datagramSocket) await stopSocketHelper(datagramSocket);
+    if (boundStream) await stopSocketHelper(boundStream);
+    await closeUnixSocket(server);
+  }
+});
+
+test("explicit --ozone-platform selections from every source suppress automatic Wayland defaults", async (t) => {
+  const scenarios = [
+    {
+      name: "global Electron flags exact ozone platform",
+      setup: (root) => {
+        fs.mkdirSync(path.join(root, "config"), { recursive: true });
+        fs.writeFileSync(path.join(root, "config", "electron-flags.conf"), "--ozone-platform\n");
+      },
+      expected: ["--class=codex-desktop", "--ozone-platform", "--probe"],
+    },
+    {
+      name: "direct assigned ozone platform",
+      setup: () => {},
+      args: ["--ozone-platform=x11", "--probe"],
+      expected: ["--class=codex-desktop", "--ozone-platform=x11", "--probe"],
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const root = createApp(t);
+    const runtimeDir = path.join(root, "runtime");
+    const socketName = "wayland-test";
+    fs.mkdirSync(runtimeDir);
+    const server = await listenUnixSocket(path.join(runtimeDir, socketName));
+    try {
+      scenario.setup(root);
+      const result = launch(root, scenario.args ?? ["--probe"], {
+        XDG_RUNTIME_DIR: runtimeDir,
+        XDG_SESSION_TYPE: "wayland",
+        WAYLAND_DISPLAY: socketName,
+      });
+      assert.equal(result.status, 7, scenario.name);
+      assert.deepEqual(capturedArguments(root), scenario.expected, scenario.name);
+    } finally {
+      await closeUnixSocket(server);
+    }
+  }
+});
+
+test("explicit Wayland IME configuration keeps precedence over automatic defaults", async (t) => {
+  const root = createApp(t);
+  const runtimeDir = path.join(root, "runtime");
+  const socketName = "wayland-test";
+  fs.mkdirSync(runtimeDir);
+  const server = await listenUnixSocket(path.join(runtimeDir, socketName));
+  try {
+    const result = launch(root, ["--disable-wayland-ime", "--probe"], {
+      XDG_RUNTIME_DIR: runtimeDir,
+      XDG_SESSION_TYPE: "wayland",
+      WAYLAND_DISPLAY: socketName,
+    });
+    assert.equal(result.status, 7);
+    assert.deepEqual(capturedArguments(root), [
+      "--ozone-platform=wayland",
+      "--class=codex-desktop",
+      "--disable-wayland-ime",
+      "--probe",
+    ]);
+  } finally {
+    await closeUnixSocket(server);
+  }
+});
+
+test("NIXOS_OZONE_WL preserves its explicit compatibility opt-in", (t) => {
+  const root = createApp(t);
+  const result = launch(root, ["--probe"], {
+    NIXOS_OZONE_WL: "1",
+    WAYLAND_DISPLAY: "wayland-without-session-metadata",
+  });
+  assert.equal(result.status, 7);
+  assert.deepEqual(capturedArguments(root), [...nativeWaylandDefaults, "--class=codex-desktop", "--probe"]);
+
+  const optOut = launch(root, ["--ozone-platform=x11", "--probe"], {
+    NIXOS_OZONE_WL: "1",
+    WAYLAND_DISPLAY: "wayland-without-session-metadata",
+  });
+  assert.equal(optOut.status, 7);
+  assert.deepEqual(capturedArguments(root), ["--class=codex-desktop", "--ozone-platform=x11", "--probe"]);
+});
+
 test("diagnose validates the official runtime without starting it", (t) => {
   const root = createApp(t);
   const result = childProcess.spawnSync(path.join(root, "start.sh"), ["--diagnose"], {
-    env: { ...process.env, XDG_CONFIG_HOME: path.join(root, "config"), TEST_ROOT: root }, encoding: "utf8",
+    env: launcherEnvironment(root), encoding: "utf8",
   });
   assert.equal(result.status, 0);
   assert.match(result.stdout, /ok: .*\/ChatGPT/);
@@ -373,12 +653,7 @@ test("launcher replaces only matching retired Browser and Chrome plugin caches",
   fs.chmodSync(pluginAppserver, 0o775);
 
   const result = childProcess.spawnSync(path.join(root, "start.sh"), [], {
-    env: {
-      ...process.env,
-      CODEX_HOME: codexHome,
-      XDG_CONFIG_HOME: path.join(root, "config"),
-      TEST_ROOT: root,
-    },
+    env: launcherEnvironment(root, { CODEX_HOME: codexHome }),
     encoding: "utf8",
   });
   assert.equal(result.status, 7);


### PR DESCRIPTION
## Summary

The shared launcher now selects native Wayland automatically when
`XDG_SESSION_TYPE=wayland` and `WAYLAND_DISPLAY` resolves to a live listening
Unix socket. `DISPLAY` does not disable detection because normal Wayland
sessions commonly export it for XWayland compatibility.

Explicit backend selections from global or app-specific Electron flags,
features, launcher hooks, and command-line arguments always suppress automatic
defaults. Users can opt out for one launch with:

```bash
codex-desktop --ozone-platform=x11
```

The existing `NIXOS_OZONE_WL` compatibility opt-in remains supported. Backend
selection now lives in the shared launcher instead of the Nix wrapper, so the
same behavior applies to Nix, deb, RPM, pacman, and AppImage packages.

This fixes incorrectly tiny XWayland cursors on HiDPI GNOME sessions while
keeping an explicit X11 escape hatch.

## Validation

- `bash -n launcher/start.sh.template`
- `node --test launcher/start.test.js` — 10 passed
- Verified detection against the live GNOME Wayland socket with
  `NIXOS_OZONE_WL` unset
- Built and launched the Nix package; the app selected
  `--ozone-platform=wayland` and the cursor rendered at the expected size

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest signed stable OpenAI Linux package and removes obsolete fallback code and tests.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.

## Before / after

### XWayland — before

<img width="1092" height="268" alt="Tiny cursor under XWayland" src="https://github.com/user-attachments/assets/6f5d1ae1-4b52-40fa-9080-dd5880b916c1" />

### Native Wayland — after

<img width="1216" height="366" alt="Correctly scaled cursor under native Wayland" src="https://github.com/user-attachments/assets/c2fcfcce-5dee-4cc2-9de5-edb63e2ee132" />

The screenshot tool renders both cursors larger than they appeared on screen;
the relative size difference is what matters.

Tested end-to-end on GNOME Wayland with `XDG_SESSION_TYPE=wayland`,
`WAYLAND_DISPLAY=wayland-0`, and `NIXOS_OZONE_WL` unset. Native Wayland works
correctly. Explicit backend overrides were also verified from global and
app-specific Electron flags, feature arguments, launcher hooks, and direct CLI
arguments; `codex-desktop --ozone-platform=x11` remains a working opt-out.