### PR TITLE
fix(bootstrap): handle existing Rust installations on pacman systems

### DIFF
--- a/.github/workflows/install-deps.yml
+++ b/.github/workflows/install-deps.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - install.sh
       - scripts/install-deps.sh
+      - tests/install_deps_pacman_rust_matrix.sh
       - packaging/linux/control
       - .github/workflows/install-deps.yml
   push:
@@ -13,6 +14,7 @@ on:
     paths:
       - install.sh
       - scripts/install-deps.sh
+      - tests/install_deps_pacman_rust_matrix.sh
       - packaging/linux/control
       - .github/workflows/install-deps.yml
 
@@ -63,3 +65,29 @@ jobs:
           test "$status" -ne 0
           printf '%s\n' "$output" | grep -q "macOS DMG inputs are no longer supported"
           ! printf '%s\n' "$output" | grep -q "Node.js 20+ required"
+
+  pacman-rust-bootstrap:
+    name: pacman ${{ matrix.rust-state }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    container:
+      image: docker.io/library/archlinux:latest
+      options: --user root
+    strategy:
+      fail-fast: false
+      matrix:
+        rust-state:
+          - working-distro-cargo
+          - rustup-without-toolchain
+          - neither-rust-nor-rustup
+          - shadowed-user-local-proxy
+    steps:
+      - name: Bootstrap checkout tools
+        run: pacman -Syu --noconfirm --needed ca-certificates git
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Verify pacman Rust bootstrap state
+        env:
+          CODEX_RUN_ARCH_INSTALL_DEPS_MATRIX: "1"
+        run: bash tests/install_deps_pacman_rust_matrix.sh "${{ matrix.rust-state }}"

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -26,10 +26,19 @@ Targets:
   deb                        Build and inspect the Debian package
   rpm                        Build and inspect the RPM package
   pacman                     Build and inspect the pacman package
-  install-deps               Test install-deps on Ubuntu 22.04, Ubuntu 24.04, and Debian 12
+  install-deps               Test install-deps on apt images and the Arch Rust matrix
   install-deps:ubuntu-22.04  Test install-deps on one apt image
   install-deps:ubuntu-24.04  Test install-deps on one apt image
   install-deps:debian-12     Test install-deps on one apt image
+  install-deps:arch-rust     Test the full pacman Rust state matrix
+  install-deps:arch-working-distro-cargo
+                             Test pacman with working distro Cargo
+  install-deps:arch-rustup-without-toolchain
+                             Test pacman with rustup but no toolchain
+  install-deps:arch-neither-rust-nor-rustup
+                             Test pacman with no Rust or rustup
+  install-deps:arch-shadowed-user-local-proxy
+                             Test pacman with system Cargo shadowed by user rustup
   nix                        Run the heavy Nix flake build checks
   upstream                   Build the app from the signed official Linux package
 
@@ -106,6 +115,7 @@ mount_github_summary_args() {
 run_container_job() {
     local job="$1"
     local image_key="$2"
+    local install_deps_case="${3:-${CI_INSTALL_DEPS_CASE:-}}"
     local engine
     local image
     engine="$(container_engine)"
@@ -132,6 +142,10 @@ run_container_job() {
         -v "$CI_CACHE_DIR:/ci-cache"
         -w /work
     )
+
+    if [ -n "$install_deps_case" ]; then
+        args+=(-e "CI_INSTALL_DEPS_CASE=$install_deps_case")
+    fi
 
     # Linked worktrees keep only a pointer in /work/.git. Mount the shared Git
     # metadata at its original absolute path so git ls-files/diff work inside
@@ -182,6 +196,7 @@ run_target() {
             run_target install-deps:ubuntu-22.04
             run_target install-deps:ubuntu-24.04
             run_target install-deps:debian-12
+            run_target install-deps:arch-rust
             ;;
         install-deps:ubuntu-22.04)
             run_container_job install-deps ubuntu-22.04
@@ -191,6 +206,21 @@ run_target() {
             ;;
         install-deps:debian-12)
             run_container_job install-deps debian-12
+            ;;
+        install-deps:arch-rust)
+            run_container_job install-deps archlinux-base-devel
+            ;;
+        install-deps:arch-working-distro-cargo)
+            run_container_job install-deps archlinux-base-devel working-distro-cargo
+            ;;
+        install-deps:arch-rustup-without-toolchain)
+            run_container_job install-deps archlinux-base-devel rustup-without-toolchain
+            ;;
+        install-deps:arch-neither-rust-nor-rustup)
+            run_container_job install-deps archlinux-base-devel neither-rust-nor-rustup
+            ;;
+        install-deps:arch-shadowed-user-local-proxy)
+            run_container_job install-deps archlinux-base-devel shadowed-user-local-proxy
             ;;
         *)
             usage >&2

--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -98,6 +98,16 @@ run_upstream() {
 }
 
 run_install_deps() {
+    if [ "${CI_IMAGE_KEY:-}" = archlinux-base-devel ]; then
+        local -a matrix_args=()
+        if [ -n "${CI_INSTALL_DEPS_CASE:-}" ]; then
+            matrix_args+=("$CI_INSTALL_DEPS_CASE")
+        fi
+        CODEX_RUN_ARCH_INSTALL_DEPS_MATRIX=1 \
+            bash tests/install_deps_pacman_rust_matrix.sh "${matrix_args[@]}"
+        return
+    fi
+
     bash scripts/install-deps.sh
     output="$(./install.sh /tmp/retired-source.dmg 2>&1)" && status=0 || status=$?
     test "$status" -ne 0

--- a/scripts/ci/github-actions-workflows.test.js
+++ b/scripts/ci/github-actions-workflows.test.js
@@ -114,6 +114,33 @@ test("official Linux validation runs fully on every pull request but not hourly"
   assert.match(dockFeatureAlone, /test -x "\$hook"/);
 });
 
+test("install-deps workflow covers apt and pacman Rust bootstrap", () => {
+  const workflow = read(".github/workflows/install-deps.yml");
+  assert.match(workflow, /^      - tests\/install_deps_pacman_rust_matrix\.sh$/m);
+
+  const apt = job(workflow, "apt-node-bootstrap");
+  for (const image of [
+    "docker.io/library/ubuntu:22.04",
+    "docker.io/library/ubuntu:24.04",
+    "docker.io/library/debian:12",
+  ]) {
+    assert.match(apt, new RegExp(image.replaceAll(".", "\\.")));
+  }
+
+  const pacman = job(workflow, "pacman-rust-bootstrap");
+  assert.match(pacman, /docker\.io\/library\/archlinux:latest/);
+  assert.match(pacman, /CODEX_RUN_ARCH_INSTALL_DEPS_MATRIX: "1"/);
+  assert.match(pacman, /bash tests\/install_deps_pacman_rust_matrix\.sh/);
+  for (const rustState of [
+    "working-distro-cargo",
+    "rustup-without-toolchain",
+    "neither-rust-nor-rustup",
+    "shadowed-user-local-proxy",
+  ]) {
+    assert.match(pacman, new RegExp(`^          - ${rustState}$`, "m"));
+  }
+});
+
 test("official Linux metadata expires after seven days", () => {
   const workflow = read(".github/workflows/upstream-build-app.yml");
   const signedBaseline = job(workflow, "signed-baseline");

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -70,17 +70,31 @@ install_zypper() {
 }
 
 install_pacman() {
+    local rust_packages=()
+
+    # Respect an existing working Rust toolchain. Arch's rust and rustup
+    # packages conflict, so only install rustup when neither a working Cargo
+    # nor rustup is already available.
+    if ! cargo --version >/dev/null 2>&1 && \
+       ! command -v rustup >/dev/null 2>&1; then
+        rust_packages=(rustup)
+    fi
+
     run_privileged pacman -Syu --noconfirm --needed base-devel ca-certificates \
-        curl dpkg git gnupg nodejs npm python rustup tar unzip util-linux xz zstd
+        curl dpkg git gnupg nodejs npm python "${rust_packages[@]}" \
+        tar unzip util-linux xz zstd
 }
 
 install_rust() {
-    command -v cargo >/dev/null 2>&1 && return 0
+    # A distro-provided Rust toolchain is sufficient.
+    cargo --version >/dev/null 2>&1 && return 0
+
     command -v rustup >/dev/null 2>&1 || {
         info 'Rust is only required for the updater and retained native feature helpers.'
-        info 'Install rustup for your distribution, then rerun this script.'
+        info 'Install Rust or rustup for your distribution, then rerun this script.'
         return 0
     }
+
     rustup toolchain install stable --profile minimal
     rustup default stable
 }

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -16,6 +16,22 @@ run_privileged() {
 info() { printf '[deps] %s\n' "$*"; }
 fail() { printf '[deps][ERROR] %s\n' "$*" >&2; exit 1; }
 
+build_path() {
+    printf '%s:%s\n' "$HOME/.cargo/bin" "$PATH"
+}
+
+cargo_works_for_build() {
+    PATH="$(build_path)" cargo --version >/dev/null 2>&1
+}
+
+rustc_works_for_build() {
+    PATH="$(build_path)" rustc --version >/dev/null 2>&1
+}
+
+rustup_available_for_build() {
+    PATH="$(build_path)" command -v rustup >/dev/null 2>&1
+}
+
 install_nodesource_apt() {
     local nodejs_major="${NODEJS_MAJOR:-24}"
     local keyring=/usr/share/keyrings/nodesource.gpg
@@ -72,11 +88,10 @@ install_zypper() {
 install_pacman() {
     local rust_packages=()
 
-    # Respect an existing working Rust toolchain. Arch's rust and rustup
-    # packages conflict, so only install rustup when neither a working Cargo
-    # nor rustup is already available.
-    if ! cargo --version >/dev/null 2>&1 && \
-       ! command -v rustup >/dev/null 2>&1; then
+    # Match bootstrap-native's Rust resolution order. A user-local rustup
+    # proxy can shadow a working distro Cargo once $HOME/.cargo/bin is
+    # prepended for the native build.
+    if ! cargo_works_for_build && ! rustup_available_for_build; then
         rust_packages=(rustup)
     fi
 
@@ -86,17 +101,18 @@ install_pacman() {
 }
 
 install_rust() {
-    # A distro-provided Rust toolchain is sufficient.
-    cargo --version >/dev/null 2>&1 && return 0
+    cargo_works_for_build && rustc_works_for_build && return 0
 
-    command -v rustup >/dev/null 2>&1 || {
+    rustup_available_for_build || {
         info 'Rust is only required for the updater and retained native feature helpers.'
         info 'Install Rust or rustup for your distribution, then rerun this script.'
         return 0
     }
 
-    rustup toolchain install stable --profile minimal
-    rustup default stable
+    PATH="$(build_path)" rustup toolchain install stable --profile minimal
+    PATH="$(build_path)" rustup default stable
+    cargo_works_for_build || fail 'Cargo is unavailable after Rust toolchain setup.'
+    rustc_works_for_build || fail 'rustc is unavailable after Rust toolchain setup.'
 }
 
 manager="$(detect_package_manager)"

--- a/tests/install_deps_pacman_rust_matrix.sh
+++ b/tests/install_deps_pacman_rust_matrix.sh
@@ -23,9 +23,14 @@ assert_fails() {
     ! "$@" >/dev/null 2>&1 || fail "expected command to fail: $*"
 }
 
+pacman_package_installed() {
+    local package="$1"
+    [ "$(pacman -Qq "$package" 2>/dev/null || true)" = "$package" ]
+}
+
 assert_no_pacman_rust_conflict() {
-    if pacman -Q rust >/dev/null 2>&1 &&
-       pacman -Q rustup >/dev/null 2>&1; then
+    if pacman_package_installed rust &&
+       pacman_package_installed rustup; then
         fail 'pacman rust and rustup packages must not be installed together'
     fi
 }
@@ -34,7 +39,7 @@ reset_rust_state() {
     local -a installed=()
     local package
     for package in rust rustup; do
-        if pacman -Q "$package" >/dev/null 2>&1; then
+        if pacman_package_installed "$package"; then
             installed+=("$package")
         fi
     done
@@ -66,8 +71,8 @@ case_working_distro_cargo() {
     assert_succeeds with_build_path cargo --version
     run_install_deps
     verify_build_rust
-    pacman -Q rust >/dev/null 2>&1 || fail 'expected pacman rust to remain installed'
-    ! pacman -Q rustup >/dev/null 2>&1 || fail 'did not expect pacman rustup with distro rust'
+    pacman_package_installed rust || fail 'expected pacman rust to remain installed'
+    ! pacman_package_installed rustup || fail 'did not expect pacman rustup with distro rust'
 }
 
 case_rustup_without_toolchain() {
@@ -77,8 +82,8 @@ case_rustup_without_toolchain() {
     assert_succeeds with_build_path rustup --version
     run_install_deps
     verify_build_rust
-    pacman -Q rustup >/dev/null 2>&1 || fail 'expected pacman rustup to remain installed'
-    ! pacman -Q rust >/dev/null 2>&1 || fail 'did not expect pacman rust with rustup'
+    pacman_package_installed rustup || fail 'expected pacman rustup to remain installed'
+    ! pacman_package_installed rust || fail 'did not expect pacman rust with rustup'
 }
 
 case_neither_rust_nor_rustup() {
@@ -87,8 +92,8 @@ case_neither_rust_nor_rustup() {
     assert_fails with_build_path rustup --version
     run_install_deps
     verify_build_rust
-    pacman -Q rustup >/dev/null 2>&1 || fail 'expected install-deps to install pacman rustup'
-    ! pacman -Q rust >/dev/null 2>&1 || fail 'did not expect pacman rust with rustup'
+    pacman_package_installed rustup || fail 'expected install-deps to install pacman rustup'
+    ! pacman_package_installed rust || fail 'did not expect pacman rust with rustup'
 }
 
 case_shadowed_user_local_proxy() {
@@ -112,8 +117,8 @@ case_shadowed_user_local_proxy() {
     verify_build_rust
     [ "$(with_build_path command -v cargo)" = "$HOME/.cargo/bin/cargo" ] ||
         fail 'expected native build path to keep resolving user-local cargo after setup'
-    pacman -Q rust >/dev/null 2>&1 || fail 'expected pacman rust to remain installed'
-    ! pacman -Q rustup >/dev/null 2>&1 || fail 'did not expect pacman rustup with distro rust'
+    pacman_package_installed rust || fail 'expected pacman rust to remain installed'
+    ! pacman_package_installed rustup || fail 'did not expect pacman rustup with distro rust'
 }
 
 require_arch_container() {

--- a/tests/install_deps_pacman_rust_matrix.sh
+++ b/tests/install_deps_pacman_rust_matrix.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail() { printf '[pacman-rust-matrix][ERROR] %s\n' "$*" >&2; exit 1; }
+info() { printf '[pacman-rust-matrix] %s\n' "$*"; }
+
+build_path() {
+    printf '%s:%s\n' "$HOME/.cargo/bin" "$PATH"
+}
+
+with_build_path() {
+    PATH="$(build_path)" "$@"
+}
+
+assert_succeeds() {
+    "$@" >/dev/null 2>&1 || fail "expected command to succeed: $*"
+}
+
+assert_fails() {
+    ! "$@" >/dev/null 2>&1 || fail "expected command to fail: $*"
+}
+
+assert_no_pacman_rust_conflict() {
+    if pacman -Q rust >/dev/null 2>&1 &&
+       pacman -Q rustup >/dev/null 2>&1; then
+        fail 'pacman rust and rustup packages must not be installed together'
+    fi
+}
+
+reset_rust_state() {
+    local -a installed=()
+    local package
+    for package in rust rustup; do
+        if pacman -Q "$package" >/dev/null 2>&1; then
+            installed+=("$package")
+        fi
+    done
+    if [ "${#installed[@]}" -gt 0 ]; then
+        pacman -Rns --noconfirm "${installed[@]}"
+    fi
+    rm -rf -- "$HOME/.cargo" "$HOME/.rustup"
+    hash -r
+}
+
+install_base_tools() {
+    pacman -Syu --noconfirm --needed ca-certificates curl
+}
+
+run_install_deps() {
+    (cd "$REPO_DIR" && bash scripts/install-deps.sh)
+}
+
+verify_build_rust() {
+    assert_succeeds with_build_path cargo --version
+    assert_succeeds with_build_path rustc --version
+    assert_no_pacman_rust_conflict
+}
+
+case_working_distro_cargo() {
+    reset_rust_state
+    pacman -S --noconfirm --needed rust
+    assert_succeeds /usr/bin/cargo --version
+    assert_succeeds with_build_path cargo --version
+    run_install_deps
+    verify_build_rust
+    pacman -Q rust >/dev/null 2>&1 || fail 'expected pacman rust to remain installed'
+    ! pacman -Q rustup >/dev/null 2>&1 || fail 'did not expect pacman rustup with distro rust'
+}
+
+case_rustup_without_toolchain() {
+    reset_rust_state
+    pacman -S --noconfirm --needed rustup
+    assert_fails with_build_path cargo --version
+    assert_succeeds with_build_path rustup --version
+    run_install_deps
+    verify_build_rust
+    pacman -Q rustup >/dev/null 2>&1 || fail 'expected pacman rustup to remain installed'
+    ! pacman -Q rust >/dev/null 2>&1 || fail 'did not expect pacman rust with rustup'
+}
+
+case_neither_rust_nor_rustup() {
+    reset_rust_state
+    assert_fails with_build_path cargo --version
+    assert_fails with_build_path rustup --version
+    run_install_deps
+    verify_build_rust
+    pacman -Q rustup >/dev/null 2>&1 || fail 'expected install-deps to install pacman rustup'
+    ! pacman -Q rust >/dev/null 2>&1 || fail 'did not expect pacman rust with rustup'
+}
+
+case_shadowed_user_local_proxy() {
+    local installer
+
+    reset_rust_state
+    pacman -S --noconfirm --needed rust
+    installer="$(mktemp)"
+    curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs -o "$installer"
+    RUSTUP_INIT_SKIP_PATH_CHECK=yes \
+        sh "$installer" -y --profile minimal --default-toolchain none --no-modify-path
+    rm -f -- "$installer"
+    hash -r
+
+    assert_succeeds /usr/bin/cargo --version
+    [ "$(with_build_path command -v cargo)" = "$HOME/.cargo/bin/cargo" ] ||
+        fail 'expected user-local rustup cargo proxy to shadow /usr/bin/cargo'
+    assert_fails with_build_path cargo --version
+
+    run_install_deps
+    verify_build_rust
+    [ "$(with_build_path command -v cargo)" = "$HOME/.cargo/bin/cargo" ] ||
+        fail 'expected native build path to keep resolving user-local cargo after setup'
+    pacman -Q rust >/dev/null 2>&1 || fail 'expected pacman rust to remain installed'
+    ! pacman -Q rustup >/dev/null 2>&1 || fail 'did not expect pacman rustup with distro rust'
+}
+
+require_arch_container() {
+    [ "${CODEX_RUN_ARCH_INSTALL_DEPS_MATRIX:-0}" = "1" ] ||
+        fail 'set CODEX_RUN_ARCH_INSTALL_DEPS_MATRIX=1 to run this destructive Arch container test'
+    [ "$(id -u)" -eq 0 ] || fail 'this test must run as root inside a disposable Arch container'
+    command -v pacman >/dev/null 2>&1 || fail 'pacman is required'
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    case "${ID:-}" in
+        arch|archlinux) ;;
+        *) fail "expected an Arch container, found ${PRETTY_NAME:-unknown}" ;;
+    esac
+}
+
+run_case() {
+    local name="$1"
+    info "case: $name"
+    case "$name" in
+        working-distro-cargo) case_working_distro_cargo ;;
+        rustup-without-toolchain) case_rustup_without_toolchain ;;
+        neither-rust-nor-rustup) case_neither_rust_nor_rustup ;;
+        shadowed-user-local-proxy) case_shadowed_user_local_proxy ;;
+        *) fail "unknown case: $name" ;;
+    esac
+    info "case passed: $name"
+}
+
+require_arch_container
+install_base_tools
+
+if [ "$#" -eq 0 ]; then
+    set -- \
+        working-distro-cargo \
+        rustup-without-toolchain \
+        neither-rust-nor-rustup \
+        shadowed-user-local-proxy
+fi
+
+for case_name in "$@"; do
+    run_case "$case_name"
+done

--- a/tests/install_deps_pacman_rust_matrix.sh
+++ b/tests/install_deps_pacman_rust_matrix.sh
@@ -96,16 +96,24 @@ case_neither_rust_nor_rustup() {
     ! pacman_package_installed rust || fail 'did not expect pacman rust with rustup'
 }
 
-case_shadowed_user_local_proxy() {
-    local installer
+install_user_local_rustup_proxy_from_pacman() {
+    local rustup_cmd
 
+    pacman -S --noconfirm --needed rustup
+    pacman_package_installed rustup || fail 'expected pacman rustup package to be installed'
+    rustup_cmd="$(command -v rustup)"
+    install -d -m 0755 "$HOME/.cargo/bin"
+    install -m 0755 "$rustup_cmd" "$HOME/.cargo/bin/rustup"
+    ln -s rustup "$HOME/.cargo/bin/cargo"
+    ln -s rustup "$HOME/.cargo/bin/rustc"
+    pacman -Rns --noconfirm rustup
+    hash -r
+}
+
+case_shadowed_user_local_proxy() {
     reset_rust_state
+    install_user_local_rustup_proxy_from_pacman
     pacman -S --noconfirm --needed rust
-    installer="$(mktemp)"
-    curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs -o "$installer"
-    RUSTUP_INIT_SKIP_PATH_CHECK=yes \
-        sh "$installer" -y --profile minimal --default-toolchain none --no-modify-path
-    rm -f -- "$installer"
     hash -r
 
     assert_succeeds /usr/bin/cargo --version

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -18,7 +18,9 @@ assert_executable scripts/ci/validate-nix-pins.sh
 assert_file assets/openai-codex-linux-repository-key.gpg.base64
 assert_file nix/upstream-linux-packages.json
 
-bash -n install.sh launcher/start.sh.template scripts/rebuild-candidate.sh scripts/select-latest-package.sh
+bash -n install.sh launcher/start.sh.template scripts/install-deps.sh \
+  scripts/rebuild-candidate.sh scripts/select-latest-package.sh \
+  tests/install_deps_pacman_rust_matrix.sh
 bash -n scripts/lib/*.sh scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh
 
 assert_contains packaging/linux/codex-desktop.desktop '^Name=ChatGPT Community$'


### PR DESCRIPTION
**IMPORTANT: Please keep only one pull request open at a time. The default maximum is two active pull requests from the same contributor, and even that should be reserved for exceptional circumstances. Maintainers may configure a different per-contributor limit for explicit exceptions. Do not open several pull requests at once; finish or close existing work before submitting more. An automated bot will close pull requests that exceed the effective limit.**

<!-- Complete this template before requesting review or merge. -->

## Problem

`install-deps.sh` unconditionally installs `rustup` on pacman systems.
On Arch-derived distributions, `rustup` conflicts with the distro-provided
`rust` package, causing `make bootstrap-native` to abort when Rust is already
installed.

The existing `install_rust()` check also only verifies that the `cargo`
command exists. A rustup installation without an installed toolchain may
provide the command while Cargo itself is not usable.

## Solution

- Preserve an existing working distro-provided Rust/Cargo toolchain.
- Install `rustup` on pacman systems only when neither working Cargo nor
  rustup is available.
- Check `cargo --version` instead of only checking command presence.
- Initialize the stable toolchain when rustup exists but Cargo is not usable.

## Validation

Tested on Manjaro x86_64 with the distro `rust` package installed.

Before:
`make bootstrap-native` failed because pacman tried to install conflicting
`rustup`.

After:
`scripts/install-deps.sh` preserves the existing Rust toolchain and completes
successfully.

Also validated with:

    bash -n scripts/install-deps.sh
    git diff --check

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest signed stable OpenAI Linux package and removes obsolete fallback code and tests.
- [ ] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
