### PR TITLE
Fix RPM GnuPG dependency on SUSE

### DIFF
--- a/packaging/linux/codex-desktop.spec
+++ b/packaging/linux/codex-desktop.spec
@@ -12,7 +12,12 @@ ExclusiveArch:  __ARCH__
 %endif
 
 %if __PACKAGE_WITH_UPDATER__
-Requires:       polkit, curl, dpkg, gnupg2, nodejs, xdg-utils
+Requires:       polkit, curl, dpkg, nodejs, xdg-utils
+%if 0%{?suse_version}
+Requires:       gpg2
+%else
+Requires:       gnupg2
+%endif
 %else
 Requires:       xdg-utils
 %endif

--- a/scripts/lib/package-common.test.js
+++ b/scripts/lib/package-common.test.js
@@ -82,6 +82,14 @@ test("non-Debian package formats map the official runtime libraries", () => {
   }
 });
 
+test("RPM updater selects the distro-specific GnuPG package", () => {
+  const rpm = fs.readFileSync(path.join(repoRoot, "packaging/linux/codex-desktop.spec"), "utf8");
+  assert.match(
+    rpm,
+    /%if __PACKAGE_WITH_UPDATER__\nRequires:\s+polkit, curl, dpkg, nodejs, xdg-utils\n%if 0%\{\?suse_version\}\nRequires:\s+gpg2\n%else\nRequires:\s+gnupg2\n%endif\n%else\nRequires:\s+xdg-utils\n%endif/,
+  );
+});
+
 test("update-builder copies staged native feature artifacts without Cargo workspaces", (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-update-builder-artifact-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary

- select `gpg2` for updater-enabled RPM builds on openSUSE/SLES
- retain `gnupg2` for Fedora and other RPM environments
- add regression coverage for both distro branches and updater-disabled packages

Fixes #1362

## Tests

- `node --test scripts/lib/package-common.test.js`
- `bash tests/scripts_smoke.sh`
- `bash -n scripts/build-rpm.sh scripts/install-deps.sh`
- `rpmspec -q --requires` with and without `suse_version`
- `CI_SKIP_PULL=1 ./scripts/ci-local.sh rpm`
- `git diff --check`

## Notes

The dependency choice is evaluated at RPM build time, matching the native `make bootstrap-native` workflow reported in the issue.