### PR TITLE
Retarget Suggested Prompts to Linux 26.810

### DIFF
--- a/linux-features/ui-tweaks/patches/suggested-prompts.js
+++ b/linux-features/ui-tweaks/patches/suggested-prompts.js
@@ -33,11 +33,11 @@ function appPageEligibilityPattern() {
 }
 
 function mainEligibilityPattern() {
-  return /let\{ambientSuggestionsStaleTimeMs:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\);if\(!([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\|\|\1==null\)return\{enabled:!1\};let\{account:([A-Za-z_$][\w$]*)\}=await ([A-Za-z_$][\w$]*)\.getAccount\(\);return ([A-Za-z_$][\w$]*)\(\5\)\?\{enabled:!0,staleTimeMs:\1\}:\{enabled:!1\}/gu;
+  return /let\{ambientSuggestionsFeatureDiscovery:([A-Za-z_$][\w$]*),ambientSuggestionsStaleTimeMs:([A-Za-z_$][\w$]*),computerUse:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\);if\(!([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\|\|\2==null\)return\{enabled:!1\};let\{account:([A-Za-z_$][\w$]*)\}=await ([A-Za-z_$][\w$]*)\.getAccount\(\);return ([A-Za-z_$][\w$]*)\(\7\)\?\{enabled:!0,computerUseAvailable:\3,featureDiscoveryEnabled:\1,staleTimeMs:\2\}:\{enabled:!1\}/gu;
 }
 
 function patchedMainEligibilityPattern() {
-  return /let\{ambientSuggestionsStaleTimeMs:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\);if\(!([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\|\|\1==null\)return\{enabled:!1\};let\{account:([A-Za-z_$][\w$]*)\}=await ([A-Za-z_$][\w$]*)\.getAccount\(\);return\(([A-Za-z_$][\w$]*)\(\5\),function codexLinuxUiTweaksSuggestedPromptsMainEnabled\(\)\{return!0\}\(\)\)\?\{enabled:!0,staleTimeMs:\1\}:\{enabled:!1\}/gu;
+  return /let\{ambientSuggestionsFeatureDiscovery:([A-Za-z_$][\w$]*),ambientSuggestionsStaleTimeMs:([A-Za-z_$][\w$]*),computerUse:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\);if\(!([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\|\|\2==null\)return\{enabled:!1\};let\{account:([A-Za-z_$][\w$]*)\}=await ([A-Za-z_$][\w$]*)\.getAccount\(\);return\(([A-Za-z_$][\w$]*)\(\7\),function codexLinuxUiTweaksSuggestedPromptsMainEnabled\(\)\{return!0\}\(\)\)\?\{enabled:!0,computerUseAvailable:\3,featureDiscoveryEnabled:\1,staleTimeMs:\2\}:\{enabled:!1\}/gu;
 }
 
 function settingsEligibilityPattern() {
@@ -45,7 +45,11 @@ function settingsEligibilityPattern() {
 }
 
 function homeContentSourcePattern() {
-  return /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)===`curated`(?=,[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\.email\),[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\(\{canUsePersonalizedSuggestions:[A-Za-z_$][\w$]*,generatedSuggestionsEnabled:[A-Za-z_$][\w$]*,hasGeneratedSuggestionsReadSettled:[A-Za-z_$][\w$]*,shouldUseCuratedNewChatPageSuggestions:\1\}\))/gu;
+  return /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)===`curated`(?=,[\s\S]{0,400}?canUsePersonalizedSuggestions:[A-Za-z_$][\w$]*,generatedSuggestionsEnabled:[A-Za-z_$][\w$]*,hasGeneratedSuggestionsReadSettled:[A-Za-z_$][\w$]*,shouldUseCuratedNewChatPageSuggestions:\1\})/gu;
+}
+
+function patchedHomeContentSourcePattern() {
+  return /([A-Za-z_$][\w$]*)=\(([A-Za-z_$][\w$]*)===`curated`,function codexLinuxSuggestedPromptsGeneratedSource\(\)\{return!1\}\(\)\)(?=,[\s\S]{0,400}?canUsePersonalizedSuggestions:[A-Za-z_$][\w$]*,generatedSuggestionsEnabled:[A-Za-z_$][\w$]*,hasGeneratedSuggestionsReadSettled:[A-Za-z_$][\w$]*,shouldUseCuratedNewChatPageSuggestions:\1\})/gu;
 }
 
 function matchCount(source, pattern) {
@@ -100,10 +104,11 @@ function suggestedPromptsHomeContentContract(source) {
   }
   const markerMatches = source.split(HOME_CONTENT_SOURCE_MARKER).length - 1;
   const cleanMatches = matchCount(source, homeContentSourcePattern());
-  if (markerMatches === 0 && cleanMatches === 1) {
+  const patchedMatches = matchCount(source, patchedHomeContentSourcePattern());
+  if (markerMatches === 0 && cleanMatches === 1 && patchedMatches === 0) {
     return "current";
   }
-  if (markerMatches === 1 && cleanMatches === 0) {
+  if (markerMatches === 1 && cleanMatches === 0 && patchedMatches === 1) {
     return "patched";
   }
   return "drifted";
@@ -172,7 +177,9 @@ function applySuggestedPromptsMainPatch(source) {
       mainEligibilityPattern(),
       (
         _match,
+        featureDiscoveryName,
         staleTimeName,
+        computerUseName,
         featureStateName,
         settingsEligibilityName,
         settingsStoreName,
@@ -180,7 +187,7 @@ function applySuggestedPromptsMainPatch(source) {
         appServerConnectionName,
         accountEligibilityName,
       ) =>
-        `let{ambientSuggestionsStaleTimeMs:${staleTimeName}}=${featureStateName}();if(!${settingsEligibilityName}(${settingsStoreName})||${staleTimeName}==null)return{enabled:!1};let{account:${accountName}}=await ${appServerConnectionName}.getAccount();return(${accountEligibilityName}(${accountName}),function ${MAIN_ELIGIBILITY_MARKER}(){return!0}())?{enabled:!0,staleTimeMs:${staleTimeName}}:{enabled:!1}`,
+        `let{ambientSuggestionsFeatureDiscovery:${featureDiscoveryName},ambientSuggestionsStaleTimeMs:${staleTimeName},computerUse:${computerUseName}}=${featureStateName}();if(!${settingsEligibilityName}(${settingsStoreName})||${staleTimeName}==null)return{enabled:!1};let{account:${accountName}}=await ${appServerConnectionName}.getAccount();return(${accountEligibilityName}(${accountName}),function ${MAIN_ELIGIBILITY_MARKER}(){return!0}())?{enabled:!0,computerUseAvailable:${computerUseName},featureDiscoveryEnabled:${featureDiscoveryName},staleTimeMs:${staleTimeName}}:{enabled:!1}`,
     );
   } catch (error) {
     console.warn(

--- a/linux-features/ui-tweaks/suggested-prompts.test.js
+++ b/linux-features/ui-tweaks/suggested-prompts.test.js
@@ -56,8 +56,9 @@ function mainFixture() {
   return [
     "function Or(e){return br().ambientSuggestions&&e.getEffective(n.Wi.enabled.key)===!0}",
     "async function kr({appServerConnection:e,settingsStore:t}){",
-    "let{ambientSuggestionsStaleTimeMs:n}=br();if(!Or(t)||n==null)return{enabled:!1};",
-    "let{account:r}=await e.getAccount();return ie(r)?{enabled:!0,staleTimeMs:n}:{enabled:!1}}",
+    "let{ambientSuggestionsFeatureDiscovery:n,ambientSuggestionsStaleTimeMs:r,computerUse:i}=br();",
+    "if(!Or(t)||r==null)return{enabled:!1};let{account:a}=await e.getAccount();",
+    "return ie(a)?{enabled:!0,computerUseAvailable:i,featureDiscoveryEnabled:n,staleTimeMs:r}:{enabled:!1}}",
   ].join("");
 }
 
@@ -67,7 +68,8 @@ function homeContentFixture() {
     "let Ee=d(b.enabled)===!0,De=a(jn),Oe=a(fn),Me=i&&l!=null,",
     "Ne=De==null&&Me&&Ee,{data:Pe,isLoading:Fe}=rr({enabled:Ne}),",
     "ze=Ne&&(Fe||Le&&P)?null:ir({debugOverride:De,experimentEligible:Le,personalized:Re}),",
-    "z=ze===`curated`,Be=ln(ye.email),Ve=ar({canUsePersonalizedSuggestions:Ee,",
+    "z=ze===`curated`,Be;e[48]===ye.email?Be=e[49]:(Be=ln(ye.email),e[48]=ye.email,e[49]=Be);",
+    "let Xe=Be,Ve=ar({canUsePersonalizedSuggestions:Ee,",
     "generatedSuggestionsEnabled:Me,hasGeneratedSuggestionsReadSettled:x,",
     "shouldUseCuratedNewChatPageSuggestions:z});return Ve}",
   ].join("");
@@ -134,8 +136,10 @@ test("main patch enables refresh while preserving the upstream account call", ()
 
   assert.notEqual(patched, source);
   assert.equal((patched.match(new RegExp(MAIN_ELIGIBILITY_MARKER, "g")) || []).length, 1);
-  assert.match(patched, /ie\(r\)/);
-  assert.match(patched, /staleTimeMs:n/);
+  assert.match(patched, /ie\(a\)/);
+  assert.match(patched, /computerUseAvailable:i/);
+  assert.match(patched, /featureDiscoveryEnabled:n/);
+  assert.match(patched, /staleTimeMs:r/);
   assert.match(patched, /await e\.getAccount\(\)/);
   assert.equal(applySuggestedPromptsMainPatch(patched), patched);
 });
@@ -143,10 +147,12 @@ test("main patch enables refresh while preserving the upstream account call", ()
 test("main patch preserves current minified aliases", () => {
   const source = [
     "async function refresh({appServerConnection:connection,settingsStore:store}){",
-    "let{ambientSuggestionsStaleTimeMs:stale}=featureState();",
+    "let{ambientSuggestionsFeatureDiscovery:discovery,ambientSuggestionsStaleTimeMs:stale,",
+    "computerUse:computerUse}=featureState();",
     "if(!settingsEligible(store)||stale==null)return{enabled:!1};",
     "let{account:account}=await connection.getAccount();",
-    "return accountEligible(account)?{enabled:!0,staleTimeMs:stale}:{enabled:!1}}",
+    "return accountEligible(account)?{enabled:!0,computerUseAvailable:computerUse,",
+    "featureDiscoveryEnabled:discovery,staleTimeMs:stale}:{enabled:!1}}",
   ].join("");
   const patched = applySuggestedPromptsMainPatch(source);
 
@@ -155,6 +161,8 @@ test("main patch preserves current minified aliases", () => {
   assert.match(patched, /settingsEligible\(store\)/);
   assert.match(patched, /await connection\.getAccount\(\)/);
   assert.match(patched, /accountEligible\(account\)/);
+  assert.match(patched, /computerUseAvailable:computerUse/);
+  assert.match(patched, /featureDiscoveryEnabled:discovery/);
   assert.match(patched, /staleTimeMs:stale/);
   assert.equal(applySuggestedPromptsMainPatch(patched), patched);
 });
@@ -164,9 +172,12 @@ test("main patch rejects incomplete, duplicate, and mixed contracts byte-identic
   const patched = applySuggestedPromptsMainPatch(current);
   const sources = [
     current.replace("ambientSuggestionsStaleTimeMs", "ambientSuggestionStaleTimeMs"),
+    current.replace("ambientSuggestionsFeatureDiscovery", "ambientSuggestionFeatureDiscovery"),
+    current.replace("computerUseAvailable:i", "computerUseAvailable:n"),
+    current.replace("featureDiscoveryEnabled:n", "featureDiscoveryEnabled:i"),
     current.replace("await e.getAccount()", "await e.account()"),
-    patched.replace("(ie(r),function", "(ie(r)&&function"),
-    patched.replace("staleTimeMs:n", "staleTimeMs:refreshMs"),
+    patched.replace("(ie(a),function", "(ie(a)&&function"),
+    patched.replace("staleTimeMs:r", "staleTimeMs:refreshMs"),
     patched.replace(
       `function ${MAIN_ELIGIBILITY_MARKER}(){return!0}`,
       `function ${MAIN_ELIGIBILITY_MARKER}(){return!1}`,

--- a/linux-features/ui-tweaks/suggested-prompts.test.js
+++ b/linux-features/ui-tweaks/suggested-prompts.test.js
@@ -208,6 +208,45 @@ test("Home content renders generated suggestions instead of selecting curated ca
   assert.equal(applySuggestedPromptsHomeContentPatch(patched), patched);
 });
 
+test("Home content rejects incomplete, duplicate, and mixed contracts byte-identically", () => {
+  const current = homeContentFixture();
+  const patched = applySuggestedPromptsHomeContentPatch(current);
+  const sources = [
+    current.replace(
+      "shouldUseCuratedNewChatPageSuggestions:z",
+      "shouldUseCuratedNewChatPageSuggestions:other",
+    ),
+    patched.replace(
+      `function ${HOME_CONTENT_SOURCE_MARKER}(){return!1}`,
+      `function ${HOME_CONTENT_SOURCE_MARKER}(){return!0}`,
+    ),
+    patched.replace(
+      "shouldUseCuratedNewChatPageSuggestions:z",
+      "shouldUseCuratedNewChatPageSuggestions:other",
+    ),
+    current + current,
+    patched + patched,
+    current + patched,
+    `${current}function ${HOME_CONTENT_SOURCE_MARKER}(){return!1}`,
+    `${patched}function ${HOME_CONTENT_SOURCE_MARKER}(){return!1}`,
+  ];
+
+  for (const source of sources) {
+    const result = captureWarnings(() => applySuggestedPromptsHomeContentPatch(source));
+    assert.equal(result.value, source);
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /current Suggested Prompts Home generated-source contract/);
+  }
+});
+
+test("Home content ignores unrelated curated-source lookalikes", () => {
+  const source = `unrelated=source===\`curated\`;${homeContentFixture()}`;
+  const patched = applySuggestedPromptsHomeContentPatch(source);
+
+  assert.match(patched, /^unrelated=source===`curated`;/);
+  assert.equal((patched.match(new RegExp(HOME_CONTENT_SOURCE_MARKER, "g")) || []).length, 1);
+});
+
 test("multi-point patches reject mixed and drifted contracts byte-identically", () => {
   const cleanAppPage = appPageFixture();
   const patchedAppPage = applySuggestedPromptsAppPagePatch(cleanAppPage);


### PR DESCRIPTION
## Summary

- retarget the UI Tweaks Suggested Prompts main-process contract to the fields shipped by the current official Linux package
- retarget the Home generated-source matcher across the current React compiler memo-cache sequence
- require complete clean or patched Home contracts so orphaned markers, duplicates, mixed shapes, and downstream alias drift fail closed

Dock icon does not need a retarget in this package. Its descriptors apply successfully both feature-alone in #1347 and in the full enabled-feature composition used to validate this change, so this PR deliberately avoids Dock churn.

As agreed for these UI Tweaks opt-ins, I will continue monitoring and maintaining Dock icon and Suggested Prompts against future official-package drift.

## Reproduction

On current `origin/main`, an official-package build with Suggested Prompts enabled reports these two required descriptors as drifted:

- `feature:ui-tweaks:home-suggested-prompts-main-process`
- `feature:ui-tweaks:home-suggested-prompts-content`

The focused current-contract fixtures also failed before the matcher update and pass after it.

## Official package identity

- package: `chatgpt 26.810.41047` (`amd64`)
- SHA-256: `78715fa3cd136ff67070daa76819adaecc5b42e99851559659645dce1fbf2af3`
- size: `391786694` bytes
- Electron: `42.3.0`
- base: `7a017ddf89621246449ab0f169979e80428220dd`

The package was resolved and verified through the repository's signed stable APT metadata flow.

## Contract

The current main process returns the enabled refresh state with `computerUseAvailable`, `featureDiscoveryEnabled`, and `staleTimeMs`. The patch preserves all three fields, the upstream account lookup, and the account eligibility diagnostic while applying the existing opt-in override.

The current Home asset inserts compiler memo-cache statements between the curated-source assignment and its owning suggestion-options object. The matcher permits that bounded sequence but still requires the same minified alias at `shouldUseCuratedNewChatPageSuggestions`.

Both paths remain atomic and idempotent: incomplete, duplicated, mixed, corrupted-marker, and alias-mismatch forms are left byte-identical with a warning.

## Validation

- `node --test linux-features/ui-tweaks/test.js`: 60/60
- `node --test scripts/patch-linux-window-ui.test.js`: 3/3
- direct extracted-ASAR first and second pass: markers exactly once, second pass byte-identical
- Suggested-only official-package build: 6 applied, 5 skipped-disabled, no warnings
- Suggested-only second pass: 6 already-applied; tree hash unchanged (`641f15f5bfb006f638f7109bbc071bf3fb095e40e456c6ab440462d95c03accc`)
- full local enabled-feature composition: 47 applied, 1 already-applied, 3 skipped-disabled, no warnings
- full second pass: 48 already-applied, 3 skipped-disabled; tree hash unchanged (`b5ec04287ee9a46586696649d84316d18542a87b3a5c7db15722c64f8b9298f5`)
- generated affected JavaScript assets: `node --check`
- `./scripts/ci-local.sh pr`: passed, including smoke, 736 passing Node tests (1 skipped), deb, RPM, and pacman package builds
- `git diff --check`

Authenticated side-by-side UI interaction was not rerun because the installed daily driver is active and the community and official packages share the upstream `Codex` profile; concurrent instances are unsupported. This manual runtime matrix remains disclosed for maintainer review; the official-package asset, idempotency, feature-only, composition, and cross-format gates are complete.