### PR TITLE
test: wait for queued Git policy follow-up

### DIFF
--- a/linux-features/directory-only-working-tree-watch/test.js
+++ b/linux-features/directory-only-working-tree-watch/test.js
@@ -4817,6 +4817,11 @@ test("new Git policy events discard stale in-flight query snapshots", async (t) 
     "fresh Git policy after the newer event",
     3500,
   );
+  await waitFor(
+    () => ignoredQueryCalls >= 3,
+    "queued Git policy follow-up",
+    3500,
+  );
   const latest = main.replacements.at(-1).prefixes;
   // The second event cancels the first query, forces an immediate fresh query,
   // and retains its own queued conservative follow-up snapshot.


### PR DESCRIPTION
## Summary

- wait for the queued conservative Git-policy follow-up before asserting its invocation count
- remove a timing race from the stale in-flight query snapshot regression test
- keep production watcher behavior unchanged

## Root cause and impact

The test waited until the newer policy had produced a replacement and then immediately asserted that the queued follow-up query had started. Those are separate asynchronous events, so the replacement could become visible first and the assertion intermittently observed 2 calls instead of 3.

This is test-only. It makes local and CI validation deterministic for the `directory-only-working-tree-watch` feature and does not change packaged application behavior, supported architectures, or package formats.

## Validation

- Reproduced before the fix: the focused test failed in 2 of 3 isolated runs with `2 !== 3`.
- Focused regression: 20/20 consecutive runs passed.
- Feature suite: 119 passed, 0 failed.
- Global Linux feature/patch suite: 752 passed, 1 explicitly opt-in integration test skipped, 0 failed.
- `git diff --check`.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] This does not fix upstream drift or add a version-specific fallback.
- [x] I updated the relevant test synchronization and ran the validation listed above.
- [x] I reviewed the final diff with my coding agent, addressed the identified race, and reran the relevant tests.
