### PR TITLE
Fix Nix Computer Use staging permissions

### DIFF
--- a/linux-features/computer-use-linux/README.md
+++ b/linux-features/computer-use-linux/README.md
@@ -1,8 +1,15 @@
 # Linux Computer Use
 
 Disabled-by-default Linux Computer Use integration. It owns the seven ASAR
-descriptors that used to be unconditional core port glue and stages the native
-MCP plugin only when explicitly enabled.
+descriptors that used to be unconditional core port glue, the Nix staging
+permission repair, and the native MCP plugin staged only when explicitly
+enabled.
+
+The feature also repairs owner-write permissions on the app's fresh bundled
+marketplace staging copy. Nix store inputs are `0555`/`0444`, and Electron's
+recursive copy preserves those modes before it rewrites plugin metadata. The
+repair is scoped to the newly copied tree, does not follow symlinks, and leaves
+the default feature-free ASAR unchanged.
 
 Enable it in `linux-features/features.json`:
 
@@ -16,7 +23,8 @@ Enable it in `linux-features/features.json`:
 `CODEX_COMPUTER_USE_BINARY_SOURCE` and `CODEX_COMPUTER_USE_COSMIC_BINARY_SOURCE`.
 Updater rebuilds reuse the packaged artifacts and never invoke Cargo.
 
-Validate descriptor ownership and artifact-only staging with:
+Validate descriptor ownership, Nix staging permissions, and artifact-only
+staging with:
 
 ```bash
 node --test linux-features/computer-use-linux/test.js

--- a/linux-features/computer-use-linux/patch.js
+++ b/linux-features/computer-use-linux/patch.js
@@ -13,6 +13,68 @@ const {
   matchesLinuxComputerUseInstallFlowContract,
 } = require("../../scripts/patches/impl/computer-use.js");
 
+const NIX_STAGING_PERMISSIONS_MARKER = "codex-linux-computer-use-nix-staging-permissions-v1";
+const IDENT = "[A-Za-z_$][\\w$]*";
+
+const NIX_STAGING_PERMISSIONS_HELPER = `/* ${NIX_STAGING_PERMISSIONS_MARKER} */
+async function codexLinuxComputerUseMakeStagingCopyWritable(fs,destination){
+  let stat;
+  try{stat=await fs.lstat(destination)}catch(error){if(error?.code===\`ENOENT\`)return;throw error}
+  if(stat.isSymbolicLink()||(!stat.isDirectory()&&!stat.isFile()))return;
+  if((stat.mode&0o200)===0)await fs.chmod(destination,stat.mode|0o200);
+  if(!stat.isDirectory())return;
+  for(const entry of await fs.readdir(destination)){
+    await codexLinuxComputerUseMakeStagingCopyWritable(fs,\`\${destination}/\${entry}\`);
+  }
+}
+`;
+
+function applyLinuxComputerUseNixStagingPermissionsPatch(source) {
+  if (source.includes(NIX_STAGING_PERMISSIONS_MARKER)) return source;
+  if (!source.includes(".staging-${")) {
+    throw new Error("Linux Computer Use Nix staging patch could not find the bundled marketplace staging contract");
+  }
+
+  const copyPattern = new RegExp(
+    `await (${IDENT})\\.default\\.cp\\((${IDENT}),(${IDENT}),\\{recursive:!0,verbatimSymlinks:!0\\}\\)` +
+      "(?=;return\\}let\\{copyDirectoryAllowDecryptedDestinationOnEncryptionFailure:)",
+    "g",
+  );
+  const matches = [...source.matchAll(copyPattern)].filter((match) => {
+    const prefix = source.slice(Math.max(0, match.index - 160), match.index);
+    const suffix = source.slice(match.index + match[0].length, match.index + match[0].length + 420);
+    return prefix.includes("platform!==`win32`") && suffix.includes("windows-file-copy-");
+  });
+  if (matches.length !== 1) {
+    throw new Error(`Linux Computer Use Nix staging copy contract matched ${matches.length} times`);
+  }
+
+  const match = matches[0];
+  const [, fsName] = match;
+  const copyFunctionPrefix = source.slice(0, match.index);
+  const copyFunctionMatch = [...copyFunctionPrefix.matchAll(new RegExp(`async function (${IDENT})\\([^)]*\\)\\{`, "g"))].at(-1);
+  if (copyFunctionMatch == null) {
+    throw new Error("Linux Computer Use Nix staging patch could not resolve the copy helper name");
+  }
+  const copyFunctionName = copyFunctionMatch[1];
+  const stagingCalls = [...source.matchAll(new RegExp(`await ${copyFunctionName}\\((${IDENT}),(${IDENT})\\)`, "g"))]
+    .filter((call) => {
+      const prefix = source.slice(Math.max(0, call.index - 3_000), call.index);
+      const suffix = source.slice(call.index + call[0].length, call.index + call[0].length + 1_200);
+      return prefix.includes(".staging-${") && suffix.includes(`pluginRoot:${call[2]}`);
+    });
+  if (stagingCalls.length !== 1) {
+    throw new Error(`Linux Computer Use bundled marketplace staging call matched ${stagingCalls.length} times`);
+  }
+
+  const stagingCall = stagingCalls[0];
+  const stagingDestinationName = stagingCall[2];
+  const replacement =
+    `try{${stagingCall[0]}}finally{` +
+    `await codexLinuxComputerUseMakeStagingCopyWritable(${fsName}.default,${stagingDestinationName})}`;
+  return `${NIX_STAGING_PERMISSIONS_HELPER}${source.slice(0, stagingCall.index)}${replacement}${source.slice(stagingCall.index + stagingCall[0].length)}`;
+}
+
 module.exports = [
   mainBundlePatch({
     id: "avatar-cursor",
@@ -73,5 +135,12 @@ module.exports = [
     missingDescription: "current Computer Use install flow app-initial contract",
     skipDescription: "Linux Computer Use install flow patch",
     apply: applyLinuxComputerUseInstallFlowPatch,
+  }),
+  mainBundlePatch({
+    id: "nix-staging-permissions",
+    phase: "main-bundle",
+    order: 20_170,
+    ciPolicy: "optional",
+    apply: applyLinuxComputerUseNixStagingPermissionsPatch,
   }),
 ];

--- a/linux-features/computer-use-linux/test.js
+++ b/linux-features/computer-use-linux/test.js
@@ -10,7 +10,7 @@ const test = require("node:test");
 const manifest = require("./feature.json");
 const descriptors = require("./patch.js");
 
-test("computer-use-linux is opt-in and owns the seven Linux descriptors", () => {
+test("computer-use-linux is opt-in and owns the eight Linux descriptors", () => {
   assert.equal(manifest.defaultEnabled, false);
   assert.deepEqual(
     descriptors.map(({ id }) => id),
@@ -22,8 +22,159 @@ test("computer-use-linux is opt-in and owns the seven Linux descriptors", () => 
       "ui-availability",
       "host-platform",
       "install-flow",
+      "nix-staging-permissions",
     ],
   );
+});
+
+const STAGING_COPY_FIXTURE = `async function Mne(source,destination){if(S.default.platform===\`darwin\`){await ditto(\`ditto\`,[source,destination]);return}if(S.default.platform!==\`win32\`){await y.default.cp(source,destination,{recursive:!0,verbatimSymlinks:!0});return}let{copyDirectoryAllowDecryptedDestinationOnEncryptionFailure:copy}=await Promise.resolve().then(()=>require("./windows-file-copy-Bw9CB6bJ.js"));await copy({copy:()=>y.default.cp(source,destination,{recursive:!0,verbatimSymlinks:!0}),destination,source})}
+async function copyPlugins(source,destination){const staging=\`openai-bundled.staging-\${randomUUID()}\`;await Mne(source,destination);await transform({pluginRoot:destination});return staging}`;
+
+function stagingFs({ copyError = null, writable = false } = {}) {
+  const nodes = new Map([
+    ["destination", { kind: "directory", mode: writable ? 0o755 : 0o555, entries: ["nested", "manifest", "link", "socket"] }],
+    ["destination/nested", { kind: "directory", mode: writable ? 0o755 : 0o555, entries: [] }],
+    ["destination/manifest", { kind: "file", mode: writable ? 0o644 : 0o444 }],
+    ["destination/link", { kind: "symlink", mode: 0o777 }],
+    ["destination/socket", { kind: "special", mode: 0o600 }],
+  ]);
+  const chmodCalls = [];
+  return {
+    chmodCalls,
+    nodes,
+    fs: {
+      async cp() {
+        if (copyError != null) throw copyError;
+      },
+      async lstat(target) {
+        const node = nodes.get(target);
+        if (node == null) {
+          const error = new Error("missing");
+          error.code = "ENOENT";
+          throw error;
+        }
+        return {
+          mode: node.mode,
+          isDirectory: () => node.kind === "directory",
+          isFile: () => node.kind === "file",
+          isSymbolicLink: () => node.kind === "symlink",
+        };
+      },
+      async chmod(target, mode) {
+        chmodCalls.push(target);
+        nodes.get(target).mode = mode;
+      },
+      async readdir(target) {
+        return [...nodes.get(target).entries];
+      },
+    },
+  };
+}
+
+function materializeStagingCopy(source, fsApi) {
+  const context = {
+    randomUUID: () => "uuid",
+    S: { default: { platform: "linux" } },
+    transform: async () => {},
+    y: { default: fsApi },
+  };
+  require("node:vm").runInNewContext(`${source};globalThis.copy=copyPlugins;`, context);
+  return context.copy;
+}
+
+test("computer-use-linux makes copied Nix staging nodes owner-writable", async () => {
+  const descriptor = descriptors.find(({ id }) => id === "nix-staging-permissions");
+  assert.ok(descriptor);
+  const patched = descriptor.apply(STAGING_COPY_FIXTURE);
+  const { fs: fsApi, nodes } = stagingFs();
+
+  await materializeStagingCopy(patched, fsApi)("source", "destination");
+
+  assert.equal(nodes.get("destination").mode, 0o755);
+  assert.equal(nodes.get("destination/nested").mode, 0o755);
+  assert.equal(nodes.get("destination/manifest").mode, 0o644);
+  assert.equal(nodes.get("destination/link").mode, 0o777);
+  assert.equal(nodes.get("destination/socket").mode, 0o600);
+});
+
+test("computer-use-linux repairs partial Nix staging copies for cleanup", async () => {
+  const descriptor = descriptors.find(({ id }) => id === "nix-staging-permissions");
+  const patched = descriptor.apply(STAGING_COPY_FIXTURE);
+  const copyError = new Error("copy failed");
+  const { fs: fsApi, nodes } = stagingFs({ copyError });
+
+  await assert.rejects(materializeStagingCopy(patched, fsApi)("source", "destination"), copyError);
+  assert.equal(nodes.get("destination").mode, 0o755);
+  assert.equal(nodes.get("destination/nested").mode, 0o755);
+  assert.equal(nodes.get("destination/manifest").mode, 0o644);
+});
+
+test("computer-use-linux leaves already-writable staging nodes unchanged", async () => {
+  const descriptor = descriptors.find(({ id }) => id === "nix-staging-permissions");
+  const patched = descriptor.apply(STAGING_COPY_FIXTURE);
+  const { chmodCalls, fs: fsApi } = stagingFs({ writable: true });
+
+  await materializeStagingCopy(patched, fsApi)("source", "destination");
+
+  assert.deepEqual(chmodCalls, []);
+});
+
+test("computer-use-linux Nix staging patch is unique, fail-closed, and idempotent", () => {
+  const descriptor = descriptors.find(({ id }) => id === "nix-staging-permissions");
+  const patched = descriptor.apply(STAGING_COPY_FIXTURE);
+
+  assert.equal(descriptor.apply(patched), patched);
+  assert.throws(
+    () => descriptor.apply(STAGING_COPY_FIXTURE.replace("platform!==`win32`", "platform===`linux`")),
+    /matched 0 times/,
+  );
+  assert.throws(
+    () => descriptor.apply(`${STAGING_COPY_FIXTURE}\n${STAGING_COPY_FIXTURE}`),
+    /matched 2 times/,
+  );
+  assert.throws(
+    () => descriptor.apply(STAGING_COPY_FIXTURE.replace("await Mne(source,destination)", "await otherCopy(source,destination)")),
+    /staging call matched 0 times/,
+  );
+
+  const withUnrelatedCaller = `${STAGING_COPY_FIXTURE}\nasync function unrelated(source,destination){await Mne(source,destination)}`;
+  const narrowlyPatched = descriptor.apply(withUnrelatedCaller);
+  assert.match(narrowlyPatched, /try\{await Mne\(source,destination\)\}finally/);
+  assert.match(narrowlyPatched, /async function unrelated\(source,destination\)\{await Mne\(source,destination\)\}/);
+  assert.match(
+    narrowlyPatched,
+    /platform!==`win32`\)\{await y\.default\.cp\(source,destination,\{recursive:!0,verbatimSymlinks:!0\}\);return}/,
+  );
+});
+
+test("computer-use-linux repairs real fs.cp modes before plugin metadata rewriting", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "computer-use-linux-nix-copy-"));
+  const source = path.join(root, "source");
+  const destination = path.join(root, "destination");
+  const sourceMetadata = path.join(source, ".codex-plugin");
+  const destinationManifest = path.join(destination, ".codex-plugin", "plugin.json");
+  t.after(() => {
+    for (const directory of [sourceMetadata, source]) {
+      if (fs.existsSync(directory)) fs.chmodSync(directory, 0o755);
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  fs.mkdirSync(sourceMetadata, { recursive: true });
+  fs.writeFileSync(path.join(sourceMetadata, "plugin.json"), "{}\n");
+  fs.chmodSync(path.join(sourceMetadata, "plugin.json"), 0o444);
+  fs.chmodSync(sourceMetadata, 0o555);
+  fs.chmodSync(source, 0o555);
+
+  const descriptor = descriptors.find(({ id }) => id === "nix-staging-permissions");
+  const patched = descriptor.apply(STAGING_COPY_FIXTURE);
+  await materializeStagingCopy(patched, fs.promises)(source, destination);
+
+  assert.equal(fs.statSync(destination).mode & 0o777, 0o755);
+  assert.equal(fs.statSync(path.dirname(destinationManifest)).mode & 0o777, 0o755);
+  assert.equal(fs.statSync(destinationManifest).mode & 0o777, 0o644);
+  await fs.promises.writeFile(destinationManifest, '{"rewritten":true}\n');
+  assert.deepEqual(JSON.parse(fs.readFileSync(destinationManifest, "utf8")), { rewritten: true });
 });
 
 test("computer-use-linux staging consumes release artifacts without invoking Cargo", () => {


### PR DESCRIPTION
## Summary
- make fresh bundled-marketplace staging copies owner-writable when `computer-use-linux` is enabled
- scope the repair to the validated staging copy call and skip symlinks, special nodes, and already-writable files
- add real `fs.cp` regression coverage for Nix `0555`/`0444` modes and metadata rewriting

Fixes #1356

## Tests
- `node --test linux-features/computer-use-linux/test.js scripts/lib/linux-features.test.js scripts/patches/runner.test.js`
- `bash tests/scripts_smoke.sh`
- feature-alone `./install.sh` build against signed upstream `26.810.50856` (`applied=8`)
- `git diff --check`

## Notes
- local Nix execution was unavailable on the Ubuntu review host; GitHub CI provides the Nix validation signal
- the default feature-free ASAR remains byte-identical