### PR TITLE
test: stabilize launcher background cleanup

### DIFF
--- a/launcher/start.test.js
+++ b/launcher/start.test.js
@@ -20,7 +20,14 @@ function writeExecutable(filePath, source) {
 
 function createApp(t) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-launcher-test-"));
-  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  t.after(() =>
+    fs.rmSync(root, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 20,
+    }),
+  );
   const launcher = fs.readFileSync(templatePath, "utf8")
     .replaceAll("__CODEX_LINUX_APP_ID__", "codex-desktop")
     .replaceAll("__CODEX_LINUX_APP_DISPLAY_NAME__", "ChatGPT Community");
@@ -50,11 +57,13 @@ test("launcher reports only one anonymous usage event per UTC day", (t) => {
   const root = createApp(t);
   const binDir = path.join(root, "bin");
   const callsPath = path.join(root, "curl-calls");
+  const donePath = path.join(root, "curl-done");
   writeExecutable(
     path.join(binDir, "curl"),
     `#!/bin/bash
 printf 'call\\n' >> "$TEST_ROOT/curl-calls"
 printf '<%s>\\n' "$@" >> "$TEST_ROOT/curl-arguments"
+printf 'done\\n' > "$TEST_ROOT/curl-done"
 `,
   );
 
@@ -74,7 +83,7 @@ printf '<%s>\\n' "$@" >> "$TEST_ROOT/curl-arguments"
     });
     assert.equal(result.status, 7);
     assert.equal(result.stderr, "");
-    if (launch === 0) waitForFile(callsPath);
+    if (launch === 0) waitForFile(donePath);
   }
 
   assert.equal(fs.readFileSync(callsPath, "utf8"), "call\n");


### PR DESCRIPTION
## Summary

- wait for the fake usage-reporting `curl` process to finish writing all of its fixture output
- retry recursive fixture cleanup briefly when launcher background jobs still have filesystem activity in flight

## Root cause

The launcher intentionally starts daily usage reporting in the background. The test previously waited only for the first write to `curl-calls`, so the fake `curl` process could still be writing its arguments when teardown began. A second launch also starts a short-lived reporting subshell that can overlap teardown after it observes the existing daily marker. That race occasionally caused `fs.rmSync` to fail with `ENOTEMPTY` in CI even though all assertions had passed.

This is a test-only stabilization; production launcher behavior is unchanged.

## Validation

- reproduced before the fix in focused sequential stress runs (including a failure at run 183)
- 500 focused sequential runs
- 200 focused runs at concurrency 8
- `node --test launcher/start.test.js` (7/7)
- `bash tests/scripts_smoke.sh` (51/51)
- `git diff --check`