### PR TITLE
fix: reconcile updater state after self-upgrade

### DIFF
--- a/docs/updater.md
+++ b/docs/updater.md
@@ -40,6 +40,25 @@ waits for process exit, then performs the same atomic candidate exchange used by
 manual rebuilds. A durable journal recovers interrupted promotion, and the
 immediately previous managed package remains the rollback target.
 
+Recording a new candidate drops the previous candidate's package artifact, so a
+recorded artifact always belongs to the pending candidate. A failed download or
+build therefore leaves nothing for `install-ready` to retry until a rebuild
+produces a package; an explicit `install-ready` in that state reports the
+recorded failure instead of succeeding silently.
+
+A self-upgrade replaces the updater itself, so the package lifecycle can stop
+the service before the daemon records the install. On startup an `Installing`
+state is recovered only when the native package version of the candidate
+artifact equals the package version the system reports as installed, and only
+when the package manager reports that version for a payload it has committed.
+dpkg answers with the new version from the moment it starts unpacking, so an
+`unpacked` or `half-installed` package is not treated as installed;
+`half-configured` is, because the service is started from `postinst` inside the
+same transaction. A missing or uninspectable artifact, any other native
+version, or any other status keeps the candidate pending: the upstream version
+and SHA-256 identify the signed OpenAI input, not the per-user package rebuilt
+from it.
+
 Automated user-local operations cannot override the running-app guard or
 silently accept unverified input. A failed privileged installation remains
 failed until an explicit retry or a newer candidate.
@@ -138,8 +157,8 @@ rollback path; it is not a normal troubleshooting step.
 ## Validation scenarios
 
 Tests cover new and unchanged releases, interrupted downloads, all trust
-failures, build-while-running, promotion-after-exit, rollback, cleanup, and old
-state migration. Run:
+failures, build-while-running, promotion-after-exit, interrupted self-install
+recovery, rollback, cleanup, and old state migration. Run:
 
 ```bash
 cargo test -p codex-update-manager

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result};
 use chrono::Utc;
 use std::{fs::{self, OpenOptions}, path::Path, time::Duration};
 use tokio::time;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 pub async fn run(cli: Cli) -> Result<()> {
     if let Some(result) = run_privileged_command(&cli.command) {
@@ -24,6 +24,24 @@ pub async fn run(cli: Cli) -> Result<()> {
     let config = RuntimeConfig::load_or_default(&paths)?;
     let mut state = PersistedState::load_or_default(&paths.state_file, config.auto_install_on_app_exit)?;
     state.installed_version = install::installed_package_version();
+    // Only the commands that act on the state recover it; `status` and
+    // `diagnose` report what is persisted and must not change the recorded
+    // status or drop a candidate. (They still rewrite the file with the
+    // refreshed `installed_version`, as they always have.)
+    //
+    // This is deliberately not serialised against a concurrent updater
+    // process. `check.lock` would not help: neither `install_ready` nor the
+    // daemon's deferred-install tick holds it, and failing to take it would
+    // silently skip the recovery for the life of the process — reinstating the
+    // rebuild loop. The predicate is safe unsynchronised because it fires only
+    // once the package manager already reports the candidate's own package
+    // version.
+    if matches!(
+        cli.command,
+        Commands::Daemon | Commands::CheckNow | Commands::InstallReady | Commands::Rollback
+    ) {
+        reconcile_interrupted_install(&mut state);
+    }
     state.save_updater(&paths.state_file)?;
 
     match cli.command {
@@ -40,6 +58,126 @@ pub async fn run(cli: Cli) -> Result<()> {
         | Commands::InstallRollbackRpm { .. }
         | Commands::InstallRollbackPacman { .. } => unreachable!(),
     }
+}
+
+/// Records a newly detected upstream release as the pending candidate.
+///
+/// The previous candidate's package artifact is dropped here. `build_update`
+/// only republishes `artifact_paths` once it has produced a package, so a
+/// download or build failure would otherwise leave `package_path` pointing at
+/// the artifact of the currently installed release while the candidate fields
+/// already describe the new one. Every consumer of `package_path` — the
+/// `install-ready` retry and the interrupted-install recovery — reads it as the
+/// artifact built for the current candidate, so it must be absent until it is.
+///
+/// The rollback target is captured before the reset, and this runs only for a
+/// genuinely new release: `check` returns earlier for a repeated failed
+/// candidate and for a candidate that is already built and pending.
+fn record_new_candidate(state: &mut PersistedState, metadata: &upstream::PackageMetadata) {
+    rollback::record_current_package_as_known_good(state);
+    state.candidate_version = Some(metadata.version.clone());
+    state.candidate_architecture = Some(metadata.architecture.clone());
+    state.candidate_repository_path = Some(metadata.repository_path.clone());
+    state.upstream_package_sha256 = Some(metadata.sha256.clone());
+    state.artifact_paths.package_path = None;
+    state.status = UpdateStatus::DownloadingPackage;
+}
+
+/// Recovers the persisted state when a self-upgrade replaced this updater
+/// before it could record the install.
+///
+/// The native package lifecycle stops the updater service while the privileged
+/// install is still returning to the daemon that started it, so the `Installed`
+/// transition is never persisted and the next check rebuilds the same release.
+///
+/// The upstream version and SHA-256 cannot decide this: they identify the
+/// signed OpenAI input, not the per-user package rebuilt from it, and a package
+/// hook restarts every active user's updater. Only the native package version
+/// of the artifact this state was installing proves that this candidate is the
+/// one now installed.
+///
+/// `state.installed_version` is the caller's freshly read
+/// `install::installed_package_version`, so the comparison is against the
+/// package the system reports right now, not a persisted value.
+///
+/// A reported version is not on its own proof that the package is installed:
+/// dpkg answers with the new version from the moment it starts unpacking, so
+/// `install::installed_package_is_usable` additionally requires a package state
+/// in which the payload is committed. It accepts `half-configured`, because
+/// `codex-update-manager.postinst` starts the service from inside the dpkg
+/// transaction and the recovering daemon therefore usually runs while the
+/// package it is recovering is still being configured.
+fn reconcile_interrupted_install(state: &mut PersistedState) {
+    reconcile_interrupted_install_with(
+        state,
+        install::installed_package_is_usable,
+        candidate_package_version,
+    );
+}
+
+/// Reads the native package version of the artifact an interrupted install was
+/// applying, reporting `None` when the artifact cannot be inspected.
+fn candidate_package_version(path: &Path) -> Option<String> {
+    match install::package_file_version(path) {
+        Ok(version) => Some(version),
+        Err(error) => {
+            // The candidate stays pending, so the visible symptom is the
+            // rebuild loop this recovery exists to prevent. Say why.
+            warn!(
+                ?error,
+                package = %path.display(),
+                "could not inspect the interrupted candidate package"
+            );
+            None
+        }
+    }
+}
+
+fn reconcile_interrupted_install_with(
+    state: &mut PersistedState,
+    installed_package_is_usable: impl FnOnce() -> bool,
+    candidate_package_version: impl FnOnce(&Path) -> Option<String>,
+) {
+    if state.status != UpdateStatus::Installing || state.installed_version == "unknown" {
+        return;
+    }
+    let (Some(upstream_version), Some(upstream_sha256), Some(package)) = (
+        state.candidate_version.clone(),
+        state.upstream_package_sha256.clone(),
+        state.artifact_paths.package_path.clone(),
+    ) else {
+        return;
+    };
+    if candidate_package_version(&package).as_deref() != Some(state.installed_version.as_str()) {
+        return;
+    }
+    if !installed_package_is_usable() {
+        // The package manager reports the candidate's version for a payload it
+        // has not committed, so the install failed after `prerm` stopped the
+        // previous daemon. Keep the candidate so it is installed again.
+        warn!(
+            installed_version = %state.installed_version,
+            "the interrupted candidate is recorded but not installed; keeping it pending"
+        );
+        return;
+    }
+
+    info!(
+        installed_version = %state.installed_version,
+        %upstream_version,
+        "recovered an interrupted self-upgrade"
+    );
+    state.installed_upstream_version = Some(upstream_version);
+    state.installed_upstream_sha256 = Some(upstream_sha256);
+    state.status = UpdateStatus::Installed;
+    state
+        .last_known_good_version
+        .get_or_insert_with(|| state.installed_version.clone());
+    state.candidate_version = None;
+    state.candidate_architecture = None;
+    state.candidate_repository_path = None;
+    state.waiting_for_app_exit_auto_install = false;
+    state.error_message = None;
 }
 
 fn run_privileged_command(command: &Commands) -> Option<Result<()>> {
@@ -118,12 +256,7 @@ async fn check(config: &RuntimeConfig, state: &mut PersistedState, paths: &Runti
         return install_ready(config, state, paths, false).await;
     }
 
-    rollback::record_current_package_as_known_good(state);
-    state.candidate_version = Some(metadata.version.clone());
-    state.candidate_architecture = Some(metadata.architecture.clone());
-    state.candidate_repository_path = Some(metadata.repository_path.clone());
-    state.upstream_package_sha256 = Some(metadata.sha256.clone());
-    state.status = UpdateStatus::DownloadingPackage;
+    record_new_candidate(state, &metadata);
     state.save_updater(&paths.state_file)?;
 
     let upstream_package = match upstream::download_verified_package(
@@ -159,7 +292,19 @@ async fn install_ready(
     if state.status == UpdateStatus::Failed && !explicit_retry {
         return Ok(());
     }
-    let package = state.artifact_paths.package_path.clone().context("ready state has no package")?;
+    // A failed download or build leaves a candidate with no artifact, so this
+    // is a routine `install-ready` outcome rather than an unreachable state.
+    // An explicit retry of a `Failed` state still has to report the failure it
+    // was asked to retry, rather than looking like "no update is pending".
+    let Some(package) = state.artifact_paths.package_path.clone() else {
+        if state.status == UpdateStatus::Failed {
+            let recorded = state.error_message.as_deref();
+            let reason = recorded.unwrap_or("no error recorded");
+            anyhow::bail!("the last update failed before a package was built: {reason}");
+        }
+        println!("No rebuilt package is ready to install.");
+        return Ok(());
+    };
     anyhow::ensure!(package.is_file(), "rebuilt package is missing: {}", package.display());
     if liveness::is_app_running(config)? {
         state.status = UpdateStatus::WaitingForAppExit;
@@ -259,3 +404,220 @@ impl CheckLock {
     }
 }
 impl Drop for CheckLock { fn drop(&mut self) { let _ = self.0.unlock(); } }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    const INSTALLED_PACKAGE_VERSION: &str = "2026.08.16.221717+3f9a1c2e";
+    const OTHER_PACKAGE_VERSION: &str = "2026.08.16.104402+7b2d5e10";
+    const UPSTREAM_VERSION: &str = "26.810.52044";
+
+    fn interrupted_install_state() -> PersistedState {
+        let mut state = PersistedState::new(true);
+        state.installed_version = INSTALLED_PACKAGE_VERSION.to_string();
+        state.candidate_version = Some(UPSTREAM_VERSION.to_string());
+        state.candidate_architecture = Some("amd64".to_string());
+        state.candidate_repository_path = Some("pool/main/c/chatgpt/package.deb".to_string());
+        state.upstream_package_sha256 = Some("a".repeat(64));
+        state.artifact_paths.package_path = Some(PathBuf::from("/tmp/codex-desktop.deb"));
+        state.status = UpdateStatus::Installing;
+        state.waiting_for_app_exit_auto_install = true;
+        state.error_message = Some("stale error".to_string());
+        state
+    }
+
+    fn metadata(version: &str, sha256: &str) -> upstream::PackageMetadata {
+        upstream::PackageMetadata {
+            package: "chatgpt".to_string(),
+            version: version.to_string(),
+            architecture: "amd64".to_string(),
+            repository_path: "pool/main/c/chatgpt/package.deb".to_string(),
+            sha256: sha256.to_string(),
+            size: 1,
+            repository: "https://example.invalid/repo".to_string(),
+            path: None,
+        }
+    }
+
+    #[test]
+    fn a_new_candidate_drops_the_previous_candidates_package_artifact() -> Result<()> {
+        // `record_current_package_as_known_good` only retains an artifact that
+        // is still on disk, so the rollback assertion needs a real file.
+        let temp = tempfile::tempdir()?;
+        let installed_artifact = temp.path().join("installed.deb");
+        fs::write(&installed_artifact, b"deb")?;
+        let mut state = PersistedState::new(true);
+        state.installed_version = INSTALLED_PACKAGE_VERSION.to_string();
+        state.artifact_paths.package_path = Some(installed_artifact.clone());
+
+        record_new_candidate(&mut state, &metadata("26.811.10000", &"b".repeat(64)));
+
+        // A download or build failure now leaves no artifact to mistake for the
+        // new candidate, and the installed one is still the rollback target.
+        assert_eq!(state.artifact_paths.package_path, None);
+        assert_eq!(
+            state.artifact_paths.rollback_package_path,
+            Some(installed_artifact)
+        );
+        assert_eq!(state.candidate_version.as_deref(), Some("26.811.10000"));
+        assert_eq!(state.status, UpdateStatus::DownloadingPackage);
+        Ok(())
+    }
+
+    #[test]
+    fn a_failed_build_cannot_be_recovered_as_an_installed_candidate() {
+        // The state a failed download or build leaves behind: a pending
+        // candidate that never produced an artifact.
+        let mut state = interrupted_install_state();
+        record_new_candidate(&mut state, &metadata("26.811.10000", &"b".repeat(64)));
+        state.status = UpdateStatus::Installing;
+        let expected = state.clone();
+
+        reconcile_interrupted_install_with(
+            &mut state,
+            || panic!("a candidate without an artifact must not query the package manager"),
+            |_| panic!("a candidate without an artifact must not be inspected"),
+        );
+
+        assert_eq!(state, expected);
+    }
+
+    #[test]
+    fn recovers_an_install_whose_native_package_is_the_installed_one() {
+        let mut state = interrupted_install_state();
+
+        reconcile_interrupted_install_with(
+            &mut state,
+            || true,
+            |path| {
+                assert_eq!(path, Path::new("/tmp/codex-desktop.deb"));
+                Some(INSTALLED_PACKAGE_VERSION.to_string())
+            },
+        );
+
+        assert_eq!(state.status, UpdateStatus::Installed);
+        assert_eq!(
+            state.installed_upstream_version.as_deref(),
+            Some(UPSTREAM_VERSION)
+        );
+        assert_eq!(state.installed_upstream_sha256, Some("a".repeat(64)));
+        assert_eq!(
+            state.last_known_good_version.as_deref(),
+            Some(INSTALLED_PACKAGE_VERSION)
+        );
+        assert_eq!(state.candidate_version, None);
+        assert_eq!(state.candidate_architecture, None);
+        assert_eq!(state.candidate_repository_path, None);
+        assert!(!state.waiting_for_app_exit_auto_install);
+        assert_eq!(state.error_message, None);
+    }
+
+    #[test]
+    fn preserves_a_candidate_the_package_manager_recorded_but_did_not_install() {
+        // dpkg reports the new version from the moment it starts unpacking, and
+        // `prerm` has already stopped the daemon by then, so a failed unpack or
+        // a failed `postinst` leaves the candidate's version visible for a
+        // payload that was never committed.
+        let mut state = interrupted_install_state();
+        let expected = state.clone();
+
+        reconcile_interrupted_install_with(
+            &mut state,
+            || false,
+            |_| Some(INSTALLED_PACKAGE_VERSION.to_string()),
+        );
+
+        assert_eq!(state, expected);
+    }
+
+    #[test]
+    fn preserves_a_candidate_that_shares_the_upstream_release_but_not_the_native_package() {
+        let mut state = interrupted_install_state();
+        state.installed_upstream_version = Some(UPSTREAM_VERSION.to_string());
+        state.installed_upstream_sha256 = Some("a".repeat(64));
+        let expected = state.clone();
+
+        reconcile_interrupted_install_with(
+            &mut state,
+            || panic!("a differing native package version must not query the package manager"),
+            |_| Some(OTHER_PACKAGE_VERSION.to_string()),
+        );
+
+        assert_eq!(state, expected);
+    }
+
+    #[test]
+    fn preserves_the_candidate_when_the_package_artifact_cannot_be_inspected() {
+        let mut state = interrupted_install_state();
+        let expected = state.clone();
+
+        reconcile_interrupted_install_with(
+            &mut state,
+            || panic!("an uninspectable artifact must not query the package manager"),
+            |_| None,
+        );
+
+        assert_eq!(state, expected);
+    }
+
+    #[test]
+    fn preserves_the_candidate_when_the_state_records_no_package_artifact() {
+        let mut state = interrupted_install_state();
+        state.artifact_paths.package_path = None;
+        let expected = state.clone();
+
+        reconcile_interrupted_install_with(
+            &mut state,
+            || panic!("a state without a package artifact must not query the package manager"),
+            |_| panic!("a state without a package artifact must not be inspected"),
+        );
+
+        assert_eq!(state, expected);
+    }
+
+    #[test]
+    fn preserves_the_candidate_when_the_installed_package_version_is_unknown() {
+        let mut state = interrupted_install_state();
+        state.installed_version = "unknown".to_string();
+        let expected = state.clone();
+
+        reconcile_interrupted_install_with(
+            &mut state,
+            || panic!("an unknown installed version must not query the package manager"),
+            |_| Some("unknown".to_string()),
+        );
+
+        assert_eq!(state, expected);
+    }
+
+    #[test]
+    fn does_not_reconcile_states_other_than_installing() {
+        for status in [
+            UpdateStatus::Idle,
+            UpdateStatus::CheckingUpstream,
+            UpdateStatus::UpdateDetected,
+            UpdateStatus::DownloadingPackage,
+            UpdateStatus::PreparingWorkspace,
+            UpdateStatus::PatchingApp,
+            UpdateStatus::BuildingPackage,
+            UpdateStatus::ReadyToInstall,
+            UpdateStatus::WaitingForAppExit,
+            UpdateStatus::Installed,
+            UpdateStatus::Failed,
+        ] {
+            let mut state = interrupted_install_state();
+            state.status = status.clone();
+            let expected = state.clone();
+
+            reconcile_interrupted_install_with(
+                &mut state,
+                || panic!("{status:?} must not query the package manager"),
+                |_| panic!("{status:?} must not inspect the package artifact"),
+            );
+
+            assert_eq!(state, expected, "{status:?} must not be reconciled");
+        }
+    }
+}

--- a/updater/src/install.rs
+++ b/updater/src/install.rs
@@ -175,6 +175,71 @@ pub fn installed_package_version() -> String {
     }
 }
 
+/// Returns the native package version recorded inside a built package artifact.
+///
+/// The format is derived from the artifact path so a caller holding only a
+/// persisted `package_path` can compare it against `installed_package_version`
+/// without knowing which package manager produced it.
+pub fn package_file_version(path: &Path) -> Result<String> {
+    anyhow::ensure!(
+        path.is_file(),
+        "package artifact is missing: {}",
+        path.display()
+    );
+
+    // The pacman version lives in the file name, so resolve a symlink such as
+    // `codex-desktop-latest.pkg.tar.zst` to the versioned identity first, the
+    // same way `stable_validated_package` does.
+    let path = &package_identity_path(path)?;
+    match PackageKind::from_path(path) {
+        PackageKind::Deb => deb_package_version(path),
+        PackageKind::Rpm => rpm_package_version(path),
+        PackageKind::Pacman => pacman_package_version(path),
+    }
+}
+
+/// Reports whether the version `installed_package_version` returned belongs to
+/// a package whose payload is actually in place.
+///
+/// `dpkg-query -W -f=${Version}` answers for any package dpkg knows about, so
+/// it reports the new version from the moment unpacking starts and keeps
+/// reporting a version after a removal that retained configuration files.
+/// `codex-update-manager.prerm` stops the updater before dpkg unpacks, so a
+/// self-upgrade that then fails to unpack or to configure leaves the new
+/// version visible with no daemon left to record the failure.
+///
+/// RPM and pacman commit the payload before their databases answer for the new
+/// version, so only dpkg needs the distinction.
+pub fn installed_package_is_usable() -> bool {
+    match PackageKind::detect() {
+        PackageKind::Deb => deb_status_is_usable(&installed_deb_status()),
+        PackageKind::Rpm | PackageKind::Pacman => true,
+    }
+}
+
+fn installed_deb_status() -> String {
+    installed_version_from_command(
+        &program_path(DPKG_QUERY_CANDIDATES, "dpkg-query"),
+        &["-W", "-f=${db:Status-Status}", PACKAGE_NAME],
+    )
+}
+
+/// Accepts only the dpkg states in which the package payload is installed.
+///
+/// `half-configured` is deliberately accepted: `codex-update-manager.postinst`
+/// starts the service from inside the dpkg transaction, so the recovering
+/// daemon usually runs while the package it is recovering is still being
+/// configured. `unpacked` and `half-installed` are rejected because the files
+/// are not committed, and every unrecognised state is rejected as well: the
+/// cost of rejecting is a preserved candidate and another rebuild, while the
+/// cost of accepting is recording a broken package as successfully installed.
+fn deb_status_is_usable(status: &str) -> bool {
+    matches!(
+        status,
+        "installed" | "half-configured" | "triggers-awaited" | "triggers-pending"
+    )
+}
+
 fn installed_deb_version() -> String {
     installed_version_from_command(
         &program_path(DPKG_QUERY_CANDIDATES, "dpkg-query"),
@@ -1203,6 +1268,115 @@ mod tests {
             parse_pacman_installed_version(b"codex-desktop 2026.04.02.120000-1\n".to_vec()),
             "2026.04.02.120000-1"
         );
+    }
+
+    fn build_minimal_deb(dir: &Path, version: &str) -> Result<PathBuf> {
+        let root = dir.join("root");
+        fs::create_dir_all(root.join("DEBIAN"))?;
+        fs::write(
+            root.join("DEBIAN/control"),
+            format!(
+                "Package: {PACKAGE_NAME}\nVersion: {version}\nArchitecture: amd64\n\
+                 Section: web\nPriority: optional\n\
+                 Maintainer: test <test@example.com>\nDescription: test fixture\n"
+            ),
+        )?;
+        let package = dir.join(format!("{PACKAGE_NAME}_{version}_amd64.deb"));
+        let output = Command::new(program_path(DPKG_DEB_CANDIDATES, "dpkg-deb"))
+            .arg("--root-owner-group")
+            .arg("--build")
+            .arg("--")
+            .arg(&root)
+            .arg(&package)
+            .output()
+            .context("Failed to run dpkg-deb --build")?;
+        anyhow::ensure!(
+            output.status.success(),
+            "dpkg-deb could not build the test package: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+        Ok(package)
+    }
+
+    #[test]
+    fn reads_the_native_package_version_from_a_pacman_artifact() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let package = temp
+            .path()
+            .join("codex-desktop-2026.04.02.120000-1-x86_64.pkg.tar.zst");
+        fs::write(&package, b"pkg")?;
+
+        assert_eq!(package_file_version(&package)?, "2026.04.02.120000-1");
+        Ok(())
+    }
+
+    #[test]
+    fn reads_the_native_package_version_from_a_deb_artifact() -> Result<()> {
+        if !program_exists(DPKG_DEB_CANDIDATES, "dpkg-deb") {
+            eprintln!("skipping: dpkg-deb is unavailable, the deb branch was not exercised");
+            return Ok(());
+        }
+        let temp = tempfile::tempdir()?;
+        let package = build_minimal_deb(temp.path(), "2026.04.02.120000+abcdef12")?;
+
+        assert_eq!(
+            package_file_version(&package)?,
+            "2026.04.02.120000+abcdef12"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reads_the_native_package_version_through_a_pacman_latest_symlink() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let package_name = "codex-desktop-2026.04.02.120000-1-x86_64.pkg.tar.zst";
+        fs::write(temp.path().join(package_name), b"pkg")?;
+        let latest = temp.path().join("codex-desktop-latest.pkg.tar.zst");
+        std::os::unix::fs::symlink(package_name, &latest)?;
+
+        assert_eq!(package_file_version(&latest)?, "2026.04.02.120000-1");
+        Ok(())
+    }
+
+    #[test]
+    fn accepts_only_the_dpkg_states_that_have_the_package_payload_installed() {
+        // `half-configured` is the state the recovery normally runs in: the
+        // service is started from `postinst`, inside the dpkg transaction.
+        for status in [
+            "installed",
+            "half-configured",
+            "triggers-awaited",
+            "triggers-pending",
+        ] {
+            assert!(deb_status_is_usable(status), "{status} must be accepted");
+        }
+        // dpkg still reports a version in each of these, so accepting one would
+        // record a package that is not installed as successfully installed.
+        for status in [
+            "unpacked",
+            "half-installed",
+            "config-files",
+            "not-installed",
+            "unknown",
+            "",
+        ] {
+            assert!(!deb_status_is_usable(status), "{status} must be rejected");
+        }
+    }
+
+    #[test]
+    fn rejects_a_missing_package_artifact() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let missing = temp
+            .path()
+            .join("codex-desktop-2026.04.02.120000-1-x86_64.pkg.tar.zst");
+
+        let error = package_file_version(&missing)
+            .expect_err("a missing artifact cannot identify an installed package");
+
+        assert!(error.to_string().contains("package artifact is missing"));
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## What this fixes

A self-upgrade replaces the updater itself. `codex-update-manager.prerm` stops every
active user's `codex-update-manager.service` before dpkg unpacks, so the daemon that
launched the privileged install can exit before it persists the `Installing` →
`Installed` transition. The next daemon reads a pending candidate whose upstream
release is already installed, and rebuilds and reinstalls it on every check.

## What changed

Startup reconciliation of an interrupted install, gated on evidence that identifies
**this** rebuilt artifact rather than the upstream input:

1. It runs only from the persisted `Installing` status, and only for the commands that
   act on state (`daemon`, `check-now`, `install-ready`, `rollback`). `status` and
   `diagnose` keep reporting what is persisted.
2. It reads the native package version out of `state.artifact_paths.package_path` with
   the existing deb/RPM/pacman parsers (`install::package_file_version`) and compares it
   against `install::installed_package_version()`.
3. It additionally requires the package manager to report that version for a payload it
   has committed (`install::installed_package_is_usable`). `dpkg-query -W -f=${Version}`
   answers from the moment unpacking starts, and `prerm` has already stopped the daemon
   by then, so a failed unpack or a failed `postinst` would otherwise be recorded as a
   successful install. The allowlist accepts `installed`, `half-configured`,
   `triggers-awaited` and `triggers-pending`; `half-configured` is accepted because
   `postinst` starts the service from inside the dpkg transaction, so the recovering
   daemon normally runs while the package it is recovering is still being configured.
   RPM and pacman commit the payload before their databases answer, so the distinction
   is dpkg-only.
4. Only when all of that holds does it move the candidate upstream version/SHA-256 into
   the installed fields and clear the candidate. A missing artifact, an uninspectable
   artifact, a differing native version, an uncommitted payload, or an `unknown`
   installed version all preserve the candidate and skip reconciliation.

The upstream version and SHA-256 are never used as the decision input: they identify the
signed OpenAI `.deb`, not the per-user package rebuilt from it, and different per-user
builds can share them while differing in package version or enabled features.

No new `build-info.json` parser, no new state schema, no new dependency.

### Supporting changes

- `record_new_candidate` now clears `artifact_paths.package_path`. `build_update` only
  republishes the artifact paths once it has produced a package, so a failed download or
  build previously left `package_path` pointing at the *previous* release's artifact
  while the candidate fields already described the new one. Both consumers of
  `package_path` (the `install-ready` retry and this reconciliation) read it as the
  artifact of the current candidate, so it has to be absent until it is. The rollback
  target is captured, and the cache pruned, before the reset.
- `install-ready` with no recorded artifact is now a routine outcome instead of a
  `context()` error; on a `Failed` status it reports the recorded `error_message` rather
  than printing "No rebuilt package is ready to install."
- `package_file_version` resolves symlinks through the existing `package_identity_path`
  helper before parsing, because the pacman version lives in the file name and
  `codex-desktop-latest.pkg.tar.zst` is a symlink — the same thing
  `stable_validated_package` does.

## Tests

`updater/src/app.rs` (reconciliation is exercised through an injected
`installed_package_is_usable` and package-version reader, so no package manager is
needed):

- recovers an install whose native package version is the installed one;
- **preserves a candidate that shares the upstream release but has a different native
  package version** (the case called out in review);
- preserves a candidate the package manager recorded but did not install (payload not
  committed);
- preserves the candidate when the artifact is missing from the state, cannot be
  inspected, or the installed version is `unknown`;
- **does not reconcile any status other than `Installing`** (loops over all eleven);
- a failed build cannot be recovered as an installed candidate;
- a new candidate drops the previous candidate's artifact.

`updater/src/install.rs`: reads the native version from a real `dpkg-deb`-built `.deb`
(skipped when `dpkg-deb` is absent), from a pacman artifact, through a pacman `latest`
symlink, rejects a missing artifact, and accepts only the dpkg states that have the
payload installed.

## Verification

- `cargo test -p codex-update-manager` — 63 passed
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings` — clean
- `cargo test -p codex-record-replay-linux` and its clippy — clean
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template` — clean
- `cargo fmt --check` reports the same 51 hunks on `main` and on this branch; a
  hunk-by-hunk diff shows this branch adds none. Per CONTRIBUTING the pre-existing
  formatting churn is left out of this behaviour change.
- `bash tests/scripts_smoke.sh` could not run locally (no `ripgrep` on this machine); CI
  installs it.
- Branch is rebased on current `main`.

## Self-review

The base-to-head diff was run through a code-review model repeatedly, fixing what it
found, until the remaining findings were all pre-existing conditions rather than
anything the diff introduces:

1. `record_new_candidate` was leaving the previous release's artifact reachable from a
   new candidate — fixed (see above).
2. `package_file_version` was not resolving the pacman `latest` symlink — fixed.
3. `install-ready` was reporting a `Failed` state as "nothing to install" — fixed.
4. `dpkg-query` reports a version for a payload it has not committed — fixed with the
   status allowlist.
5. Two findings left unfixed, both verbatim on `main` and unchanged by this diff:
   - `check`'s `same_failed_candidate` guard (identical on `main`) keeps the updater in
     `Failed` for as long as upstream serves the release whose download or build failed,
     so a transient network error suspends updates until the next upstream release. This
     PR does not introduce that; it removes the one escape hatch that "worked", which
     was `install-ready` installing the *previous* release's artifact and recording it
     under the new upstream version and SHA-256 — exactly the corruption this PR exists
     to prevent. Making that state retry is a retry-policy decision (a naive re-check
     would rebuild a deterministically failing candidate on every tick), so it is left
     to you rather than folded in here.
   - `state.installed_version` is still assigned from the raw package-manager answer at
     every entry point, as it is on `main` (three sites, unchanged), so during a dpkg
     transaction `status` can report a version whose payload is not committed. The
     reconciliation does not rely on that field alone, which is why the stricter test
     lives in the predicate. Applying it to the assignment as well would change what
     `installed_version` means for `rollback`'s known-good capture too, which is beyond
     this fix.

## Out of scope, reported rather than bundled

Two further pre-existing issues found while reviewing this change. CONTRIBUTING asks not
to mix unrelated cleanup into a behaviour change, and the one-open-PR rule rules out a
parallel PR, so they are only reported here:

- `builder.rs` `find_package` requires exactly one match in `DIST_DIR`, but
  `scripts/build-pacman.sh` leaves both the versioned package and the
  `codex-desktop-latest.pkg.tar.zst` symlink there, so every Arch rebuild on `main`
  fails the match. Happy to send a fix once this PR is resolved.
- An interrupted **rollback** has the same shape of problem, but rollback persists no
  candidate tuple, so recovering it needs the rollback target's upstream identity, which
  is not in the state today. That is a different mechanism from the candidate-scoped fix
  requested here.
