### PR TITLE
Fix pacman updater package discovery

### DIFF
--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -170,7 +170,11 @@ async fn read_stream<R: tokio::io::AsyncRead + Unpin>(stream: R) -> Result<Strin
 fn find_package(dist: &Path) -> Result<PathBuf> {
     let mut matches = Vec::new();
     for entry in fs::read_dir(dist).with_context(|| format!("Failed to read {}", dist.display()))? {
-        let path = entry?.path();
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let path = entry.path();
         let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
         if name.ends_with(".deb") || name.ends_with(".rpm") || name.contains(".pkg.tar.") {
             matches.push(path);
@@ -187,6 +191,22 @@ mod tests {
     #[test]
     fn workspace_component_never_contains_separators() {
         assert_eq!(safe_component("26.1/../../x"), "26.1_.._.._x");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn package_discovery_ignores_pacman_latest_symlink() -> Result<()> {
+        let dist = tempfile::tempdir()?;
+        let package_name = "codex-desktop-2026.08.17.131838-1-x86_64.pkg.tar.zst";
+        let package_path = dist.path().join(package_name);
+        fs::write(&package_path, b"package")?;
+        std::os::unix::fs::symlink(
+            package_name,
+            dist.path().join("codex-desktop-latest.pkg.tar.zst"),
+        )?;
+
+        assert_eq!(find_package(dist.path())?, package_path);
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- require rebuilt package candidates to be regular files
- ignore pacman's `codex-desktop-latest.pkg.tar.zst` symlink during artifact discovery
- add a regression test covering the versioned archive plus latest-symlink layout

The pacman builder intentionally writes both a versioned package and a stable
`latest` symlink. The updater previously matched entries by filename alone, so
it counted both paths and left Arch updates in `Failed` with
`expected one rebuilt package, found 2`.

This keeps the existing exactly-one-artifact invariant while excluding aliases,
directories, and other non-regular entries from the candidate set.

## Validation

- `cargo test -p codex-update-manager` (50 passed)
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `git diff --check`
- end-to-end Arch update from the signed `26.810.52044` package: rebuild,
  privileged pacman install, state transition to `Installed`, and subsequent
  check settling to `Idle`

`cargo fmt --all -- --check` was also inspected, but current unmodified `main`
already reports repository-wide formatting differences across updater files;
this PR does not broaden the diff to reformat them.

## Checklist

- [ ] This pull request is ready for review and is no longer a draft.
- [x] I followed `CONTRIBUTING.md`, kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] Upstream drift checklist is not applicable; this fixes local pacman updater artifact discovery.
- [x] I added relevant regression coverage and ran the validation listed above.
- [ ] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
