### PR TITLE
feat: show usage limits in Linux tray menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ requirements, known limitations, configuration, and tests.
 | `shallow-repository-watches` | Avoid recursive main-thread walks for transient repository previews | [Docs](linux-features/shallow-repository-watches/README.md) |
 | `shared-app-server-socket` | Share one protocol-transparent Unix app-server socket | [Docs](linux-features/shared-app-server-socket/README.md) |
 | `thorium-chrome-plugin` | Add Thorium to the official bundled Chrome integration | [Docs](linux-features/thorium-chrome-plugin/README.md) |
+| `tray-usage` | Show usage remaining in the Linux system-tray menu | [Docs](linux-features/tray-usage/README.md) |
 | `ui-tweaks` | Optional visual and interaction customizations | [Docs](linux-features/ui-tweaks/README.md) |
 
 Account rollouts and server-side ChatGPT features remain controlled by OpenAI.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -226,6 +226,7 @@ Nix 用户应从 profile、Home Manager 配置或 NixOS module 中删除该包�
 | `shallow-repository-watches` | 避免临时 repo preview 在主线程递归遍历 | [文档](linux-features/shallow-repository-watches/README.md) |
 | `shared-app-server-socket` | 共享 protocol-transparent Unix app-server socket | [文档](linux-features/shared-app-server-socket/README.md) |
 | `thorium-chrome-plugin` | 为官方 Chrome integration 添加 Thorium | [文档](linux-features/thorium-chrome-plugin/README.md) |
+| `tray-usage` | 在 Linux 系统托盘菜单显示剩余用量 | [文档](linux-features/tray-usage/README.md) |
 | `ui-tweaks` | 可选 UI 与交互自定义 | [文档](linux-features/ui-tweaks/README.md) |
 
 ChatGPT account rollout 和 server-side 功能仍由 OpenAI 控制。重新构建本项目

--- a/linux-features/tray-usage/README.md
+++ b/linux-features/tray-usage/README.md
@@ -1,0 +1,41 @@
+# Tray Usage
+
+This optional feature shows the same rate-limit windows already used by the
+profile menu in the Linux system-tray menu. It does not make a second request
+or move account credentials into the Electron main process: the renderer's
+existing `tray-menu-threads-changed` message already carries compact usage
+labels, and this feature enables those labels in the Linux menu.
+
+Enable it by copying `linux-features/features.example.json` to
+`linux-features/features.json` and adding the feature id:
+
+```json
+{
+  "enabled": [
+    "tray-usage"
+  ]
+}
+```
+
+Then rerun `./install.sh` or the native package build flow. Fully quit every
+ChatGPT Community process before launching the rebuilt app. Depending on the
+desktop shell, open the tray menu with the tray icon's context-menu click
+(usually right-click on Linux); a normal left click still opens the app.
+
+The labels are read-only and can be absent while usage data is loading or when
+the account has no rate-limit windows. They refresh whenever the app's existing
+usage state refreshes. Multiple windows (for example, five-hour and weekly)
+are shown separately with their reset time when available.
+
+## Known risks
+
+The patch targets a minified upstream Electron bundle and is intentionally
+optional. If the upstream tray-menu contract changes, the patch leaves the
+bundle unchanged and records optional drift rather than guessing at a new
+location.
+
+## Testing
+
+```bash
+node --test linux-features/tray-usage/test.js
+```

--- a/linux-features/tray-usage/feature.json
+++ b/linux-features/tray-usage/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "tray-usage",
+  "title": "Tray Usage",
+  "description": "Show the current Codex usage remaining in the Linux system-tray menu.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/tray-usage/patch.js
+++ b/linux-features/tray-usage/patch.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const CURRENT_USAGE_GATE =
+  /([A-Za-z_$][\w$]*)=process\.platform!==`darwin`\|\|([A-Za-z_$][\w$]*)\.length===0\?\[\]:/g;
+const PATCHED_USAGE_GATE =
+  /([A-Za-z_$][\w$]*)=process\.platform!==`darwin`&&process\.platform!==`linux`\|\|([A-Za-z_$][\w$]*)\.length===0\?\[\]:/g;
+
+function countMatches(source, pattern) {
+  if (typeof source !== "string") return 0;
+  pattern.lastIndex = 0;
+  return [...source.matchAll(pattern)].length;
+}
+
+function trayUsageMainContract(source) {
+  const currentCount = countMatches(source, CURRENT_USAGE_GATE);
+  const patchedCount = countMatches(source, PATCHED_USAGE_GATE);
+  if (currentCount === 1 && patchedCount === 0) return "current";
+  if (currentCount === 0 && patchedCount === 1) return "patched";
+  return "drifted";
+}
+
+function applyTrayUsageMainPatch(source) {
+  const contract = trayUsageMainContract(source);
+  if (contract === "patched") return source;
+  if (contract !== "current") {
+    console.warn(
+      "WARN: Could not find the current Linux tray-usage main-process contract - skipping tray usage patch",
+    );
+    return source;
+  }
+
+  const patched = source.replace(
+    CURRENT_USAGE_GATE,
+    (_match, menuItemsAlias, usageLimitsAlias) =>
+      `${menuItemsAlias}=process.platform!==\`darwin\`&&process.platform!==\`linux\`||${usageLimitsAlias}.length===0?[]:`,
+  );
+  if (trayUsageMainContract(patched) !== "patched") {
+    console.warn(
+      "WARN: Linux tray-usage main-process contract changed while patching - skipping tray usage patch",
+    );
+    return source;
+  }
+  return patched;
+}
+
+const descriptors = [
+  {
+    id: "linux-tray-usage-main-process",
+    phase: "main-bundle",
+    order: 20_960,
+    ciPolicy: "optional",
+    apply: applyTrayUsageMainPatch,
+  },
+];
+
+module.exports = {
+  applyTrayUsageMainPatch,
+  descriptors,
+  trayUsageMainContract,
+};

--- a/linux-features/tray-usage/patch.js
+++ b/linux-features/tray-usage/patch.js
@@ -1,19 +1,55 @@
 "use strict";
 
-const CURRENT_USAGE_GATE =
-  /([A-Za-z_$][\w$]*)=process\.platform!==`darwin`\|\|([A-Za-z_$][\w$]*)\.length===0\?\[\]:/g;
-const PATCHED_USAGE_GATE =
-  /([A-Za-z_$][\w$]*)=process\.platform!==`darwin`&&process\.platform!==`linux`\|\|([A-Za-z_$][\w$]*)\.length===0\?\[\]:/g;
+const TRAY_USAGE_ANCHOR =
+  /getNativeTrayMenuItems\(\)\{let\{pinnedThreads:[A-Za-z_$][\w$]*,recentThreads:[A-Za-z_$][\w$]*,runningThreads:[A-Za-z_$][\w$]*,unreadThreads:[A-Za-z_$][\w$]*,usageLimits:([A-Za-z_$][\w$]*)\}=this\.trayMenuThreads,/g;
+const TRAY_USAGE_WINDOW_LENGTH = 6_000;
+const TRAY_USAGE_RETURN_BOUNDARY = ";return[";
 
-function countMatches(source, pattern) {
-  if (typeof source !== "string") return 0;
-  pattern.lastIndex = 0;
-  return [...source.matchAll(pattern)].length;
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function trayUsageGates(source, patched) {
+  if (typeof source !== "string") return [];
+  TRAY_USAGE_ANCHOR.lastIndex = 0;
+  const matches = [];
+
+  for (const anchor of source.matchAll(TRAY_USAGE_ANCHOR)) {
+    const usageLimitsAlias = anchor[1];
+    const escapedUsageLimitsAlias = escapeRegExp(usageLimitsAlias);
+    const platformGate = patched
+      ? "process\\.platform!==`darwin`&&process\\.platform!==`linux`"
+      : "process\\.platform!==`darwin`";
+    const gatePattern = new RegExp(
+      `([A-Za-z_$][\\w$]*)=${platformGate}\\|\\|${escapedUsageLimitsAlias}\\.length===0\\?\\[\\]:`,
+    );
+    const labelMapPattern = new RegExp(
+      `${escapedUsageLimitsAlias}\\.map\\(\\(\\{label:([A-Za-z_$][\\w$]*)\\}\\)=>\\(\\{label:\\1,enabled:!1\\}\\)\\)`,
+    );
+    const windowStart = anchor.index + anchor[0].length;
+    const window = source.slice(windowStart, windowStart + TRAY_USAGE_WINDOW_LENGTH);
+    const returnBoundary = window.indexOf(TRAY_USAGE_RETURN_BOUNDARY);
+    if (returnBoundary === -1) continue;
+    const methodBody = window.slice(0, returnBoundary);
+    const gate = gatePattern.exec(methodBody);
+    if (gate == null) continue;
+    const labelMapStart = gate.index + gate[0].length;
+    const labelMap = labelMapPattern.exec(methodBody.slice(labelMapStart, labelMapStart + 700));
+    if (labelMap == null) continue;
+    matches.push({
+      index: windowStart + gate.index,
+      match: gate[0],
+      menuItemsAlias: gate[1],
+      usageLimitsAlias,
+    });
+  }
+
+  return matches;
 }
 
 function trayUsageMainContract(source) {
-  const currentCount = countMatches(source, CURRENT_USAGE_GATE);
-  const patchedCount = countMatches(source, PATCHED_USAGE_GATE);
+  const currentCount = trayUsageGates(source, false).length;
+  const patchedCount = trayUsageGates(source, true).length;
   if (currentCount === 1 && patchedCount === 0) return "current";
   if (currentCount === 0 && patchedCount === 1) return "patched";
   return "drifted";
@@ -29,11 +65,9 @@ function applyTrayUsageMainPatch(source) {
     return source;
   }
 
-  const patched = source.replace(
-    CURRENT_USAGE_GATE,
-    (_match, menuItemsAlias, usageLimitsAlias) =>
-      `${menuItemsAlias}=process.platform!==\`darwin\`&&process.platform!==\`linux\`||${usageLimitsAlias}.length===0?[]:`,
-  );
+  const [{ index, match, menuItemsAlias, usageLimitsAlias }] = trayUsageGates(source, false);
+  const replacement = `${menuItemsAlias}=process.platform!==\`darwin\`&&process.platform!==\`linux\`||${usageLimitsAlias}.length===0?[]:`;
+  const patched = `${source.slice(0, index)}${replacement}${source.slice(index + match.length)}`;
   if (trayUsageMainContract(patched) !== "patched") {
     console.warn(
       "WARN: Linux tray-usage main-process contract changed while patching - skipping tray usage patch",

--- a/linux-features/tray-usage/test.js
+++ b/linux-features/tray-usage/test.js
@@ -15,10 +15,10 @@ const {
 
 function officialMainFixture(alias = "i", menuAlias = "f") {
   return [
-    "function qTe(){let{pinnedThreads:e,recentThreads:t,runningThreads:n,unreadThreads:r,usageLimits:",
-    `${alias}}=this.trayMenuThreads;`,
+    "getNativeTrayMenuItems(){let{pinnedThreads:e,recentThreads:t,runningThreads:n,unreadThreads:r,usageLimits:",
+    `${alias}}=this.trayMenuThreads,a=[];`,
     `let ${menuAlias}=process.platform!==\`darwin\`||${alias}.length===0?[]:[{label:\`Usage\`,enabled:!1},...${alias}.map(({label:e})=>({label:e,enabled:!1}))];`,
-    `return ${menuAlias}}`,
+    `return[${menuAlias}]}`,
   ].join("");
 }
 
@@ -87,11 +87,15 @@ test("main-process patch preserves minified aliases", () => {
 test("drifted, duplicate, and mixed contracts remain byte-identical", () => {
   const current = officialMainFixture();
   const patched = applyTrayUsageMainPatch(current);
+  const drifted = current.replace("process.platform!==`darwin`", "process.platform===`darwin`");
+  const unrelatedLookalike =
+    "function unrelated(){let x=process.platform!==`darwin`||i.length===0?[]:[...i.map(({label:e})=>({label:e,enabled:!1}))];return[x]}";
   const sources = [
-    current.replace("process.platform!==`darwin`", "process.platform===`darwin`"),
+    drifted,
     current + current,
     patched + patched,
     current + patched,
+    drifted + unrelatedLookalike,
   ];
 
   for (const source of sources) {

--- a/linux-features/tray-usage/test.js
+++ b/linux-features/tray-usage/test.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const { loadLinuxFeaturePatchDescriptors } = require("../../scripts/lib/linux-features.js");
+const {
+  applyTrayUsageMainPatch,
+  descriptors,
+  trayUsageMainContract,
+} = require("./patch.js");
+
+function officialMainFixture(alias = "i", menuAlias = "f") {
+  return [
+    "function qTe(){let{pinnedThreads:e,recentThreads:t,runningThreads:n,unreadThreads:r,usageLimits:",
+    `${alias}}=this.trayMenuThreads;`,
+    `let ${menuAlias}=process.platform!==\`darwin\`||${alias}.length===0?[]:[{label:\`Usage\`,enabled:!1},...${alias}.map(({label:e})=>({label:e,enabled:!1}))];`,
+    `return ${menuAlias}}`,
+  ].join("");
+}
+
+function captureWarnings(callback) {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.map(String).join(" "));
+  try {
+    return { value: callback(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+function withFeatureConfig(enabled, callback) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tray-usage-feature-"));
+  const configPath = path.join(tempDir, "features.json");
+  const previous = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  fs.writeFileSync(configPath, `${JSON.stringify({ enabled })}\n`);
+  process.env.CODEX_LINUX_FEATURES_CONFIG = configPath;
+  try {
+    return callback(path.resolve(__dirname, ".."));
+  } finally {
+    if (previous == null) delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+    else process.env.CODEX_LINUX_FEATURES_CONFIG = previous;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("tray-usage is disabled by default and exposes one optional main descriptor", () => {
+  withFeatureConfig([], (featuresRoot) => {
+    assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot }), []);
+  });
+
+  withFeatureConfig(["tray-usage"], (featuresRoot) => {
+    const loaded = loadLinuxFeaturePatchDescriptors({ featuresRoot });
+    assert.deepEqual(
+      loaded.map(({ id, phase, ciPolicy }) => [id, phase, ciPolicy]),
+      [["feature:tray-usage:linux-tray-usage-main-process", "main-bundle", "optional"]],
+    );
+  });
+
+  assert.deepEqual(
+    descriptors.map(({ id, phase, ciPolicy }) => [id, phase, ciPolicy]),
+    [["linux-tray-usage-main-process", "main-bundle", "optional"]],
+  );
+});
+
+test("main-process patch enables usage labels on Linux and is idempotent", () => {
+  const source = officialMainFixture();
+  assert.equal(trayUsageMainContract(source), "current");
+  const patched = applyTrayUsageMainPatch(source);
+  assert.notEqual(patched, source);
+  assert.equal(trayUsageMainContract(patched), "patched");
+  assert.match(patched, /process\.platform!==`darwin`&&process\.platform!==`linux`\|\|i\.length===0/);
+  assert.equal(applyTrayUsageMainPatch(patched), patched);
+});
+
+test("main-process patch preserves minified aliases", () => {
+  const patched = applyTrayUsageMainPatch(officialMainFixture("usage", "items"));
+  assert.equal(trayUsageMainContract(patched), "patched");
+  assert.match(patched, /items=process\.platform!==`darwin`&&process\.platform!==`linux`\|\|usage\.length===0/);
+  assert.equal(applyTrayUsageMainPatch(patched), patched);
+});
+
+test("drifted, duplicate, and mixed contracts remain byte-identical", () => {
+  const current = officialMainFixture();
+  const patched = applyTrayUsageMainPatch(current);
+  const sources = [
+    current.replace("process.platform!==`darwin`", "process.platform===`darwin`"),
+    current + current,
+    patched + patched,
+    current + patched,
+  ];
+
+  for (const source of sources) {
+    const result = captureWarnings(() => applyTrayUsageMainPatch(source));
+    assert.equal(result.value, source);
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /current Linux tray-usage main-process contract/);
+  }
+});


### PR DESCRIPTION
## Summary

- Add an opt-in `tray-usage` Linux feature that shows the existing usage-limit labels in the system-tray context menu.
- Reuse the usage data already delivered by the app's renderer; no new requests, credentials, background service, or updater behavior are added.
- Document the feature and add drift-safe patch tests.

## Problem

The renderer already sends `usageLimits` with the tray window state, but the main-process tray menu only renders those labels for macOS. Linux therefore receives the data but silently omits it.

This feature enables the same existing menu path on Linux while preserving the current macOS behavior and Windows exclusion. Left-click still opens the app; the usage labels are available in the Linux tray context menu.

## Scope

- Disabled by default; clean builds are unchanged unless `tray-usage` is explicitly enabled.
- No changes to the updater or tray icon.
- No new API surface or account/session handling.
- The patch is fail-soft when the upstream minified bundle drifts, with duplicate/mixed-match coverage.

## Validation

- `node --test linux-features/tray-usage/test.js` — 4 passed.
- `node --test scripts/lib/linux-features.test.js scripts/patch-linux-window-ui.test.js linux-features/*/test.js` — 757 tests, 756 passed, 1 skipped.
- `bash tests/scripts_smoke.sh` — passed.
- `cargo test -p codex-update-manager` — 49 passed.
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings` — passed.

