### PR TITLE
Preserve Record Replay and Skysight lifecycle ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
           components: clippy
       - run: cargo test -p codex-update-manager
       - run: cargo clippy -p codex-update-manager -- -D warnings
+      - run: cargo test -p codex-record-replay-linux
+      - run: cargo clippy -p codex-record-replay-linux --all-targets -- -D warnings
 
   nix-build:
     strategy:
@@ -71,6 +73,8 @@ jobs:
         run: nix build ".#checks.${{ matrix.system }}.modules" --no-link
       - name: Build audited default runtime
         run: nix build ".#checks.${{ matrix.system }}.nix-runtime" --no-link
+      - name: Build audited Chronicle-only runtime
+        run: nix build ".#checks.${{ matrix.system }}.nix-runtime-chronicle-skysight" --no-link
       - name: Build audited directory-watch feature profile
         run: nix build ".#checks.${{ matrix.system }}.nix-runtime-maximal-directory-watch" --no-link
       - name: Build audited shallow-watch feature profile

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ build-native-feature-helpers:
 	if has computer-use-linux; then cargo build $(CARGO_JOBS_ARG) --release -p codex-computer-use-linux --bin codex-computer-use-linux --bin codex-computer-use-cosmic; fi; \
 	if has global-dictation; then cargo build $(CARGO_JOBS_ARG) --release --manifest-path global-dictation-linux/Cargo.toml --target-dir global-dictation-linux/target; fi; \
 	if has read-aloud-mcp; then cargo build $(CARGO_JOBS_ARG) --release -p codex-read-aloud-linux; fi; \
-	if has record-and-replay; then cargo build $(CARGO_JOBS_ARG) --release -p codex-record-replay-linux; fi; \
+	if has chronicle-skysight || has record-and-replay; then cargo build $(CARGO_JOBS_ARG) --release -p codex-record-replay-linux; fi; \
 	if has mcp-helper-reaper; then cargo build $(CARGO_JOBS_ARG) --release --manifest-path linux-features/mcp-helper-reaper/reaper/Cargo.toml; fi
 
 update: rebuild-install

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ requirements, known limitations, configuration, and tests.
 | `appshots` | Capture and crop the focused Linux window from the composer | [Docs](linux-features/appshots/README.md) |
 | `authenticated-proxy` | Username/password support for HTTP proxies | [Docs](linux-features/authenticated-proxy/README.md) |
 | `automation-extensions` | Multi-time schedules and eager `automation_update` exposure | [Docs](linux-features/automation-extensions/README.md) |
+| `chronicle-skysight` | Opt-in Linux desktop activity memory and restricted Skysight MCP tools | [Docs](linux-features/chronicle-skysight/README.md) |
 | `codex-micro` | Work Louder Codex Micro hotplug and hidraw policy using upstream `node-hid` | [Docs](linux-features/codex-micro/README.md) |
 | `computer-use-linux` | Linux desktop-control UI and native MCP backend | [Docs](linux-features/computer-use-linux/README.md) |
 | `copilot-reasoning-effort` | Persistent reasoning-effort defaults for Copilot-auth sessions | [Docs](linux-features/copilot-reasoning-effort/README.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -187,6 +187,7 @@ Nix 用户应从 profile、Home Manager 配置或 NixOS module 中删除该包�
 | `appshots` | 从 composer 捕获并裁剪当前 Linux 窗口 | [文档](linux-features/appshots/README.md) |
 | `authenticated-proxy` | 带用户名和密码的 HTTP proxy | [文档](linux-features/authenticated-proxy/README.md) |
 | `automation-extensions` | 多时间调度和 eager `automation_update` | [文档](linux-features/automation-extensions/README.md) |
+| `chronicle-skysight` | 可选的 Linux 桌面活动记忆与受限 Skysight MCP 工具 | [文档](linux-features/chronicle-skysight/README.md) |
 | `codex-micro` | 使用上游 `node-hid` 的 Codex Micro hotplug/hidraw policy | [文档](linux-features/codex-micro/README.md) |
 | `computer-use-linux` | Linux desktop-control UI 与原生 MCP backend | [文档](linux-features/computer-use-linux/README.md) |
 | `copilot-reasoning-effort` | Copilot auth 的 reasoning-effort 默认值 | [文档](linux-features/copilot-reasoning-effort/README.md) |

--- a/docs/linux-chronicle-skysight.md
+++ b/docs/linux-chronicle-skysight.md
@@ -1,16 +1,40 @@
 # Linux Chronicle / Skysight
 
-Chronicle/Skysight is the screen and event-memory companion to Record & Replay
-on Linux. It is part of the demo-to-skill capture path, not a microphone
-transcription system.
+Chronicle/Skysight is the independent screen and event-memory feature on Linux.
+It can run without Record & Replay and is not a microphone transcription
+system.
 
 ## Relationship To Record & Replay
 
 - Record & Replay owns the user-facing demo-to-skill flow.
 - Chronicle/Skysight keeps the recent activity memory that helps draft the
   resulting skill.
+- Enabling Record & Replay also enables its required `chronicle-skysight`
+  feature. Chronicle/Skysight may be enabled by itself.
+- Standalone Chronicle/Skysight registers a restricted `skysight` MCP server
+  with activity-memory tools only. Recording and skill-composition tools remain
+  exclusive to Record & Replay's `event-stream` MCP server.
 - `speech_context` remains the transcript channel when spoken text is
   available; it is separate from Chronicle-compatible resources.
+
+### Capture Lifecycle
+
+Having either feature installed, enabling Chronicle, or polling
+Chronicle permissions/status does not start continuous desktop capture. The
+event-stream recording path uses bounded session evidence by default and does
+not start the Skysight daemon.
+
+Continuous capture starts only through an explicit Skysight start or Chronicle
+tray action. Each start records a `source` and `owner` in `status.json`; direct
+starts default to `source: cli` and `owner: manual-continuous`. A recording may
+use an owner such as `recording-session:<id>`. Finalizing, canceling, or
+expiring that recording, and clean shutdown of its event-stream MCP server,
+requests stop only when the persisted owner exactly matches that session.
+Manual continuous capture is not stopped by an unrelated recording boundary.
+
+The stop request is a bounded daemon lifecycle signal; the daemon exits on its
+normal loop boundary and records the initiating stop source. Status and
+permission probes remain read-only with respect to daemon startup and capture.
 
 ## Runtime Locations
 
@@ -113,7 +137,7 @@ may also require the system package that provides `libGL.so.1`.
 
 ## Verification After Rebuild
 
-1. Run `node --test linux-features/record-and-replay/test.js`.
+1. Run `node --test linux-features/chronicle-skysight/test.js linux-features/record-and-replay/test.js`.
 2. Rebuild and reinstall the feature bundle.
 3. Confirm the bridge exposes `linux-record-replay-skysight-pause` and
    `linux-record-replay-skysight-resume`.
@@ -123,3 +147,8 @@ may also require the system package that provides `libGL.so.1`.
 6. Capture `skysight snapshot` and confirm the segment has `events.jsonl`,
    `metadata.json`, `artifacts/diagnostics.json`, a `*-10min-*.md` resource,
    and either a newly-created or previously-current `*-6h-*.md` rollup.
+
+This lifecycle fix does not add a new empty-exclusion confirmation dialog or a
+hard kill path for an MCP process terminated without a clean transport
+shutdown. Existing exclusion matching, suppression, pruning, and retention
+behavior remains the privacy boundary for captured artifacts.

--- a/docs/record-and-replay-linux.md
+++ b/docs/record-and-replay-linux.md
@@ -11,7 +11,8 @@ skills.
 ## Phase 1 Support Definition
 
 Phase 1 supports the first Linux-native Record & Replay path behind the
-disabled-by-default `record-and-replay` Linux feature.
+disabled-by-default `record-and-replay` Linux feature. That feature requires
+`chronicle-skysight`; feature selectors enable the dependency automatically.
 
 Supported in Phase 1 means Linux can surface the opt-in `Record & Replay`
 plugin shell, start a local recording session through its `event-stream` MCP
@@ -57,11 +58,21 @@ current macOS bundle supplies that server through
 
 ## Chronicle / Skysight Parity
 
-Chronicle/Skysight is the screen and event-memory sidecar for Record & Replay
-on Linux. It is not microphone transcription. The Linux bridge now exposes
+Chronicle/Skysight is the independently selectable screen and event-memory
+feature used by Record & Replay on Linux. It is not microphone transcription.
+Its standalone `skysight` MCP server exposes only activity-memory tools, while
+Record & Replay's full `event-stream` server adds recording and skill-composer
+tools. The Linux bridge now exposes
 pause and resume alongside the existing start, status, stop, snapshot, and
 exclusion methods so the app can keep the active capture session alive while
 the backend moves between recording states.
+
+Feature availability and Chronicle permission/status polling are passive: they
+do not start the continuous Skysight daemon. Record & Replay uses bounded
+session evidence by default. Explicit Skysight starts persist a source and
+owner, and stop/cancel/expiry plus clean event-stream MCP shutdown stop only a
+daemon whose owner matches `recording-session:<id>`; manual-continuous capture
+remains independently controllable.
 
 Chronicle-compatible resources are written under
 `${CODEX_HOME:-$HOME/.codex}/memories/extensions/chronicle/resources`, while the
@@ -99,7 +110,7 @@ provider; Tesseract remains the safe local fallback.
 
 After rebuilding the feature, Josh can verify the branch with:
 
-1. `node --test linux-features/record-and-replay/test.js`
+1. `node --test linux-features/chronicle-skysight/test.js linux-features/record-and-replay/test.js`
 2. A rebuild/install of the app or feature bundle.
 3. A live `skysight status` check that reports the resource root.
 4. `skysight pause`, `skysight resume`, and `skysight stop` through the

--- a/flake.nix
+++ b/flake.nix
@@ -127,15 +127,16 @@
           let
             computerUseEnabled = lib.elem "computer-use-linux" featureIds;
             readAloudEnabled = lib.elem "read-aloud-mcp" featureIds;
-            recordReplayEnabled = lib.elem "record-and-replay" featureIds;
+            recordReplayBackendEnabled =
+              lib.elem "chronicle-skysight" featureIds || lib.elem "record-and-replay" featureIds;
             cargoPackages =
               lib.optionals computerUseEnabled [ "codex-computer-use-linux" ]
               ++ lib.optionals readAloudEnabled [ "codex-read-aloud-linux" ]
-              ++ lib.optionals recordReplayEnabled [ "codex-record-replay-linux" ];
+              ++ lib.optionals recordReplayBackendEnabled [ "codex-record-replay-linux" ];
             expectedBinaries =
               lib.optionals computerUseEnabled [ "codex-computer-use-linux" "codex-computer-use-cosmic" ]
               ++ lib.optionals readAloudEnabled [ "codex-read-aloud-linux" ]
-              ++ lib.optionals recordReplayEnabled [ "codex-record-replay-linux" ];
+              ++ lib.optionals recordReplayBackendEnabled [ "codex-record-replay-linux" ];
           in
           if cargoPackages == [ ] then null else pkgs.rustPlatform.buildRustPackage {
             pname = "codex-desktop-feature-helpers";
@@ -285,6 +286,9 @@
             normalizedFeatureIds = nixLinuxFeatures.normalize (
               linuxFeatureIds ++ lib.optional enableComputerUseUi "computer-use-linux"
             );
+            recordReplayBackendEnabled =
+              lib.elem "chronicle-skysight" normalizedFeatureIds
+              || lib.elem "record-and-replay" normalizedFeatureIds;
             workspaceHelpers = mkWorkspaceHelpers normalizedFeatureIds;
             watchboundEnabled = lib.elem "directory-only-working-tree-watch" normalizedFeatureIds;
             codexMicroEnabled = lib.elem "codex-micro" normalizedFeatureIds;
@@ -339,7 +343,7 @@
               ${lib.optionalString (lib.elem "read-aloud-mcp" normalizedFeatureIds) ''
               export CODEX_LINUX_READ_ALOUD_MCP_SOURCE="${workspaceHelpers}/bin/codex-read-aloud-linux"
               ''}
-              ${lib.optionalString (lib.elem "record-and-replay" normalizedFeatureIds) ''
+              ${lib.optionalString recordReplayBackendEnabled ''
               export CODEX_RECORD_REPLAY_LINUX_SOURCE="${workspaceHelpers}/bin/codex-record-replay-linux"
               ''}
               ${lib.optionalString (lib.elem "global-dictation" normalizedFeatureIds) ''
@@ -421,6 +425,7 @@
         codexDesktop = lib.makeOverridable mkCodexDesktop { };
         remoteMobile = codexDesktop.override { linuxFeatureIds = [ "remote-mobile-control" ]; };
         computerUse = codexDesktop.override { linuxFeatureIds = [ "computer-use-linux" ]; };
+        chronicleSkysight = codexDesktop.override { linuxFeatureIds = [ "chronicle-skysight" ]; };
         maximalDirectoryFeatureIds = lib.filter (
           featureId: featureId != "shallow-repository-watches"
         ) nixLinuxFeatures.supportedFeatureIds;
@@ -878,6 +883,8 @@
         '';
         checks.modules = import ./nix/modules-test.nix { inherit pkgs self system; };
         checks.nix-runtime = mkRuntimeCheck "nix-runtime-check" codexDesktop true false;
+        checks.nix-runtime-chronicle-skysight =
+          mkRuntimeCheck "nix-runtime-chronicle-skysight" chronicleSkysight false false;
         checks.nix-runtime-maximal-directory-watch =
           mkRuntimeCheck "nix-runtime-maximal-directory-watch" maximalDirectory false true;
         checks.nix-runtime-maximal-shallow-watch =

--- a/linux-features/chronicle-skysight/README.md
+++ b/linux-features/chronicle-skysight/README.md
@@ -1,0 +1,18 @@
+# Chronicle / Skysight Activity Memory
+
+Opt-in Linux activity memory for recent desktop context. This feature is usable
+without Record & Replay and never starts continuous capture merely because it
+is installed or queried.
+
+Record & Replay requires this feature and adds the bounded demo-to-skill
+workflow on top. Enabling Record & Replay therefore enables Chronicle /
+Skysight automatically; disabling Chronicle / Skysight also disables Record &
+Replay through the feature dependency contract.
+
+The standalone bundled plugin runs `codex-record-replay-linux skysight mcp`
+and exposes only Skysight activity-memory tools. It does not register the
+Record & Replay composer plugin, recording HUD, bundle compiler, or skill
+import tools.
+
+See [Linux Chronicle / Skysight](../../docs/linux-chronicle-skysight.md) for the
+capture lifecycle, privacy boundaries, runtime paths, and OCR configuration.

--- a/linux-features/chronicle-skysight/cleanup.sh
+++ b/linux-features/chronicle-skysight/cleanup.sh
@@ -3,26 +3,24 @@ set -Eeuo pipefail
 
 : "${INSTALL_DIR:?INSTALL_DIR is required}"
 
-plugin_dir="$INSTALL_DIR/resources/plugins/openai-bundled/plugins/record-and-replay"
+native_binary="$INSTALL_DIR/resources/native/codex-record-replay-linux"
+plugin_dir="$INSTALL_DIR/resources/plugins/openai-bundled/plugins/chronicle-skysight"
 marketplace="$INSTALL_DIR/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
 
+rm -f "$native_binary"
 rm -rf "$plugin_dir"
 
 [ -f "$marketplace" ] || exit 0
-
 node - "$marketplace" <<'NODE'
 const fs = require("node:fs");
-
 const marketplacePath = process.argv[2];
-let marketplace = { plugins: [] };
+let marketplace;
 try {
   marketplace = JSON.parse(fs.readFileSync(marketplacePath, "utf8"));
 } catch (_error) {
   process.exit(0);
 }
-if (!Array.isArray(marketplace.plugins)) {
-  process.exit(0);
-}
-marketplace.plugins = marketplace.plugins.filter((plugin) => plugin?.name !== "record-and-replay");
+if (!Array.isArray(marketplace.plugins)) process.exit(0);
+marketplace.plugins = marketplace.plugins.filter((plugin) => plugin?.name !== "chronicle-skysight");
 fs.writeFileSync(marketplacePath, `${JSON.stringify(marketplace, null, 2)}\n`);
 NODE

--- a/linux-features/chronicle-skysight/feature.json
+++ b/linux-features/chronicle-skysight/feature.json
@@ -1,0 +1,11 @@
+{
+  "id": "chronicle-skysight",
+  "title": "Chronicle / Skysight Activity Memory",
+  "description": "Opt-in Linux activity memory with Chronicle controls and a standalone Skysight MCP server.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js",
+    "stageHook": "./stage.sh",
+    "cleanupHook": "./cleanup.sh"
+  }
+}

--- a/linux-features/chronicle-skysight/patch.js
+++ b/linux-features/chronicle-skysight/patch.js
@@ -1,0 +1,124 @@
+"use strict";
+
+const CHRONICLE_MODULE_EXPRESSIONS = Object.freeze({
+  childProcessVar: 'require("node:child_process")',
+  fsVar: 'require("node:fs")',
+  pathVar: 'require("node:path")',
+});
+
+function warn(message, patchName) {
+  console.warn(`WARN: ${message} - skipping ${patchName}`);
+}
+
+function countOccurrences(source, needle) {
+  return source.split(needle).length - 1;
+}
+
+function regexMatchCount(source, pattern) {
+  const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
+  return [...source.matchAll(new RegExp(pattern.source, flags))].length;
+}
+
+function chronicleSkysightBridgeSource() {
+  return [
+    `"chronicle-permissions":async()=>{let e=await codexLinuxChronicleSidecarControlStateAsync(),t=e.enabled===!0?"granted":"unknown";return{accessibility:t,screenRecording:t,chronicleSidecarPresent:e.enabled===!0,chronicleSidecarProcessState:e.state??"disabled",chronicleOcrAvailable:e.chronicleOcrAvailable===!0,chronicleOcrStatus:e.chronicleOcrStatus??"unknown",chronicleOcrBackend:e.chronicleOcrBackend??null,chronicleOcrLanguage:e.chronicleOcrLanguage??null}}`,
+    `"getChronicleSidecarControlState":async()=>codexLinuxChronicleSidecarControlStateAsync()`,
+    `"toggleChronicleSidecar":async()=>codexLinuxChronicleToggleSidecar()`,
+    `"linux-record-replay-skysight-start":async({intervalSeconds:e,summaryAgent:t,source:r,owner:a}={})=>{let n=["skysight","start"];e&&n.push("--interval-seconds",String(e));r&&n.push("--source",String(r));a&&n.push("--owner",String(a));t===!0&&n.push("--summary-agent","enabled");t===!1&&n.push("--summary-agent","disabled");return codexLinuxRecordReplayRun(n,15000)}`,
+    `"linux-record-replay-skysight-status":async()=>codexLinuxRecordReplayRun(["skysight","status"],5000)`,
+    `"linux-record-replay-skysight-pause":async()=>codexLinuxRecordReplayRun(["skysight","pause"],10000)`,
+    `"linux-record-replay-skysight-resume":async()=>codexLinuxRecordReplayRun(["skysight","resume"],10000)`,
+    `"linux-record-replay-skysight-stop":async()=>codexLinuxRecordReplayRun(["skysight","stop"],10000)`,
+    `"linux-record-replay-skysight-snapshot":async({source:e}={})=>{let t=["skysight","snapshot"];e&&t.push("--source",String(e));return codexLinuxRecordReplayRun(t,15000)}`,
+    `"linux-record-replay-skysight-list-exclusions":async()=>codexLinuxRecordReplayRun(["skysight","list-exclusions"],5000)`,
+    `"linux-record-replay-skysight-update-exclusion":async({kind:e,value:t,reason:n,remove:r}={})=>{let a=codexLinuxRecordReplayString(e),o=codexLinuxRecordReplayString(t);if(!a||!o)return{ok:!1,action:"skysight.update-exclusion",message:"kind and value are required"};let s=["skysight","update-exclusion","--kind",a,"--value",o];n&&s.push("--reason",String(n));r&&s.push("--remove");return codexLinuxRecordReplayRun(s,10000)}`,
+  ].join(",");
+}
+
+function recordReplayRuntimeHelperSource({ childProcessVar, fsVar, pathVar }) {
+  return `function codexLinuxRecordReplayString(e){return typeof e==="string"&&e.trim().length>0?e.trim():null}
+function codexLinuxRecordReplayBin(){let e=codexLinuxRecordReplayString(process.env.CODEX_RECORD_REPLAY_LINUX_BIN);if(e)return e;let t=[];try{process.resourcesPath&&t.push(${pathVar}.join(process.resourcesPath,"native","codex-record-replay-linux"))}catch{}try{t.push(${pathVar}.join(process.cwd(),"resources","native","codex-record-replay-linux"))}catch{}try{let e=process.env.PATH||"";for(let n of e.split(${pathVar}.delimiter))n&&t.push(${pathVar}.join(n,"codex-record-replay-linux"))}catch{}t.push("codex-record-replay-linux");for(let e of t){try{if(e==="codex-record-replay-linux"||${fsVar}.existsSync(e))return e}catch{}}return "codex-record-replay-linux"}
+function codexLinuxRecordReplayParse(e){let t=String(e||"").trim();if(!t)return null;try{return JSON.parse(t)}catch{return{raw:t}}}
+function codexLinuxRecordReplayRun(e,t){let n=codexLinuxRecordReplayBin();return new Promise(r=>{${childProcessVar}.execFile(n,e,{encoding:"utf8",timeout:t,maxBuffer:16777216},(t,a,o)=>{let s=codexLinuxRecordReplayParse(a);if(t)return r({ok:!1,command:n,args:e,message:t instanceof Error?t.message:String(t),code:t?.code??null,stdout:a||"",stderr:o||"",json:s});r({ok:!0,command:n,args:e,stdout:a||"",stderr:o||"",json:s})})})}
+${chronicleSkysightHelperSource({ childProcessVar })}`;
+}
+
+function chronicleSkysightHelperSource({ childProcessVar }) {
+  return `function codexLinuxRecordReplayRunSync(e,t){let n=codexLinuxRecordReplayBin();try{let r=${childProcessVar}.execFileSync(n,e,{encoding:"utf8",timeout:t,maxBuffer:16777216});return{ok:!0,command:n,args:e,stdout:r||"",stderr:"",json:codexLinuxRecordReplayParse(r)}}catch(r){let a=typeof r?.stdout==="string"?r.stdout:r?.stdout?String(r.stdout):"",o=typeof r?.stderr==="string"?r.stderr:r?.stderr?String(r.stderr):"";return{ok:!1,command:n,args:e,message:r instanceof Error?r.message:String(r),code:r?.status??r?.code??null,stdout:a,stderr:o,json:codexLinuxRecordReplayParse(a)}}}
+function codexLinuxChronicleControlStateFromSkysight(e){let t=e?.json&&typeof e.json==="object"?e.json:null;if(!e?.ok&&t==null)return{enabled:!1,running:!1,state:"disabled"};let n=String(t?.state||""),r=t?.is_running===!0||t?.isRunning===!0,a=t?.paused===!0||t?.is_paused===!0||t?.isPaused===!0||n==="paused",o=n==="running"&&r&&!a;return{enabled:!0,running:o,state:o?"running":"stopped",skysight:t,chronicleOcrAvailable:t?.ocr_available===!0||t?.ocrAvailable===!0,chronicleOcrStatus:t?.ocr_status??t?.ocrStatus??"unknown",chronicleOcrBackend:t?.ocr_backend??t?.ocrBackend??null,chronicleOcrLanguage:t?.ocr_language??t?.ocrLanguage??null}}
+function codexLinuxChronicleSidecarControlState(){return codexLinuxChronicleControlStateFromSkysight(codexLinuxRecordReplayRunSync(["skysight","status"],3000))}
+async function codexLinuxChronicleSidecarControlStateAsync(){return codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","status"],5000))}
+function codexLinuxChronicleSummaryAgentArgs(e){return e===!0?["--summary-agent","enabled"]:e===!1?["--summary-agent","disabled"]:[]}
+async function codexLinuxChronicleEnsureSidecarRunning(e,u,l){let t=await codexLinuxRecordReplayRun(["skysight","status"],5000),n=t?.json&&typeof t.json==="object"?t.json:null,r=String(n?.state||""),a=n?.is_running===!0||n?.isRunning===!0,o=n?.paused===!0||n?.is_paused===!0||n?.isPaused===!0||r==="paused",s=codexLinuxChronicleSummaryAgentArgs(e),i=e===!0&&(n?.summary_agent_enabled!==!0&&n?.summaryAgentEnabled!==!0),c=u||l||i;u&&s.push("--source",String(u));l&&s.push("--owner",String(l));if(r==="running"&&a&&!o)return c?codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","start",...s],15000)):codexLinuxChronicleControlStateFromSkysight(t);if(a&&o){c&&await codexLinuxRecordReplayRun(["skysight","start",...s],15000);return codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","resume"],10000))}return codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","start",...s],15000))}
+async function codexLinuxChronicleToggleSidecar(){let e=await codexLinuxRecordReplayRun(["skysight","status"],5000),t=e?.json&&typeof e.json==="object"?e.json:null,n=String(t?.state||""),r=t?.is_running===!0||t?.isRunning===!0,a=t?.paused===!0||t?.is_paused===!0||t?.isPaused===!0||n==="paused";if(n==="running"&&r&&!a)return codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","pause"],10000));if(r&&a)return codexLinuxChronicleEnsureSidecarRunning(!0,"chronicle-tray","manual-continuous");return codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","start","--source","chronicle-tray","--owner","manual-continuous","--summary-agent","enabled"],15000))}`;
+}
+
+function chronicleTrayControlPattern() {
+  return /getChronicleSidecarControlState:\(\)=>([A-Za-z_$][\w$]*)\(\)\.skysight\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\(`local`\)\?\.getChronicleSidecarControlState\(\)\?\?\2),toggleChronicleSidecar:async\(\)=>\{if\(\1\(\)\.skysight\)return \2;let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\([A-Za-z_$][\w$]*\));return \4==null\?\2:\4\.getChronicleSidecarControlState\(\)\.running\?\4\.pauseChronicleSidecar\(\):\4\.resumeChronicleSidecar\(\)\}/u;
+}
+
+function chronicleTrayPatchedPattern() {
+  return /getChronicleSidecarControlState:\(\)=>process\.platform===`linux`\?codexLinuxChronicleSidecarControlState\(\):([A-Za-z_$][\w$]*)\(\)\.skysight\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\(`local`\)\?\.getChronicleSidecarControlState\(\)\?\?\2),toggleChronicleSidecar:async\(\)=>\{if\(process\.platform===`linux`\)return codexLinuxChronicleToggleSidecar\(\);if\(\1\(\)\.skysight\)return \2;let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\([A-Za-z_$][\w$]*\));return \4==null\?\2:\4\.getChronicleSidecarControlState\(\)\.running\?\4\.pauseChronicleSidecar\(\):\4\.resumeChronicleSidecar\(\)\}/u;
+}
+
+function applyChronicleTrayPatch(currentSource) {
+  if (chronicleTrayPatchedPattern().test(currentSource)) return currentSource;
+  const pattern = chronicleTrayControlPattern();
+  if (!pattern.test(currentSource)) {
+    warn("Could not find Chronicle tray control callbacks", "Chronicle / Skysight tray bridge patch");
+    return currentSource;
+  }
+  return currentSource.replace(
+    pattern,
+    (_match, availabilityFunction, disabledStateVar, upstreamStateExpression, connectionVar, connectionExpression) =>
+      `getChronicleSidecarControlState:()=>process.platform===\`linux\`?codexLinuxChronicleSidecarControlState():${availabilityFunction}().skysight?${disabledStateVar}:${upstreamStateExpression},toggleChronicleSidecar:async()=>{if(process.platform===\`linux\`)return codexLinuxChronicleToggleSidecar();if(${availabilityFunction}().skysight)return ${disabledStateVar};let ${connectionVar}=${connectionExpression};return ${connectionVar}==null?${disabledStateVar}:${connectionVar}.getChronicleSidecarControlState().running?${connectionVar}.pauseChronicleSidecar():${connectionVar}.resumeChronicleSidecar()}`,
+  );
+}
+
+function hasCompleteChroniclePatch(source) {
+  const helper = recordReplayRuntimeHelperSource(CHRONICLE_MODULE_EXPRESSIONS);
+  const bridge = chronicleSkysightBridgeSource();
+  return countOccurrences(source, helper) === 1
+    && countOccurrences(source, bridge) === 1
+    && regexMatchCount(source, chronicleTrayPatchedPattern()) === 1;
+}
+
+function applyChronicleSkysightMainBridgePatch(currentSource) {
+  const patchName = "Chronicle / Skysight main bridge patch";
+  if (currentSource.includes("codexLinuxChronicleControlStateFromSkysight")) {
+    if (!hasCompleteChroniclePatch(currentSource)) {
+      warn("Found incomplete Chronicle / Skysight bridge patch", patchName);
+    }
+    return currentSource;
+  }
+  if (!chronicleTrayControlPattern().test(currentSource)) {
+    warn("Could not find Chronicle tray control callbacks", patchName);
+    return currentSource;
+  }
+  const handlerNeedle = `"get-global-state":async({key:`;
+  if (!currentSource.includes(handlerNeedle)) {
+    warn("Could not find global-state bridge insertion point", patchName);
+    return currentSource;
+  }
+  const helper = recordReplayRuntimeHelperSource(CHRONICLE_MODULE_EXPRESSIONS);
+  const bridge = chronicleSkysightBridgeSource();
+  const patched = `${helper}\n${currentSource.replace(handlerNeedle, `${bridge},${handlerNeedle}`)}`;
+  return applyChronicleTrayPatch(patched);
+}
+
+const descriptors = [
+  {
+    id: "linux-chronicle-skysight-main-bridge",
+    phase: "main-bundle",
+    order: 151,
+    apply: applyChronicleSkysightMainBridgePatch,
+  },
+];
+
+module.exports = {
+  applyChronicleSkysightMainBridgePatch,
+  chronicleSkysightBridgeSource,
+  chronicleSkysightHelperSource,
+  descriptors,
+  recordReplayRuntimeHelperSource,
+};

--- a/linux-features/chronicle-skysight/plugin-template/.codex-plugin/plugin.json
+++ b/linux-features/chronicle-skysight/plugin-template/.codex-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "name": "chronicle-skysight",
+  "version": "0.1.0-linux-alpha1",
+  "description": "Keep privacy-aware local activity memory with Chronicle and Skysight on Linux.",
+  "author": {
+    "name": "joshyorko"
+  },
+  "license": "MIT",
+  "keywords": [
+    "chronicle",
+    "skysight",
+    "activity-memory",
+    "linux"
+  ],
+  "mcpServers": "./.mcp.json",
+  "skills": "./skills",
+  "interface": {
+    "displayName": "Chronicle / Skysight",
+    "shortDescription": "Local activity memory for Linux",
+    "longDescription": "Chronicle / Skysight provides explicit, privacy-aware Linux activity snapshots and continuous memory controls. Installing or checking status never starts capture; continuous capture begins only after an explicit request.",
+    "developerName": "joshyorko",
+    "category": "Productivity",
+    "logo": "./assets/app-icon.svg",
+    "defaultPrompt": [
+      "Show the current Chronicle / Skysight status",
+      "Capture one Skysight activity snapshot",
+      "List my Chronicle / Skysight exclusions"
+    ],
+    "brandColor": "#1D4ED8",
+    "screenshots": []
+  }
+}

--- a/linux-features/chronicle-skysight/plugin-template/.mcp.json
+++ b/linux-features/chronicle-skysight/plugin-template/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "chronicle-skysight": {
+      "command": "./bin/codex-record-replay-linux",
+      "args": [
+        "skysight",
+        "mcp"
+      ],
+      "cwd": "."
+    }
+  }
+}

--- a/linux-features/chronicle-skysight/plugin-template/assets/app-icon.svg
+++ b/linux-features/chronicle-skysight/plugin-template/assets/app-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="16" fill="#1d4ed8"/>
+  <path d="M16 34c8-14 24-14 32 0-8 14-24 14-32 0Z" fill="none" stroke="#fff" stroke-width="4"/>
+  <circle cx="32" cy="34" r="6" fill="#fff"/>
+</svg>

--- a/linux-features/chronicle-skysight/plugin-template/skills/chronicle-skysight/SKILL.md
+++ b/linux-features/chronicle-skysight/plugin-template/skills/chronicle-skysight/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: chronicle-skysight
+description: Use when recent Linux desktop activity memory would help answer a question or when the user asks to inspect or control Chronicle or Skysight.
+---
+
+# Chronicle / Skysight
+
+Call `skysight_status` first. Status and doctor calls are passive and must not
+start capture. Call `skysight_snapshot` for one bounded activity snapshot.
+Start continuous capture with `skysight_start` only after the user explicitly
+requests it. Honor exclusions and use `skysight_pause`, `skysight_resume`, or
+`skysight_stop` as requested. Chronicle-compatible resources stay local under
+`${CODEX_HOME:-$HOME/.codex}/memories/extensions/chronicle/resources`.

--- a/linux-features/chronicle-skysight/shared-backend.sh
+++ b/linux-features/chronicle-skysight/shared-backend.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+find_cargo_for_chronicle_skysight() {
+    if command -v cargo >/dev/null 2>&1; then
+        command -v cargo
+        return 0
+    fi
+    if [ -x "$HOME/.cargo/bin/cargo" ]; then
+        echo "$HOME/.cargo/bin/cargo"
+        return 0
+    fi
+    return 1
+}
+
+build_chronicle_skysight_backend() {
+    local source_binary="$SCRIPT_DIR/target/release/codex-record-replay-linux"
+    local cargo_cmd=""
+
+    if [ -n "${CODEX_RECORD_REPLAY_LINUX_SOURCE:-}" ]; then
+        [ -x "$CODEX_RECORD_REPLAY_LINUX_SOURCE" ] || {
+            echo "Chronicle / Skysight backend source is not executable: $CODEX_RECORD_REPLAY_LINUX_SOURCE" >&2
+            return 1
+        }
+        printf '%s\n' "$CODEX_RECORD_REPLAY_LINUX_SOURCE"
+        return 0
+    fi
+
+    if ! cargo_cmd="$(find_cargo_for_chronicle_skysight)"; then
+        echo "cargo not found; Chronicle / Skysight backend cannot be built" >&2
+        echo "Install/use a Rust toolchain, or set CODEX_RECORD_REPLAY_LINUX_SOURCE to an executable codex-record-replay-linux binary." >&2
+        return 1
+    fi
+
+    echo "Building Chronicle / Skysight backend..." >&2
+    (cd "$SCRIPT_DIR" && "$cargo_cmd" build --release -p codex-record-replay-linux >&2)
+    [ -x "$source_binary" ] || {
+        echo "Chronicle / Skysight backend missing after build: $source_binary" >&2
+        return 1
+    }
+    printf '%s\n' "$source_binary"
+}

--- a/linux-features/chronicle-skysight/shared-backend.sh
+++ b/linux-features/chronicle-skysight/shared-backend.sh
@@ -25,6 +25,11 @@ build_chronicle_skysight_backend() {
         return 0
     fi
 
+    if [ -x "$source_binary" ]; then
+        printf '%s\n' "$source_binary"
+        return 0
+    fi
+
     if ! cargo_cmd="$(find_cargo_for_chronicle_skysight)"; then
         echo "cargo not found; Chronicle / Skysight backend cannot be built" >&2
         echo "Install/use a Rust toolchain, or set CODEX_RECORD_REPLAY_LINUX_SOURCE to an executable codex-record-replay-linux binary." >&2

--- a/linux-features/chronicle-skysight/stage.sh
+++ b/linux-features/chronicle-skysight/stage.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+: "${SCRIPT_DIR:?SCRIPT_DIR is required}"
+: "${INSTALL_DIR:?INSTALL_DIR is required}"
+
+source "$SCRIPT_DIR/linux-features/chronicle-skysight/shared-backend.sh"
+
+backend_binary="$(build_chronicle_skysight_backend)"
+native_binary="$INSTALL_DIR/resources/native/codex-record-replay-linux"
+plugin_template="$SCRIPT_DIR/linux-features/chronicle-skysight/plugin-template"
+plugin_dir="$INSTALL_DIR/resources/plugins/openai-bundled/plugins/chronicle-skysight"
+marketplace="$INSTALL_DIR/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
+
+mkdir -p "$(dirname "$native_binary")" "$(dirname "$plugin_dir")" "$(dirname "$marketplace")"
+cp "$backend_binary" "$native_binary"
+chmod 0755 "$native_binary"
+
+rm -rf "$plugin_dir"
+cp -R "$plugin_template" "$plugin_dir"
+mkdir -p "$plugin_dir/bin"
+cp "$native_binary" "$plugin_dir/bin/codex-record-replay-linux"
+chmod 0755 "$plugin_dir/bin/codex-record-replay-linux"
+
+node - "$marketplace" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+const marketplacePath = process.argv[2];
+let marketplace = { plugins: [] };
+try {
+  marketplace = JSON.parse(fs.readFileSync(marketplacePath, "utf8"));
+} catch (_error) {
+  marketplace = { plugins: [] };
+}
+if (!Array.isArray(marketplace.plugins)) marketplace.plugins = [];
+marketplace.plugins = marketplace.plugins.filter((plugin) => plugin?.name !== "chronicle-skysight");
+marketplace.plugins.push({
+  name: "chronicle-skysight",
+  source: { source: "local", path: "./plugins/chronicle-skysight" },
+  policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" },
+  category: "Productivity",
+});
+fs.mkdirSync(path.dirname(marketplacePath), { recursive: true });
+fs.writeFileSync(marketplacePath, `${JSON.stringify(marketplace, null, 2)}\n`);
+NODE
+
+echo "Chronicle / Skysight standalone plugin and shared backend staged" >&2

--- a/linux-features/chronicle-skysight/test.js
+++ b/linux-features/chronicle-skysight/test.js
@@ -95,6 +95,35 @@ test("chronicle-skysight stages restricted MCP plugin and shared backend", () =>
   }
 });
 
+test("chronicle-skysight reuses the updater-staged backend without Cargo", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-chronicle-skysight-backend-"));
+  try {
+    const backend = path.join(workspace, "target/release/codex-record-replay-linux");
+    fs.mkdirSync(path.dirname(backend), { recursive: true });
+    fs.writeFileSync(backend, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+    const selected = execFileSync(
+      "bash",
+      ["-c", ". \"$FEATURE_DIR/shared-backend.sh\"; build_chronicle_skysight_backend"],
+      {
+        cwd: workspace,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FEATURE_DIR: featureDir,
+          SCRIPT_DIR: workspace,
+          CODEX_RECORD_REPLAY_LINUX_SOURCE: "",
+          HOME: path.join(workspace, "home-without-cargo"),
+        },
+      },
+    ).trim();
+
+    assert.equal(selected, backend);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
 test("chronicle-skysight owns activity-memory bridge and tray integration", () => {
   const source = [
     'const cp=require("node:child_process"),fs=require("node:fs"),path=require("node:path");',

--- a/linux-features/chronicle-skysight/test.js
+++ b/linux-features/chronicle-skysight/test.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const { execFileSync } = require("node:child_process");
+
+const {
+  applyChronicleSkysightMainBridgePatch,
+  descriptors,
+} = require("./patch.js");
+
+const featureDir = __dirname;
+
+function repoRoot() {
+  return path.resolve(featureDir, "../..");
+}
+
+test("chronicle-skysight is an independent disabled-by-default feature", () => {
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(featureDir, "feature.json"), "utf8"),
+  );
+
+  assert.equal(manifest.id, "chronicle-skysight");
+  assert.equal(manifest.title, "Chronicle / Skysight Activity Memory");
+  assert.equal(manifest.defaultEnabled, false);
+  assert.deepEqual(manifest.requires ?? [], []);
+  assert.equal(fs.existsSync(path.join(featureDir, "README.md")), true);
+});
+
+test("chronicle-skysight owns standalone plugin and backend stage files", () => {
+  for (const relative of [
+    "stage.sh",
+    "cleanup.sh",
+    "plugin-template/.codex-plugin/plugin.json",
+    "plugin-template/.mcp.json",
+    "plugin-template/skills/chronicle-skysight/SKILL.md",
+  ]) {
+    assert.equal(fs.existsSync(path.join(featureDir, relative)), true, relative);
+  }
+});
+
+test("chronicle-skysight stages restricted MCP plugin and shared backend", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-chronicle-skysight-stage-"));
+  try {
+    const installDir = path.join(workspace, "install");
+    const fakeBinary = path.join(workspace, "codex-record-replay-linux");
+    const marketplace = path.join(
+      installDir,
+      "resources/plugins/openai-bundled/.agents/plugins/marketplace.json",
+    );
+    fs.mkdirSync(path.dirname(marketplace), { recursive: true });
+    fs.writeFileSync(marketplace, JSON.stringify({ plugins: [] }));
+    fs.writeFileSync(fakeBinary, "#!/bin/sh\nprintf '{\"ok\":true}\\n'\n");
+    fs.chmodSync(fakeBinary, 0o755);
+
+    execFileSync("bash", [path.join(featureDir, "stage.sh")], {
+      cwd: workspace,
+      env: {
+        ...process.env,
+        SCRIPT_DIR: repoRoot(),
+        INSTALL_DIR: installDir,
+        CODEX_RECORD_REPLAY_LINUX_SOURCE: fakeBinary,
+      },
+      stdio: "pipe",
+    });
+
+    const nativeBinary = path.join(installDir, "resources/native/codex-record-replay-linux");
+    const pluginDir = path.join(
+      installDir,
+      "resources/plugins/openai-bundled/plugins/chronicle-skysight",
+    );
+    const mcp = JSON.parse(fs.readFileSync(path.join(pluginDir, ".mcp.json"), "utf8"));
+    const plugins = JSON.parse(fs.readFileSync(marketplace, "utf8")).plugins;
+    assert.equal(fs.statSync(nativeBinary).mode & 0o111 ? true : false, true);
+    assert.equal(fs.existsSync(path.join(pluginDir, "bin/codex-record-replay-linux")), true);
+    assert.deepEqual(mcp.mcpServers["chronicle-skysight"], {
+      command: "./bin/codex-record-replay-linux",
+      args: ["skysight", "mcp"],
+      cwd: ".",
+    });
+    assert.equal(
+      plugins.some(
+        (plugin) => plugin.name === "chronicle-skysight"
+          && plugin.source?.path === "./plugins/chronicle-skysight",
+      ),
+      true,
+    );
+    assert.equal(plugins.some((plugin) => plugin.name === "record-and-replay"), false);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("chronicle-skysight owns activity-memory bridge and tray integration", () => {
+  const source = [
+    'const cp=require("node:child_process"),fs=require("node:fs"),path=require("node:path");',
+    "var tray={getChronicleSidecarControlState:()=>tt().skysight?$9:Se.appServerConnectionRegistry.getMaybeConnection(`local`)?.getChronicleSidecarControlState()??$9,toggleChronicleSidecar:async()=>{if(tt().skysight)return $9;let e=Se.appServerConnectionRegistry.getMaybeConnection(V);return e==null?$9:e.getChronicleSidecarControlState().running?e.pauseChronicleSidecar():e.resumeChronicleSidecar()}};",
+    'var bridge={"get-global-state":async({key:e})=>null};',
+  ].join("");
+
+  const patched = applyChronicleSkysightMainBridgePatch(source);
+
+  assert.equal(descriptors.length, 1);
+  assert.equal(descriptors[0].id, "linux-chronicle-skysight-main-bridge");
+  assert.notEqual(patched, source);
+  assert.equal(applyChronicleSkysightMainBridgePatch(patched), patched);
+  assert.match(patched, /"chronicle-permissions":async/);
+  assert.match(patched, /"linux-record-replay-skysight-start":async/);
+  assert.match(patched, /codexLinuxChronicleToggleSidecar/);
+  assert.doesNotMatch(patched, /"linux-record-replay-start":async/);
+  assert.doesNotMatch(patched, /"linux-record-replay-draft-skill":async/);
+});

--- a/linux-features/record-and-replay/feature.json
+++ b/linux-features/record-and-replay/feature.json
@@ -3,6 +3,9 @@
   "title": "Record & Replay",
   "description": "Opt-in Linux demo-to-skill recording workflow powered by codex-record-replay-linux.",
   "defaultEnabled": false,
+  "requires": [
+    "chronicle-skysight"
+  ],
   "entrypoints": {
     "patchDescriptors": "./patch.js",
     "stageHook": "./stage.sh",

--- a/linux-features/record-and-replay/patch.js
+++ b/linux-features/record-and-replay/patch.js
@@ -20,11 +20,6 @@ function countOccurrences(source, needle) {
   return source.split(needle).length - 1;
 }
 
-function regexMatchCount(source, pattern) {
-  const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
-  return [...source.matchAll(new RegExp(pattern.source, flags))].length;
-}
-
 function pluginNameExpressionRegex(pluginName) {
   const escaped = escapeRegExp(pluginName);
   return String.raw`(?:\`${escaped}\`|"${escaped}"|'${escaped}')`;
@@ -137,22 +132,11 @@ function applyRecordReplayPluginGatePatch(currentSource) {
   return `${currentSource.slice(0, insertionIndex)}${buildRecordReplayDescriptor()},${currentSource.slice(insertionIndex)}`;
 }
 
-function recordReplayBridgeSource({ childProcessVar, fsVar, pathVar }) {
+function recordReplayBridgeSource({ fsVar }) {
   return [
-    `"chronicle-permissions":async()=>{let e=await codexLinuxChronicleSidecarControlStateAsync(),t=e.enabled===!0?"granted":"unknown";return{accessibility:t,screenRecording:t,chronicleSidecarPresent:e.enabled===!0,chronicleSidecarProcessState:e.state??"disabled",chronicleOcrAvailable:e.chronicleOcrAvailable===!0,chronicleOcrStatus:e.chronicleOcrStatus??"unknown",chronicleOcrBackend:e.chronicleOcrBackend??null,chronicleOcrLanguage:e.chronicleOcrLanguage??null}}`,
-    `"getChronicleSidecarControlState":async()=>codexLinuxChronicleSidecarControlStateAsync()`,
-    `"toggleChronicleSidecar":async()=>codexLinuxChronicleToggleSidecar()`,
     `"linux-record-replay-doctor":async()=>codexLinuxRecordReplayRun([${JSON.stringify("doctor")}],15000)`,
     `"linux-record-replay-status":async()=>codexLinuxRecordReplayRun([${JSON.stringify("status")}],5000)`,
     `"linux-record-replay-start":async({sessionDir:e,appId:t,windowId:n,goal:r,includeScreenshot:a,includeAccessibility:o,includeAudio:s}={})=>{let i=codexLinuxRecordReplayString(e);if(!i)return{ok:!1,action:"record.start",message:"sessionDir is required"};let c=["record","start","--session-dir",i];t&&c.push("--app-id",String(t));n&&c.push("--window-id",String(n));r&&c.push("--goal",String(r));a===!1&&c.push("--no-screenshot");o===!1&&c.push("--no-accessibility");s===!0&&c.push("--audio");s===!1&&c.push("--no-audio");return codexLinuxRecordReplayRun(c,60000)}`,
-    `"linux-record-replay-skysight-start":async({intervalSeconds:e,summaryAgent:t}={})=>{let n=["skysight","start"];e&&n.push("--interval-seconds",String(e));t===!0&&n.push("--summary-agent","enabled");t===!1&&n.push("--summary-agent","disabled");return codexLinuxRecordReplayRun(n,15000)}`,
-    `"linux-record-replay-skysight-status":async()=>codexLinuxRecordReplayRun(["skysight","status"],5000)`,
-    `"linux-record-replay-skysight-pause":async()=>codexLinuxRecordReplayRun(["skysight","pause"],10000)`,
-    `"linux-record-replay-skysight-resume":async()=>codexLinuxRecordReplayRun(["skysight","resume"],10000)`,
-    `"linux-record-replay-skysight-stop":async()=>codexLinuxRecordReplayRun(["skysight","stop"],10000)`,
-    `"linux-record-replay-skysight-snapshot":async({source:e}={})=>{let t=["skysight","snapshot"];e&&t.push("--source",String(e));return codexLinuxRecordReplayRun(t,15000)}`,
-    `"linux-record-replay-skysight-list-exclusions":async()=>codexLinuxRecordReplayRun(["skysight","list-exclusions"],5000)`,
-    `"linux-record-replay-skysight-update-exclusion":async({kind:e,value:t,reason:n,remove:r}={})=>{let a=codexLinuxRecordReplayString(e),o=codexLinuxRecordReplayString(t);if(!a||!o)return{ok:!1,action:"skysight.update-exclusion",message:"kind and value are required"};let s=["skysight","update-exclusion","--kind",a,"--value",o];n&&s.push("--reason",String(n));r&&s.push("--remove");return codexLinuxRecordReplayRun(s,10000)}`,
     `"linux-record-replay-mark":async({sessionDir:e,note:t}={})=>{let n=codexLinuxRecordReplayString(e),r=codexLinuxRecordReplayString(t);if(!n||!r)return{ok:!1,action:"record.mark",message:"sessionDir and note are required"};return codexLinuxRecordReplayRun(["record","mark","--session-dir",n,"--note",r],15000)}`,
     `"linux-record-replay-speech-context":async({sessionDir:e,transcript:t,source:n}={})=>{let r=codexLinuxRecordReplayString(e),a=codexLinuxRecordReplayString(t);if(!r||!a)return{ok:!1,action:"record.speech",message:"sessionDir and transcript are required"};let o=["record","speech","--session-dir",r,"--text",a];n&&o.push("--source",String(n));return codexLinuxRecordReplayRun(o,15000)}`,
     recordReplayActiveSpeechContextBridgeHandler(),
@@ -173,31 +157,8 @@ function recordReplayActiveSpeechContextBridgeHandler() {
   return `"linux-record-replay-speech-context-active":async({transcript:e,source:t}={})=>{let n=codexLinuxRecordReplayString(e);if(!n)return{ok:!1,action:"record.speech-active",message:"transcript is required"};let r=await codexLinuxRecordReplayRun(["status"],5000),a=r?.json?.session_dir;if(!r?.ok||r?.json?.state!==\`active\`||!a)return{ok:!1,action:"record.speech-active",message:"No active Record & Replay session",status:r};let o=["record","speech","--session-dir",String(a),"--text",n];t&&o.push("--source",String(t));return codexLinuxRecordReplayRun(o,15000)}`;
 }
 
-function recordReplayHelperSource({ childProcessVar, fsVar, pathVar }) {
-  return `function codexLinuxRecordReplayString(e){return typeof e==="string"&&e.trim().length>0?e.trim():null}
-function codexLinuxRecordReplayBin(){let e=codexLinuxRecordReplayString(process.env.CODEX_RECORD_REPLAY_LINUX_BIN);if(e)return e;let t=[];try{process.resourcesPath&&t.push(${pathVar}.join(process.resourcesPath,"native","codex-record-replay-linux"))}catch{}try{t.push(${pathVar}.join(process.cwd(),"resources","native","codex-record-replay-linux"))}catch{}try{let e=process.env.PATH||"";for(let n of e.split(${pathVar}.delimiter))n&&t.push(${pathVar}.join(n,"codex-record-replay-linux"))}catch{}t.push("codex-record-replay-linux");for(let e of t){try{if(e==="codex-record-replay-linux"||${fsVar}.existsSync(e))return e}catch{}}return "codex-record-replay-linux"}
-function codexLinuxRecordReplayParse(e){let t=String(e||"").trim();if(!t)return null;try{return JSON.parse(t)}catch{return{raw:t}}}
-function codexLinuxRecordReplayWriteTempJson(e){let t=process.env.XDG_RUNTIME_DIR||process.env.TMPDIR||"/tmp",n=${pathVar}.join(t,"codex-record-replay-traces-"+(process.getuid?process.getuid():process.pid));${fsVar}.mkdirSync(n,{recursive:true,mode:448});try{if(${fsVar}.lstatSync(n).isSymbolicLink())throw Error("trace directory is a symlink");${fsVar}.chmodSync(n,448)}catch(r){throw r}let r=${pathVar}.join(n,"trace-"+Date.now()+"-"+process.pid+"-"+Math.random().toString(36).slice(2)+".json");${fsVar}.writeFileSync(r,String(e),{mode:384});return r}
-function codexLinuxRecordReplayRun(e,t){let n=codexLinuxRecordReplayBin();return new Promise(r=>{${childProcessVar}.execFile(n,e,{encoding:"utf8",timeout:t,maxBuffer:16777216},(t,a,o)=>{let s=codexLinuxRecordReplayParse(a);if(t)return r({ok:!1,command:n,args:e,message:t instanceof Error?t.message:String(t),code:t?.code??null,stdout:a||"",stderr:o||"",json:s});r({ok:!0,command:n,args:e,stdout:a||"",stderr:o||"",json:s})})})}
-${recordReplayChronicleHelperSource({ childProcessVar })}`;
-}
-
-function recordReplayChronicleHelperSource({ childProcessVar }) {
-  return `function codexLinuxRecordReplayRunSync(e,t){let n=codexLinuxRecordReplayBin();try{let r=${childProcessVar}.execFileSync(n,e,{encoding:"utf8",timeout:t,maxBuffer:16777216});return{ok:!0,command:n,args:e,stdout:r||"",stderr:"",json:codexLinuxRecordReplayParse(r)}}catch(r){let a=typeof r?.stdout==="string"?r.stdout:r?.stdout?String(r.stdout):"",o=typeof r?.stderr==="string"?r.stderr:r?.stderr?String(r.stderr):"";return{ok:!1,command:n,args:e,message:r instanceof Error?r.message:String(r),code:r?.status??r?.code??null,stdout:a,stderr:o,json:codexLinuxRecordReplayParse(a)}}}
-function codexLinuxChronicleControlStateFromSkysight(e){let t=e?.json&&typeof e.json==="object"?e.json:null;if(!e?.ok&&t==null)return{enabled:!1,running:!1,state:"disabled"};let n=String(t?.state||""),r=t?.is_running===!0||t?.isRunning===!0,a=t?.paused===!0||t?.is_paused===!0||t?.isPaused===!0||n==="paused",o=n==="running"&&r&&!a;return{enabled:!0,running:o,state:o?"running":"stopped",skysight:t,chronicleOcrAvailable:t?.ocr_available===!0||t?.ocrAvailable===!0,chronicleOcrStatus:t?.ocr_status??t?.ocrStatus??"unknown",chronicleOcrBackend:t?.ocr_backend??t?.ocrBackend??null,chronicleOcrLanguage:t?.ocr_language??t?.ocrLanguage??null}}
-function codexLinuxChronicleSidecarControlState(){return codexLinuxChronicleControlStateFromSkysight(codexLinuxRecordReplayRunSync(["skysight","status"],3000))}
-async function codexLinuxChronicleSidecarControlStateAsync(){return codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","status"],5000))}
-function codexLinuxChronicleSummaryAgentArgs(e){return e===!0?["--summary-agent","enabled"]:e===!1?["--summary-agent","disabled"]:[]}
-async function codexLinuxChronicleEnsureSidecarRunning(e){let t=await codexLinuxRecordReplayRun(["skysight","status"],5000),n=t?.json&&typeof t.json==="object"?t.json:null,r=String(n?.state||""),a=n?.is_running===!0||n?.isRunning===!0,o=n?.paused===!0||n?.is_paused===!0||n?.isPaused===!0||r==="paused",s=codexLinuxChronicleSummaryAgentArgs(e),i=e===!0&&(n?.summary_agent_enabled!==!0&&n?.summaryAgentEnabled!==!0);if(r==="running"&&a&&!o)return i?codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","start",...s],15000)):codexLinuxChronicleControlStateFromSkysight(t);if(a&&o){i&&await codexLinuxRecordReplayRun(["skysight","start",...s],15000);return codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","resume"],10000))}return codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","start",...s],15000))}
-async function codexLinuxChronicleToggleSidecar(){let e=await codexLinuxRecordReplayRun(["skysight","status"],5000),t=e?.json&&typeof e.json==="object"?e.json:null,n=String(t?.state||""),r=t?.is_running===!0||t?.isRunning===!0,a=t?.paused===!0||t?.is_paused===!0||t?.isPaused===!0||n==="paused";if(n==="running"&&r&&!a)return codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","pause"],10000));if(r&&a)return codexLinuxChronicleEnsureSidecarRunning(!0);return codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","start","--summary-agent","enabled"],15000))}`;
-}
-
-function recordReplayChronicleTrayControlPattern() {
-  return /getChronicleSidecarControlState:\(\)=>([A-Za-z_$][\w$]*)\(\)\.skysight\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\(`local`\)\?\.getChronicleSidecarControlState\(\)\?\?\2),toggleChronicleSidecar:async\(\)=>\{if\(\1\(\)\.skysight\)return \2;let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\([A-Za-z_$][\w$]*\));return \4==null\?\2:\4\.getChronicleSidecarControlState\(\)\.running\?\4\.pauseChronicleSidecar\(\):\4\.resumeChronicleSidecar\(\)\}/u;
-}
-
-function recordReplayChronicleTrayPatchedPattern() {
-  return /getChronicleSidecarControlState:\(\)=>process\.platform===`linux`\?codexLinuxChronicleSidecarControlState\(\):([A-Za-z_$][\w$]*)\(\)\.skysight\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\(`local`\)\?\.getChronicleSidecarControlState\(\)\?\?\2),toggleChronicleSidecar:async\(\)=>\{if\(process\.platform===`linux`\)return codexLinuxChronicleToggleSidecar\(\);if\(\1\(\)\.skysight\)return \2;let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\([A-Za-z_$][\w$]*\));return \4==null\?\2:\4\.getChronicleSidecarControlState\(\)\.running\?\4\.pauseChronicleSidecar\(\):\4\.resumeChronicleSidecar\(\)\}/u;
+function recordReplayHelperSource({ fsVar, pathVar }) {
+  return `function codexLinuxRecordReplayWriteTempJson(e){let t=process.env.XDG_RUNTIME_DIR||process.env.TMPDIR||"/tmp",n=${pathVar}.join(t,"codex-record-replay-traces-"+(process.getuid?process.getuid():process.pid));${fsVar}.mkdirSync(n,{recursive:true,mode:448});try{if(${fsVar}.lstatSync(n).isSymbolicLink())throw Error("trace directory is a symlink");${fsVar}.chmodSync(n,448)}catch(r){throw r}let r=${pathVar}.join(n,"trace-"+Date.now()+"-"+process.pid+"-"+Math.random().toString(36).slice(2)+".json");${fsVar}.writeFileSync(r,String(e),{mode:384});return r}`;
 }
 
 function hasCompleteRecordReplayMainBridgePatch(source) {
@@ -206,40 +167,12 @@ function hasCompleteRecordReplayMainBridgePatch(source) {
   const bridgeInsertion = `${bridgePayload},"get-global-state":async({key:`;
   return countOccurrences(source, helperPayload) === 1
     && countOccurrences(source, bridgePayload) === 1
-    && countOccurrences(source, bridgeInsertion) === 1
-    && regexMatchCount(source, recordReplayChronicleTrayPatchedPattern()) === 1;
+    && countOccurrences(source, bridgeInsertion) === 1;
 }
 
 function hasAnyRecordReplayMainBridgeArtifact(source) {
-  return source.includes("codexLinuxRecordReplay")
-    || source.includes("codexLinuxChronicle")
-    || source.includes('"linux-record-replay-');
-}
-
-function applyRecordReplayChronicleTrayPatch(currentSource) {
-  const patchName = "Record & Replay Chronicle tray bridge patch";
-  if (currentSource.includes("process.platform===`linux`?codexLinuxChronicleSidecarControlState()")) {
-    return currentSource;
-  }
-
-  const trayControlPattern = recordReplayChronicleTrayControlPattern();
-  if (!trayControlPattern.test(currentSource)) {
-    warn("Could not find Chronicle tray control callbacks", patchName);
-    return currentSource;
-  }
-
-  return currentSource.replace(
-    trayControlPattern,
-    (
-      _match,
-      availabilityFunction,
-      disabledStateVar,
-      upstreamStateExpression,
-      connectionVar,
-      connectionExpression,
-    ) =>
-      `getChronicleSidecarControlState:()=>process.platform===\`linux\`?codexLinuxChronicleSidecarControlState():${availabilityFunction}().skysight?${disabledStateVar}:${upstreamStateExpression},toggleChronicleSidecar:async()=>{if(process.platform===\`linux\`)return codexLinuxChronicleToggleSidecar();if(${availabilityFunction}().skysight)return ${disabledStateVar};let ${connectionVar}=${connectionExpression};return ${connectionVar}==null?${disabledStateVar}:${connectionVar}.getChronicleSidecarControlState().running?${connectionVar}.pauseChronicleSidecar():${connectionVar}.resumeChronicleSidecar()}`,
-  );
+  return source.includes("codexLinuxRecordReplayWriteTempJson")
+    || source.includes('"linux-record-replay-start"');
 }
 
 function applyRecordReplayMainBridgePatch(currentSource) {
@@ -250,8 +183,8 @@ function applyRecordReplayMainBridgePatch(currentSource) {
     }
     return currentSource;
   }
-  if (!recordReplayChronicleTrayControlPattern().test(currentSource)) {
-    warn("Could not find Chronicle tray control callbacks", patchName);
+  if (!currentSource.includes("codexLinuxRecordReplayRun")) {
+    warn("Chronicle / Skysight dependency bridge is missing", patchName);
     return currentSource;
   }
 
@@ -266,7 +199,7 @@ function applyRecordReplayMainBridgePatch(currentSource) {
     handlerNeedle,
     `${recordReplayBridgeSource(RECORD_REPLAY_MODULE_EXPRESSIONS)},${handlerNeedle}`,
   )}`;
-  return applyRecordReplayChronicleTrayPatch(patchedSource);
+  return patchedSource;
 }
 
 function recordReplayHudRuntimeSource() {
@@ -432,13 +365,13 @@ const descriptors = [
   {
     id: "linux-record-replay-main-bridge",
     phase: "main-bundle",
-    order: 151,
+    order: 152,
     apply: applyRecordReplayMainBridgePatch,
   },
   {
     id: "record-replay-hud",
     phase: "webview-asset",
-    order: 152,
+    order: 153,
     ciPolicy: "optional",
     pattern: /^index-.*\.js$/,
     missingDescription: "webview index bundle",
@@ -477,7 +410,6 @@ module.exports = {
   applyRecordReplayHudPatch,
   applyRecordReplayMainBridgePatch,
   descriptors,
-  recordReplayChronicleHelperSource,
   recordReplayBridgeSource,
   recordReplayHudRuntimeSource,
   recordReplayHelperSource,

--- a/linux-features/record-and-replay/stage.sh
+++ b/linux-features/record-and-replay/stage.sh
@@ -183,6 +183,7 @@ NODE
 
 build_record_replay_backend() {
     local source_binary="$SCRIPT_DIR/target/release/codex-record-replay-linux"
+    local packaged_binary="$INSTALL_DIR/resources/native/codex-record-replay-linux"
 
     if [ -n "${CODEX_RECORD_REPLAY_LINUX_SOURCE:-}" ]; then
         [ -x "$CODEX_RECORD_REPLAY_LINUX_SOURCE" ] || {
@@ -191,6 +192,11 @@ build_record_replay_backend() {
         }
         echo "Using prebuilt Record & Replay backend" >&2
         printf '%s\n' "$CODEX_RECORD_REPLAY_LINUX_SOURCE"
+        return 0
+    fi
+
+    if [ -x "$packaged_binary" ]; then
+        printf '%s\n' "$packaged_binary"
         return 0
     fi
 
@@ -214,7 +220,9 @@ target_marketplace="$INSTALL_DIR/resources/plugins/openai-bundled/.agents/plugin
 }
 
 mkdir -p "$native_target_dir"
-cp "$backend_binary" "$native_target_dir/codex-record-replay-linux"
+if [ "$backend_binary" != "$native_target_dir/codex-record-replay-linux" ]; then
+    cp "$backend_binary" "$native_target_dir/codex-record-replay-linux"
+fi
 chmod 0755 "$native_target_dir/codex-record-replay-linux"
 
 stage_record_replay_plugin_base "$target_plugin" "$plugin_template"

--- a/linux-features/record-and-replay/test.js
+++ b/linux-features/record-and-replay/test.js
@@ -26,6 +26,11 @@ const {
   recordReplayHelperSource,
   recordReplayHudRuntimeSource,
 } = require("./patch.js");
+const {
+  applyChronicleSkysightMainBridgePatch,
+  chronicleSkysightHelperSource: recordReplayChronicleHelperSource,
+  recordReplayRuntimeHelperSource,
+} = require("../chronicle-skysight/patch.js");
 
 const featureDir = __dirname;
 
@@ -44,12 +49,30 @@ function repoRoot() {
   return path.resolve(featureDir, "../..");
 }
 
+function stageSharedChronicleBackend(workspace, installDir, fakeBinary) {
+  execFileSync(
+    "bash",
+    [path.join(featureDir, "../chronicle-skysight/stage.sh")],
+    {
+      cwd: workspace,
+      env: {
+        ...process.env,
+        SCRIPT_DIR: repoRoot(),
+        INSTALL_DIR: installDir,
+        CODEX_RECORD_REPLAY_LINUX_SOURCE: fakeBinary,
+      },
+      stdio: "pipe",
+    },
+  );
+}
+
 function withTempFeatureRoot(enabled, fn) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-record-and-replay-feature-test-"));
   const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
   try {
     fs.writeFileSync(path.join(root, "features.example.json"), JSON.stringify({ enabled: [] }, null, 2));
     fs.writeFileSync(path.join(root, "features.json"), JSON.stringify({ enabled }, null, 2));
+    fs.cpSync(path.resolve(__dirname, "../chronicle-skysight"), path.join(root, "chronicle-skysight"), { recursive: true });
     fs.cpSync(path.resolve(__dirname), path.join(root, "record-and-replay"), { recursive: true });
     return fn(root);
   } finally {
@@ -85,6 +108,7 @@ test("manifest keeps record-and-replay disabled by default", () => {
   const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
   assert.equal(manifest.id, "record-and-replay");
   assert.equal(manifest.defaultEnabled, false);
+  assert.deepEqual(manifest.requires, ["chronicle-skysight"]);
 });
 
 test("record-and-replay required files exist", () => {
@@ -106,13 +130,23 @@ test("record-and-replay is opt-in and disabled unless configured", () => {
   });
 });
 
-test("record-and-replay enables when listed in features.json", () => {
-  withTempFeatureRoot(["record-and-replay"], (root) => {
+test("record-and-replay enables with chronicle-skysight dependency", () => {
+  withTempFeatureRoot(["chronicle-skysight", "record-and-replay"], (root) => {
     const ids = enabledLinuxFeatureIds({ featuresRoot: root });
-    assert.deepEqual(ids, ["record-and-replay"]);
+    assert.deepEqual(ids, ["chronicle-skysight", "record-and-replay"]);
     assert.deepEqual(loadEnabledLinuxFeatures({ featuresRoot: root }).map((feature) => feature.id), [
+      "chronicle-skysight",
       "record-and-replay",
     ]);
+  });
+});
+
+test("record-and-replay rejects direct config without chronicle-skysight", () => {
+  withTempFeatureRoot(["record-and-replay"], (root) => {
+    assert.throws(
+      () => loadEnabledLinuxFeatures({ featuresRoot: root }),
+      /requires 'chronicle-skysight' to be enabled/,
+    );
   });
 });
 
@@ -120,9 +154,10 @@ test("record-and-replay patch descriptor loads only when feature is enabled", ()
   withTempFeatureConfig([], (root) => {
     assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot: root }), []);
   });
-  withTempFeatureConfig(["record-and-replay"], (root) => {
+  withTempFeatureConfig(["chronicle-skysight", "record-and-replay"], (root) => {
     const loaded = loadLinuxFeaturePatchDescriptors({ featuresRoot: root });
     assert.deepEqual(loaded.map((descriptor) => descriptor.id), [
+      "feature:chronicle-skysight:linux-chronicle-skysight-main-bridge",
       "feature:record-and-replay:record-and-replay-plugin-gate",
       "feature:record-and-replay:linux-record-replay-main-bridge",
       "feature:record-and-replay:record-replay-hud",
@@ -161,7 +196,8 @@ test("record-and-replay bridge patch is idempotent and uses execFile", () => {
     "var bridge={\"get-global-state\":async({key:e})=>null};",
   ].join("");
 
-  const patched = applyRecordReplayMainBridgePatch(source);
+  const chroniclePatched = applyChronicleSkysightMainBridgePatch(source);
+  const patched = applyRecordReplayMainBridgePatch(chroniclePatched);
   assert.notEqual(patched, source);
   assert.equal(applyRecordReplayMainBridgePatch(patched), patched);
   assert.match(patched, /"linux-record-replay-doctor":async/);
@@ -215,25 +251,9 @@ test("record-and-replay bridge patch is idempotent and uses execFile", () => {
   assert.doesNotMatch(patched, /"--target"/);
   assert.doesNotMatch(patched, /"--target-dir"/);
   assert.doesNotMatch(patched, /"--mode"/);
-});
-
-test("record-and-replay bridge is complete and idempotent on the official bundle", () => {
-  const source = [
-    '"use strict";let electron=require("electron");',
-    'const cp=require("node:child_process"),fs=require("node:fs"),path=require("node:path");',
-    "var tray={getChronicleSidecarControlState:()=>tt().skysight?$9:Se.appServerConnectionRegistry.getMaybeConnection(`local`)?.getChronicleSidecarControlState()??$9,toggleChronicleSidecar:async()=>{if(tt().skysight)return $9;let e=Se.appServerConnectionRegistry.getMaybeConnection(V);return e==null?$9:e.getChronicleSidecarControlState().running?e.pauseChronicleSidecar():e.resumeChronicleSidecar()}};",
-    'var bridge={"get-global-state":async({key:e})=>null};',
-  ].join("");
-  const recordPatched = applyRecordReplayMainBridgePatch(source);
-  const { value, warnings } = captureWarns(() =>
-    applyRecordReplayMainBridgePatch(recordPatched),
-  );
-
-  assert.equal(value, recordPatched);
-  assert.deepEqual(warnings, []);
-  assert.match(
-    recordPatched,
-    /require\("node:child_process"\)\.execFile\(/,
+  assert.doesNotMatch(
+    recordReplayBridgeSource({ fsVar: "fs" }),
+    /chronicle-permissions|linux-record-replay-skysight/,
   );
 });
 
@@ -243,7 +263,8 @@ test("record-and-replay rejects incomplete current bridge variants byte-identica
     "var tray={getChronicleSidecarControlState:()=>tt().skysight?$9:Se.appServerConnectionRegistry.getMaybeConnection(`local`)?.getChronicleSidecarControlState()??$9,toggleChronicleSidecar:async()=>{if(tt().skysight)return $9;let e=Se.appServerConnectionRegistry.getMaybeConnection(V);return e==null?$9:e.getChronicleSidecarControlState().running?e.pauseChronicleSidecar():e.resumeChronicleSidecar()}};",
     'var bridge={"get-global-state":async({key:e})=>null};',
   ].join("");
-  const patched = applyRecordReplayMainBridgePatch(source);
+  const chroniclePatched = applyChronicleSkysightMainBridgePatch(source);
+  const patched = applyRecordReplayMainBridgePatch(chroniclePatched);
   const moduleExpressions = {
     childProcessVar: 'require("node:child_process")',
     fsVar: 'require("node:fs")',
@@ -251,17 +272,7 @@ test("record-and-replay rejects incomplete current bridge variants byte-identica
   };
   const bridgePayload = recordReplayBridgeSource(moduleExpressions);
   const helperPayload = recordReplayHelperSource(moduleExpressions);
-  const trayStart = patched.indexOf("var tray=");
-  const trayEnd = patched.indexOf(";var bridge=", trayStart);
-  const trayStatement = patched.slice(trayStart, trayEnd + 1);
   const variants = {
-    "legacy tray shape": patched
-      .replace(":tt().skysight?$9:", ":")
-      .replace("if(tt().skysight)return $9;", ""),
-    "missing Linux toggle branch": patched.replace(
-      "if(process.platform===`linux`)return codexLinuxChronicleToggleSidecar();",
-      "",
-    ),
     "missing current bridge handler": patched.replace(
       '"linux-record-replay-status":async',
       '"linux-record-replay-status-missing":async',
@@ -274,9 +285,8 @@ test("record-and-replay rejects incomplete current bridge variants byte-identica
       `${bridgePayload},"get-global-state":async`,
       `${bridgePayload},${bridgePayload},"get-global-state":async`,
     ),
-    "helper-only partial": `${helperPayload}\n${source}`,
+    "helper-only partial": `${helperPayload}\n${chroniclePatched}`,
     "duplicate helper payload": `${helperPayload}\n${patched}`,
-    "duplicate patched tray": `${patched}${trayStatement}`,
   };
 
   for (const [name, drifted] of Object.entries(variants)) {
@@ -289,7 +299,7 @@ test("record-and-replay rejects incomplete current bridge variants byte-identica
 });
 
 test("record-and-replay Chronicle helpers map Skysight status into upstream sidecar state", () => {
-  const helperSource = recordReplayHelperSource({
+  const helperSource = recordReplayRuntimeHelperSource({
     childProcessVar: "childProcess",
     fsVar: "fs",
     pathVar: "path",
@@ -346,7 +356,7 @@ test("record-and-replay Chronicle helpers map Skysight status into upstream side
 });
 
 test("record-and-replay Chronicle permissions probe is side-effect free", async () => {
-  const helperSource = recordReplayHelperSource({
+  const helperSource = recordReplayRuntimeHelperSource({
     childProcessVar: "childProcess",
     fsVar: "fs",
     pathVar: "path",
@@ -379,7 +389,7 @@ test("record-and-replay Chronicle permissions probe is side-effect free", async 
 });
 
 test("record-and-replay Chronicle setup probe starts stopped Linux Skysight", async () => {
-  const helperSource = recordReplayHelperSource({
+  const helperSource = recordReplayRuntimeHelperSource({
     childProcessVar: "childProcess",
     fsVar: "fs",
     pathVar: "path",
@@ -419,7 +429,7 @@ test("record-and-replay Chronicle setup probe starts stopped Linux Skysight", as
 });
 
 test("record-and-replay Chronicle setup probe enables summary agent when Settings turns Chronicle on", async () => {
-  const helperSource = recordReplayHelperSource({
+  const helperSource = recordReplayRuntimeHelperSource({
     childProcessVar: "childProcess",
     fsVar: "fs",
     pathVar: "path",
@@ -459,7 +469,7 @@ test("record-and-replay Chronicle setup probe enables summary agent when Setting
 });
 
 test("record-and-replay Chronicle setup probe does not churn start when summary agent is already enabled", async () => {
-  const helperSource = recordReplayHelperSource({
+  const helperSource = recordReplayRuntimeHelperSource({
     childProcessVar: "childProcess",
     fsVar: "fs",
     pathVar: "path",
@@ -506,11 +516,13 @@ test("record-and-replay generic Skysight start can pass summary agent true or fa
     "var tray={getChronicleSidecarControlState:()=>tt().skysight?$9:Se.appServerConnectionRegistry.getMaybeConnection(`local`)?.getChronicleSidecarControlState()??$9,toggleChronicleSidecar:async()=>{if(tt().skysight)return $9;let e=Se.appServerConnectionRegistry.getMaybeConnection(V);return e==null?$9:e.getChronicleSidecarControlState().running?e.pauseChronicleSidecar():e.resumeChronicleSidecar()}};",
     "var bridge={\"get-global-state\":async({key:e})=>null};",
   ].join("");
-  const patched = applyRecordReplayMainBridgePatch(source);
+  const patched = applyChronicleSkysightMainBridgePatch(source);
   assert.match(
     patched,
-    /"linux-record-replay-skysight-start":async\(\{intervalSeconds:e,summaryAgent:t\}=\{\}\)=>\{let n=\["skysight","start"\]/,
+    /"linux-record-replay-skysight-start":async\(\{intervalSeconds:e,summaryAgent:t,source:r,owner:a\}=\{\}\)=>\{let n=\["skysight","start"\]/,
   );
+  assert.match(patched, /r&&n\.push\("--source",String\(r\)\)/);
+  assert.match(patched, /a&&n\.push\("--owner",String\(a\)\)/);
   assert.match(patched, /t===!0&&n\.push\("--summary-agent","enabled"\)/);
   assert.match(patched, /t===!1&&n\.push\("--summary-agent","disabled"\)/);
 });
@@ -521,10 +533,10 @@ test("record-and-replay patch wires Linux Chronicle tray controls to Skysight", 
     "var tray={getChronicleSidecarControlState:()=>tt().skysight?$9:Se.appServerConnectionRegistry.getMaybeConnection(`local`)?.getChronicleSidecarControlState()??$9,toggleChronicleSidecar:async()=>{if(tt().skysight)return $9;let e=Se.appServerConnectionRegistry.getMaybeConnection(V);return e==null?$9:e.getChronicleSidecarControlState().running?e.pauseChronicleSidecar():e.resumeChronicleSidecar()}};",
     'var bridge={"get-global-state":async({key:e})=>null};',
   ].join("");
-  const patched = applyRecordReplayMainBridgePatch(source);
+  const patched = applyChronicleSkysightMainBridgePatch(source);
 
   assert.notEqual(patched, source);
-  assert.equal(applyRecordReplayMainBridgePatch(patched), patched);
+  assert.equal(applyChronicleSkysightMainBridgePatch(patched), patched);
   assert.match(patched, /getChronicleSidecarControlState:\(\)=>process\.platform===`linux`\?codexLinuxChronicleSidecarControlState\(\)/);
   assert.match(patched, /toggleChronicleSidecar:async\(\)=>\{if\(process\.platform===`linux`\)return codexLinuxChronicleToggleSidecar\(\)/);
   assert.match(patched, /if\(tt\(\)\.skysight\)return \$9/);
@@ -538,7 +550,7 @@ test("record-and-replay rejects partial current Chronicle tray drift byte-identi
     'var bridge={"get-global-state":async({key:e})=>null};',
   ].join("");
 
-  assert.equal(applyRecordReplayMainBridgePatch(source), source);
+  assert.equal(applyChronicleSkysightMainBridgePatch(source), source);
 });
 
 test("record-and-replay docs mention pause resume and Chronicle-compatible resources", () => {
@@ -923,6 +935,7 @@ test("record-and-replay stage hook records marketplace entry and stages plugin",
     fs.writeFileSync(marketplace, JSON.stringify({ plugins: [{ name: "computer-use", source: { path: "./plugins/computer-use" } }] }));
     fs.writeFileSync(fakeBinary, "#!/bin/sh\nprintf '{\"ok\":true}\\n'\n");
     fs.chmodSync(fakeBinary, 0o755);
+    stageSharedChronicleBackend(workspace, installDir, fakeBinary);
 
     execFileSync("bash", [path.join(featureDir, "stage.sh")], {
       cwd: workspace,
@@ -930,7 +943,6 @@ test("record-and-replay stage hook records marketplace entry and stages plugin",
         ...process.env,
         SCRIPT_DIR: repoRoot(),
         INSTALL_DIR: installDir,
-        CODEX_RECORD_REPLAY_LINUX_SOURCE: fakeBinary,
       },
       stdio: "pipe",
     });
@@ -968,7 +980,7 @@ test("record-and-replay stage hook records marketplace entry and stages plugin",
   }
 });
 
-test("record-and-replay disabled rebuild exposes cleanup hook for staged payload", () => {
+test("record-and-replay cleanup preserves Chronicle shared backend", () => {
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-record-replay-cleanup-"));
   const originalRoot = process.env.CODEX_LINUX_FEATURES_ROOT;
   try {
@@ -1001,7 +1013,7 @@ test("record-and-replay disabled rebuild exposes cleanup hook for staged payload
     });
     stageEnabledLinuxFeatureInstall(installDir, { featuresRoot });
 
-    assert.equal(fs.existsSync(staleNative), false);
+    assert.equal(fs.existsSync(staleNative), true);
     assert.equal(fs.existsSync(stalePlugin), false);
     const parsedMarketplace = JSON.parse(fs.readFileSync(marketplace, "utf8"));
     assert.deepEqual(parsedMarketplace.plugins.map((plugin) => plugin.name), ["computer-use"]);
@@ -1022,7 +1034,7 @@ test("record-and-replay stage hook uses the current upstream plugin shell when p
     const fakeBinary = path.join(workspace, "codex-record-replay-linux");
     const upstreamPlugin = path.join(
       workspace,
-      "upstream/usr/lib/chatgpt/resources/plugins/openai-bundled/plugins/record-and-replay",
+      "upstream/ChatGPT/resources/plugins/openai-bundled/plugins/record-and-replay",
     );
     const marketplace = path.join(installDir, "resources/plugins/openai-bundled/.agents/plugins/marketplace.json");
     fs.mkdirSync(path.join(upstreamPlugin, ".codex-plugin"), { recursive: true });
@@ -1068,6 +1080,7 @@ test("record-and-replay stage hook uses the current upstream plugin shell when p
     fs.writeFileSync(marketplace, JSON.stringify({ plugins: [] }));
     fs.writeFileSync(fakeBinary, "#!/bin/sh\nprintf '{\"ok\":true}\\n'\n");
     fs.chmodSync(fakeBinary, 0o755);
+    stageSharedChronicleBackend(workspace, installDir, fakeBinary);
 
     execFileSync("bash", [path.join(featureDir, "stage.sh")], {
       cwd: workspace,
@@ -1075,8 +1088,7 @@ test("record-and-replay stage hook uses the current upstream plugin shell when p
         ...process.env,
         SCRIPT_DIR: repoRoot(),
         INSTALL_DIR: installDir,
-        CODEX_UPSTREAM_APP_DIR: path.join(workspace, "upstream/usr/lib/chatgpt"),
-        CODEX_RECORD_REPLAY_LINUX_SOURCE: fakeBinary,
+        CODEX_UPSTREAM_APP_DIR: path.join(workspace, "upstream/ChatGPT"),
       },
       stdio: "pipe",
     });
@@ -1115,7 +1127,7 @@ test("record-and-replay stage hook rejects the obsolete nested-app plugin shell"
     const fakeBinary = path.join(workspace, "codex-record-replay-linux");
     const upstreamPlugin = path.join(
       workspace,
-      "upstream/usr/lib/chatgpt/resources/plugins/openai-bundled/plugins/record-and-replay",
+      "upstream/ChatGPT/resources/plugins/openai-bundled/plugins/record-and-replay",
     );
     const oldClient = path.join(
       upstreamPlugin,
@@ -1156,6 +1168,7 @@ test("record-and-replay stage hook rejects the obsolete nested-app plugin shell"
     fs.writeFileSync(marketplace, JSON.stringify({ plugins: [] }));
     fs.writeFileSync(fakeBinary, "#!/bin/sh\nprintf '{\"ok\":true}\\n'\n");
     fs.chmodSync(fakeBinary, 0o755);
+    stageSharedChronicleBackend(workspace, installDir, fakeBinary);
 
     execFileSync("bash", [path.join(featureDir, "stage.sh")], {
       cwd: workspace,
@@ -1163,8 +1176,7 @@ test("record-and-replay stage hook rejects the obsolete nested-app plugin shell"
         ...process.env,
         SCRIPT_DIR: repoRoot(),
         INSTALL_DIR: installDir,
-        CODEX_UPSTREAM_APP_DIR: path.join(workspace, "upstream/usr/lib/chatgpt"),
-        CODEX_RECORD_REPLAY_LINUX_SOURCE: fakeBinary,
+        CODEX_UPSTREAM_APP_DIR: path.join(workspace, "upstream/ChatGPT"),
       },
       stdio: "pipe",
     });
@@ -1188,6 +1200,7 @@ test("record-and-replay stage hook borrows upstream webview icon when present", 
     fs.writeFileSync(path.join(assetsDir, "record-and-replay-plugin-icon-fixture.png"), "fake-png");
     fs.writeFileSync(fakeBinary, "#!/bin/sh\nprintf '{\"ok\":true}\\n'\n");
     fs.chmodSync(fakeBinary, 0o755);
+    stageSharedChronicleBackend(workspace, installDir, fakeBinary);
 
     execFileSync("bash", [path.join(featureDir, "stage.sh")], {
       cwd: workspace,
@@ -1195,7 +1208,6 @@ test("record-and-replay stage hook borrows upstream webview icon when present", 
         ...process.env,
         SCRIPT_DIR: repoRoot(),
         INSTALL_DIR: installDir,
-        CODEX_RECORD_REPLAY_LINUX_SOURCE: fakeBinary,
       },
       stdio: "pipe",
     });

--- a/linux-features/record-and-replay/test.js
+++ b/linux-features/record-and-replay/test.js
@@ -141,11 +141,11 @@ test("record-and-replay enables with chronicle-skysight dependency", () => {
   });
 });
 
-test("record-and-replay rejects direct config without chronicle-skysight", () => {
+test("record-and-replay migrates direct config by enabling chronicle-skysight", () => {
   withTempFeatureRoot(["record-and-replay"], (root) => {
-    assert.throws(
-      () => loadEnabledLinuxFeatures({ featuresRoot: root }),
-      /requires 'chronicle-skysight' to be enabled/,
+    assert.deepEqual(
+      loadEnabledLinuxFeatures({ featuresRoot: root }).map((feature) => feature.id),
+      ["chronicle-skysight", "record-and-replay"],
     );
   });
 });

--- a/nix/linux-features.nix
+++ b/nix/linux-features.nix
@@ -27,6 +27,16 @@ let
   sortAndDeduplicate = featureIds:
     lib.sort builtins.lessThan (lib.unique featureIds);
 
+  expandFeature = stack: featureId:
+    if lib.elem featureId stack then
+      throw "Linux feature dependency cycle: ${lib.concatStringsSep " -> " (stack ++ [ featureId ])}"
+    else if !(lib.elem featureId supportedFeatureIds) then
+      [ featureId ]
+    else
+      let manifest = manifestById.${featureId};
+      in lib.concatMap (expandFeature (stack ++ [ featureId ])) (manifest.requires or [ ])
+        ++ [ featureId ];
+
   normalize = featureIds:
     if !builtins.isList featureIds then
       throw "Nix Linux feature IDs must be provided as a list"
@@ -35,17 +45,16 @@ let
     else
       let
         canonical = map (featureId: aliases.${featureId} or featureId) featureIds;
-        normalized = sortAndDeduplicate (lib.filter
+        selected = sortAndDeduplicate (lib.filter
           (featureId: !(lib.elem featureId retiredFeatureIds))
           canonical);
+        normalized = sortAndDeduplicate (lib.concatMap (expandFeature [ ]) selected);
         unsupported = lib.filter (featureId: !(lib.elem featureId supportedFeatureIds)) normalized;
         dependencyErrors = lib.concatMap
           (featureId:
             let manifest = manifestById.${featureId};
             in
-              map (required: "'${featureId}' requires '${required}'")
-                (lib.filter (required: !(lib.elem required normalized)) (manifest.requires or [ ]))
-              ++ map (conflict: "'${featureId}' conflicts with '${conflict}'")
+              map (conflict: "'${featureId}' conflicts with '${conflict}'")
                 (lib.filter (conflict: lib.elem conflict normalized) (manifest.conflicts or [ ])))
           (lib.filter (featureId: lib.elem featureId supportedFeatureIds) normalized);
       in

--- a/nix/modules-test.nix
+++ b/nix/modules-test.nix
@@ -107,6 +107,9 @@ assert lib.assertMsg
   (features.normalize [ "ui-tweaks" "ui-tweaks" "agent-workspace" ] == [ "agent-workspace" "ui-tweaks" ])
   "Nix feature IDs are not sorted and deduplicated";
 assert lib.assertMsg
+  (features.normalize [ "record-and-replay" ] == [ "chronicle-skysight" "record-and-replay" ])
+  "Nix feature dependencies were not added to an existing direct selection";
+assert lib.assertMsg
   (features.normalize [ "codex-wrapper-updater" "zed-opener" ] == [ ])
   "known retired and aliased-retired feature IDs were not ignored";
 assert lib.assertMsg

--- a/record-replay-linux/src/lib.rs
+++ b/record-replay-linux/src/lib.rs
@@ -20,6 +20,16 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 use serde_json::Value;
 use std::path::PathBuf;
 
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    pub(crate) fn env_guard() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+}
+
 pub use audio::{available_audio_recorders, AudioCaptureReport};
 pub use backends::{
     available_recorders, recording_backend_catalog, recording_backend_catalog_from_signals,
@@ -49,9 +59,9 @@ pub use skill::{
 };
 pub use skysight::{
     capture_skysight_snapshot, list_skysight_exclusions, pause_skysight, resume_skysight,
-    run_skysight_daemon, skysight_status, start_skysight, stop_skysight, update_skysight_exclusion,
-    SkysightExclusion, SkysightExclusionUpdate, SkysightPaths, SkysightStartOptions,
-    SkysightStatus,
+    run_skysight_daemon, skysight_status, start_skysight, stop_skysight, stop_skysight_if_owned,
+    update_skysight_exclusion, SkysightExclusion, SkysightExclusionUpdate, SkysightPaths,
+    SkysightStartOptions, SkysightStatus,
 };
 pub use timeline::{
     append_timeline_record, parse_timeline_line, read_timeline, TimelineEvent, TimelineParseError,
@@ -179,6 +189,12 @@ pub struct SkysightStartArgs {
     pub interval_seconds: u64,
     #[arg(long, value_enum)]
     pub summary_agent: Option<SkysightSummaryAgentArg>,
+    /// Initiating surface for this explicit continuous capture start.
+    #[arg(long)]
+    pub source: Option<String>,
+    /// Capture owner, such as manual-continuous or recording-session:<id>.
+    #[arg(long)]
+    pub owner: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -376,6 +392,8 @@ pub async fn command_json(command: Commands) -> Result<Value> {
                     SkysightStartOptions {
                         interval_seconds: args.interval_seconds,
                         summary_agent: args.summary_agent.map(SkysightSummaryAgentArg::as_bool),
+                        source: args.source,
+                        owner: args.owner,
                     },
                 )?)?),
                 SkysightCommand::Status => Ok(serde_json::to_value(skysight_status(&paths)?)?),
@@ -392,6 +410,8 @@ pub async fn command_json(command: Commands) -> Result<Value> {
                         &paths,
                         args.interval_seconds,
                         args.summary_agent.map(SkysightSummaryAgentArg::as_bool),
+                        args.source,
+                        args.owner,
                     )?;
                     Ok(serde_json::to_value(skysight_status(&paths)?)?)
                 }

--- a/record-replay-linux/src/main.rs
+++ b/record-replay-linux/src/main.rs
@@ -7,17 +7,15 @@ use codex_record_replay_linux::{
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
-    if matches!(
-        &cli.command,
+    match &cli.command {
         Commands::Mcp
-            | Commands::EventStream {
-                command: EventStreamCommand::Mcp,
-            }
-            | Commands::Skysight {
-                command: SkysightCommand::Mcp,
-            }
-    ) {
-        return mcp::serve_mcp().await;
+        | Commands::EventStream {
+            command: EventStreamCommand::Mcp,
+        } => return mcp::serve_event_stream_mcp().await,
+        Commands::Skysight {
+            command: SkysightCommand::Mcp,
+        } => return mcp::serve_skysight_mcp().await,
+        _ => {}
     }
 
     let response = command_json(cli.command).await?;

--- a/record-replay-linux/src/mcp.rs
+++ b/record-replay-linux/src/mcp.rs
@@ -1,6 +1,10 @@
 use anyhow::Result;
 use rmcp::{
-    handler::server::wrapper::{Json, Parameters},
+    handler::server::{
+        tool::ToolRouter,
+        wrapper::{Json, Parameters},
+    },
+    model::{Implementation, ServerCapabilities, ServerInfo},
     schemars::JsonSchema,
     tool, tool_handler, tool_router, ServerHandler, ServiceExt,
 };
@@ -25,10 +29,36 @@ use crate::{
 
 const DEFAULT_MAX_DURATION_SECONDS: u64 = 30 * 60;
 
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpMode {
+    EventStream,
+    Skysight,
+}
+
+const SKYSIGHT_TOOL_NAMES: &[&str] = &[
+    "doctor",
+    "skysight_list_exclusions",
+    "skysight_pause",
+    "skysight_resume",
+    "skysight_snapshot",
+    "skysight_start",
+    "skysight_status",
+    "skysight_stop",
+    "skysight_update_exclusion",
+];
+
+#[derive(Clone)]
 pub struct RecordReplayLinux {
     active_session: Arc<Mutex<Option<PathBuf>>>,
     last_session: Arc<Mutex<Option<PathBuf>>>,
+    mode: McpMode,
+    tool_router: ToolRouter<Self>,
+}
+
+impl Default for RecordReplayLinux {
+    fn default() -> Self {
+        Self::for_mode(McpMode::EventStream)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -89,6 +119,8 @@ impl RecordReplayLinux {
             SkysightStartOptions {
                 interval_seconds: params.interval_seconds.unwrap_or(60),
                 summary_agent: params.summary_agent,
+                source: params.source,
+                owner: params.owner,
             },
         ) {
             Ok(status) => tool_json(json!({
@@ -602,23 +634,83 @@ impl RecordReplayLinux {
     }
 }
 
-#[tool_handler(
-    name = "event-stream",
-    version = "0.1.0-linux-alpha1",
-    instructions = "Use Event-stream to record Linux desktop/browser workflows and compile them into reusable Codex skills. Call doctor before first recording when readiness is uncertain. Use skysight_start or skysight_snapshot when recent activity context will help the skill draft. Use start/event_stream_start, let the user perform the workflow, call desktop_snapshot at meaningful app/window changes, call speech_context only for additional transcript text that is explicitly available, call browser_trace when browser/CDP trace evidence is available, optionally call mark for meaningful intent boundaries, call stop/event_stream_stop when the user says they are done, inspect the bundle, draft a skill prompt, create or refine SKILL.md, then import the skill when the user approves. Replay through Codex skills and Computer Use; do not replay raw pointer coordinates as the main architecture."
-)]
-impl ServerHandler for RecordReplayLinux {}
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for RecordReplayLinux {
+    fn get_info(&self) -> ServerInfo {
+        let (name, instructions) = match self.mode {
+            McpMode::EventStream => (
+                "event-stream",
+                "Use Event-stream to record Linux desktop/browser workflows and compile them into reusable Codex skills. Call doctor before first recording when readiness is uncertain. Use skysight_start or skysight_snapshot when recent activity context will help the skill draft. Use start/event_stream_start, let the user perform the workflow, call desktop_snapshot at meaningful app/window changes, call speech_context only for additional transcript text that is explicitly available, call browser_trace when browser/CDP trace evidence is available, optionally call mark for meaningful intent boundaries, call stop/event_stream_stop when the user says they are done, inspect the bundle, draft a skill prompt, create or refine SKILL.md, then import the skill when the user approves. Replay through Codex skills and Computer Use; do not replay raw pointer coordinates as the main architecture.",
+            ),
+            McpMode::Skysight => (
+                "chronicle-skysight",
+                "Use Skysight for explicit Linux activity-memory capture. Status and doctor calls are passive. Start continuous capture only when the user requests it, honor exclusions, and use pause, resume, stop, or snapshot to control bounded local evidence.",
+            ),
+        };
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new(name, env!("CARGO_PKG_VERSION")))
+            .with_instructions(instructions)
+    }
+}
 
-pub async fn serve_mcp() -> Result<()> {
-    RecordReplayLinux::default()
-        .serve(rmcp::transport::stdio())
-        .await?
-        .waiting()
-        .await?;
+pub fn tool_names(mode: McpMode) -> Vec<String> {
+    RecordReplayLinux::router_for_mode(mode)
+        .list_all()
+        .into_iter()
+        .map(|tool| tool.name.into_owned())
+        .collect()
+}
+
+pub async fn serve_event_stream_mcp() -> Result<()> {
+    serve_mcp_mode(McpMode::EventStream).await
+}
+
+pub async fn serve_skysight_mcp() -> Result<()> {
+    serve_mcp_mode(McpMode::Skysight).await
+}
+
+async fn serve_mcp_mode(mode: McpMode) -> Result<()> {
+    let service = RecordReplayLinux::for_mode(mode);
+    let cleanup_service = service.clone();
+    let server_result: Result<()> = async move {
+        service
+            .serve(rmcp::transport::stdio())
+            .await?
+            .waiting()
+            .await?;
+        Ok(())
+    }
+    .await;
+    let cleanup_result = if mode == McpMode::EventStream {
+        cleanup_service.stop_owned_skysight_for_active_session("event-stream-shutdown")
+    } else {
+        Ok(())
+    };
+    server_result?;
+    cleanup_result?;
     Ok(())
 }
 
 impl RecordReplayLinux {
+    fn for_mode(mode: McpMode) -> Self {
+        Self {
+            active_session: Arc::new(Mutex::new(None)),
+            last_session: Arc::new(Mutex::new(None)),
+            mode,
+            tool_router: Self::router_for_mode(mode),
+        }
+    }
+
+    fn router_for_mode(mode: McpMode) -> ToolRouter<Self> {
+        let mut router = Self::tool_router();
+        if mode == McpMode::Skysight {
+            router
+                .map
+                .retain(|name, _route| SKYSIGHT_TOOL_NAMES.contains(&name.as_ref()));
+        }
+        router
+    }
+
     fn status_value(&self, command: &'static str) -> Value {
         let status = crate::refresh_runtime_status();
         let session_dir = status
@@ -688,6 +780,18 @@ impl RecordReplayLinux {
             .and_then(|guard| guard.clone())
     }
 
+    fn stop_owned_skysight_for_active_session(&self, source: &str) -> Result<()> {
+        let status = crate::refresh_runtime_status();
+        let session_dir = status
+            .session_dir
+            .filter(|_| matches!(&status.state, RecordingRuntimeState::Active))
+            .or_else(|| self.active_session_dir());
+        if let Some(session_dir) = session_dir {
+            crate::recorder::stop_owned_skysight_for_session(&session_dir, source)?;
+        }
+        Ok(())
+    }
+
     fn resolve_session(&self, explicit: Option<&str>, active_first: bool) -> Option<PathBuf> {
         if let Some(value) = explicit.and_then(non_empty) {
             return Some(expand_path(value));
@@ -748,6 +852,10 @@ struct SkysightStartParams {
     /// Enable or disable the Chronicle summary agent for this running Skysight daemon.
     #[serde(alias = "summaryAgent")]
     summary_agent: Option<bool>,
+    /// Initiating surface for this explicit continuous capture start.
+    source: Option<String>,
+    /// Capture owner, such as manual-continuous or recording-session:<id>.
+    owner: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
@@ -994,6 +1102,10 @@ fn event_stream_end_reason(state: &RecordingRuntimeState) -> Option<&'static str
 mod tests {
     use super::*;
 
+    fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+        crate::test_support::env_guard()
+    }
+
     #[test]
     fn add_event_stream_fields_includes_suppressed_events_path() {
         let temp = tempfile::tempdir().unwrap();
@@ -1018,6 +1130,7 @@ mod tests {
 
     #[test]
     fn status_value_includes_suppressed_events_path() {
+        let _guard = env_guard();
         let temp = tempfile::tempdir().unwrap();
         let session_dir = temp.path().join("session");
         let previous = std::env::var_os("CODEX_RECORD_REPLAY_STATUS_PATH");
@@ -1046,6 +1159,7 @@ mod tests {
 
     #[test]
     fn stop_recording_includes_suppressed_events_path() {
+        let _guard = env_guard();
         let temp = tempfile::tempdir().unwrap();
         let session_dir = temp.path().join("session");
         std::fs::create_dir_all(&session_dir).unwrap();
@@ -1082,5 +1196,137 @@ mod tests {
             Some(path) => std::env::set_var("CODEX_RECORD_REPLAY_STATUS_PATH", path),
             None => std::env::remove_var("CODEX_RECORD_REPLAY_STATUS_PATH"),
         }
+    }
+
+    #[test]
+    fn recording_stop_cleans_session_skysight_but_preserves_manual_continuous_capture() {
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let env_keys = [
+            "CODEX_HOME",
+            "CODEX_SKYSIGHT_RUNTIME_DIR",
+            "CODEX_SKYSIGHT_RESOURCES_DIR",
+            "CODEX_SKYSIGHT_EXCLUSIONS_PATH",
+            "CODEX_RECORD_REPLAY_STATUS_PATH",
+        ];
+        let previous = env_keys
+            .iter()
+            .map(|key| (*key, std::env::var_os(key)))
+            .collect::<Vec<_>>();
+        std::env::set_var("CODEX_HOME", temp.path().join("codex-home"));
+        std::env::set_var(
+            "CODEX_SKYSIGHT_RUNTIME_DIR",
+            temp.path().join("skysight-runtime"),
+        );
+        std::env::set_var(
+            "CODEX_SKYSIGHT_RESOURCES_DIR",
+            temp.path().join("skysight-resources"),
+        );
+        std::env::set_var(
+            "CODEX_SKYSIGHT_EXCLUSIONS_PATH",
+            temp.path().join("exclusions.json"),
+        );
+        std::env::set_var(
+            "CODEX_RECORD_REPLAY_STATUS_PATH",
+            temp.path().join("record-replay-status.json"),
+        );
+
+        let result = (|| {
+            let paths = SkysightPaths::from_env();
+            let mut initial_status = skysight_status(&paths)?;
+            initial_status.state = "running".to_string();
+            initial_status.is_running = true;
+            initial_status.owner = Some("recording-session:fixture-session".to_string());
+            initial_status.source = Some("event-stream-start".to_string());
+            std::fs::write(
+                &paths.status_path,
+                format!("{}\n", serde_json::to_string_pretty(&initial_status)?),
+            )?;
+
+            let session_dir = temp.path().join("fixture-session");
+            std::fs::create_dir_all(&session_dir)?;
+            let manifest = crate::manifest::RecordingBundleManifest::new(
+                "fixture-session".to_string(),
+                "2026-07-15T12:00:00Z".to_string(),
+            );
+            crate::manifest::write_manifest(&session_dir, &manifest)?;
+            std::fs::write(session_dir.join(crate::manifest::TIMELINE_FILE_NAME), "")?;
+
+            let service = RecordReplayLinux::default();
+            let response = service.stop_recording(
+                StopParams {
+                    session_dir: Some(session_dir.to_string_lossy().to_string()),
+                },
+                "event_stream_stop",
+            );
+            assert_eq!(
+                response.0.fields.get("ok").and_then(Value::as_bool),
+                Some(true)
+            );
+            assert!(paths.stop_request_path.is_file());
+
+            std::fs::remove_file(&paths.stop_request_path)?;
+            let mut manual_status = skysight_status(&paths)?;
+            manual_status.state = "running".to_string();
+            manual_status.is_running = true;
+            manual_status.owner = Some("manual-continuous".to_string());
+            manual_status.source = Some("chronicle-tray".to_string());
+            std::fs::write(
+                &paths.status_path,
+                format!("{}\n", serde_json::to_string_pretty(&manual_status)?),
+            )?;
+
+            let manual_session_dir = temp.path().join("manual-session");
+            std::fs::create_dir_all(&manual_session_dir)?;
+            let manual_manifest = crate::manifest::RecordingBundleManifest::new(
+                "manual-session".to_string(),
+                "2026-07-15T12:00:00Z".to_string(),
+            );
+            crate::manifest::write_manifest(&manual_session_dir, &manual_manifest)?;
+            std::fs::write(
+                manual_session_dir.join(crate::manifest::TIMELINE_FILE_NAME),
+                "",
+            )?;
+
+            let manual_response = service.stop_recording(
+                StopParams {
+                    session_dir: Some(manual_session_dir.to_string_lossy().to_string()),
+                },
+                "event_stream_stop",
+            );
+            assert_eq!(
+                manual_response.0.fields.get("ok").and_then(Value::as_bool),
+                Some(true)
+            );
+            assert!(!paths.stop_request_path.exists());
+
+            let mut shutdown_status = skysight_status(&paths)?;
+            shutdown_status.state = "running".to_string();
+            shutdown_status.is_running = true;
+            shutdown_status.owner = Some("recording-session:fixture-session".to_string());
+            shutdown_status.source = Some("event-stream-start".to_string());
+            std::fs::write(
+                &paths.status_path,
+                format!("{}\n", serde_json::to_string_pretty(&shutdown_status)?),
+            )?;
+            service.set_active_session(Some(session_dir.clone()));
+            service.stop_owned_skysight_for_active_session("event-stream-shutdown")?;
+            assert!(paths.stop_request_path.is_file());
+            let stopped = skysight_status(&paths)?;
+            assert_eq!(
+                stopped.owner.as_deref(),
+                Some("recording-session:fixture-session")
+            );
+            assert_eq!(stopped.source.as_deref(), Some("event-stream-shutdown"));
+            Ok::<(), anyhow::Error>(())
+        })();
+
+        for (key, value) in previous {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+        result.unwrap();
     }
 }

--- a/record-replay-linux/src/mcp.rs
+++ b/record-replay-linux/src/mcp.rs
@@ -781,12 +781,7 @@ impl RecordReplayLinux {
     }
 
     fn stop_owned_skysight_for_active_session(&self, source: &str) -> Result<()> {
-        let status = crate::refresh_runtime_status();
-        let session_dir = status
-            .session_dir
-            .filter(|_| matches!(&status.state, RecordingRuntimeState::Active))
-            .or_else(|| self.active_session_dir());
-        if let Some(session_dir) = session_dir {
+        if let Some(session_dir) = self.active_session_dir() {
             crate::recorder::stop_owned_skysight_for_session(&session_dir, source)?;
         }
         Ok(())
@@ -1318,6 +1313,88 @@ mod tests {
                 Some("recording-session:fixture-session")
             );
             assert_eq!(stopped.source.as_deref(), Some("event-stream-shutdown"));
+            Ok::<(), anyhow::Error>(())
+        })();
+
+        for (key, value) in previous {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+        result.unwrap();
+    }
+
+    #[test]
+    fn stale_mcp_shutdown_does_not_stop_reconnected_session_skysight() {
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let env_keys = [
+            "CODEX_HOME",
+            "CODEX_SKYSIGHT_RUNTIME_DIR",
+            "CODEX_SKYSIGHT_RESOURCES_DIR",
+            "CODEX_SKYSIGHT_EXCLUSIONS_PATH",
+            "CODEX_RECORD_REPLAY_STATUS_PATH",
+        ];
+        let previous = env_keys
+            .iter()
+            .map(|key| (*key, std::env::var_os(key)))
+            .collect::<Vec<_>>();
+        std::env::set_var("CODEX_HOME", temp.path().join("codex-home"));
+        std::env::set_var(
+            "CODEX_SKYSIGHT_RUNTIME_DIR",
+            temp.path().join("skysight-runtime"),
+        );
+        std::env::set_var(
+            "CODEX_SKYSIGHT_RESOURCES_DIR",
+            temp.path().join("skysight-resources"),
+        );
+        std::env::set_var(
+            "CODEX_SKYSIGHT_EXCLUSIONS_PATH",
+            temp.path().join("exclusions.json"),
+        );
+        std::env::set_var(
+            "CODEX_RECORD_REPLAY_STATUS_PATH",
+            temp.path().join("record-replay-status.json"),
+        );
+
+        let result = (|| {
+            let old_session = temp.path().join("old-session");
+            let new_session = temp.path().join("new-session");
+            for (session_dir, session_id) in
+                [(&old_session, "old-session"), (&new_session, "new-session")]
+            {
+                std::fs::create_dir_all(session_dir)?;
+                let manifest = crate::manifest::RecordingBundleManifest::new(
+                    session_id.to_string(),
+                    "2026-07-15T12:00:00Z".to_string(),
+                );
+                crate::manifest::write_manifest(session_dir, &manifest)?;
+            }
+
+            let stale_service = RecordReplayLinux::default();
+            stale_service.set_active_session(Some(old_session));
+            crate::runtime_status::write_active_status(&new_session, None)?;
+
+            let paths = SkysightPaths::from_env();
+            let mut status = skysight_status(&paths)?;
+            status.state = "running".to_string();
+            status.is_running = true;
+            status.owner = Some("recording-session:new-session".to_string());
+            status.source = Some("event-stream-start".to_string());
+            std::fs::write(
+                &paths.status_path,
+                format!("{}\n", serde_json::to_string_pretty(&status)?),
+            )?;
+
+            stale_service.stop_owned_skysight_for_active_session("event-stream-shutdown")?;
+
+            assert!(!paths.stop_request_path.exists());
+            let current = skysight_status(&paths)?;
+            assert_eq!(
+                current.owner.as_deref(),
+                Some("recording-session:new-session")
+            );
             Ok::<(), anyhow::Error>(())
         })();
 

--- a/record-replay-linux/src/ocr.rs
+++ b/record-replay-linux/src/ocr.rs
@@ -1544,9 +1544,6 @@ TSV
     }
 
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-        LOCK.get_or_init(|| std::sync::Mutex::new(()))
-            .lock()
-            .unwrap()
+        crate::test_support::env_guard()
     }
 }

--- a/record-replay-linux/src/recorder.rs
+++ b/record-replay-linux/src/recorder.rs
@@ -409,6 +409,29 @@ pub fn expire_session(bundle_dir: &Path) -> Result<crate::timeline::TimelineReco
     )
 }
 
+pub(crate) fn stop_owned_skysight_for_session(bundle_dir: &Path, source: &str) -> Result<()> {
+    let manifest = crate::manifest::read_manifest(bundle_dir)?;
+    stop_owned_skysight_for_session_id(&manifest.session_id, source)
+}
+
+fn stop_owned_skysight_for_session_id(session_id: &str, source: &str) -> Result<()> {
+    let owner = format!("recording-session:{session_id}");
+    let paths = crate::skysight::SkysightPaths::from_env();
+    let _ = crate::skysight::stop_skysight_if_owned(&paths, &owner, source)?;
+    Ok(())
+}
+
+fn skysight_cleanup_source(end_reason: &str) -> &'static str {
+    match end_reason {
+        "recording_controls_stopped" => "event-stream-stop",
+        "recording_controls_cancelled" | "recording_controls_cancelled_discarded" => {
+            "event-stream-cancel"
+        }
+        "max_duration" => "event-stream-expiry",
+        _ => "recording-session-end",
+    }
+}
+
 pub fn ranked_recorders(diagnostics: &DoctorReport) -> Vec<String> {
     let catalog = recording_backend_catalog(diagnostics);
     available_recorders(&catalog)
@@ -684,6 +707,18 @@ fn finalize_session(
         }
     }
     let record = append_timeline_record(bundle_dir, event)?;
+    if let Err(error) = stop_owned_skysight_for_session_id(
+        &manifest.session_id,
+        skysight_cleanup_source(end_reason),
+    ) {
+        let _ = append_timeline_record(
+            bundle_dir,
+            TimelineEvent::Diagnostic {
+                level: "warn".to_string(),
+                message: format!("failed to stop session-owned Skysight capture: {error}"),
+            },
+        );
+    }
     let _ = update_status(bundle_dir);
     Ok(record)
 }
@@ -708,11 +743,9 @@ fn ensure_bundle_open(bundle_dir: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
 
-    fn status_env_guard() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    fn status_env_guard() -> std::sync::MutexGuard<'static, ()> {
+        crate::test_support::env_guard()
     }
 
     fn window(title: &str, app_id: &str, wm_class: &str) -> windowing::WindowInfo {

--- a/record-replay-linux/src/skysight.rs
+++ b/record-replay-linux/src/skysight.rs
@@ -38,6 +38,10 @@ const TEN_MINUTE_WINDOW_SECONDS: i64 = 10 * 60;
 const SIX_HOUR_ROLLUP_SECONDS: i64 = 6 * 60 * 60;
 const SIX_HOUR_ROLLUP_REFRESH_SECONDS: i64 = 60 * 60;
 const SUMMARY_AGENT_ENABLE_ENV: &str = "CODEX_SKYSIGHT_SUMMARY_AGENT";
+const SOURCE_ENV: &str = "CODEX_SKYSIGHT_SOURCE";
+const OWNER_ENV: &str = "CODEX_SKYSIGHT_OWNER";
+const DEFAULT_START_SOURCE: &str = "cli";
+const DEFAULT_START_OWNER: &str = "manual-continuous";
 const ARTIFACTS_DIR_NAME: &str = "artifacts";
 const ACCESSIBILITY_NODE_LIMIT: usize = 160;
 const ACCESSIBILITY_DEPTH_LIMIT: u32 = 10;
@@ -64,6 +68,10 @@ pub struct SkysightStatus {
     pub schema_version: u32,
     pub state: String,
     pub is_running: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
     #[serde(default)]
     pub paused: bool,
     #[serde(default)]
@@ -204,6 +212,10 @@ pub struct SkysightStartOptions {
     pub interval_seconds: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary_agent: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -283,6 +295,8 @@ impl Default for SkysightStartOptions {
         Self {
             interval_seconds: DEFAULT_INTERVAL_SECONDS,
             summary_agent: None,
+            source: None,
+            owner: None,
         }
     }
 }
@@ -361,6 +375,8 @@ pub fn start_skysight(
     options: SkysightStartOptions,
 ) -> Result<SkysightStatus> {
     ensure_layout(paths)?;
+    let requested_source = options.source.filter(|value| !value.trim().is_empty());
+    let requested_owner = options.owner.filter(|value| !value.trim().is_empty());
     if let Some(summary_agent) = options.summary_agent {
         write_summary_agent_runtime_setting(paths, summary_agent)?;
     }
@@ -370,9 +386,19 @@ pub fn start_skysight(
                 .pid
                 .is_some_and(|pid| process_is_alive(pid, status.process_start_time_ticks))
         {
+            let mut status = status;
+            if let Some(source) = requested_source.as_deref() {
+                status.source = Some(source.to_string());
+            }
+            if let Some(owner) = requested_owner.as_deref() {
+                status.owner = Some(owner.to_string());
+            }
+            write_status(paths, &status)?;
             return skysight_status(paths);
         }
     }
+    let source = requested_source.unwrap_or_else(|| DEFAULT_START_SOURCE.to_string());
+    let owner = requested_owner.unwrap_or_else(|| DEFAULT_START_OWNER.to_string());
     let _ = fs::remove_file(&paths.stop_request_path);
     let _ = fs::remove_file(&paths.pause_request_path);
     let exe =
@@ -386,6 +412,8 @@ pub fn start_skysight(
         .env("CODEX_SKYSIGHT_RUNTIME_DIR", &paths.runtime_dir)
         .env("CODEX_SKYSIGHT_SEGMENTS_DIR", &paths.segments_dir)
         .env("CODEX_SKYSIGHT_RESOURCES_DIR", &paths.resources_dir)
+        .env(SOURCE_ENV, &source)
+        .env(OWNER_ENV, &owner)
         .env(
             "CODEX_SKYSIGHT_MEMORY_EXTENSION_DIR",
             &paths.memory_extension_dir,
@@ -397,7 +425,7 @@ pub fn start_skysight(
     let pid = crate::process_reaper::spawn_reaped(&mut command, "failed to spawn Skysight daemon")?;
     write_chronicle_started_pid(pid)?;
 
-    let status = status_value(StatusValueInput {
+    let mut status = status_value(StatusValueInput {
         paths,
         state: "running",
         is_running: true,
@@ -411,6 +439,8 @@ pub fn start_skysight(
         ocr_policy: None,
         ocr_readiness: None,
     })?;
+    status.source = Some(source);
+    status.owner = Some(owner);
     write_status(paths, &status)?;
     Ok(status)
 }
@@ -419,15 +449,28 @@ pub fn run_skysight_daemon(
     paths: &SkysightPaths,
     interval_seconds: u64,
     summary_agent: Option<bool>,
+    source: Option<String>,
+    owner: Option<String>,
 ) -> Result<()> {
     ensure_layout(paths)?;
     if let Some(summary_agent) = summary_agent {
         write_summary_agent_runtime_setting(paths, summary_agent)?;
     }
+    let requested_source = source.filter(|value| !value.trim().is_empty());
+    let requested_owner = owner.filter(|value| !value.trim().is_empty());
     let interval = Duration::from_secs(interval_seconds.max(1));
     let ocr_policy = crate::ocr::OcrPolicy::from_env();
     let mut ocr_readiness = None;
     write_chronicle_started_pid(std::process::id())?;
+    let initial_ocr_readiness = cached_ocr_readiness(&ocr_policy, &mut ocr_readiness);
+    initialize_daemon_status(
+        paths,
+        interval_seconds,
+        ocr_policy.clone(),
+        initial_ocr_readiness,
+        requested_source.as_deref(),
+        requested_owner.as_deref(),
+    )?;
     loop {
         let cached_ocr_readiness = cached_ocr_readiness(&ocr_policy, &mut ocr_readiness);
         if paths.stop_request_path.exists() {
@@ -495,6 +538,47 @@ pub fn run_skysight_daemon(
         }
         thread::sleep(interval);
     }
+}
+
+fn initialize_daemon_status(
+    paths: &SkysightPaths,
+    interval_seconds: u64,
+    ocr_policy: crate::ocr::OcrPolicy,
+    ocr_readiness: crate::ocr::OcrReadiness,
+    source: Option<&str>,
+    owner: Option<&str>,
+) -> Result<SkysightStatus> {
+    let status = status_value(StatusValueInput {
+        paths,
+        state: "running",
+        is_running: true,
+        paused: false,
+        pause_reason: None,
+        interval_seconds: Some(interval_seconds.max(1)),
+        pid: Some(std::process::id()),
+        started_at: Some(now_timestamp()),
+        end_reason: None,
+        message: Some("Skysight daemon started".to_string()),
+        ocr_policy: Some(ocr_policy),
+        ocr_readiness: Some(ocr_readiness),
+    })?;
+    let status = apply_requested_daemon_ownership(status, source, owner);
+    write_status(paths, &status)?;
+    Ok(status)
+}
+
+fn apply_requested_daemon_ownership(
+    mut status: SkysightStatus,
+    source: Option<&str>,
+    owner: Option<&str>,
+) -> SkysightStatus {
+    if let Some(source) = source {
+        status.source = Some(source.to_string());
+    }
+    if let Some(owner) = owner {
+        status.owner = Some(owner.to_string());
+    }
+    status
 }
 
 fn cached_ocr_readiness(
@@ -787,6 +871,24 @@ pub fn skysight_status(paths: &SkysightPaths) -> Result<SkysightStatus> {
 }
 
 pub fn stop_skysight(paths: &SkysightPaths) -> Result<SkysightStatus> {
+    stop_skysight_with_source(paths, "skysight_stop")
+}
+
+pub fn stop_skysight_if_owned(
+    paths: &SkysightPaths,
+    owner: &str,
+    source: &str,
+) -> Result<Option<SkysightStatus>> {
+    let Ok(status) = read_status(paths) else {
+        return Ok(None);
+    };
+    if !status.is_running || status.owner.as_deref() != Some(owner) {
+        return Ok(None);
+    }
+    stop_skysight_with_source(paths, source).map(Some)
+}
+
+fn stop_skysight_with_source(paths: &SkysightPaths, source: &str) -> Result<SkysightStatus> {
     ensure_layout(paths)?;
     if let Ok(status) = read_status(paths) {
         if let Some(pid) = status.pid {
@@ -798,7 +900,7 @@ pub fn stop_skysight(paths: &SkysightPaths) -> Result<SkysightStatus> {
     crate::secure_fs::write_private_file(&paths.stop_request_path, "stop\n")?;
     let _ = fs::remove_file(&paths.pause_request_path);
     let _ = remove_chronicle_started_pid();
-    let status = status_value(StatusValueInput {
+    let mut status = status_value(StatusValueInput {
         paths,
         state: "stopped",
         is_running: false,
@@ -812,6 +914,7 @@ pub fn stop_skysight(paths: &SkysightPaths) -> Result<SkysightStatus> {
         ocr_policy: None,
         ocr_readiness: None,
     })?;
+    status.source = Some(source.to_string());
     write_status(paths, &status)?;
     Ok(status)
 }
@@ -2136,6 +2239,22 @@ struct StatusValueInput<'a> {
 
 fn status_value(input: StatusValueInput<'_>) -> Result<SkysightStatus> {
     let existing = read_status(input.paths).ok();
+    let source = existing
+        .as_ref()
+        .and_then(|status| status.source.clone())
+        .or_else(|| {
+            env::var(SOURCE_ENV)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        });
+    let owner = existing
+        .as_ref()
+        .and_then(|status| status.owner.clone())
+        .or_else(|| {
+            env::var(OWNER_ENV)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        });
     let latest = latest_segment(input.paths)?;
     let exclusions_count = list_skysight_exclusions(input.paths)?.len();
     let capture_capabilities = capture_capability_notes();
@@ -2182,6 +2301,8 @@ fn status_value(input: StatusValueInput<'_>) -> Result<SkysightStatus> {
         schema_version: 3,
         state: input.state.to_string(),
         is_running: input.is_running,
+        source,
+        owner,
         paused: input.paused,
         is_paused: input.paused,
         pause_reason: input.pause_reason,
@@ -3116,11 +3237,9 @@ fn request_process_stop(pid: u32) {
 mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
-    use std::sync::{Mutex, OnceLock};
 
     fn env_guard() -> std::sync::MutexGuard<'static, ()> {
-        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+        crate::test_support::env_guard()
     }
 
     fn exclusion(kind: &str, value: &str) -> SkysightExclusion {
@@ -3478,6 +3597,86 @@ mod tests {
     }
 
     #[test]
+    fn daemon_initial_status_applies_requested_source_and_owner() {
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let paths = SkysightPaths::new(temp.path().join("runtime"), temp.path().join("resources"));
+
+        let status = initialize_daemon_status(
+            &paths,
+            60,
+            crate::ocr::OcrPolicy::from_env(),
+            crate::ocr::OcrReadiness {
+                enabled: false,
+                available: false,
+                backend: "auto".to_string(),
+                status: "disabled".to_string(),
+                language: "eng".to_string(),
+                version: None,
+                dependency_hint: None,
+                error: None,
+            },
+            Some("direct-daemon"),
+            Some("recording-session:test"),
+        )
+        .unwrap();
+
+        assert_eq!(status.source.as_deref(), Some("direct-daemon"));
+        assert_eq!(status.owner.as_deref(), Some("recording-session:test"));
+        let persisted = read_status(&paths).unwrap();
+        assert_eq!(persisted.source, status.source);
+        assert_eq!(persisted.owner, status.owner);
+    }
+
+    #[test]
+    fn daemon_snapshot_status_preserves_live_ownership_reassignment() {
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let paths = SkysightPaths::new(temp.path().join("runtime"), temp.path().join("resources"));
+        ensure_layout(&paths).unwrap();
+
+        let mut reassigned = status_value(StatusValueInput {
+            paths: &paths,
+            state: "running",
+            is_running: true,
+            paused: false,
+            pause_reason: None,
+            interval_seconds: Some(60),
+            pid: Some(std::process::id()),
+            started_at: Some(now_timestamp()),
+            end_reason: None,
+            message: Some("ownership reassigned while daemon is live".to_string()),
+            ocr_policy: None,
+            ocr_readiness: None,
+        })
+        .unwrap();
+        reassigned.source = Some("chronicle-tray".to_string());
+        reassigned.owner = Some("manual-continuous".to_string());
+        write_status(&paths, &reassigned).unwrap();
+
+        let status = capture_skysight_snapshot_with_ocr(
+            &paths,
+            Some("daemon"),
+            crate::ocr::OcrPolicy::from_env(),
+            crate::ocr::OcrReadiness {
+                enabled: false,
+                available: false,
+                backend: "auto".to_string(),
+                status: "disabled".to_string(),
+                language: "eng".to_string(),
+                version: None,
+                dependency_hint: None,
+                error: None,
+            },
+            Some(std::process::id()),
+        )
+        .unwrap();
+
+        assert_eq!(status.source.as_deref(), Some("chronicle-tray"));
+        assert_eq!(status.owner.as_deref(), Some("manual-continuous"));
+    }
+
+    #[test]
     fn cached_ocr_readiness_reuses_daemon_session_probe() {
         let _guard = env_guard();
         let env_keys = [
@@ -3628,7 +3827,7 @@ echo '__CODEX_RAPIDOCR_JSON__{{"rapidocr":"3.9.1","onnxruntime":"1.22.0","lang_t
         env::set_var("CODEX_HOME", temp.path().join("codex-home"));
 
         ensure_layout(&paths).unwrap();
-        let status = status_value(StatusValueInput {
+        let mut status = status_value(StatusValueInput {
             paths: &paths,
             state: "running",
             is_running: true,
@@ -3643,6 +3842,8 @@ echo '__CODEX_RAPIDOCR_JSON__{{"rapidocr":"3.9.1","onnxruntime":"1.22.0","lang_t
             ocr_readiness: None,
         })
         .unwrap();
+        status.source = Some("recording-session".to_string());
+        status.owner = Some("recording-session:fixture".to_string());
         write_status(&paths, &status).unwrap();
 
         let updated = start_skysight(
@@ -3650,6 +3851,8 @@ echo '__CODEX_RAPIDOCR_JSON__{{"rapidocr":"3.9.1","onnxruntime":"1.22.0","lang_t
             SkysightStartOptions {
                 interval_seconds: 60,
                 summary_agent: Some(true),
+                source: None,
+                owner: None,
             },
         )
         .unwrap();
@@ -3664,6 +3867,8 @@ echo '__CODEX_RAPIDOCR_JSON__{{"rapidocr":"3.9.1","onnxruntime":"1.22.0","lang_t
             fs::read_to_string(&paths.summary_agent_setting_path).unwrap(),
             "enabled\n"
         );
+        assert_eq!(updated.source.as_deref(), Some("recording-session"));
+        assert_eq!(updated.owner.as_deref(), Some("recording-session:fixture"));
 
         match old_value {
             Some(value) => env::set_var(SUMMARY_AGENT_ENABLE_ENV, value),

--- a/record-replay-linux/src/skysight.rs
+++ b/record-replay-linux/src/skysight.rs
@@ -25,6 +25,7 @@ const RESOURCES_DIR_NAME: &str = "resources";
 const EXCLUSIONS_FILE_NAME: &str = "exclusions.json";
 const STOP_REQUEST_FILE_NAME: &str = "stop-requested";
 const PAUSE_REQUEST_FILE_NAME: &str = "pause-requested";
+const LIFECYCLE_LOCK_FILE_NAME: &str = ".lifecycle.lock";
 const SUMMARY_AGENT_SETTING_FILE_NAME: &str = "summary-agent";
 const MEMORY_INSTRUCTIONS_FILE_NAME: &str = "SkysightMemoryInstructions.md";
 const CHRONICLE_INSTRUCTIONS_FILE_NAME: &str = "instructions.md";
@@ -380,6 +381,7 @@ pub fn start_skysight(
     if let Some(summary_agent) = options.summary_agent {
         write_summary_agent_runtime_setting(paths, summary_agent)?;
     }
+    let _lifecycle_lock = lifecycle_lock(paths)?;
     if let Ok(status) = read_status(paths) {
         if status.is_running
             && status
@@ -393,7 +395,8 @@ pub fn start_skysight(
             if let Some(owner) = requested_owner.as_deref() {
                 status.owner = Some(owner.to_string());
             }
-            write_status(paths, &status)?;
+            write_status_locked(paths, &status)?;
+            drop(_lifecycle_lock);
             return skysight_status(paths);
         }
     }
@@ -409,6 +412,10 @@ pub fn start_skysight(
         .arg("daemon")
         .arg("--interval-seconds")
         .arg(options.interval_seconds.to_string())
+        .arg("--source")
+        .arg(&source)
+        .arg("--owner")
+        .arg(&owner)
         .env("CODEX_SKYSIGHT_RUNTIME_DIR", &paths.runtime_dir)
         .env("CODEX_SKYSIGHT_SEGMENTS_DIR", &paths.segments_dir)
         .env("CODEX_SKYSIGHT_RESOURCES_DIR", &paths.resources_dir)
@@ -441,7 +448,7 @@ pub fn start_skysight(
     })?;
     status.source = Some(source);
     status.owner = Some(owner);
-    write_status(paths, &status)?;
+    write_status_locked(paths, &status)?;
     Ok(status)
 }
 
@@ -456,8 +463,22 @@ pub fn run_skysight_daemon(
     if let Some(summary_agent) = summary_agent {
         write_summary_agent_runtime_setting(paths, summary_agent)?;
     }
-    let requested_source = source.filter(|value| !value.trim().is_empty());
-    let requested_owner = owner.filter(|value| !value.trim().is_empty());
+    let requested_source = source
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            env::var(SOURCE_ENV)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .unwrap_or_else(|| DEFAULT_START_SOURCE.to_string());
+    let requested_owner = owner
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            env::var(OWNER_ENV)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .unwrap_or_else(|| DEFAULT_START_OWNER.to_string());
     let interval = Duration::from_secs(interval_seconds.max(1));
     let ocr_policy = crate::ocr::OcrPolicy::from_env();
     let mut ocr_readiness = None;
@@ -468,8 +489,8 @@ pub fn run_skysight_daemon(
         interval_seconds,
         ocr_policy.clone(),
         initial_ocr_readiness,
-        requested_source.as_deref(),
-        requested_owner.as_deref(),
+        Some(&requested_source),
+        Some(&requested_owner),
     )?;
     loop {
         let cached_ocr_readiness = cached_ocr_readiness(&ocr_policy, &mut ocr_readiness);
@@ -871,7 +892,9 @@ pub fn skysight_status(paths: &SkysightPaths) -> Result<SkysightStatus> {
 }
 
 pub fn stop_skysight(paths: &SkysightPaths) -> Result<SkysightStatus> {
-    stop_skysight_with_source(paths, "skysight_stop")
+    ensure_layout(paths)?;
+    let _lifecycle_lock = lifecycle_lock(paths)?;
+    stop_skysight_with_source_locked(paths, "skysight_stop")
 }
 
 pub fn stop_skysight_if_owned(
@@ -879,17 +902,18 @@ pub fn stop_skysight_if_owned(
     owner: &str,
     source: &str,
 ) -> Result<Option<SkysightStatus>> {
+    ensure_layout(paths)?;
+    let _lifecycle_lock = lifecycle_lock(paths)?;
     let Ok(status) = read_status(paths) else {
         return Ok(None);
     };
     if !status.is_running || status.owner.as_deref() != Some(owner) {
         return Ok(None);
     }
-    stop_skysight_with_source(paths, source).map(Some)
+    stop_skysight_with_source_locked(paths, source).map(Some)
 }
 
-fn stop_skysight_with_source(paths: &SkysightPaths, source: &str) -> Result<SkysightStatus> {
-    ensure_layout(paths)?;
+fn stop_skysight_with_source_locked(paths: &SkysightPaths, source: &str) -> Result<SkysightStatus> {
     if let Ok(status) = read_status(paths) {
         if let Some(pid) = status.pid {
             if process_is_alive(pid, status.process_start_time_ticks) {
@@ -915,7 +939,7 @@ fn stop_skysight_with_source(paths: &SkysightPaths, source: &str) -> Result<Skys
         ocr_readiness: None,
     })?;
     status.source = Some(source.to_string());
-    write_status(paths, &status)?;
+    write_status_locked(paths, &status)?;
     Ok(status)
 }
 
@@ -2215,7 +2239,26 @@ fn read_status(paths: &SkysightPaths) -> Result<SkysightStatus> {
         .with_context(|| format!("failed to parse {}", paths.status_path.display()))
 }
 
+fn lifecycle_lock(paths: &SkysightPaths) -> Result<crate::secure_fs::DirectoryLock> {
+    crate::secure_fs::lock_directory(&paths.runtime_dir, LIFECYCLE_LOCK_FILE_NAME)
+}
+
 fn write_status(paths: &SkysightPaths, status: &SkysightStatus) -> Result<()> {
+    let _lifecycle_lock = lifecycle_lock(paths)?;
+    let mut status = status.clone();
+    if let Ok(current) = read_status(paths) {
+        if current.is_running {
+            if current.pid != status.pid {
+                return Ok(());
+            }
+            status.source = current.source;
+            status.owner = current.owner;
+        }
+    }
+    write_status_locked(paths, &status)
+}
+
+fn write_status_locked(paths: &SkysightPaths, status: &SkysightStatus) -> Result<()> {
     crate::secure_fs::write_private_file(
         &paths.status_path,
         format!("{}\n", serde_json::to_string_pretty(status)?),
@@ -3674,6 +3717,102 @@ mod tests {
 
         assert_eq!(status.source.as_deref(), Some("chronicle-tray"));
         assert_eq!(status.owner.as_deref(), Some("manual-continuous"));
+    }
+
+    #[test]
+    fn concurrent_manual_handoff_wins_before_owned_stop() {
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let paths = SkysightPaths::new(temp.path().join("runtime"), temp.path().join("resources"));
+        ensure_layout(&paths).unwrap();
+
+        let mut status = status_value(StatusValueInput {
+            paths: &paths,
+            state: "running",
+            is_running: true,
+            paused: false,
+            pause_reason: None,
+            interval_seconds: Some(60),
+            pid: Some(std::process::id()),
+            started_at: Some(now_timestamp()),
+            end_reason: None,
+            message: Some("recording-owned capture".to_string()),
+            ocr_policy: None,
+            ocr_readiness: None,
+        })
+        .unwrap();
+        status.source = Some("event-stream-start".to_string());
+        status.owner = Some("recording-session:old".to_string());
+        write_status_locked(&paths, &status).unwrap();
+
+        let lifecycle = lifecycle_lock(&paths).unwrap();
+        let thread_paths = paths.clone();
+        let (attempting_tx, attempting_rx) = std::sync::mpsc::channel();
+        let stop = std::thread::spawn(move || {
+            attempting_tx.send(()).unwrap();
+            stop_skysight_if_owned(
+                &thread_paths,
+                "recording-session:old",
+                "event-stream-shutdown",
+            )
+        });
+        attempting_rx.recv().unwrap();
+
+        status.source = Some("chronicle-tray".to_string());
+        status.owner = Some("manual-continuous".to_string());
+        write_status_locked(&paths, &status).unwrap();
+        drop(lifecycle);
+
+        assert!(stop.join().unwrap().unwrap().is_none());
+        assert!(!paths.stop_request_path.exists());
+        let persisted = read_status(&paths).unwrap();
+        assert_eq!(persisted.source.as_deref(), Some("chronicle-tray"));
+        assert_eq!(persisted.owner.as_deref(), Some("manual-continuous"));
+    }
+
+    #[test]
+    fn stale_daemon_status_write_preserves_new_owner() {
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let paths = SkysightPaths::new(temp.path().join("runtime"), temp.path().join("resources"));
+        ensure_layout(&paths).unwrap();
+
+        let mut stale_daemon_status = status_value(StatusValueInput {
+            paths: &paths,
+            state: "running",
+            is_running: true,
+            paused: false,
+            pause_reason: None,
+            interval_seconds: Some(60),
+            pid: Some(std::process::id()),
+            started_at: Some(now_timestamp()),
+            end_reason: None,
+            message: Some("daemon status before handoff".to_string()),
+            ocr_policy: None,
+            ocr_readiness: None,
+        })
+        .unwrap();
+        stale_daemon_status.source = Some("event-stream-start".to_string());
+        stale_daemon_status.owner = Some("recording-session:old".to_string());
+        write_status_locked(&paths, &stale_daemon_status).unwrap();
+
+        let reassigned = start_skysight(
+            &paths,
+            SkysightStartOptions {
+                interval_seconds: 60,
+                summary_agent: None,
+                source: Some("chronicle-tray".to_string()),
+                owner: Some("manual-continuous".to_string()),
+            },
+        )
+        .unwrap();
+        assert_eq!(reassigned.owner.as_deref(), Some("manual-continuous"));
+
+        write_status(&paths, &stale_daemon_status).unwrap();
+
+        let persisted = read_status(&paths).unwrap();
+        assert_eq!(persisted.source.as_deref(), Some("chronicle-tray"));
+        assert_eq!(persisted.owner.as_deref(), Some("manual-continuous"));
     }
 
     #[test]

--- a/record-replay-linux/tests/mcp_modes.rs
+++ b/record-replay-linux/tests/mcp_modes.rs
@@ -1,0 +1,29 @@
+use codex_record_replay_linux::mcp::{tool_names, McpMode};
+
+#[test]
+fn skysight_mode_exposes_only_activity_memory_tools() {
+    let names = tool_names(McpMode::Skysight);
+
+    assert!(names.contains(&"doctor".to_string()));
+    assert!(names.contains(&"skysight_start".to_string()));
+    assert!(names.contains(&"skysight_status".to_string()));
+    assert!(names.contains(&"skysight_pause".to_string()));
+    assert!(names.contains(&"skysight_resume".to_string()));
+    assert!(names.contains(&"skysight_stop".to_string()));
+    assert!(names.contains(&"skysight_snapshot".to_string()));
+    assert!(names.contains(&"skysight_update_exclusion".to_string()));
+    assert!(names.contains(&"skysight_list_exclusions".to_string()));
+    assert!(!names.contains(&"event_stream_start".to_string()));
+    assert!(!names.contains(&"start".to_string()));
+    assert!(!names.contains(&"draft_skill_prompt".to_string()));
+    assert!(!names.contains(&"import_skill".to_string()));
+}
+
+#[test]
+fn event_stream_mode_retains_recording_and_activity_memory_tools() {
+    let names = tool_names(McpMode::EventStream);
+
+    assert!(names.contains(&"event_stream_start".to_string()));
+    assert!(names.contains(&"draft_skill_prompt".to_string()));
+    assert!(names.contains(&"skysight_start".to_string()));
+}

--- a/record-replay-linux/tests/skysight_tests.rs
+++ b/record-replay-linux/tests/skysight_tests.rs
@@ -1,7 +1,7 @@
 use codex_record_replay_linux::{
     capture_skysight_snapshot, list_skysight_exclusions, pause_skysight, resume_skysight,
-    skysight_status, stop_skysight, update_skysight_exclusion, SkysightExclusionUpdate,
-    SkysightPaths,
+    skysight_status, stop_skysight, stop_skysight_if_owned, update_skysight_exclusion,
+    SkysightExclusionUpdate, SkysightPaths,
 };
 use serde_json::Value;
 use std::{
@@ -22,6 +22,48 @@ fn restore_env(key: &str, value: Option<std::ffi::OsString>) {
         Some(value) => env::set_var(key, value),
         None => env::remove_var(key),
     }
+}
+
+fn write_running_status(paths: &SkysightPaths, owner: &str, source: &str) {
+    let mut status = skysight_status(paths).unwrap();
+    status.state = "running".to_string();
+    status.is_running = true;
+    status.owner = Some(owner.to_string());
+    status.source = Some(source.to_string());
+    fs::write(
+        &paths.status_path,
+        format!("{}\n", serde_json::to_string_pretty(&status).unwrap()),
+    )
+    .unwrap();
+}
+
+#[test]
+fn skysight_owned_stop_records_owner_and_initiating_source() {
+    let temp = tempfile::tempdir().unwrap();
+    let paths = SkysightPaths::new(temp.path().join("runtime"), temp.path().join("resources"));
+    write_running_status(&paths, "recording-session:fixture", "event-stream-start");
+
+    let stopped = stop_skysight_if_owned(&paths, "recording-session:fixture", "event-stream-stop")
+        .unwrap()
+        .expect("matching session owner should be stopped");
+
+    assert!(!stopped.is_running);
+    assert_eq!(stopped.owner.as_deref(), Some("recording-session:fixture"));
+    assert_eq!(stopped.source.as_deref(), Some("event-stream-stop"));
+    assert!(paths.stop_request_path.is_file());
+}
+
+#[test]
+fn skysight_owned_stop_does_not_stop_manual_continuous_capture() {
+    let temp = tempfile::tempdir().unwrap();
+    let paths = SkysightPaths::new(temp.path().join("runtime"), temp.path().join("resources"));
+    write_running_status(&paths, "manual-continuous", "chronicle-tray");
+
+    let stopped =
+        stop_skysight_if_owned(&paths, "recording-session:fixture", "event-stream-stop").unwrap();
+
+    assert!(stopped.is_none());
+    assert!(!paths.stop_request_path.exists());
 }
 
 #[test]

--- a/scripts/bootstrap-wizard.sh
+++ b/scripts/bootstrap-wizard.sh
@@ -742,11 +742,48 @@ def read_enabled_ids(data, path):
 def csv(ids):
     return ", ".join(ids) if ids else "none"
 
+def expand_enabled(ids):
+    expanded = []
+    completed = set()
+    visiting = []
+
+    def visit(feature_id):
+        if feature_id in completed:
+            return
+        if feature_id in visiting:
+            cycle = visiting[visiting.index(feature_id):] + [feature_id]
+            die(f"Linux feature dependency cycle: {' -> '.join(cycle)}")
+        visiting.append(feature_id)
+        feature = features.get(feature_id)
+        if feature is not None:
+            for required in feature["requires"]:
+                visit(required)
+        visiting.pop()
+        completed.add(feature_id)
+        expanded.append(feature_id)
+
+    for feature_id in ids:
+        visit(feature_id)
+    return expanded
+
+def disabled_with_dependents(ids):
+    disabled = set(ids)
+    changed = True
+    while changed:
+        changed = False
+        for feature_id, feature in features.items():
+            if feature_id not in disabled and any(
+                required in disabled for required in feature["requires"]
+            ):
+                disabled.add(feature_id)
+                changed = True
+    return disabled
+
 features = discover_features(features_root)
 config_data = read_feature_config(config_path)
 if not isinstance(config_data, dict):
     die(f"Linux features config {config_path} must be a JSON object")
-current = read_enabled_ids(config_data, config_path)
+current = expand_enabled(read_enabled_ids(config_data, config_path))
 
 if output_mode == "tsv":
     # Machine-readable discovery for the GUI feature picker: one
@@ -771,10 +808,10 @@ for feature_id in disable:
     if feature_id not in features and feature_id not in current:
         die(f"Unknown Linux feature id: {feature_id}")
 
-final = [feature_id for feature_id in current if feature_id not in set(disable)]
-for feature_id in enable:
-    if feature_id not in final:
-        final.append(feature_id)
+disabled = disabled_with_dependents(disable)
+final = [feature_id for feature_id in current if feature_id not in disabled]
+final = expand_enabled(final + enable)
+final = [feature_id for feature_id in final if feature_id not in disabled]
 
 final_set = set(final)
 for feature_id in final:

--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -54,6 +54,7 @@ run_core() {
     tail -n 12 "$node_test_log"
     if command -v cargo >/dev/null 2>&1; then
         cargo test -p codex-update-manager
+        cargo test -p codex-record-replay-linux
     fi
 }
 

--- a/scripts/ci/github-actions-workflows.test.js
+++ b/scripts/ci/github-actions-workflows.test.js
@@ -29,9 +29,14 @@ test("CI runs the complete workflow regression suite", () => {
   assert.match(nixBuild, /system: aarch64-linux/);
   assert.match(nixBuild, /runner: ubuntu-24\.04-arm/);
   assert.match(nixBuild, /checks\.\$\{\{ matrix\.system \}\}\.modules/);
+  assert.match(nixBuild, /nix-runtime-chronicle-skysight/);
   assert.match(nixBuild, /nix-runtime-maximal-directory-watch/);
   assert.match(nixBuild, /nix-runtime-maximal-shallow-watch/);
   assert.match(nixBuild, /nix-installer/);
+
+  const rust = job(workflow, "rust");
+  assert.match(rust, /cargo test -p codex-record-replay-linux/);
+  assert.match(rust, /cargo clippy -p codex-record-replay-linux --all-targets -- -D warnings/);
 
   const nixVm = job(workflow, "nix-vm");
   assert.match(nixVm, /checks\.x86_64-linux\.nixos-vm/);

--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -231,12 +231,14 @@ function linuxFeaturesConfig(options = {}) {
   if (config == null) {
     return { enabled: [], settings: {}, configPath };
   }
+  const normalizedEnabled = normalizeEnabledFeatureIds(
+    config.enabled,
+    configPath,
+    { strict: options.strictConfig === true },
+  );
+  const available = linuxFeatureManifestMap(options);
   return {
-    enabled: normalizeEnabledFeatureIds(
-      config.enabled,
-      configPath,
-      { strict: options.strictConfig === true },
-    ),
+    enabled: expandEnabledFeatureDependencies(normalizedEnabled, available),
     settings: normalizeLinuxFeatureSettings(config.settings, configPath),
     configPath,
   };
@@ -355,6 +357,37 @@ function linuxFeatureManifestMap(options = {}) {
   return new Map(discoverLinuxFeatureManifests(options).map((feature) => [feature.id, feature]));
 }
 
+function expandEnabledFeatureDependencies(enabled, available) {
+  const expanded = [];
+  const completed = new Set();
+  const visiting = [];
+
+  const visit = (id) => {
+    if (completed.has(id)) {
+      return;
+    }
+    const cycleIndex = visiting.indexOf(id);
+    if (cycleIndex !== -1) {
+      throw new Error(
+        `Linux feature dependency cycle: ${[...visiting.slice(cycleIndex), id].join(" -> ")}`,
+      );
+    }
+    visiting.push(id);
+    const feature = available.get(id);
+    for (const required of feature?.manifest.requires ?? []) {
+      visit(required);
+    }
+    visiting.pop();
+    completed.add(id);
+    expanded.push(id);
+  };
+
+  for (const id of enabled) {
+    visit(id);
+  }
+  return expanded;
+}
+
 function loadLinuxFeatureManifest(featuresRoot, id, options = {}) {
   const feature = linuxFeatureManifestMap({ ...options, featuresRoot }).get(id);
   if (feature == null) {
@@ -384,7 +417,9 @@ function loadEnabledLinuxFeatures(options = {}) {
   const featuresRoot = linuxFeaturesRoot(options);
   const available = linuxFeatureManifestMap({ ...options, featuresRoot });
   const config = linuxFeaturesConfig({ ...options, featuresRoot });
-  const enabled = options.enabledFeatureIds ?? config.enabled;
+  const enabled = options.enabledFeatureIds == null
+    ? config.enabled
+    : expandEnabledFeatureDependencies(options.enabledFeatureIds, available);
   const features = [];
   const missing = [];
   for (const id of enabled) {
@@ -1474,6 +1509,7 @@ module.exports = {
   enabledLinuxFeaturePackagePlan,
   enabledLinuxFeatureStageHooks,
   featuresJsonSummary,
+  expandEnabledFeatureDependencies,
   loadEnabledLinuxFeatures,
   loadLinuxFeaturePatchDescriptors,
   linuxFeatureManifestMap,

--- a/scripts/lib/linux-features.test.js
+++ b/scripts/lib/linux-features.test.js
@@ -53,6 +53,37 @@ test("known retired feature ids are ignored while arbitrary unknown ids fail", (
   );
 });
 
+test("enabled feature dependencies are added for persisted and explicit selections", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-dependency-closure-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const featuresRoot = path.join(root, "linux-features");
+  const configPath = path.join(featuresRoot, "features.json");
+  fs.mkdirSync(featuresRoot);
+  fs.writeFileSync(configPath, `${JSON.stringify({ enabled: ["recording"] })}\n`);
+  for (const [id, requires] of [
+    ["chronicle", []],
+    ["recording", ["chronicle"]],
+  ]) {
+    const featureDir = path.join(featuresRoot, id);
+    fs.mkdirSync(featureDir);
+    fs.writeFileSync(path.join(featureDir, "README.md"), `# ${id}\n`);
+    fs.writeFileSync(
+      path.join(featureDir, "feature.json"),
+      `${JSON.stringify({ id, title: id, requires }, null, 2)}\n`,
+    );
+  }
+
+  assert.deepEqual(
+    linuxFeaturesConfig({ featuresRoot, featuresConfigPath: configPath }).enabled,
+    ["chronicle", "recording"],
+  );
+  assert.deepEqual(
+    loadEnabledLinuxFeatures({ featuresRoot, enabledFeatureIds: ["recording"] })
+      .map((feature) => feature.id),
+    ["chronicle", "recording"],
+  );
+});
+
 function makeFeatureRoot(root, featureManifest) {
   const featuresRoot = path.join(root, "linux-features");
   const featureDir = path.join(featuresRoot, "unsafe-link");

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -1000,7 +1000,7 @@ stage_enabled_native_feature_artifacts() {
                     "$update_builder_root/target/release/codex-read-aloud-linux" \
                     "$feature_id backend"
                 ;;
-            record-and-replay)
+            chronicle-skysight)
                 stage_update_builder_native_artifact \
                     "$APP_DIR/resources/native/codex-record-replay-linux" \
                     "$update_builder_root/target/release/codex-record-replay-linux" \

--- a/scripts/lib/package-common.test.js
+++ b/scripts/lib/package-common.test.js
@@ -112,6 +112,56 @@ test("update-builder copies staged native feature artifacts without Cargo worksp
   }
 });
 
+test("Chronicle-only packaging retains the shared backend for updater rebuilds", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-update-builder-chronicle-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const config = path.join(root, "features.json");
+  const backend = path.join(root, "app/resources/native/codex-record-replay-linux");
+  const builder = path.join(root, "builder");
+  fs.writeFileSync(config, `${JSON.stringify({ enabled: ["chronicle-skysight"] })}\n`);
+  fs.mkdirSync(path.dirname(backend), { recursive: true });
+  fs.writeFileSync(backend, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+  runPackageCommon(
+    `CODEX_LINUX_FEATURES_CONFIG=${JSON.stringify(config)} stage_enabled_native_feature_artifacts ${JSON.stringify(builder)}`,
+    path.join(root, "app"),
+  );
+
+  const retainedBackend = path.join(builder, "target/release/codex-record-replay-linux");
+  assert.equal(fs.readFileSync(retainedBackend, "utf8"), "#!/bin/sh\nexit 0\n");
+  assert.equal(fs.statSync(retainedBackend).mode & 0o777, 0o755);
+});
+
+test("Chronicle-only native helper setup builds the shared backend", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-native-helper-chronicle-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const config = path.join(root, "features.json");
+  const binDir = path.join(root, "bin");
+  const cargoLog = path.join(root, "cargo.log");
+  fs.writeFileSync(config, `${JSON.stringify({ enabled: ["chronicle-skysight"] })}\n`);
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(binDir, "cargo"),
+    "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$CARGO_LOG\"\n",
+    { mode: 0o755 },
+  );
+
+  const result = childProcess.spawnSync("make", ["build-native-feature-helpers"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CARGO_LOG: cargoLog,
+      CODEX_LINUX_FEATURES_CONFIG: config,
+      PATH: `${binDir}:${process.env.PATH}`,
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(cargoLog), true);
+  assert.match(fs.readFileSync(cargoLog, "utf8"), /build .*--release -p codex-record-replay-linux/);
+});
+
 test("update-builder carries the shared feature compatibility registry", (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-update-builder-features-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary

- preserve manually started Chronicle/Skysight capture when Record & Replay stops
- track daemon source and ownership across runtime reassignment and stale PID recovery
- add a restricted activity-memory MCP mode while retaining the full event-stream mode
- split the shared Skysight backend into its own opt-in feature so lifecycle ownership is explicit

Closes #1352. Related to #536 and the standalone feature work in #1354.

## Validation

- `node --test linux-features/chronicle-skysight/test.js linux-features/record-and-replay/test.js` (45 passed)
- `cargo test -p codex-record-replay-linux` (38 unit, 65 integration, 0 failed)
- `git diff --check`

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest signed stable OpenAI Linux package and removes obsolete fallback code and tests.
- [x] I added or updated relevant tests and ran the validation listed above. Required remote CI checks are pending.
- [ ] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
