### PR TITLE
fix(directory-watch): adopt Watchbound 2.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ target/
 dist/
 dist-next/
 reports/upstream-linux-package/
+reports/watchbound-signed-runtime/
 linux-features/features.json
 linux-features/local/
 .idea/

--- a/flake.nix
+++ b/flake.nix
@@ -262,18 +262,7 @@
               -C "$out/lib/node_modules/watchbound" --strip-components=1
             tar -xzf ${watchboundLoaderArchive} \
               -C "$out/lib/node_modules/@gadicc/watchbound-node" --strip-components=1
-            # Apply the one explicit downstream compatibility delta for the
-            # signed app's Node 24.14. The package verifier pins the adjusted
-            # loader hash separately from the upstream artifact manifest, and
-            # the maximal check exercises its lifecycle with that CUA runtime.
-            substituteInPlace \
-              "$out/lib/node_modules/@gadicc/watchbound-node/native-matrix.json" \
-              --replace-fail '"nodeRange": ">=24.15.0 <25"' '"nodeRange": ">=24.14.0 <25"' \
-              --replace-fail '"nodeMinimum": "24.15.0"' '"nodeMinimum": "24.14.0"'
-            grep -q '"nodeMinimum": "24.14.0"' \
-              "$out/lib/node_modules/@gadicc/watchbound-node/native-matrix.json"
-            CODEX_WATCHBOUND_NIX_NODE_24_14=1 \
-              node ${sourceRoot}/linux-features/directory-only-working-tree-watch/watchbound-package.js \
+            node ${sourceRoot}/linux-features/directory-only-working-tree-watch/watchbound-package.js \
               --verify-controlled-package-root "$out/lib/node_modules" ${watchboundTarget.electronArch}
             runHook postInstall
           '';
@@ -359,7 +348,6 @@
               ''}
               ${lib.optionalString watchboundEnabled ''
               export CODEX_WATCHBOUND_PACKAGE_ROOT="${watchboundPackage}/lib/node_modules"
-              export CODEX_WATCHBOUND_NIX_NODE_24_14=1
               ''}
               bash "$source_dir/install.sh" "${upstreamDeb}"
 
@@ -603,7 +591,6 @@
             export CODEX_GLOBAL_DICTATION_LINUX_SOURCE="${globalDictationHelper}/bin/codex-global-dictation-linux"
             export CODEX_MCP_HELPER_REAPER_SOURCE="${mcpReaperHelper}/bin/codex-mcp-helper-reaper"
             export CODEX_WATCHBOUND_PACKAGE_ROOT="${watchboundPackage}/lib/node_modules"
-            export CODEX_WATCHBOUND_NIX_NODE_24_14=1
             upstream_contract_root="$(mktemp -d)"
             dpkg-deb -x ${upstreamDeb} "$upstream_contract_root"
             node ${sourceRoot}/nix/elf-runtime.cjs validate-upstream \

--- a/linux-features/directory-only-working-tree-watch/README.md
+++ b/linux-features/directory-only-working-tree-watch/README.md
@@ -17,7 +17,7 @@ coverage.
 
 ## Current OpenAI working-tree route
 
-OpenAI Desktop `26.803.81509` has a Linux-specific Parcel working-tree path in
+OpenAI Desktop `26.814.41957` has a Linux-specific Parcel working-tree path in
 the official Linux package. That path calls `@parcel/watcher` directly instead of
 the local `startFileWatch()` method this feature intercepts. When this feature
 is selected, its current-package patch reroutes that one local recursive
@@ -57,7 +57,7 @@ alternative policies; do not enable both at once.
 
 ## Current package boundary
 
-The integration pins the official Watchbound `2.1.1` wrapper, neutral loader,
+The integration pins the official Watchbound `2.1.2` wrapper, neutral loader,
 x64 GNU target, and ARM64 GNU target archives. The
 artifact manifest records each registry URL, npm integrity, npm shasum, archive
 SHA-256, complete file contract, and native SHA-256. It must contain both
@@ -70,56 +70,55 @@ Normal builds fetch the pinned npm packages. The manifest pins four archives in
 total; a fully offline build provides the three selected for its architecture:
 
 ```bash
-export CODEX_WATCHBOUND_ARCHIVE=/path/to/watchbound-2.1.1.tgz
-export CODEX_WATCHBOUND_NODE_ARCHIVE=/path/to/gadicc-watchbound-node-2.1.1.tgz
-export CODEX_WATCHBOUND_NODE_X64_ARCHIVE=/path/to/gadicc-watchbound-node-linux-x64-gnu-2.1.1.tgz
+export CODEX_WATCHBOUND_ARCHIVE=/path/to/watchbound-2.1.2.tgz
+export CODEX_WATCHBOUND_NODE_ARCHIVE=/path/to/gadicc-watchbound-node-2.1.2.tgz
+export CODEX_WATCHBOUND_NODE_X64_ARCHIVE=/path/to/gadicc-watchbound-node-linux-x64-gnu-2.1.2.tgz
 # Use CODEX_WATCHBOUND_NODE_ARM64_ARCHIVE on ARM64.
 ./install.sh /path/to/chatgpt_<version>_<arch>.deb
 ```
 
-Watchbound `2.1.1` qualifies x64 and ARM64 GNU/Linux with a Linux 5.15 floor,
-Node 24.15–24.x, and a GLIBC 2.35
+Watchbound `2.1.2` qualifies x64 and ARM64 GNU/Linux with a Linux 5.15 floor,
+Node 18.15 or newer with Node-API 6 or newer, and a GLIBC 2.35
 baseline. Its native matrix covers Ubuntu 22.04/24.04, Debian 12, Fedora 42,
 openSUSE Tumbleweed, Nix, and Arch on x64; ARM64 has the same lanes except Arch.
+The checked-in consumer manifest records the signed Owl runtime's Node 24.14.
 The adapter consumes capability schema 9 and requires binding API 5,
-lockstep wrapper/native/engine `2.1.1` identities, native directory-name exclusions,
+lockstep wrapper/native/engine `2.1.2` identities, native directory-name exclusions,
 observed excluded paths, exact path bytes, root qualification, physical root
 resolution, and `support.currentRuntime.targetCompatible`. It requires
 `qualifyRoot()` to approve the actual workspace and verifies that the
 established physical root still matches that qualification snapshot. It does
 not recreate Watchbound's target or root decision from host strings.
 
-Watchbound's wrapper and loader detect libc through `process.report.getReport()`.
-Inside the packaged Electron binary that call is fatal — an internal CHECK
-aborts the process with SIGILL (the openai/codex#38123 git-watcher crash
-class) — so the adapter replaces `process.report` in both patched bundles
-(the worker and the main-process src bundle) with a shim that keeps the
-original report members and overrides only `getReport`, before any Watchbound
-code loads. The shim serves the same libc facts from
-probes that stay in JavaScript: the ELF interpreter of `/proc/self/exe`,
-`/usr/bin/ldd` content, and a `getconf GNU_LIBC_VERSION` subprocess. A Nix
-store interpreter names its exact glibc, so closure-only Nix launches (no
-`/usr/bin/ldd`, no `getconf` on the runtime `PATH`) take the version straight
-from the `PT_INTERP` path — readable because the Nix build relocates
-`PT_INTERP` into the scanned range (#1332). The shim stays
-installed for the process's lifetime so later capability reads remain safe.
-When every probe fails, the shim reports an empty header; Watchbound then
-refuses at load, the adapter catches the refused import, and the request
-degrades to the preserved Parcel route (worker) or the original local watch
+Watchbound `2.1.2` no longer reads `process.report`, whose native
+`getReport()` aborts inside the packaged Owl executable. Its loader reads the
+exact bounded `PT_INTERP` segment from `/proc/self/exe`, opens that exact
+interpreter, and runs the already-open descriptor as `/proc/self/fd/3
+--version` under bounded output and timeout limits. The loader records this
+admission snapshot and the public capability layer consumes the same evidence.
+The downstream report shim from #1336 is therefore removed; import refusal
+still degrades to the preserved Parcel route (worker) or original local watch
 (src bundle) instead of crashing.
+
+The Nix `PT_INTERP` relocation from #1332 remains necessary for upstream
+`@parcel/watcher`, which still owns the disabled-feature and unqualified-root
+fallback routes. Watchbound itself accepts the relocated interpreter without
+a consumer-side compatibility path.
 
 Build-time runtime qualification does not execute the upstream Electron
 binary. The extracted app's pinned Electron dependency must match the exact
-Electron/Node pair in the checked-in Watchbound artifact manifest; a mismatch
-rejects this enabled feature before package materialization.
+Electron version in the checked-in Watchbound artifact manifest, and an
+explicit target Node version must satisfy Watchbound's published `>=18.15.0`
+range. A mismatch rejects this enabled feature before package materialization.
 
 Nix builds do not run npm or perform unpinned registry resolution. The flake
-pins Watchbound's `v2.1.1` source commit and archive digest, builds the selected
+pins Watchbound's `v2.1.2` source commit and archive digest, builds the selected
 native target from its Cargo lock, and fetches the wrapper and neutral loader
 as fixed-output archives using the same checked-in artifact manifest as normal
 builds. It byte-verifies both JavaScript packages against that manifest before
-staging the three-package runtime tree. This follows Watchbound's qualified Nix
-route on both `x86_64-linux` and `aarch64-linux`.
+staging the three-package runtime tree without rewriting their runtime
+metadata. This follows Watchbound's qualified Nix route on both `x86_64-linux`
+and `aarch64-linux`.
 
 ## Maintenance and failure model
 
@@ -141,6 +140,51 @@ Watchbound-enabled watchdog output then exercise that state. Missing targets,
 package drift, runtime mismatch, current-package drift, or an unprovable rollback
 reject an enabled-feature candidate; users who leave the feature disabled do
 not enter this package or patch path.
+
+## Runtime diagnostics
+
+After opening a local working tree, this line confirms that Watchbound owns the
+route rather than Parcel:
+
+```text
+INFO: directory-only working-tree watch established with Watchbound 2.1.2 for <root> (target=<target>, native=<count>, limit=<budget>).
+```
+
+It is emitted once per resolved physical root per app process, after that
+root's native subscription, identity, Git policy, and initial complete
+working-tree coverage are established. Reopening the same project, including
+through an alias of the same physical root, does not repeat the line. The
+remaining diagnostics distinguish the fallback and degraded states:
+
+- `runtime rejected Watchbound` means the packaged runtime failed a supported
+  platform, libc, kernel, Node, or Node-API check. The named upstream watcher
+  is used instead. Missing, corrupt, or API-incompatible Watchbound packages
+  remain hard errors and do not silently fall back.
+- `root is unqualified` means Watchbound definitively rejected that particular
+  working-tree root, so the upstream Parcel watcher is selected immediately.
+- `root is unknown after 4 bounded retries` means root qualification stayed
+  indeterminate or threw. The adapter retries after 250, 500, 1000, and 2000
+  milliseconds, then preserves correctness by selecting Parcel.
+- `coverage is partial` or `coverage is unknown` means Watchbound still owns
+  the route but cannot currently claim complete recursive coverage. The
+  adapter sends a conservative root invalidation and keeps Codex focus recovery
+  active; `coverage recovered` confirms the episode ended.
+- Configuration warnings identify an invalid or capped feature setting and
+  state the effective default or limit that will be used.
+
+Fallback diagnostics are deduplicated process-wide, while coverage warnings
+appear once per incomplete episode. The success line is therefore the clearest
+positive confirmation for the named root; its absence can also mean that the
+working tree has not attempted the route yet or that the same physical root was
+already logged through another path.
+
+Completely exit an existing app instance before launching from a terminal,
+because the existing single-instance process owns its logs:
+
+```bash
+/opt/codex-desktop/start.sh 2>&1 | rg --line-buffered \
+  'directory-only[ -]working-tree[ -]watch|Watchbound|Parcel'
+```
 
 ## Policy retained by Codex
 
@@ -255,6 +299,11 @@ programs.codexDesktopLinux.linuxFeatures = [
 ```
 
 ## Tests
+
+The exact-candidate signed Owl acceptance harness and its durable sanitized
+evidence are documented in [`acceptance/README.md`](acceptance/README.md). It is
+consumer-owned, requires the recorded signed executable, and is intentionally
+not a substitute for ordinary feature unit tests or ARM64 qualification.
 
 Watchbound now owns the low-level topology, overflow, allocation, fairness,
 reconciliation, recovery, exact-byte, cancellation, and disposal suites. This

--- a/linux-features/directory-only-working-tree-watch/acceptance/README.md
+++ b/linux-features/directory-only-working-tree-watch/acceptance/README.md
@@ -1,0 +1,55 @@
+# Signed Owl runtime acceptance
+
+This consumer-owned fixture validates the exact published Watchbound `2.1.2`
+packages inside OpenAI's signed Linux x64 executable. It preserves the official
+ASAR main entrypoint, adds only the pinned packages and validation hook, and
+executes the byte-identical signed ELF as a normal Owl application.
+It does not use system Node, stock Electron, or `ELECTRON_RUN_AS_NODE`.
+
+Run it from the repository root after installing Watchbound's development
+dependencies in a clean source checkout and extracting the matching signed
+application into `codex-app/`. The artifact manifest pins all four supported npm
+artifacts; the package stager fetches and byte-verifies the three selected for
+x64. The usual `CODEX_WATCHBOUND*_ARCHIVE` variables can supply
+already-downloaded archives.
+
+```bash
+node linux-features/directory-only-working-tree-watch/acceptance/run-signed-runtime.mjs \
+  --watchbound-source /path/to/watchbound \
+  --signed-deb /path/to/chatgpt_26.814.41957_amd64.deb \
+  --raw-dir reports/watchbound-signed-runtime/2.1.2-x64 \
+  --evidence linux-features/directory-only-working-tree-watch/acceptance/evidence/signed-runtime-2.1.2-x64.json
+```
+
+The runner fails before constructing a fixture unless Watchbound is clean and
+checked out at `fa188992ef2cc800f9e65b9395139f85ef945c45`, its report-free
+runtime parent is `4996ff1d027a95d6ffb677e41236399eae400a16`, and the signed
+26.814.41957 deb, executable, and official ASAR have their recorded SHA-256
+values. The deb must match the checked-in signed-stable APT pin, and the runner
+compares the complete application file/symlink inventory against the deb data
+payload before using the supplied extraction. Three
+fresh-profile lifecycle processes and one tampered native process are then run.
+Every process first calls the exact injected production adapter with no module
+override, resolves the bare `watchbound` specifier, and proves Parcel was not
+selected. The tampered native must fail through that adapter without falling
+back. A timeout or output overflow terminates only the isolated child process
+group and makes the acceptance fail; successful evidence requires normal,
+unforced exits.
+
+The tracked JSON is sanitized and contains no temporary or private absolute
+paths. It binds the current manifest, adapter, runner, harness, helper sources,
+npm archive identities, and signed deb pin by SHA-256 so a clean checkout fails
+if evidence becomes stale. Path-bearing stdout, stderr, per-process JSON, and
+construction metadata are stored under ignored
+`reports/watchbound-signed-runtime/`; their recorded hashes are supplemental
+local diagnostics, while the tracked inputs and reproduction command are the
+portable evidence. The temporary hybrid application is deleted after the run.
+
+No `process.report` shim is installed or referenced. Watchbound's unmodified
+2.1.2 loader derives libc admission from the runtime ELF interpreter and the
+tracked evidence records the loader's immutable admission snapshot. This also
+exercises the published `>=18.15.0` Node admission directly, without the
+retired Nix-only metadata rewrite.
+
+ARM64 remains a separate unavailable result until both a signed ARM64
+executable and a real ARM64 execution environment are present.

--- a/linux-features/directory-only-working-tree-watch/acceptance/evidence/signed-runtime-2.1.2-x64.json
+++ b/linux-features/directory-only-working-tree-watch/acceptance/evidence/signed-runtime-2.1.2-x64.json
@@ -1,0 +1,626 @@
+{
+  "schemaVersion": 1,
+  "kind": "codex-watchbound-signed-runtime-acceptance",
+  "verdict": "passed",
+  "recordedAt": "2026-08-19T09:19:20.587Z",
+  "scope": "signed OpenAI Linux x64 executable; ARM64 unavailable",
+  "inputs": {
+    "files": {
+      "linux-features/directory-only-working-tree-watch/acceptance/run-signed-runtime.mjs": "bf8a2ebea1dcf02e6417123b8afcbc826271ac3a3a01816834157edd5bf34544",
+      "linux-features/directory-only-working-tree-watch/acceptance/runtime-harness.mjs": "c8a38b877840254cd6617b52ddaf347f78dc5f4e04b637d42a75d9e5f0428f79",
+      "linux-features/directory-only-working-tree-watch/acceptance/installed-package-smoke-helpers.mjs": "da6d2a3721a7066a76fb0781d5f6a8ea611f528342303f3547edce8da9bb9152",
+      "linux-features/directory-only-working-tree-watch/acceptance/fixtures/exclusion-smoke-helpers.cjs": "234a277c0ba0c513d131e07e00252bcddce342a46383d2fbda1503f5a423ad11",
+      "linux-features/directory-only-working-tree-watch/patch.js": "66222e9b24c438e224e7779468407b8e334fa20aa0d9fcf3ed4103679c74ff76",
+      "linux-features/directory-only-working-tree-watch/watchbound-artifacts.json": "c87d026d282d1be85d47d3aa602527ed9ccb6ace9001df940195d6dae76aa291",
+      "nix/upstream-linux-packages.json": "4f17ce3bdbe0f190c655c5d378c34dd0389c97e096fc3d144dbc367698854852"
+    },
+    "generatedProductionAdapterSha256": "2b18143c4ce1ee280a6cb4c44bc87ace989d66486fa313303ccda304f1b6e2ce",
+    "watchboundArchives": {
+      "watchbound": {
+        "sha256": "f297d6753d847170433216c73b9787e322d0849d2c0582e3e557a0f332a20ba1",
+        "shasum": "6f762ffbf8376b66e4b054479c107d651a579a31",
+        "integrity": "sha512-1tk1bBZ+djRXVu6K31anpNCN0CUMe5Oft/ey955IHrPSFwtV3L66gi6mjwzyVz43+9p51RpUJSu7eP+F6kwE2A=="
+      },
+      "@gadicc/watchbound-node": {
+        "sha256": "e12c138118990425892e606184f9cd9f96cd32c841254078747240c5942ba770",
+        "shasum": "fecc1eeb7d5e2c27cde414bc1c3533d091973c00",
+        "integrity": "sha512-h66Xgk2tNowLj1HfRn87whqsuzg4FJulusSrv3NsdIKE/89tONc2wGqHc2DDkn8j90C7XWYmRtZm0cIA0fok6Q=="
+      },
+      "@gadicc/watchbound-node-linux-x64-gnu": {
+        "sha256": "2b4aff140baf6a512dab3fa0f14c12dfb1f785d60b3d2ba28e4144e7d275eded",
+        "shasum": "80c76f8269df698fc146b6721428925da1c386cc",
+        "integrity": "sha512-UuEIg6OrHcksCl/yR3JsX6SneEYvxDpT8n68AKPEWajLclj9+aSgCWHi6t2ihh+yC1a5qQbGYNkuUpjSkZh7Dg=="
+      },
+      "@gadicc/watchbound-node-linux-arm64-gnu": {
+        "sha256": "8a016583cd3ad16bf627e314f72e515ab80c1e1415af7a1b65fdea0b1856d9e3",
+        "shasum": "a86224b5709f74ddb7aa8d57f5765aa865b3edf4",
+        "integrity": "sha512-Eo/jJL+I1UKnxIeSZP1Vk6QIve4Oy9Ik2wcpfq+ifRQfxlyjClSm7KCt94tyYmDzpZUUGq92CjM+/DxiEhJZiA=="
+      }
+    },
+    "signedStablePackage": {
+      "repositoryPath": "pool/main/c/chatgpt/chatgpt_26.814.41957_amd64.deb",
+      "sha256": "4778b26a7abd08647214d5b05c17bd3ebe2d9688d146dabf017c1a2faf93ac7d",
+      "pinSource": "nix/upstream-linux-packages.json"
+    }
+  },
+  "watchbound": {
+    "version": "2.1.2",
+    "sourceCommit": "fa188992ef2cc800f9e65b9395139f85ef945c45",
+    "runtimeImplementationParent": "4996ff1d027a95d6ffb677e41236399eae400a16",
+    "sourceTreeClean": true
+  },
+  "signedRuntime": {
+    "executableSha256": "85e03c4bb5814e943eb23ae7eb370ea8f7eeab67c646e46d17596a07eedfb5b6",
+    "sourceAsarSha256": "1a43bb2a6547cd2a4945a669fb14f0b15b6eddc1fc1177f51dffc554e3c5ad98",
+    "generatedAcceptanceAsarSha256": "5160ac1c90f95e2bee8adab2d034cd96af03653e1737c633f5248dd8ec6fc260",
+    "officialPackage": {
+      "name": "openai-codex-electron",
+      "version": "26.814.41957",
+      "main": ".vite/build/early-bootstrap.js",
+      "repositoryPath": "pool/main/c/chatgpt/chatgpt_26.814.41957_amd64.deb",
+      "debSha256": "4778b26a7abd08647214d5b05c17bd3ebe2d9688d146dabf017c1a2faf93ac7d",
+      "dataPayloadInventorySha256": "057ca1a94dcb2794dba42ec5c800cc7bdf3570d88813c7afeab6f60aa1363a61",
+      "dataPayloadInventoryEntries": 5148,
+      "verifiedAgainstDebDataPayload": true
+    },
+    "officialMainPreserved": true,
+    "platform": "linux",
+    "architecture": "x64",
+    "kernel": "7.1.8-arch1-3",
+    "glibc": "2.44",
+    "processVersions": {
+      "electron": "151.0.7922.137",
+      "chrome": "151.0.7922.137",
+      "node": "24.14.0",
+      "napi": 10
+    }
+  },
+  "packages": {
+    "wrapper": {
+      "name": "watchbound",
+      "version": "2.1.2"
+    },
+    "loader": {
+      "name": "@gadicc/watchbound-node",
+      "version": "2.1.2"
+    },
+    "target": {
+      "name": "@gadicc/watchbound-node-linux-x64-gnu",
+      "version": "2.1.2"
+    }
+  },
+  "native": {
+    "id": "linux-x64-gnu",
+    "platform": "linux",
+    "architecture": "x64",
+    "armAbi": null,
+    "targetTriple": "x86_64-unknown-linux-gnu",
+    "package": "@gadicc/watchbound-node-linux-x64-gnu",
+    "binary": "watchbound.linux-x64-gnu.node",
+    "nativeSha256": "1f4713bb126bc8652d83e66d25219e0c0f3c354b3e0efeafcc2ec5e8b0bbec45",
+    "size": 1513224,
+    "sha256": "1f4713bb126bc8652d83e66d25219e0c0f3c354b3e0efeafcc2ec5e8b0bbec45",
+    "resolvedPath": "resources/app.asar/node_modules/@gadicc/watchbound-node-linux-x64-gnu/watchbound.linux-x64-gnu.node",
+    "loadedPath": "resources/app.asar/node_modules/@gadicc/watchbound-node-linux-x64-gnu/watchbound.linux-x64-gnu.node",
+    "unpackedPath": "resources/app.asar.unpacked/node_modules/@gadicc/watchbound-node-linux-x64-gnu/watchbound.linux-x64-gnu.node",
+    "exactSelectionWithoutFallback": true,
+    "elf": {
+      "class": 2,
+      "endianness": 1,
+      "machine": 62,
+      "flags": 0,
+      "machineName": "Advanced Micro Devices X86-64",
+      "fileMachineName": "x86-64",
+      "neededLibraries": [
+        "ld-linux-x86-64.so.2",
+        "libc.so.6",
+        "libgcc_s.so.1"
+      ]
+    }
+  },
+  "loaderAssertions": {
+    "javascriptAdmission": ">=18.15.0",
+    "javascriptMinimum": "18.15.0",
+    "runtimeAdmissionSchema": 1,
+    "runtimeLibcEvidence": "elf-interpreter-version",
+    "kernelMinimum": "5.15",
+    "glibcMinimum": "2.35",
+    "rawCapabilitySchema": 5,
+    "publicCapabilitySchema": 9,
+    "metadataSchema": 1,
+    "bindingApi": 5,
+    "buildProfile": "release",
+    "targetTriple": "x86_64-unknown-linux-gnu",
+    "javascriptAdmissionHasNoUpperBound": true,
+    "processNodeApiMinimum": 6,
+    "observedProcessNodeApi": 10,
+    "processNodeApiSatisfied": true,
+    "packageVersionLockstep": true,
+    "digestIntegrity": true,
+    "elfIdentity": true
+  },
+  "runtimeAdmission": {
+    "schemaVersion": 1,
+    "platform": "linux",
+    "architecture": "x64",
+    "armAbi": null,
+    "kernel": "7.1.8-arch1-3",
+    "libc": {
+      "family": "glibc",
+      "version": "2.44",
+      "evidence": "elf-interpreter-version"
+    },
+    "node": {
+      "version": "24.14.0",
+      "api": 10
+    }
+  },
+  "productionAdapter": {
+    "status": "passed",
+    "exactInjectedSourceSha256": "2b18143c4ce1ee280a6cb4c44bc87ace989d66486fa313303ccda304f1b6e2ce",
+    "bareSpecifierResolved": true,
+    "moduleOverrideUsed": false,
+    "fallbackCalls": 0,
+    "watcherReturned": true,
+    "nativeSubscriptionEstablished": true,
+    "establishmentDiagnostic": {
+      "emitted": true,
+      "version": "2.1.2",
+      "target": "linux-x64-gnu",
+      "includedNativeBudget": true
+    },
+    "joinedDisposal": true
+  },
+  "iterations": [
+    {
+      "iteration": 1,
+      "status": "passed",
+      "exit": {
+        "code": 0,
+        "signal": null,
+        "timedOut": false,
+        "outputOverflow": false,
+        "terminationRequested": false,
+        "killEscalated": false,
+        "elapsedMs": 2604
+      },
+      "lifecycleAssertions": {
+        "expectedRuntimeIdentity": {
+          "expectedElectron": "151.0.7922.137",
+          "observedElectron": "151.0.7922.137",
+          "electronMatches": true,
+          "expectedChrome": "151.0.7922.137",
+          "observedChrome": "151.0.7922.137",
+          "chromeMatches": true,
+          "expectedNode": "24.14.0",
+          "observedNode": "24.14.0",
+          "nodeMatches": true,
+          "nodeApiMinimum": 6,
+          "observedNodeApi": 10,
+          "nodeApiSatisfied": true
+        },
+        "inactiveBaseline": true,
+        "completeInitialObservation": true,
+        "realDelivery": {
+          "createDelivered": true,
+          "modificationDelivered": true,
+          "deletionDelivered": true,
+          "maximumConcurrentCallbacks": 1,
+          "callbackCount": 4
+        },
+        "exclusions": {
+          "initialPrefixHidden": true,
+          "directoryNameGitHidden": true,
+          "observedGitBoundaryDelivered": true,
+          "dynamicPrefixHidden": true,
+          "reconciliationComplete": true,
+          "stableRootReplacementRecovered": true
+        },
+        "establishmentCancellation": {
+          "provisionalNativeCancellation": true,
+          "errorCode": "WATCHBOUND_OPERATION_CANCELLED",
+          "operation": "subscribe"
+        },
+        "joinedDisposal": {
+          "concurrentCallsSharedPromise": true,
+          "repeatedCallSharedPromise": true,
+          "callbackSignalAborted": true,
+          "disposalJoinedPendingCallback": true,
+          "callbackCompletedBeforeResolution": true,
+          "callbacksAfterResolution": 0
+        },
+        "contextStop": {
+          "stopIdempotent": true,
+          "signalAborted": true,
+          "callbackCount": 1,
+          "callbacksAfterStop": 0
+        },
+        "resourcesReturnedToBaseline": true
+      },
+      "runtime": {
+        "baseline": {
+          "active": false,
+          "inotifyInstances": 0,
+          "workerThreads": 0,
+          "nativeWatches": 0,
+          "nativeWatchBudget": null,
+          "deferredInterests": 0,
+          "subscriptions": 0
+        },
+        "final": {
+          "active": false,
+          "inotifyInstances": 0,
+          "workerThreads": 0,
+          "nativeWatches": 0,
+          "nativeWatchBudget": null,
+          "deferredInterests": 0,
+          "subscriptions": 0
+        }
+      },
+      "processResources": {
+        "baseline": {
+          "fileDescriptors": 223,
+          "tasks": 46,
+          "watchboundThreads": 0,
+          "inotifyDescriptors": 1
+        },
+        "final": {
+          "fileDescriptors": 223,
+          "tasks": 46,
+          "watchboundThreads": 0,
+          "inotifyDescriptors": 1
+        },
+        "tolerance": {
+          "fileDescriptors": 2,
+          "coldTasks": 4
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "status": "passed",
+      "exit": {
+        "code": 0,
+        "signal": null,
+        "timedOut": false,
+        "outputOverflow": false,
+        "terminationRequested": false,
+        "killEscalated": false,
+        "elapsedMs": 2615
+      },
+      "lifecycleAssertions": {
+        "expectedRuntimeIdentity": {
+          "expectedElectron": "151.0.7922.137",
+          "observedElectron": "151.0.7922.137",
+          "electronMatches": true,
+          "expectedChrome": "151.0.7922.137",
+          "observedChrome": "151.0.7922.137",
+          "chromeMatches": true,
+          "expectedNode": "24.14.0",
+          "observedNode": "24.14.0",
+          "nodeMatches": true,
+          "nodeApiMinimum": 6,
+          "observedNodeApi": 10,
+          "nodeApiSatisfied": true
+        },
+        "inactiveBaseline": true,
+        "completeInitialObservation": true,
+        "realDelivery": {
+          "createDelivered": true,
+          "modificationDelivered": true,
+          "deletionDelivered": true,
+          "maximumConcurrentCallbacks": 1,
+          "callbackCount": 4
+        },
+        "exclusions": {
+          "initialPrefixHidden": true,
+          "directoryNameGitHidden": true,
+          "observedGitBoundaryDelivered": true,
+          "dynamicPrefixHidden": true,
+          "reconciliationComplete": true,
+          "stableRootReplacementRecovered": true
+        },
+        "establishmentCancellation": {
+          "provisionalNativeCancellation": true,
+          "errorCode": "WATCHBOUND_OPERATION_CANCELLED",
+          "operation": "subscribe"
+        },
+        "joinedDisposal": {
+          "concurrentCallsSharedPromise": true,
+          "repeatedCallSharedPromise": true,
+          "callbackSignalAborted": true,
+          "disposalJoinedPendingCallback": true,
+          "callbackCompletedBeforeResolution": true,
+          "callbacksAfterResolution": 0
+        },
+        "contextStop": {
+          "stopIdempotent": true,
+          "signalAborted": true,
+          "callbackCount": 1,
+          "callbacksAfterStop": 0
+        },
+        "resourcesReturnedToBaseline": true
+      },
+      "runtime": {
+        "baseline": {
+          "active": false,
+          "inotifyInstances": 0,
+          "workerThreads": 0,
+          "nativeWatches": 0,
+          "nativeWatchBudget": null,
+          "deferredInterests": 0,
+          "subscriptions": 0
+        },
+        "final": {
+          "active": false,
+          "inotifyInstances": 0,
+          "workerThreads": 0,
+          "nativeWatches": 0,
+          "nativeWatchBudget": null,
+          "deferredInterests": 0,
+          "subscriptions": 0
+        }
+      },
+      "processResources": {
+        "baseline": {
+          "fileDescriptors": 223,
+          "tasks": 45,
+          "watchboundThreads": 0,
+          "inotifyDescriptors": 1
+        },
+        "final": {
+          "fileDescriptors": 224,
+          "tasks": 45,
+          "watchboundThreads": 0,
+          "inotifyDescriptors": 1
+        },
+        "tolerance": {
+          "fileDescriptors": 2,
+          "coldTasks": 4
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "status": "passed",
+      "exit": {
+        "code": 0,
+        "signal": null,
+        "timedOut": false,
+        "outputOverflow": false,
+        "terminationRequested": false,
+        "killEscalated": false,
+        "elapsedMs": 2574
+      },
+      "lifecycleAssertions": {
+        "expectedRuntimeIdentity": {
+          "expectedElectron": "151.0.7922.137",
+          "observedElectron": "151.0.7922.137",
+          "electronMatches": true,
+          "expectedChrome": "151.0.7922.137",
+          "observedChrome": "151.0.7922.137",
+          "chromeMatches": true,
+          "expectedNode": "24.14.0",
+          "observedNode": "24.14.0",
+          "nodeMatches": true,
+          "nodeApiMinimum": 6,
+          "observedNodeApi": 10,
+          "nodeApiSatisfied": true
+        },
+        "inactiveBaseline": true,
+        "completeInitialObservation": true,
+        "realDelivery": {
+          "createDelivered": true,
+          "modificationDelivered": true,
+          "deletionDelivered": true,
+          "maximumConcurrentCallbacks": 1,
+          "callbackCount": 4
+        },
+        "exclusions": {
+          "initialPrefixHidden": true,
+          "directoryNameGitHidden": true,
+          "observedGitBoundaryDelivered": true,
+          "dynamicPrefixHidden": true,
+          "reconciliationComplete": true,
+          "stableRootReplacementRecovered": true
+        },
+        "establishmentCancellation": {
+          "provisionalNativeCancellation": true,
+          "errorCode": "WATCHBOUND_OPERATION_CANCELLED",
+          "operation": "subscribe"
+        },
+        "joinedDisposal": {
+          "concurrentCallsSharedPromise": true,
+          "repeatedCallSharedPromise": true,
+          "callbackSignalAborted": true,
+          "disposalJoinedPendingCallback": true,
+          "callbackCompletedBeforeResolution": true,
+          "callbacksAfterResolution": 0
+        },
+        "contextStop": {
+          "stopIdempotent": true,
+          "signalAborted": true,
+          "callbackCount": 1,
+          "callbacksAfterStop": 0
+        },
+        "resourcesReturnedToBaseline": true
+      },
+      "runtime": {
+        "baseline": {
+          "active": false,
+          "inotifyInstances": 0,
+          "workerThreads": 0,
+          "nativeWatches": 0,
+          "nativeWatchBudget": null,
+          "deferredInterests": 0,
+          "subscriptions": 0
+        },
+        "final": {
+          "active": false,
+          "inotifyInstances": 0,
+          "workerThreads": 0,
+          "nativeWatches": 0,
+          "nativeWatchBudget": null,
+          "deferredInterests": 0,
+          "subscriptions": 0
+        }
+      },
+      "processResources": {
+        "baseline": {
+          "fileDescriptors": 223,
+          "tasks": 46,
+          "watchboundThreads": 0,
+          "inotifyDescriptors": 1
+        },
+        "final": {
+          "fileDescriptors": 223,
+          "tasks": 46,
+          "watchboundThreads": 0,
+          "inotifyDescriptors": 1
+        },
+        "tolerance": {
+          "fileDescriptors": 2,
+          "coldTasks": 4
+        }
+      }
+    }
+  ],
+  "qualifyRoot": {
+    "schemaVersion": 1,
+    "state": "qualified",
+    "reasons": [],
+    "target": {
+      "state": "qualified",
+      "packagedTargetId": "linux-x64-gnu",
+      "runtimeMatchesPackagedTarget": true,
+      "qualification": "supported"
+    },
+    "host": {
+      "state": "qualified",
+      "kernelFloor": {
+        "state": "satisfied",
+        "observed": "7.1.8-arch1-3",
+        "minimum": "5.15"
+      },
+      "glibcFloor": {
+        "state": "satisfied",
+        "observed": "2.44",
+        "minimum": "2.35"
+      },
+      "wsl": {
+        "state": "not-detected"
+      },
+      "container": {
+        "state": "not-detected"
+      }
+    },
+    "root": {
+      "state": "qualified",
+      "lexicalPath": "$CODEX_WORKSPACE",
+      "physicalPath": "$CODEX_WORKSPACE",
+      "lexicalAndPhysicalPathsEqual": true,
+      "filesystem": {
+        "kind": "ordinary-local",
+        "magic": "0x9123683e"
+      }
+    }
+  },
+  "negativeIntegrity": {
+    "status": "passed",
+    "productionAdapter": {
+      "status": "failed",
+      "exactInjectedSourceSha256": "2b18143c4ce1ee280a6cb4c44bc87ace989d66486fa313303ccda304f1b6e2ce",
+      "bareSpecifierAttempted": true,
+      "moduleOverrideUsed": false,
+      "fallbackCalls": 0,
+      "errorCode": "WATCHBOUND_NATIVE_INTEGRITY_MISMATCH"
+    },
+    "exit": {
+      "code": 1,
+      "signal": null,
+      "timedOut": false,
+      "outputOverflow": false,
+      "terminationRequested": false,
+      "killEscalated": false
+    },
+    "error": {
+      "name": "WatchboundLoaderError",
+      "code": "WATCHBOUND_NATIVE_INTEGRITY_MISMATCH",
+      "message": "Watchbound native addon watchbound.linux-x64-gnu.node does not match its package digest",
+      "details": {},
+      "cause": null
+    },
+    "fallbackAddonLoaded": false
+  },
+  "reportFreeAdmission": {
+    "downstreamShimInstalled": false,
+    "processReportUsed": false,
+    "evidence": "elf-interpreter-version",
+    "admissionSnapshotSharedWithCapabilities": true
+  },
+  "arm64": {
+    "status": "unavailable",
+    "reason": "no signed ARM64 executable or ARM64 execution environment"
+  },
+  "rawArtifacts": [
+    {
+      "filename": "reports/watchbound-signed-runtime/2.1.2-x64/per-root-acceptance/build.json",
+      "sha256": "68969bbe5ee65ab21589463d580850854cfc4db2e4d88f177b60759aec7c06d9"
+    },
+    {
+      "filename": "reports/watchbound-signed-runtime/2.1.2-x64/per-root-acceptance/cold-1.json",
+      "sha256": "dec00e8a7714a2875cccd1ca894a4b2fe00a83a75275cfea3a1c010f8fb11611"
+    },
+    {
+      "filename": "reports/watchbound-signed-runtime/2.1.2-x64/per-root-acceptance/cold-1.stderr.log",
+      "sha256": "c9dc3195d8c6dcbdbb3a1fd85bc4bcd1c963f355e281090378fed324aa2739f7"
+    },
+    {
+      "filename": "reports/watchbound-signed-runtime/2.1.2-x64/per-root-acceptance/cold-1.stdout.log",
+      "sha256": "ae83cfbac9879120dc104df01fb53a81695777708ffe7251ea3a5d7532a7ab20"
+    },
+    {
+      "filename": "reports/watchbound-signed-runtime/2.1.2-x64/per-root-acceptance/cold-2.json",
+      "sha256": "76c8e1684d93a1bb96afba67e9ae1eb7146a0c85fff1b319992b4b3892fa0edb"
+    },
+    {
+      "filename": "reports/watchbound-signed-runtime/2.1.2-x64/per-root-acceptance/cold-2.stderr.log",
+      "sha256": "f5eb742a7895c5400966a3264bfee8bb950de1dafdb4e4877b7fb5360f34580b"
+    },
+    {
+      "filename": "reports/watchbound-signed-runtime/2.1.2-x64/per-root-acceptance/cold-2.stdout.log",
+      "sha256": "a14a0447b2c6ff39b37e6b4a0e46ea7efcee7bc5ec59e5eef1d3da17831ac894"
+    },
+    {
+      "filename": "reports/watchbound-signed-runtime/2.1.2-x64/per-root-acceptance/cold-3.json",
+      "sha256": "b9ffc93f321b31e772bcedee6c319e92760c9d6d3a238a84c60397c7980590a5"
+    },
+    {
+      "filename": "reports/watchbound-signed-runtime/2.1.2-x64/per-root-acceptance/cold-3.stderr.log",
+      "sha256": "6f2ee6c5ed84edcffb9e293a228df81595da2541114efa52c1469c1cca0e7333"
+    },
+    {
+      "filename": "reports/watchbound-signed-runtime/2.1.2-x64/per-root-acceptance/cold-3.stdout.log",
+      "sha256": "6317154a11498be0030cea5d6d90110415a8e92e18f35e4c0c03a625fd6a87ec"
+    },
+    {
+      "filename": "reports/watchbound-signed-runtime/2.1.2-x64/per-root-acceptance/negative-integrity.json",
+      "sha256": "8799517663bec458c140d958802f56b015f62726c52e3837b1f918c5ed4630a0"
+    },
+    {
+      "filename": "reports/watchbound-signed-runtime/2.1.2-x64/per-root-acceptance/negative-integrity.stderr.log",
+      "sha256": "85c9334405db1e42fab1caf5426ac33bd4b015e46c627aa6207b7968ba673a65"
+    },
+    {
+      "filename": "reports/watchbound-signed-runtime/2.1.2-x64/per-root-acceptance/negative-integrity.stdout.log",
+      "sha256": "110c31864dbde21d4f6f13acaccd64d2f54f74de738d4d71c9c68d012e733eef"
+    }
+  ],
+  "reproduction": {
+    "command": "node linux-features/directory-only-working-tree-watch/acceptance/run-signed-runtime.mjs --watchbound-source <WATCHBOUND_SOURCE> --signed-deb <SIGNED_AMD64_DEB> --raw-dir reports/watchbound-signed-runtime/2.1.2-x64 --evidence linux-features/directory-only-working-tree-watch/acceptance/evidence/signed-runtime-2.1.2-x64.json",
+    "harness": [
+      "linux-features/directory-only-working-tree-watch/acceptance/run-signed-runtime.mjs",
+      "linux-features/directory-only-working-tree-watch/acceptance/runtime-harness.mjs"
+    ]
+  }
+}

--- a/linux-features/directory-only-working-tree-watch/acceptance/fixtures/exclusion-smoke-helpers.cjs
+++ b/linux-features/directory-only-working-tree-watch/acceptance/fixtures/exclusion-smoke-helpers.cjs
@@ -1,0 +1,23 @@
+"use strict";
+
+const path = require("node:path");
+
+function hasInvalidatedPathAtOrBelow(
+  batches,
+  excludedPath,
+  exclusionGeneration,
+) {
+  const descendantPrefix = `${excludedPath}${path.sep}`;
+  return batches.some((batch) => {
+    if (
+      exclusionGeneration !== undefined &&
+      batch.exclusionGeneration !== exclusionGeneration
+    ) {
+      return false;
+    }
+    return batch.invalidatedPaths.some((candidate) =>
+      candidate === excludedPath || candidate.startsWith(descendantPrefix));
+  });
+}
+
+module.exports = { hasInvalidatedPathAtOrBelow };

--- a/linux-features/directory-only-working-tree-watch/acceptance/installed-package-smoke-helpers.mjs
+++ b/linux-features/directory-only-working-tree-watch/acceptance/installed-package-smoke-helpers.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { setTimeout as delay } from "node:timers/promises";
+
+export const DEFAULT_INSTALLED_SMOKE_WAIT_TIMEOUT_MS = 4_000;
+export const MAX_INSTALLED_SMOKE_WAIT_TIMEOUT_MS = 120_000;
+
+export function parseInstalledSmokeWaitTimeoutMs(value) {
+  if (value === undefined) return DEFAULT_INSTALLED_SMOKE_WAIT_TIMEOUT_MS;
+  if (typeof value !== "string" || !/^[1-9][0-9]*$/u.test(value)) {
+    throw new RangeError(
+      `--wait-timeout-ms must be an integer from 1 through ${MAX_INSTALLED_SMOKE_WAIT_TIMEOUT_MS}`,
+    );
+  }
+  const timeoutMs = Number(value);
+  if (
+    !Number.isSafeInteger(timeoutMs) ||
+    timeoutMs > MAX_INSTALLED_SMOKE_WAIT_TIMEOUT_MS
+  ) {
+    throw new RangeError(
+      `--wait-timeout-ms must be an integer from 1 through ${MAX_INSTALLED_SMOKE_WAIT_TIMEOUT_MS}`,
+    );
+  }
+  return timeoutMs;
+}
+
+export async function waitForInstalledSmokeCondition(
+  predicate,
+  message,
+  {
+    timeoutMs = DEFAULT_INSTALLED_SMOKE_WAIT_TIMEOUT_MS,
+    retryDelayMs = 10,
+    now = Date.now,
+    sleep = delay,
+    onDeadline = () => {},
+  } = {},
+) {
+  const deadline = now() + timeoutMs;
+  while (!predicate() && now() < deadline) await sleep(retryDelayMs);
+  if (predicate()) return;
+
+  // Report the semantic deadline synchronously. Cleanup may itself need to
+  // join a stuck native operation, so an outer process timeout must not erase
+  // the fact that the package smoke had already failed semantically.
+  onDeadline(message, timeoutMs);
+  assert.fail(message);
+}
+
+export async function releaseCallbackGateAndJoinDisposal(
+  release,
+  subscription,
+) {
+  // Harness callbacks may deliberately wait on a deferred gate. Release that
+  // gate before disposal, then await the real disposal barrier. Never race or
+  // detach disposal: its settlement proves callback admission and cleanup are
+  // joined before the smoke can finish.
+  release();
+  await subscription?.dispose();
+}
+
+export async function recoverStableReplacement(
+  subscription,
+  {
+    timeoutMs = 4_000,
+    retryDelayMs = 10,
+    now = Date.now,
+    sleep = delay,
+    deadlineSleep = delay,
+    onDeadline = () => {},
+  } = {},
+) {
+  const deadline = now() + timeoutMs;
+  const deadlineController = new AbortController();
+  const deadlineMessage = `root recovery did not settle within ${timeoutMs}ms`;
+  const deadlineError = new Error(deadlineMessage);
+  const deadlineReached = deadlineSleep(
+    timeoutMs,
+    undefined,
+    { signal: deadlineController.signal },
+  ).then(() => {
+    throw deadlineError;
+  });
+  try {
+    while (true) {
+      const recovery = await Promise.race([
+        Promise.resolve().then(() => subscription.recoverRoot({
+          identityPolicy: "accept-replacement",
+        })),
+        deadlineReached,
+      ]);
+      if (
+        recovery.attachment !== "not-attached" ||
+        recovery.reason !== "identity-unstable"
+      ) {
+        return recovery;
+      }
+      if (now() >= deadline) {
+        onDeadline(
+          `root recovery remained identity-unstable for ${timeoutMs}ms`,
+          timeoutMs,
+        );
+        return recovery;
+      }
+      await Promise.race([
+        Promise.resolve().then(() => sleep(retryDelayMs)),
+        deadlineReached,
+      ]);
+    }
+  } catch (error) {
+    if (error === deadlineError) onDeadline(deadlineMessage, timeoutMs);
+    throw error;
+  } finally {
+    deadlineController.abort();
+  }
+}

--- a/linux-features/directory-only-working-tree-watch/acceptance/run-signed-runtime.mjs
+++ b/linux-features/directory-only-working-tree-watch/acceptance/run-signed-runtime.mjs
@@ -1,0 +1,817 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const EXPECTED = Object.freeze({
+  sourceCommit: "fa188992ef2cc800f9e65b9395139f85ef945c45",
+  runtimeImplementationParent: "4996ff1d027a95d6ffb677e41236399eae400a16",
+  officialPackageVersion: "26.814.41957",
+  executableSha256: "85e03c4bb5814e943eb23ae7eb370ea8f7eeab67c646e46d17596a07eedfb5b6",
+  sourceAsarSha256: "1a43bb2a6547cd2a4945a669fb14f0b15b6eddc1fc1177f51dffc554e3c5ad98",
+  nativeSha256: "1f4713bb126bc8652d83e66d25219e0c0f3c354b3e0efeafcc2ec5e8b0bbec45",
+  electron: "151.0.7922.137",
+  chrome: "151.0.7922.137",
+  node: "24.14.0",
+  nodeApiMinimum: 6,
+  targetId: "linux-x64-gnu",
+});
+const acceptanceDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(acceptanceDir, "../../..");
+const acceptanceRequire = createRequire(import.meta.url);
+const { stageWatchboundPackages } = acceptanceRequire("../watchbound-package.js");
+const { codexLinuxStartDirectoryOnlyWorkingTreeWatch } = acceptanceRequire("../patch.js");
+const productionAdapterSource =
+  `"use strict";\nmodule.exports = ${codexLinuxStartDirectoryOnlyWorkingTreeWatch.toString()};\n`;
+const productionAdapterSha256 = sha256Contents(productionAdapterSource);
+const options = parseOptions(process.argv.slice(2));
+const watchboundRoot = path.resolve(options["watchbound-source"]);
+const signedAppRoot = path.resolve(options["signed-app"] ?? path.join(repoRoot, "codex-app"));
+const signedDeb = path.resolve(options["signed-deb"]);
+const sanitizedEvidencePath = path.resolve(
+  options.evidence ?? path.join(acceptanceDir, "evidence", "signed-runtime-2.1.2-x64.json"),
+);
+const rawDir = path.resolve(
+  options["raw-dir"] ?? path.join(repoRoot, "reports", "watchbound-signed-runtime", "2.1.2-x64"),
+);
+const rawDirRelative = path.relative(repoRoot, rawDir);
+assert.ok(
+  rawDirRelative !== "" &&
+    !rawDirRelative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(rawDirRelative),
+  "--raw-dir must be a repository-owned ignored path",
+);
+const signedExecutable = path.join(signedAppRoot, "ChatGPT");
+const sourceAsar = path.join(signedAppRoot, "resources", "app.asar");
+const upstreamPinsPath = path.join(repoRoot, "nix", "upstream-linux-packages.json");
+const upstreamPins = readJson(upstreamPinsPath);
+const signedPackagePin = upstreamPins.amd64;
+
+assert.equal(process.platform, "linux", "signed runtime acceptance requires Linux");
+assert.equal(process.arch, "x64", "this acceptance record is specifically Linux x64");
+assert.equal(git(watchboundRoot, "rev-parse", "HEAD"), EXPECTED.sourceCommit);
+assert.equal(git(watchboundRoot, "rev-parse", "HEAD^"), EXPECTED.runtimeImplementationParent);
+assert.equal(git(watchboundRoot, "status", "--porcelain"), "", "Watchbound source must stay clean");
+assert.equal(upstreamPins.version, EXPECTED.officialPackageVersion);
+assert.match(signedPackagePin.repositoryPath, /_amd64\.deb$/u);
+assert.ok(fs.existsSync(signedDeb), `missing signed package: ${signedDeb}`);
+assert.equal(
+  sha256(signedDeb),
+  signedPackagePin.sha256,
+  "signed package does not match the checked-in stable APT pin",
+);
+assert.ok(fs.existsSync(signedExecutable), `missing signed executable: ${signedExecutable}`);
+assert.ok(fs.existsSync(sourceAsar), `missing official ASAR: ${sourceAsar}`);
+const executableSha256 = sha256(signedExecutable);
+if (executableSha256 !== EXPECTED.executableSha256) {
+  throw new Error(
+    `signed executable digest changed: expected ${EXPECTED.executableSha256}, observed ${executableSha256}; establish a new runtime baseline before testing`,
+  );
+}
+if (fs.existsSync(rawDir)) {
+  throw new Error(`raw evidence directory already exists: ${rawDir}`);
+}
+fs.mkdirSync(rawDir, { recursive: true });
+
+const asarEntry = createRequire(path.join(watchboundRoot, "package.json"))
+  .resolve("@electron/asar");
+const { createPackageWithOptions, extractAll, extractFile, statFile } =
+  await import(pathToFileURL(asarEntry));
+const sourcePackage = JSON.parse(extractFile(sourceAsar, "package.json"));
+assert.equal(sourcePackage.main, ".vite/build/early-bootstrap.js");
+assert.equal(sourcePackage.version, EXPECTED.officialPackageVersion);
+const sourceAsarSha256 = sha256(sourceAsar);
+assert.equal(sourceAsarSha256, EXPECTED.sourceAsarSha256);
+const artifactManifest = readJson(path.join(
+  repoRoot,
+  "linux-features",
+  "directory-only-working-tree-watch",
+  "watchbound-artifacts.json",
+));
+assert.equal(artifactManifest.version, "2.1.2");
+assert.equal(artifactManifest.source.revision, EXPECTED.sourceCommit);
+const sourceInputs = acceptanceSourceInputs();
+
+const workRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-watchbound-signed-acceptance-"));
+let aggregate;
+try {
+  const signedPackageRoot = path.join(workRoot, "signed-package");
+  execFileSync("dpkg-deb", ["--extract", signedDeb, signedPackageRoot]);
+  const signedPackageAppRoot = path.join(signedPackageRoot, "usr", "lib", "chatgpt");
+  const signedAppInventory = appPayloadInventory(signedAppRoot);
+  const signedPackageInventory = appPayloadInventory(signedPackageAppRoot);
+  assert.deepEqual(
+    signedAppInventory,
+    signedPackageInventory,
+    "--signed-app does not exactly match the verified deb data payload",
+  );
+  const signedAppInventorySha256 = sha256Contents(JSON.stringify(signedAppInventory));
+  const stagingRoot = path.join(workRoot, "app-staging");
+  extractAll(sourceAsar, stagingRoot);
+  for (const artifact of [
+    artifactManifest.packages.wrapper,
+    artifactManifest.packages.loader,
+    ...Object.values(artifactManifest.packages.targets),
+  ]) {
+    const packageParts = artifact.name.startsWith("@")
+      ? artifact.name.split("/")
+      : [artifact.name];
+    fs.rmSync(path.join(stagingRoot, "node_modules", ...packageParts), {
+      recursive: true,
+      force: true,
+    });
+  }
+  const staged = await stageWatchboundPackages({
+    extractedDir: stagingRoot,
+    arch: "x64",
+    libc: "glibc",
+    manifest: artifactManifest,
+  });
+  assert.equal(staged.version, artifactManifest.version);
+  const wrapperSource = path.join(stagingRoot, "node_modules", "watchbound");
+  const loaderSource = path.join(
+    stagingRoot,
+    "node_modules",
+    "@gadicc",
+    "watchbound-node",
+  );
+  const targetSource = path.join(
+    stagingRoot,
+    "node_modules",
+    "@gadicc",
+    "watchbound-node-linux-x64-gnu",
+  );
+  const matrix = readJson(path.join(loaderSource, "native-matrix.json"));
+  const target = matrix.targets.find(({ id }) => id === EXPECTED.targetId);
+  assert.ok(target, `missing ${EXPECTED.targetId} in published native matrix`);
+  const nativeSource = path.join(targetSource, target.binary);
+  const wrapperPackage = readJson(path.join(wrapperSource, "package.json"));
+  const loaderPackage = readJson(path.join(loaderSource, "package.json"));
+  const targetPackage = readJson(path.join(targetSource, "package.json"));
+  const nativeSha256 = sha256(nativeSource);
+  assert.equal(nativeSha256, EXPECTED.nativeSha256);
+  assert.equal(targetPackage.watchbound.nativeSha256, nativeSha256);
+  assert.equal(wrapperPackage.version, artifactManifest.version);
+  assert.equal(loaderPackage.version, artifactManifest.version);
+  assert.equal(targetPackage.version, artifactManifest.version);
+  assert.equal(
+    wrapperPackage.dependencies["@gadicc/watchbound-node"],
+    artifactManifest.version,
+  );
+  assert.equal(targetPackage.name, target.package);
+  const candidateIdentity = {
+    schemaVersion: 1,
+    sourceCommit: EXPECTED.sourceCommit,
+    runtimeImplementationParent: EXPECTED.runtimeImplementationParent,
+    packages: {
+      wrapper: { name: wrapperPackage.name, version: wrapperPackage.version },
+      loader: { name: loaderPackage.name, version: loaderPackage.version },
+      target: { name: targetPackage.name, version: targetPackage.version },
+    },
+    target: {
+      id: target.id,
+      platform: target.platform,
+      architecture: target.architecture,
+      armAbi: target.armAbi ?? null,
+      targetTriple: target.rustTarget,
+      package: target.package,
+      binary: target.binary,
+      nativeSha256,
+    },
+  };
+  fs.writeFileSync(
+    path.join(stagingRoot, "candidate-identity.json"),
+    `${JSON.stringify(candidateIdentity, null, 2)}\n`,
+  );
+  copyHarness(stagingRoot);
+  const earlyBootstrap = path.join(stagingRoot, sourcePackage.main);
+  const officialBootstrap = fs.readFileSync(earlyBootstrap, "utf8");
+  assert.match(officialBootstrap, /bootstrap-/u);
+  fs.writeFileSync(
+    earlyBootstrap,
+    `${officialBootstrap}\nvoid import("../../watchbound-acceptance/runtime-harness.mjs").catch((error)=>{console.error("WATCHBOUND_SIGNED_HARNESS_BOOT_FAILURE",error);require("electron").app.exit(1)});\n`,
+  );
+
+  const buildRoot = path.join(workRoot, "build");
+  fs.mkdirSync(buildRoot, { recursive: true });
+  const generatedAsar = path.join(buildRoot, "app.asar");
+  await createPackageWithOptions(stagingRoot, generatedAsar, {
+    unpack: "{*.node,*.so,*.dylib}",
+  });
+  const archiveNative = path.join(
+    "node_modules",
+    "@gadicc",
+    "watchbound-node-linux-x64-gnu",
+    target.binary,
+  );
+  assert.equal(statFile(generatedAsar, archiveNative).unpacked, true);
+  const generatedUnpacked = `${generatedAsar}.unpacked`;
+  assert.equal(sha256(path.join(generatedUnpacked, archiveNative)), nativeSha256);
+  const generatedAsarSha256 = sha256(generatedAsar);
+  const positiveRuntime = path.join(workRoot, "signed-positive-runtime");
+  const negativeRuntime = path.join(workRoot, "signed-negative-runtime");
+  materializeRuntime({
+    runtimeRoot: positiveRuntime,
+    signedAppRoot,
+    generatedAsar,
+    generatedUnpacked,
+    archiveNative,
+    corruptNative: false,
+  });
+  materializeRuntime({
+    runtimeRoot: negativeRuntime,
+    signedAppRoot,
+    generatedAsar,
+    generatedUnpacked,
+    archiveNative,
+    corruptNative: true,
+  });
+  assert.equal(sha256(path.join(positiveRuntime, "ChatGPT")), executableSha256);
+  assert.equal(sha256(path.join(negativeRuntime, "ChatGPT")), executableSha256);
+
+  const rawArtifacts = [];
+  writeRawJson("build.json", {
+    sourceCommit: EXPECTED.sourceCommit,
+    sourceAsar: { path: sourceAsar, sha256: sourceAsarSha256 },
+    generatedAsar: { path: generatedAsar, sha256: generatedAsarSha256 },
+    signedExecutable: { path: signedExecutable, sha256: executableSha256 },
+    positiveExecutable: {
+      path: path.join(positiveRuntime, "ChatGPT"),
+      sha256: sha256(path.join(positiveRuntime, "ChatGPT")),
+    },
+    native: {
+      sourcePath: nativeSource,
+      unpackedPath: path.join(generatedUnpacked, archiveNative),
+      sha256: nativeSha256,
+    },
+  }, rawArtifacts);
+
+  const commonEnvironment = {
+    ...process.env,
+    WATCHBOUND_EXPECTED_SOURCE_COMMIT: EXPECTED.sourceCommit,
+    WATCHBOUND_EXPECTED_ELECTRON: EXPECTED.electron,
+    WATCHBOUND_EXPECTED_CHROME: EXPECTED.chrome,
+    WATCHBOUND_EXPECTED_NODE: EXPECTED.node,
+    WATCHBOUND_EXPECTED_NODE_API_MINIMUM: String(EXPECTED.nodeApiMinimum),
+    WATCHBOUND_EXPECTED_PRODUCTION_ADAPTER_SHA256: productionAdapterSha256,
+  };
+  delete commonEnvironment.ELECTRON_RUN_AS_NODE;
+  const iterations = [];
+  for (let iteration = 1; iteration <= 3; iteration += 1) {
+    const stem = `cold-${iteration}`;
+    const evidencePath = path.join(rawDir, `${stem}.json`);
+    const result = await runSigned({
+      executable: path.join(positiveRuntime, "ChatGPT"),
+      project: path.join(positiveRuntime, "resources", "app.asar"),
+      profile: path.join(workRoot, "profiles", stem),
+      route: `signed-openai-owl-final-cold-${iteration}`,
+      evidencePath,
+      environment: commonEnvironment,
+      version: artifactManifest.version,
+      nativeSha256,
+    });
+    recordProcessArtifacts(stem, result, rawArtifacts);
+    assert.equal(result.timedOut, false, `cold iteration ${iteration} timed out`);
+    assert.equal(result.overflow, false, `cold iteration ${iteration} exceeded output limit`);
+    assert.equal(result.signal, null, `cold iteration ${iteration} terminated by ${result.signal}`);
+    assert.equal(result.code, 0, result.stderr);
+    const evidence = readJson(evidencePath);
+    assert.equal(evidence.status, "passed");
+    assert.equal(evidence.host.electron, EXPECTED.electron);
+    assert.equal(evidence.host.chrome, EXPECTED.chrome);
+    assert.equal(evidence.host.node, EXPECTED.node);
+    assert.ok(evidence.host.nodeApi >= EXPECTED.nodeApiMinimum);
+    assert.equal(evidence.native.sha256, nativeSha256);
+    iterations.push({ iteration, result, evidence });
+    recordExistingArtifact(`${stem}.json`, rawArtifacts);
+  }
+
+  const negativeEvidencePath = path.join(rawDir, "negative-integrity.json");
+  const negative = await runSigned({
+    executable: path.join(negativeRuntime, "ChatGPT"),
+    project: path.join(negativeRuntime, "resources", "app.asar"),
+    profile: path.join(workRoot, "profiles", "negative-integrity"),
+    route: "signed-openai-owl-final-negative-integrity",
+    evidencePath: negativeEvidencePath,
+    environment: {
+      ...commonEnvironment,
+      WATCHBOUND_EXPECT_NEGATIVE_LOADER_ERROR: "1",
+    },
+    version: artifactManifest.version,
+    nativeSha256,
+  });
+  recordProcessArtifacts("negative-integrity", negative, rawArtifacts);
+  assert.equal(negative.timedOut, false, "negative integrity process timed out");
+  assert.equal(negative.overflow, false, "negative integrity process exceeded output limit");
+  assert.equal(negative.signal, null, "negative integrity process received a signal");
+  assert.notEqual(negative.code, 0, "tampered native unexpectedly loaded");
+  const negativeEvidence = readJson(negativeEvidencePath);
+  assert.equal(negativeEvidence.error?.name, "WatchboundLoaderError");
+  assert.equal(negativeEvidence.error?.code, "WATCHBOUND_NATIVE_INTEGRITY_MISMATCH");
+  assert.equal(negativeEvidence.productionAdapter?.fallbackCalls, 0);
+  assert.deepEqual(negativeEvidence.loaderFailureState?.loadedNativePaths, []);
+  recordExistingArtifact("negative-integrity.json", rawArtifacts);
+
+  aggregate = sanitizeAggregate({
+    sourcePackage,
+    sourceAsarSha256,
+    generatedAsarSha256,
+    executableSha256,
+    candidateIdentity,
+    matrix,
+    target,
+    nativeSha256,
+    nativeSize: fs.statSync(nativeSource).size,
+    iterations,
+    negative,
+    negativeEvidence,
+    rawArtifacts,
+    sourceInputs,
+    signedPackagePin,
+    signedDebSha256: sha256(signedDeb),
+    signedAppInventorySha256,
+    signedAppInventoryEntries: signedAppInventory.length,
+  });
+  fs.mkdirSync(path.dirname(sanitizedEvidencePath), { recursive: true });
+  fs.writeFileSync(
+    sanitizedEvidencePath,
+    `${JSON.stringify(aggregate, null, 2)}\n`,
+  );
+} finally {
+  fs.rmSync(workRoot, { recursive: true, force: true });
+}
+
+process.stdout.write(`${JSON.stringify({
+  verdict: aggregate.verdict,
+  sourceCommit: aggregate.watchbound.sourceCommit,
+  signedExecutableSha256: aggregate.signedRuntime.executableSha256,
+  nativeSha256: aggregate.native.sha256,
+  runtimeVersions: aggregate.signedRuntime.processVersions,
+  iterations: aggregate.iterations.map(({ iteration, exit, processResources }) => ({
+    iteration,
+    exit,
+    processResources,
+  })),
+  negativeIntegrity: aggregate.negativeIntegrity,
+  arm64: aggregate.arm64,
+  evidence: path.relative(repoRoot, sanitizedEvidencePath),
+  rawEvidence: path.relative(repoRoot, rawDir),
+})}\n`);
+
+function copyHarness(stagingRoot) {
+  for (const relative of [
+    "runtime-harness.mjs",
+    "installed-package-smoke-helpers.mjs",
+    "fixtures/exclusion-smoke-helpers.cjs",
+  ]) {
+    const destination = path.join(stagingRoot, "watchbound-acceptance", relative);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.copyFileSync(path.join(acceptanceDir, relative), destination);
+  }
+  fs.writeFileSync(
+    path.join(stagingRoot, "watchbound-acceptance", "production-adapter.cjs"),
+    productionAdapterSource,
+  );
+}
+
+function materializeRuntime({
+  runtimeRoot,
+  signedAppRoot: sourceRoot,
+  generatedAsar,
+  generatedUnpacked,
+  archiveNative,
+  corruptNative,
+}) {
+  fs.mkdirSync(runtimeRoot, { recursive: true });
+  const executable = path.join(runtimeRoot, "ChatGPT");
+  fs.copyFileSync(path.join(sourceRoot, "ChatGPT"), executable);
+  fs.chmodSync(executable, fs.statSync(path.join(sourceRoot, "ChatGPT")).mode);
+  for (const entry of fs.readdirSync(sourceRoot, { withFileTypes: true })) {
+    if (entry.name === "ChatGPT" || entry.name === "resources") continue;
+    fs.symlinkSync(
+      path.join(sourceRoot, entry.name),
+      path.join(runtimeRoot, entry.name),
+      entry.isDirectory() ? "dir" : "file",
+    );
+  }
+  const resources = path.join(runtimeRoot, "resources");
+  fs.mkdirSync(resources, { recursive: true });
+  const sourceResources = path.join(sourceRoot, "resources");
+  for (const entry of fs.readdirSync(sourceResources, { withFileTypes: true })) {
+    if (entry.name === "app.asar" || entry.name === "app.asar.unpacked") continue;
+    fs.symlinkSync(
+      path.join(sourceResources, entry.name),
+      path.join(resources, entry.name),
+      entry.isDirectory() ? "dir" : "file",
+    );
+  }
+  fs.copyFileSync(generatedAsar, path.join(resources, "app.asar"));
+  fs.cpSync(generatedUnpacked, path.join(resources, "app.asar.unpacked"), {
+    recursive: true,
+  });
+  const native = path.join(resources, "app.asar.unpacked", archiveNative);
+  if (corruptNative) {
+    const bytes = fs.readFileSync(native);
+    bytes[bytes.length - 1] ^= 0xff;
+    fs.writeFileSync(native, bytes);
+  }
+}
+
+async function runSigned({
+  executable,
+  project,
+  profile,
+  route,
+  evidencePath,
+  environment,
+  version,
+  nativeSha256: expectedNativeSha256,
+}) {
+  const args = [
+    `--user-data-dir=${profile}`,
+    "--no-first-run",
+    "--project", project,
+    "--wrapper", "watchbound",
+    "--package-version", version,
+    "--native-target", EXPECTED.targetId,
+    "--native-sha256", expectedNativeSha256,
+    "--route", route,
+    "--evidence", evidencePath,
+    "--wait-timeout-ms", "10000",
+  ];
+  return collectProcess(executable, args, {
+    cwd: repoRoot,
+    env: environment,
+    timeoutMs: 60_000,
+    maxBytes: 16 * 1024 * 1024,
+  });
+}
+
+function collectProcess(executable, args, { cwd, env, timeoutMs, maxBytes }) {
+  return new Promise((resolve, reject) => {
+    const startedAt = Date.now();
+    const child = spawn(executable, args, {
+      cwd,
+      env,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = Buffer.alloc(0);
+    let stderr = Buffer.alloc(0);
+    let timedOut = false;
+    let overflow = false;
+    let terminationRequested = false;
+    let killEscalated = false;
+    let killTimer;
+    const terminate = () => {
+      if (terminationRequested) return;
+      terminationRequested = true;
+      terminateGroup(child.pid, "SIGTERM");
+      killTimer = setTimeout(() => {
+        killEscalated = true;
+        terminateGroup(child.pid, "SIGKILL");
+      }, 2_000);
+    };
+    const append = (current, chunk) => {
+      const next = Buffer.concat([current, chunk]);
+      if (next.length > maxBytes && !overflow) {
+        overflow = true;
+        terminate();
+      }
+      return next.subarray(0, maxBytes);
+    };
+    child.stdout.on("data", (chunk) => { stdout = append(stdout, chunk); });
+    child.stderr.on("data", (chunk) => { stderr = append(stderr, chunk); });
+    child.once("error", reject);
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      terminate();
+    }, timeoutMs);
+    child.once("close", (code, signal) => {
+      clearTimeout(timeout);
+      clearTimeout(killTimer);
+      resolve({
+        code,
+        signal,
+        timedOut,
+        overflow,
+        terminationRequested,
+        killEscalated,
+        elapsedMs: Date.now() - startedAt,
+        stdout: stdout.toString("utf8"),
+        stderr: stderr.toString("utf8"),
+      });
+    });
+  });
+}
+
+function terminateGroup(pid, signal) {
+  if (!Number.isInteger(pid)) return;
+  try {
+    process.kill(-pid, signal);
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+  }
+}
+
+function sanitizeAggregate({
+  sourcePackage,
+  sourceAsarSha256,
+  generatedAsarSha256,
+  executableSha256,
+  candidateIdentity,
+  matrix,
+  target,
+  nativeSha256,
+  nativeSize,
+  iterations,
+  negative,
+  negativeEvidence,
+  rawArtifacts,
+  sourceInputs,
+  signedPackagePin,
+  signedDebSha256,
+  signedAppInventorySha256,
+  signedAppInventoryEntries,
+}) {
+  const first = iterations[0].evidence;
+  for (const { evidence } of iterations.slice(1)) {
+    assert.deepEqual(evidence.host, first.host);
+    assert.deepEqual(evidence.loaderContract, first.loaderContract);
+    assert.deepEqual(evidence.runtimeAdmission, first.runtimeAdmission);
+    assert.deepEqual(evidence.qualification, first.qualification);
+    assert.deepEqual(evidence.productionAdapter, first.productionAdapter);
+  }
+  const normalizedNativePath = path.posix.join(
+    "resources/app.asar/node_modules/@gadicc/watchbound-node-linux-x64-gnu",
+    target.binary,
+  );
+  const qualification = first.qualification;
+  return {
+    schemaVersion: 1,
+    kind: "codex-watchbound-signed-runtime-acceptance",
+    verdict: "passed",
+    recordedAt: new Date().toISOString(),
+    scope: "signed OpenAI Linux x64 executable; ARM64 unavailable",
+    inputs: {
+      files: sourceInputs,
+      generatedProductionAdapterSha256: productionAdapterSha256,
+      watchboundArchives: Object.fromEntries([
+        artifactManifest.packages.wrapper,
+        artifactManifest.packages.loader,
+        ...Object.values(artifactManifest.packages.targets),
+      ].map((artifact) => [artifact.name, {
+        sha256: artifact.sha256,
+        shasum: artifact.shasum,
+        integrity: artifact.integrity,
+      }])),
+      signedStablePackage: {
+        repositoryPath: signedPackagePin.repositoryPath,
+        sha256: signedDebSha256,
+        pinSource: "nix/upstream-linux-packages.json",
+      },
+    },
+    watchbound: {
+      version: candidateIdentity.packages.wrapper.version,
+      sourceCommit: EXPECTED.sourceCommit,
+      runtimeImplementationParent: EXPECTED.runtimeImplementationParent,
+      sourceTreeClean: true,
+    },
+    signedRuntime: {
+      executableSha256,
+      sourceAsarSha256,
+      generatedAcceptanceAsarSha256: generatedAsarSha256,
+      officialPackage: {
+        name: sourcePackage.name,
+        version: sourcePackage.version,
+        main: sourcePackage.main,
+        repositoryPath: signedPackagePin.repositoryPath,
+        debSha256: signedDebSha256,
+        dataPayloadInventorySha256: signedAppInventorySha256,
+        dataPayloadInventoryEntries: signedAppInventoryEntries,
+        verifiedAgainstDebDataPayload: true,
+      },
+      officialMainPreserved: true,
+      platform: first.host.platform,
+      architecture: first.host.architecture,
+      kernel: first.host.kernel,
+      glibc: first.host.glibc,
+      processVersions: {
+        electron: first.host.electron,
+        chrome: first.host.chrome,
+        node: first.host.node,
+        napi: first.host.nodeApi,
+      },
+    },
+    packages: candidateIdentity.packages,
+    native: {
+      ...candidateIdentity.target,
+      size: nativeSize,
+      sha256: nativeSha256,
+      resolvedPath: normalizedNativePath,
+      loadedPath: normalizedNativePath,
+      unpackedPath: normalizedNativePath.replace("app.asar/", "app.asar.unpacked/"),
+      exactSelectionWithoutFallback: true,
+      elf: target.elf,
+    },
+    loaderAssertions: {
+      ...first.loaderContract,
+      javascriptAdmissionHasNoUpperBound:
+        first.loaderContract.javascriptAdmission === ">=18.15.0" &&
+        !first.loaderContract.javascriptAdmission.includes("<"),
+      processNodeApiMinimum: matrix.nodeApiMinimum,
+      observedProcessNodeApi: first.host.nodeApi,
+      processNodeApiSatisfied: first.host.nodeApi >= matrix.nodeApiMinimum,
+      packageVersionLockstep: true,
+      digestIntegrity: true,
+      elfIdentity: true,
+    },
+    runtimeAdmission: first.runtimeAdmission,
+    productionAdapter: first.productionAdapter,
+    iterations: iterations.map(({ iteration, result, evidence }) => ({
+      iteration,
+      status: "passed",
+      exit: {
+        code: result.code,
+        signal: result.signal,
+        timedOut: result.timedOut,
+        outputOverflow: result.overflow,
+        terminationRequested: result.terminationRequested,
+        killEscalated: result.killEscalated,
+        elapsedMs: result.elapsedMs,
+      },
+      lifecycleAssertions: evidence.lifecycleAssertions,
+      runtime: evidence.runtime,
+      processResources: evidence.processResources,
+    })),
+    qualifyRoot: {
+      schemaVersion: qualification.schemaVersion,
+      state: qualification.state,
+      reasons: qualification.reasons,
+      target: qualification.target,
+      host: qualification.host,
+      root: {
+        state: qualification.root.state,
+        lexicalPath: "$CODEX_WORKSPACE",
+        physicalPath: "$CODEX_WORKSPACE",
+        lexicalAndPhysicalPathsEqual:
+          qualification.root.lexicalPath === qualification.root.physicalPath,
+        filesystem: qualification.root.filesystem,
+      },
+    },
+    negativeIntegrity: {
+      status: "passed",
+      productionAdapter: negativeEvidence.productionAdapter,
+      exit: {
+        code: negative.code,
+        signal: negative.signal,
+        timedOut: negative.timedOut,
+        outputOverflow: negative.overflow,
+        terminationRequested: negative.terminationRequested,
+        killEscalated: negative.killEscalated,
+      },
+      error: {
+        name: negativeEvidence.error.name,
+        code: negativeEvidence.error.code,
+        message: negativeEvidence.error.message,
+        details: negativeEvidence.error.details,
+        cause: negativeEvidence.error.cause,
+      },
+      fallbackAddonLoaded: false,
+    },
+    reportFreeAdmission: {
+      downstreamShimInstalled: false,
+      processReportUsed: false,
+      evidence: first.runtimeAdmission.libc.evidence,
+      admissionSnapshotSharedWithCapabilities: true,
+    },
+    arm64: {
+      status: "unavailable",
+      reason: "no signed ARM64 executable or ARM64 execution environment",
+    },
+    rawArtifacts: rawArtifacts
+      .sort((left, right) => left.filename.localeCompare(right.filename)),
+    reproduction: {
+      command:
+        "node linux-features/directory-only-working-tree-watch/acceptance/run-signed-runtime.mjs --watchbound-source <WATCHBOUND_SOURCE> --signed-deb <SIGNED_AMD64_DEB> --raw-dir reports/watchbound-signed-runtime/2.1.2-x64 --evidence linux-features/directory-only-working-tree-watch/acceptance/evidence/signed-runtime-2.1.2-x64.json",
+      harness: [
+        "linux-features/directory-only-working-tree-watch/acceptance/run-signed-runtime.mjs",
+        "linux-features/directory-only-working-tree-watch/acceptance/runtime-harness.mjs",
+      ],
+    },
+  };
+}
+
+function recordProcessArtifacts(stem, result, artifacts) {
+  for (const [suffix, contents] of [
+    ["stdout.log", result.stdout],
+    ["stderr.log", result.stderr],
+  ]) {
+    const filename = `${stem}.${suffix}`;
+    fs.writeFileSync(path.join(rawDir, filename), contents);
+    recordExistingArtifact(filename, artifacts);
+  }
+}
+
+function writeRawJson(filename, value, artifacts) {
+  fs.writeFileSync(path.join(rawDir, filename), `${JSON.stringify(value, null, 2)}\n`);
+  recordExistingArtifact(filename, artifacts);
+}
+
+function recordExistingArtifact(filename, artifacts) {
+  const source = path.join(rawDir, filename);
+  artifacts.push({
+    filename: path.posix.join(rawDirRelative.split(path.sep).join("/"), filename),
+    sha256: sha256(source),
+  });
+}
+
+function git(cwd, ...args) {
+  return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" })
+    .trim();
+}
+
+function parseOptions(args) {
+  const parsed = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      throw new Error(
+        "usage: run-signed-runtime.mjs --watchbound-source <path> --signed-deb <path> [--signed-app <path>] [--raw-dir <path>] [--evidence <path>]",
+      );
+    }
+    parsed[flag.slice(2)] = value;
+  }
+  assert.ok(parsed["watchbound-source"], "--watchbound-source is required");
+  assert.ok(parsed["signed-deb"], "--signed-deb is required");
+  return parsed;
+}
+
+function acceptanceSourceInputs() {
+  const sources = [
+    path.join(acceptanceDir, "run-signed-runtime.mjs"),
+    path.join(acceptanceDir, "runtime-harness.mjs"),
+    path.join(acceptanceDir, "installed-package-smoke-helpers.mjs"),
+    path.join(acceptanceDir, "fixtures", "exclusion-smoke-helpers.cjs"),
+    path.join(repoRoot, "linux-features", "directory-only-working-tree-watch", "patch.js"),
+    path.join(repoRoot, "linux-features", "directory-only-working-tree-watch", "watchbound-artifacts.json"),
+    upstreamPinsPath,
+  ];
+  return Object.fromEntries(sources.map((source) => [
+    path.relative(repoRoot, source).split(path.sep).join("/"),
+    sha256(source),
+  ]));
+}
+
+function appPayloadInventory(root) {
+  const entries = [];
+  const visit = (relativeDirectory) => {
+    const directory = path.join(root, relativeDirectory);
+    for (const name of fs.readdirSync(directory).sort()) {
+      const relativePath = path.join(relativeDirectory, name);
+      const absolutePath = path.join(root, relativePath);
+      const stat = fs.lstatSync(absolutePath);
+      const portablePath = relativePath.split(path.sep).join("/");
+      if (stat.isDirectory()) {
+        visit(relativePath);
+      } else if (stat.isFile()) {
+        entries.push({
+          path: portablePath,
+          type: "file",
+          mode: stat.mode & 0o7777,
+          size: stat.size,
+          sha256: sha256(absolutePath),
+        });
+      } else if (stat.isSymbolicLink()) {
+        entries.push({
+          path: portablePath,
+          type: "symlink",
+          target: fs.readlinkSync(absolutePath),
+        });
+      } else {
+        throw new Error(`unsupported signed app payload entry: ${absolutePath}`);
+      }
+    }
+  };
+  visit("");
+  return entries;
+}
+
+function readJson(source) {
+  return JSON.parse(fs.readFileSync(source, "utf8"));
+}
+
+function sha256(source) {
+  return crypto.createHash("sha256").update(fs.readFileSync(source)).digest("hex");
+}
+
+function sha256Contents(contents) {
+  return crypto.createHash("sha256").update(contents).digest("hex");
+}

--- a/linux-features/directory-only-working-tree-watch/acceptance/runtime-harness.mjs
+++ b/linux-features/directory-only-working-tree-watch/acceptance/runtime-harness.mjs
@@ -1,0 +1,1081 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import exclusionSmokeHelpers from "./fixtures/exclusion-smoke-helpers.cjs";
+import {
+  parseInstalledSmokeWaitTimeoutMs,
+  releaseCallbackGateAndJoinDisposal,
+  recoverStableReplacement,
+  waitForInstalledSmokeCondition,
+} from "./installed-package-smoke-helpers.mjs";
+
+const { hasInvalidatedPathAtOrBelow } = exclusionSmokeHelpers;
+let productionAdapterFallbackCalls = 0;
+
+const smokeStartedAt = Date.now();
+const workspaceRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const options = parseOptions(
+  process.versions.electron && process.env.ELECTRON_RUN_AS_NODE !== "1"
+    ? process.argv.slice(1)
+    : process.argv.slice(2),
+);
+logPhase("startup");
+const waitTimeoutMs = parseInstalledSmokeWaitTimeoutMs(
+  options["wait-timeout-ms"],
+);
+const projectRoot = path.resolve(options.project);
+const expectedSourceCommit = process.env.WATCHBOUND_EXPECTED_SOURCE_COMMIT;
+const expectedElectron = process.env.WATCHBOUND_EXPECTED_ELECTRON;
+const expectedChrome = process.env.WATCHBOUND_EXPECTED_CHROME;
+const expectedNode = process.env.WATCHBOUND_EXPECTED_NODE;
+const expectedNodeApiMinimum = Number(
+  process.env.WATCHBOUND_EXPECTED_NODE_API_MINIMUM,
+);
+const expectedProductionAdapterSha256 =
+  process.env.WATCHBOUND_EXPECTED_PRODUCTION_ADAPTER_SHA256;
+assert.match(expectedSourceCommit ?? "", /^[0-9a-f]{40}$/u);
+assert.match(expectedElectron ?? "", /^\d+(?:\.\d+){2,3}$/u);
+assert.match(expectedChrome ?? "", /^\d+(?:\.\d+){2,3}$/u);
+assert.match(expectedNode ?? "", /^\d+\.\d+\.\d+$/u);
+assert.ok(Number.isInteger(expectedNodeApiMinimum));
+assert.match(expectedProductionAdapterSha256 ?? "", /^[0-9a-f]{64}$/u);
+assert.equal(process.versions.electron, expectedElectron);
+assert.equal(process.versions.chrome, expectedChrome);
+assert.equal(process.versions.node, expectedNode);
+assert.ok(Number(process.versions.napi) >= expectedNodeApiMinimum);
+logPhase("runtime-identity-complete", { versions: process.versions });
+const candidateIdentity = readJson(
+  path.join(projectRoot, "candidate-identity.json"),
+);
+assert.equal(candidateIdentity.sourceCommit, expectedSourceCommit);
+logPhase("candidate-identity-complete");
+const productionAdapterPath = path.join(
+  projectRoot,
+  "watchbound-acceptance",
+  "production-adapter.cjs",
+);
+assert.equal(sha256(productionAdapterPath), expectedProductionAdapterSha256);
+const productionAdapterRequire = createRequire(productionAdapterPath);
+const startProductionWatch = productionAdapterRequire(productionAdapterPath);
+assert.equal(typeof startProductionWatch, "function");
+const wrapperRoot = options["wrapper-path"]
+  ? path.resolve(options["wrapper-path"])
+  : path.join(projectRoot, "node_modules", options.wrapper);
+const wrapperEntry = fs.realpathSync(path.join(wrapperRoot, "index.js"));
+logPhase("wrapper-realpath-complete", { wrapperEntry });
+const wrapperRequire = createRequire(wrapperEntry);
+const loaderRoot = path.dirname(
+  wrapperRequire.resolve("@gadicc/watchbound-node"),
+);
+logPhase("loader-resolution-complete", { loaderRoot });
+const nativeMatrix = readJson(path.join(loaderRoot, "native-matrix.json"));
+logPhase("matrix-read-complete");
+const nativeTarget = nativeMatrix.targets.find((target) =>
+  target.platform === process.platform && target.architecture === process.arch);
+assert.ok(nativeTarget, `no installed native target for ${process.platform}/${process.arch}`);
+if (options["native-target"]) {
+  assert.equal(nativeTarget.id, options["native-target"]);
+}
+const nativeRoot = path.dirname(
+  wrapperRequire.resolve(`${nativeTarget.package}/package.json`),
+);
+logPhase("target-resolution-complete", { nativeRoot });
+const nativePath = path.join(nativeRoot, nativeTarget.binary);
+assert.ok(wrapperEntry.includes("app.asar"), "wrapper was not loaded from ASAR");
+assert.ok(nativePath.includes("app.asar"), "native target was not resolved through ASAR");
+if (process.versions.electron && process.env.ELECTRON_RUN_AS_NODE !== "1") {
+  logPhase("app-ready-wait-start");
+  await wrapperRequire("electron").app.whenReady();
+  logPhase("app-ready-wait-complete");
+  // Let the unmodified upstream bootstrap finish opening its own persistent
+  // descriptors and threads before establishing the Watchbound baseline.
+  await delay(1500);
+  logPhase("upstream-startup-settle-complete");
+}
+const evidence = {
+  schemaVersion: 1,
+  kind: "watchbound-installed-package-smoke",
+  route: options.route,
+  expectedVersion: options["package-version"],
+  expectedNativeTarget: options["native-target"] ?? nativeTarget.id,
+  expectedNativeSha256: options["native-sha256"],
+  sourceCommit: candidateIdentity.sourceCommit,
+  candidateIdentity,
+  waitTimeoutMs,
+  startedAt: new Date().toISOString(),
+  host: {
+    platform: process.platform,
+    architecture: process.arch,
+    armAbi: nativeTarget.armAbi ?? null,
+    electron: process.versions.electron,
+    chrome: process.versions.chrome,
+    node: process.versions.node,
+    nodeApi: Number(process.versions.napi),
+    kernel: os.release(),
+    glibc: null,
+  },
+};
+
+let terminalError;
+try {
+  Object.assign(evidence, await runSmoke());
+  evidence.host.glibc = evidence.runtimeAdmission.libc.version;
+  evidence.status = "passed";
+  logPhase("checks-complete");
+} catch (error) {
+  evidence.status = "failed";
+  evidence.error = {
+    name: error?.name ?? null,
+    code: error?.code ?? null,
+    message: error?.message ?? String(error),
+    details: error?.details ?? null,
+    cause: serializeCause(error?.cause),
+    stack: error?.stack ?? null,
+  };
+  evidence.loaderFailureState = {
+    loadedNativePaths: Object.keys(wrapperRequire.cache).filter((filename) =>
+      filename.endsWith(nativeTarget.binary)),
+  };
+  logPhase("checks-failed", { errorName: error?.name ?? null });
+  terminalError = error;
+} finally {
+  evidence.finishedAt = new Date().toISOString();
+  if (options.evidence) {
+    logPhase("evidence-write-start");
+    const evidencePath = path.resolve(options.evidence);
+    fs.mkdirSync(path.dirname(evidencePath), { recursive: true });
+    fs.writeFileSync(
+      evidencePath,
+      `${JSON.stringify(evidence, bigintReplacer, 2)}\n`,
+    );
+    logPhase("evidence-write-complete");
+  }
+}
+
+if (terminalError) {
+  process.stdout.write(`WATCHBOUND_SIGNED_RUNTIME_FAILURE=${JSON.stringify(evidence, bigintReplacer)}\n`);
+  if (process.versions.electron && process.env.ELECTRON_RUN_AS_NODE !== "1") {
+    wrapperRequire("electron").app.exit(1);
+  } else {
+    throw terminalError;
+  }
+} else {
+  process.stdout.write(
+    `Installed package smoke passed for ${options.route} ${options["package-version"]}\n`,
+  );
+  if (process.versions.electron && process.env.ELECTRON_RUN_AS_NODE !== "1") {
+    wrapperRequire("electron").app.quit();
+  }
+}
+
+async function runSmoke() {
+  logPhase("package-contracts-start");
+  const wrapperPackage = readJson(path.join(wrapperRoot, "package.json"));
+  const loaderPackage = readJson(path.join(loaderRoot, "package.json"));
+  const nativePackage = readJson(path.join(nativeRoot, "package.json"));
+  assert.deepEqual(candidateIdentity.packages, {
+    wrapper: { name: wrapperPackage.name, version: wrapperPackage.version },
+    loader: { name: loaderPackage.name, version: loaderPackage.version },
+    target: { name: nativePackage.name, version: nativePackage.version },
+  });
+  assert.equal(wrapperPackage.version, options["package-version"]);
+  assert.equal(loaderPackage.version, options["package-version"]);
+  assert.equal(nativePackage.version, options["package-version"]);
+  assert.equal(
+    wrapperPackage.dependencies?.["@gadicc/watchbound-node"],
+    options["package-version"],
+  );
+  assert.equal(wrapperDelivery(wrapperPackage), "bundled-native-package");
+  assert.equal(loaderPackage.watchbound?.delivery, "bundled-native-package");
+  assert.equal(nativePackage.watchbound?.delivery, "target-native-package");
+  assert.equal(nativePackage.name, nativeTarget.package);
+  assert.equal(nativePackage.watchbound?.target, nativeTarget.id);
+  assert.equal(nativePackage.watchbound?.targetTriple, nativeTarget.rustTarget);
+  assert.equal(
+    nativePackage.watchbound?.nodeApiMinimum,
+    nativeMatrix.nodeApiMinimum,
+  );
+  assert.equal(wrapperPackage.engines?.node, ">=18.15.0");
+  assert.equal(loaderPackage.engines?.node, ">=18.15.0");
+  assert.equal(nativePackage.engines?.node, ">=18.15.0");
+  assert.equal(nativeMatrix.nodeRange, ">=18.15.0");
+  assert.equal(nativeMatrix.nodeMinimum, "18.15.0");
+  assert.equal(nativeMatrix.nodeApiMinimum, 6);
+  assert.equal(nativeMatrix.nodeRange.includes("<"), false);
+  assert.ok(fs.existsSync(nativePath), `missing installed native addon: ${nativePath}`);
+  const nativeSha256 = sha256(nativePath);
+  if (process.env.WATCHBOUND_EXPECT_NEGATIVE_LOADER_ERROR !== "1") {
+    assert.equal(
+      nativeSha256,
+      options["native-sha256"],
+      "installed native addon differs from the independently approved artifact",
+    );
+  }
+  logPhase("package-contracts-complete");
+
+  logPhase("production-adapter-start");
+  try {
+    evidence.productionAdapter = await checkProductionAdapterRoute();
+  } catch (error) {
+    evidence.productionAdapter = {
+      status: "failed",
+      exactInjectedSourceSha256: expectedProductionAdapterSha256,
+      bareSpecifierAttempted: true,
+      moduleOverrideUsed: false,
+      fallbackCalls: productionAdapterFallbackCalls,
+      errorCode: error?.code ?? null,
+    };
+    throw error;
+  }
+  logPhase("production-adapter-complete");
+
+  logPhase("native-module-start");
+  const module = await import(pathToFileURL(wrapperEntry));
+  const { capabilities, createEngine, qualifyRoot } = module;
+  const rawBinding = wrapperRequire("@gadicc/watchbound-node");
+  const rawCapabilities = rawBinding.capabilities();
+  const bindingMetadata = rawBinding.bindingMetadata();
+  const deliveryMetadata = rawBinding.nativeDeliveryMetadata();
+  const runtimeAdmission = rawBinding.runtimeAdmissionMetadata();
+  const loadedNativePaths = Object.keys(wrapperRequire.cache).filter(
+    (filename) => filename.endsWith(nativeTarget.binary),
+  );
+  assert.deepEqual(
+    loadedNativePaths,
+    [nativePath],
+    "production loader did not load exactly the selected immutable native path",
+  );
+  assert.equal(rawCapabilities.schemaVersion, 5);
+  assert.equal(bindingMetadata.schemaVersion, 1);
+  assert.equal(bindingMetadata.bindingApiVersion, 5);
+  assert.equal(bindingMetadata.nodeApiVersion, 6);
+  assert.equal(bindingMetadata.targetTriple, nativeTarget.rustTarget);
+  assert.equal(bindingMetadata.buildProfile, "release");
+  assert.equal(bindingMetadata.nativeVersion, options["package-version"]);
+  assert.equal(bindingMetadata.engineVersion, options["package-version"]);
+  assert.equal(deliveryMetadata.schemaVersion, 1);
+  assert.equal(deliveryMetadata.targetId, nativeTarget.id);
+  assert.equal(deliveryMetadata.targetPackage, nativeTarget.package);
+  assert.equal(deliveryMetadata.sha256, nativeSha256);
+  assert.equal(runtimeAdmission.schemaVersion, 1);
+  assert.equal(runtimeAdmission.platform, process.platform);
+  assert.equal(runtimeAdmission.architecture, process.arch);
+  assert.equal(runtimeAdmission.armAbi, null);
+  assert.equal(runtimeAdmission.kernel, os.release());
+  assert.deepEqual(runtimeAdmission.node, {
+    version: process.versions.node,
+    api: Number(process.versions.napi),
+  });
+  assert.equal(runtimeAdmission.libc.family, "glibc");
+  assert.match(runtimeAdmission.libc.version, /^\d+\.\d+(?:\.\d+)?$/u);
+  assert.equal(runtimeAdmission.libc.evidence, "elf-interpreter-version");
+  assert.deepEqual(capabilities.versions, {
+    wrapper: options["package-version"],
+    native: options["package-version"],
+    engine: options["package-version"],
+    bindingApi: 5,
+  });
+  assert.equal(capabilities.build.delivery, "bundled-native-package");
+  assert.equal(capabilities.build.prebuilt, true);
+  assert.equal(capabilities.schemaVersion, 9);
+  assert.equal(capabilities.support.nodeRange, ">=18.15.0");
+  assert.equal(capabilities.build.nodeApi, 6);
+  assert.equal(capabilities.build.profile, "release");
+  assert.equal(capabilities.build.targetTriple, nativeTarget.rustTarget);
+  assert.equal(capabilities.features.directoryNameExclusions, true);
+  assert.equal(capabilities.features.observedExcludedPaths, true);
+  assert.equal(capabilities.features.bytesOnlyInvalidations, true);
+  assert.deepEqual(capabilities.observability.pathEncodingStates, [
+    "complete",
+    "root-collapsed",
+    "bytes-only",
+  ]);
+  assert.equal(capabilities.build.packagedTarget.id, nativeTarget.id);
+  assert.equal(capabilities.build.packagedTarget.package, nativeTarget.package);
+  assert.equal(capabilities.build.packagedTarget.sha256, nativeSha256);
+  assert.deepEqual(capabilities.runtime, {
+    platform: runtimeAdmission.platform,
+    architecture: runtimeAdmission.architecture,
+    armAbi: runtimeAdmission.armAbi,
+    kernel: runtimeAdmission.kernel,
+    libc: {
+      family: runtimeAdmission.libc.family,
+      version: runtimeAdmission.libc.version,
+    },
+    node: runtimeAdmission.node,
+  });
+  assert.equal(capabilities.support.scope, "legacy-primary-target");
+  const legacyX64Target = nativeMatrix.targets.find(
+    (target) => target.architecture === "x64",
+  );
+  assert.ok(legacyX64Target, "native matrix omits its legacy x64 target");
+  assert.equal(capabilities.support.status, legacyX64Target.qualification);
+  // These legacy single-target fields retain their original x64/Ubuntu 24.04
+  // meaning. Consumers must use support.targets and currentRuntime for the
+  // additive multi-target contract.
+  assert.equal(capabilities.support.operatingSystem.distribution, "ubuntu");
+  assert.equal(capabilities.support.operatingSystem.version, "24.04");
+  assert.equal(capabilities.support.architecture, "x64");
+  assert.deepEqual(capabilities.support.libc, {
+    family: "glibc",
+    version: "2.39",
+  });
+  assert.equal(capabilities.support.targets.length, nativeMatrix.targets.length);
+  assert.equal(
+    capabilities.support.currentRuntime.packagedTargetId,
+    nativeTarget.id,
+  );
+  assert.equal(
+    capabilities.support.currentRuntime.runtimeMatchesPackagedTarget,
+    true,
+  );
+  assert.equal(
+    capabilities.support.currentRuntime.qualification,
+    nativeTarget.qualification,
+  );
+  assert.equal(
+    capabilities.support.currentRuntime.targetCompatible,
+    nativeTarget.qualification === "supported",
+  );
+  const qualification = qualifyRoot(process.cwd());
+  assert.equal(qualification.schemaVersion, 1);
+  assert.ok(["qualified", "unqualified", "unknown"].includes(qualification.state));
+  assert.equal(qualification.target.packagedTargetId, nativeTarget.id);
+  assert.equal(qualification.state, "qualified", JSON.stringify(qualification));
+
+  const engine = createEngine();
+  const inactiveRuntime = {
+    active: false,
+    inotifyInstances: 0,
+    workerThreads: 0,
+    nativeWatches: 0,
+    nativeWatchBudget: null,
+    deferredInterests: 0,
+    subscriptions: 0,
+  };
+  assert.deepEqual(engine.runtimeStats(), inactiveRuntime);
+  const processBaseline = processResources();
+  logPhase("native-module-complete");
+
+  logPhase("real-delivery-start");
+  const realDelivery = await checkRealDeliveryAndSerialization(engine);
+  logPhase("real-delivery-complete");
+  logPhase("exclusions-recovery-start");
+  const exclusions = await checkExclusionsRecoveryAndReconciliation(engine);
+  logPhase("exclusions-recovery-complete");
+  logPhase("establishment-cancellation-start");
+  const establishmentCancellation = await checkEstablishmentCancellation(engine);
+  logPhase("establishment-cancellation-complete");
+  logPhase("joined-disposal-start");
+  const joinedDisposal = await checkContextAbortAndJoinedDisposal(engine);
+  logPhase("joined-disposal-complete");
+  logPhase("context-stop-start");
+  const contextStop = await checkContextStop(engine);
+  logPhase("context-stop-complete");
+
+  logPhase("resource-return-start");
+  await waitFor(
+    () => deepEqual(engine.runtimeStats(), inactiveRuntime),
+    "runtime resources did not return to the inactive baseline",
+  );
+  const processFinal = processResources();
+  logPhase("resource-return-snapshot", {
+    processBaseline,
+    processFinal,
+    runtimeFinal: engine.runtimeStats(),
+  });
+  assert.equal(
+    processFinal.watchboundThreads,
+    processBaseline.watchboundThreads,
+    "Watchbound threads did not return to baseline",
+  );
+  assert.equal(
+    processFinal.inotifyDescriptors,
+    processBaseline.inotifyDescriptors,
+    "inotify descriptors did not return to baseline",
+  );
+  assert.ok(
+    processFinal.fileDescriptors <= processBaseline.fileDescriptors + 2,
+    "process file descriptors did not return near baseline",
+  );
+  assert.ok(
+    processFinal.tasks <= processBaseline.tasks + 4,
+    "process tasks did not return near the cold baseline",
+  );
+  logPhase("resource-return-complete");
+
+  return {
+    wrapper: {
+      name: wrapperPackage.name,
+      version: wrapperPackage.version,
+    },
+    loader: {
+      name: loaderPackage.name,
+      version: loaderPackage.version,
+    },
+    native: {
+      name: nativePackage.name,
+      version: nativePackage.version,
+      target: nativeTarget.id,
+      targetTriple: nativeTarget.rustTarget,
+      binary: nativeTarget.binary,
+      resolvedPath: nativePath,
+      loadedPath: loadedNativePaths[0],
+      sha256: nativeSha256,
+      bytes: fs.statSync(nativePath).size,
+    },
+    loaderContract: {
+      javascriptAdmission: nativeMatrix.nodeRange,
+      javascriptMinimum: nativeMatrix.nodeMinimum,
+      runtimeAdmissionSchema: runtimeAdmission.schemaVersion,
+      runtimeLibcEvidence: runtimeAdmission.libc.evidence,
+      kernelMinimum: nativeMatrix.releaseBaseline.kernelMinimum,
+      glibcMinimum: nativeMatrix.releaseBaseline.glibcMaximum,
+      rawCapabilitySchema: rawCapabilities.schemaVersion,
+      publicCapabilitySchema: capabilities.schemaVersion,
+      metadataSchema: bindingMetadata.schemaVersion,
+      bindingApi: bindingMetadata.bindingApiVersion,
+      buildProfile: bindingMetadata.buildProfile,
+      targetTriple: bindingMetadata.targetTriple,
+    },
+    runtimeAdmission,
+    qualification,
+    lifecycleAssertions: {
+      expectedRuntimeIdentity: {
+        expectedElectron,
+        observedElectron: process.versions.electron,
+        electronMatches: process.versions.electron === expectedElectron,
+        expectedChrome,
+        observedChrome: process.versions.chrome,
+        chromeMatches: process.versions.chrome === expectedChrome,
+        expectedNode,
+        observedNode: process.versions.node,
+        nodeMatches: process.versions.node === expectedNode,
+        nodeApiMinimum: expectedNodeApiMinimum,
+        observedNodeApi: Number(process.versions.napi),
+        nodeApiSatisfied: Number(process.versions.napi) >= expectedNodeApiMinimum,
+      },
+      inactiveBaseline: true,
+      completeInitialObservation: true,
+      realDelivery,
+      exclusions,
+      establishmentCancellation,
+      joinedDisposal,
+      contextStop,
+      resourcesReturnedToBaseline: true,
+    },
+    runtime: {
+      baseline: inactiveRuntime,
+      final: engine.runtimeStats(),
+    },
+    processResources: {
+      baseline: processBaseline,
+      final: processFinal,
+      tolerance: {
+        fileDescriptors: 2,
+        coldTasks: 4,
+      },
+    },
+  };
+}
+
+async function checkProductionAdapterRoute() {
+  const root = fs.mkdtempSync(
+    path.join(process.cwd(), ".watchbound-production-adapter-"),
+  );
+  const moduleOverrideKey = Symbol.for(
+    "codex-linux.directory-only-working-tree-watch.test-module",
+  );
+  const engineKey = Symbol.for(
+    "codex-linux.directory-only-working-tree-watch.watchbound-engine",
+  );
+  assert.equal(globalThis[moduleOverrideKey], undefined);
+  delete globalThis[engineKey];
+  productionAdapterFallbackCalls = 0;
+  const establishmentMessages = [];
+  const originalInfo = console.info;
+  console.info = (...args) => {
+    const message = args.map(String).join(" ");
+    if (message.includes("established with Watchbound")) {
+      establishmentMessages.push(message);
+    }
+    originalInfo(...args);
+  };
+  let watcher;
+  try {
+    watcher = await startProductionWatch(
+      {
+        getFileSystemPath: () => root,
+        platformPath: async () => path.posix,
+      },
+      {
+        path: root,
+        recursive: true,
+        renameEventHandling: "changed-path-with-parent-directory",
+        onChange() {},
+      },
+      {
+        maxWatches: 64,
+        honorGitIgnore: false,
+        ignoredDirectoryNames: [],
+      },
+      () => {
+        productionAdapterFallbackCalls += 1;
+        return null;
+      },
+    );
+    assert.ok(watcher, "production adapter returned its Parcel fallback");
+    assert.ok(watcher.codexLinuxDirectoryWatchCount() > 0);
+    const budget = watcher.codexLinuxDirectoryWatchBudget();
+    assert.equal(budget.limit, 64);
+    assert.ok(budget.active > 0 && budget.active <= budget.limit);
+    assert.deepEqual(establishmentMessages, [
+      `INFO: directory-only working-tree watch established with Watchbound 2.1.2 ` +
+        `for ${root} (target=${nativeTarget.id}, native=${budget.active}, limit=${budget.limit}).`,
+    ]);
+    await watcher.dispose();
+    const closed = await watcher.closed;
+    assert.equal(closed.reason, "disposed");
+    assert.equal(productionAdapterFallbackCalls, 0);
+    return {
+      status: "passed",
+      exactInjectedSourceSha256: expectedProductionAdapterSha256,
+      bareSpecifierResolved: true,
+      moduleOverrideUsed: false,
+      fallbackCalls: productionAdapterFallbackCalls,
+      watcherReturned: true,
+      nativeSubscriptionEstablished: true,
+      establishmentDiagnostic: {
+        emitted: true,
+        version: "2.1.2",
+        target: nativeTarget.id,
+        includedNativeBudget: true,
+      },
+      joinedDisposal: true,
+    };
+  } finally {
+    console.info = originalInfo;
+    await watcher?.dispose();
+    delete globalThis[engineKey];
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function logPhase(phase, details = {}) {
+  process.stdout.write(
+    `WATCHBOUND_INSTALLED_SMOKE_PHASE=${JSON.stringify({
+      phase,
+      elapsedMs: Date.now() - smokeStartedAt,
+      route: options.route,
+      ...details,
+    })}\n`,
+  );
+}
+
+async function checkExclusionsRecoveryAndReconciliation(engine) {
+  const parent = fs.mkdtempSync(
+    path.join(os.tmpdir(), "watchbound-installed-platform-semantics-"),
+  );
+  const root = path.join(parent, "root");
+  const movedRoot = path.join(parent, "root-old");
+  const initialExcluded = path.join(root, "initial-hidden");
+  const dynamicExcluded = path.join(root, "dynamic-hidden");
+  const observedGit = path.join(root, ".git");
+  const nestedGit = path.join(root, "nested", ".git");
+  fs.mkdirSync(initialExcluded, { recursive: true });
+  fs.mkdirSync(dynamicExcluded, { recursive: true });
+  fs.mkdirSync(path.join(observedGit, "objects"), { recursive: true });
+  fs.mkdirSync(path.join(nestedGit, "objects"), { recursive: true });
+  const batches = [];
+  let subscription;
+  try {
+    subscription = await engine.subscribe(
+      root,
+      (batch) => batches.push(batch),
+      {
+        initialExclusions: ["initial-hidden"],
+        excludedDirectoryNames: [".git"],
+        observedExcludedPaths: [".git"],
+        batchWindowMs: 5,
+        outputQueueCapacity: 16,
+      },
+    );
+    assert.equal(subscription.initialCoverage.state, "complete");
+
+    const initialHidden = path.join(initialExcluded, "hidden.txt");
+    const initialVisible = path.join(root, "visible.txt");
+    fs.writeFileSync(initialHidden, "hidden");
+    fs.writeFileSync(initialVisible, "visible");
+    await waitFor(
+      () => batches.some((batch) => batch.invalidatedPaths.includes(initialVisible)),
+      "initial-exclusion smoke did not deliver the visible path",
+    );
+    assert.equal(
+      hasInvalidatedPathAtOrBelow(batches, initialExcluded),
+      false,
+      "initial exclusion leaked its prefix or a descendant path",
+    );
+    fs.writeFileSync(path.join(observedGit, "objects", "ignored"), "hidden");
+    fs.writeFileSync(path.join(nestedGit, "objects", "ignored"), "hidden");
+    await delay(30);
+    assert.equal(
+      hasInvalidatedPathAtOrBelow(batches, nestedGit),
+      false,
+      "nested directory-name exclusion leaked a descendant path",
+    );
+    fs.rmSync(observedGit, { recursive: true });
+    await waitFor(
+      () => batches.some((batch) => batch.invalidatedPaths.includes(observedGit)),
+      "observed excluded boundary deletion was not delivered",
+    );
+
+    const replacementCoverage = await subscription.replaceExclusions(
+      1n,
+      {
+        prefixes: ["dynamic-hidden"],
+        excludedDirectoryNames: [".git"],
+        observedExcludedPaths: [".git"],
+      },
+    );
+    assert.equal(replacementCoverage.state, "complete");
+    const dynamicHidden = path.join(dynamicExcluded, "hidden.txt");
+    const nowVisible = path.join(root, "initial-hidden", "now-visible.txt");
+    fs.writeFileSync(dynamicHidden, "hidden");
+    fs.writeFileSync(nowVisible, "visible");
+    await waitFor(
+      () => batches.some((batch) => batch.invalidatedPaths.includes(nowVisible)),
+      "dynamic-exclusion smoke did not deliver the newly visible path",
+    );
+    assert.equal(
+      hasInvalidatedPathAtOrBelow(batches, dynamicExcluded),
+      false,
+      "dynamic exclusion leaked its prefix or a descendant path",
+    );
+
+    const reconciliation = await subscription.reconcile();
+    assert.equal(reconciliation.exclusionGeneration, 1n);
+    assert.equal(reconciliation.coverage.state, "complete");
+
+    fs.renameSync(root, movedRoot);
+    fs.mkdirSync(path.join(root, "replacement"), { recursive: true });
+    await waitFor(
+      () => subscription.rootState.attachment === "lost",
+      "root replacement did not become explicitly lost",
+    );
+    const recovery = await recoverStableReplacement(subscription, {
+      timeoutMs: waitTimeoutMs,
+      onDeadline: reportSemanticDeadline,
+    });
+    assert.equal(
+      recovery.attachment,
+      "replacement-adopted",
+      `root recovery did not adopt the stable replacement: ${recovery.reason ?? "unknown"}`,
+    );
+    assert.equal(recovery.currentRootState.attachment, "attached");
+    const afterRecovery = path.join(root, "replacement", "after.txt");
+    fs.writeFileSync(afterRecovery, "after");
+    await waitFor(
+      () => batches.some((batch) => batch.invalidatedPaths.includes(afterRecovery)),
+      "root-recovery smoke did not restore real delivery",
+    );
+    await subscription.dispose();
+    subscription = undefined;
+    assert.equal(
+      hasInvalidatedPathAtOrBelow(batches, initialExcluded, 0n),
+      false,
+      "joined history exposed an initial-exclusion namespace leak",
+    );
+    assert.equal(
+      hasInvalidatedPathAtOrBelow(batches, dynamicExcluded, 1n),
+      false,
+      "joined history exposed a dynamic-exclusion namespace leak",
+    );
+    return {
+      initialPrefixHidden: true,
+      directoryNameGitHidden: true,
+      observedGitBoundaryDelivered: true,
+      dynamicPrefixHidden: true,
+      reconciliationComplete: true,
+      stableRootReplacementRecovered: true,
+    };
+  } finally {
+    await subscription?.dispose();
+    fs.rmSync(parent, { recursive: true, force: true });
+  }
+}
+
+function wrapperDelivery(manifest) {
+  if (manifest.watchbound?.delivery !== undefined) {
+    return manifest.watchbound.delivery;
+  }
+  if (
+    manifest.name === "@jsr/gadicc__watchbound" &&
+    manifest.dependencies?.["@gadicc/watchbound-node"] === manifest.version
+  ) {
+    return "bundled-native-package";
+  }
+  return undefined;
+}
+
+async function checkRealDeliveryAndSerialization(engine) {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), "watchbound-installed-serialization-"),
+  );
+  const firstRelease = deferred();
+  let subscription;
+  let entered = 0;
+  let active = 0;
+  let maximumActive = 0;
+  const invalidatedPaths = [];
+  try {
+    logPhase("real-delivery-subscribe-start");
+    subscription = await engine.subscribe(
+      root,
+      async (batch) => {
+        invalidatedPaths.push(...batch.invalidatedPaths);
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        entered += 1;
+        if (entered === 1) {
+          logPhase("real-delivery-first-callback-enter");
+          await firstRelease.promise;
+        } else if (entered === 2) {
+          logPhase("real-delivery-second-callback-enter");
+        }
+        active -= 1;
+      },
+      {
+        batchWindowMs: 5,
+        outputQueueCapacity: 4,
+      },
+    );
+    logPhase("real-delivery-subscribe-complete");
+    assert.equal(subscription.initialCoverage.state, "complete");
+    logPhase("real-delivery-first-write");
+    fs.writeFileSync(path.join(root, "first.txt"), "first");
+    logPhase("real-delivery-first-callback-wait-start");
+    await waitFor(
+      () => entered >= 1,
+      "the first serialized callback did not enter",
+    );
+    logPhase("real-delivery-first-callback-wait-complete");
+    logPhase("real-delivery-second-write");
+    fs.writeFileSync(path.join(root, "second.txt"), "second");
+    await delay(75);
+    assert.equal(entered, 1, "a later callback overlapped a pending callback");
+    firstRelease.resolve();
+    logPhase("real-delivery-second-callback-wait-start");
+    await waitFor(() => entered >= 2, "the serialized callback did not resume");
+    logPhase("real-delivery-second-callback-wait-complete");
+    assert.equal(maximumActive, 1);
+    const first = path.join(root, "first.txt");
+    const second = path.join(root, "second.txt");
+    const beforeChange = entered;
+    const firstInvalidations = invalidatedPaths.filter((value) => value === first).length;
+    fs.appendFileSync(first, "-changed");
+    await waitFor(
+      () => entered > beforeChange &&
+        invalidatedPaths.filter((value) => value === first).length > firstInvalidations,
+      "the file-change callback was not delivered",
+    );
+    const beforeDelete = entered;
+    const secondInvalidations = invalidatedPaths.filter((value) => value === second).length;
+    fs.rmSync(second);
+    await waitFor(
+      () => entered > beforeDelete &&
+        invalidatedPaths.filter((value) => value === second).length > secondInvalidations,
+      "the file-deletion callback was not delivered",
+    );
+    return {
+      createDelivered: true,
+      modificationDelivered: true,
+      deletionDelivered: true,
+      maximumConcurrentCallbacks: maximumActive,
+      callbackCount: entered,
+    };
+  } finally {
+    logPhase("real-delivery-disposal-start");
+    await releaseCallbackGateAndJoinDisposal(
+      () => firstRelease.resolve(),
+      subscription,
+    );
+    logPhase("real-delivery-disposal-complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+async function checkContextAbortAndJoinedDisposal(engine) {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), "watchbound-installed-disposal-"),
+  );
+  const completionRelease = deferred();
+  let callbackCompleted = false;
+  let callbackCalls = 0;
+  let callbackContext;
+  let subscription;
+  try {
+    subscription = await engine.subscribe(
+      root,
+      async (_batch, context) => {
+        callbackCalls += 1;
+        callbackContext = context;
+        if (!context.signal.aborted) {
+          await new Promise((resolve) => {
+            context.signal.addEventListener("abort", resolve, { once: true });
+          });
+        }
+        await completionRelease.promise;
+        callbackCompleted = true;
+      },
+      { batchWindowMs: 5 },
+    );
+    fs.writeFileSync(path.join(root, "changed.txt"), "change");
+    await waitFor(
+      () => callbackContext !== undefined,
+      "the joined-disposal callback did not enter",
+    );
+    let disposalResolved = false;
+    const joined = subscription.dispose();
+    assert.equal(subscription.dispose(), joined);
+    assert.equal(subscription.dispose(), joined);
+    const disposal = joined.then(() => {
+      disposalResolved = true;
+    });
+    assert.equal(callbackContext.signal.aborted, true);
+    await delay(50);
+    assert.equal(
+      disposalResolved,
+      false,
+      "disposal resolved before the pending callback completed",
+    );
+    completionRelease.resolve();
+    await disposal;
+    assert.equal(callbackCompleted, true);
+    assert.equal(subscription.stats().disposed, true);
+    assert.equal(subscription.dispose(), joined);
+    const callsAtDispose = callbackCalls;
+    fs.writeFileSync(path.join(root, "after-disposal.txt"), "after");
+    await delay(75);
+    assert.equal(callbackCalls, callsAtDispose);
+    return {
+      concurrentCallsSharedPromise: true,
+      repeatedCallSharedPromise: true,
+      callbackSignalAborted: callbackContext.signal.aborted,
+      disposalJoinedPendingCallback: true,
+      callbackCompletedBeforeResolution: callbackCompleted,
+      callbacksAfterResolution: callbackCalls - callsAtDispose,
+    };
+  } finally {
+    await releaseCallbackGateAndJoinDisposal(
+      () => completionRelease.resolve(),
+      subscription,
+    );
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+async function checkContextStop(engine) {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), "watchbound-installed-stop-"),
+  );
+  let calls = 0;
+  let callbackContext;
+  let subscription;
+  try {
+    subscription = await engine.subscribe(
+      root,
+      (_batch, context) => {
+        calls += 1;
+        callbackContext = context;
+        context.stop();
+        context.stop();
+      },
+      { batchWindowMs: 5 },
+    );
+    fs.writeFileSync(path.join(root, "changed.txt"), "change");
+    await waitFor(
+      () => subscription.stats().disposed,
+      "context.stop() did not dispose the subscription",
+    );
+    assert.equal(callbackContext.signal.aborted, true);
+    await subscription.dispose();
+    fs.writeFileSync(path.join(root, "after-stop.txt"), "after");
+    await delay(75);
+    assert.equal(calls, 1, "a callback started after context.stop() disposal");
+    return {
+      stopIdempotent: true,
+      signalAborted: callbackContext.signal.aborted,
+      callbackCount: calls,
+      callbacksAfterStop: 0,
+    };
+  } finally {
+    await subscription?.dispose();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function processResources() {
+  const tasks = fs.readdirSync("/proc/self/task")
+    .filter((entry) => /^\d+$/u.test(entry));
+  const watchboundThreads = tasks.filter((entry) => {
+    try {
+      return fs.readFileSync(`/proc/self/task/${entry}/comm`, "utf8")
+        .trim()
+        .startsWith("watchbound-");
+    } catch {
+      return false;
+    }
+  }).length;
+  const descriptors = fs.readdirSync("/proc/self/fd")
+    .filter((entry) => /^\d+$/u.test(entry));
+  const inotifyDescriptors = descriptors.filter((entry) => {
+    try {
+      return fs.readlinkSync(`/proc/self/fd/${entry}`) === "anon_inode:inotify";
+    } catch {
+      return false;
+    }
+  }).length;
+  return {
+    fileDescriptors: descriptors.length,
+    tasks: tasks.length,
+    watchboundThreads,
+    inotifyDescriptors,
+  };
+}
+
+async function checkEstablishmentCancellation(engine) {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), "watchbound-installed-establishment-cancel-"),
+  );
+  let listener;
+  const signal = {
+    aborted: false,
+    addEventListener(type, callback) {
+      assert.equal(type, "abort");
+      listener = callback;
+      this.aborted = true;
+      callback();
+    },
+    removeEventListener(type, callback) {
+      assert.equal(type, "abort");
+      assert.equal(callback, listener);
+    },
+  };
+  try {
+    await assert.rejects(
+      engine.subscribe(root, () => {}, { signal }),
+      (error) => {
+        assert.equal(error?.code, "WATCHBOUND_OPERATION_CANCELLED");
+        assert.equal(error?.operation, "subscribe");
+        return true;
+      },
+    );
+    assert.equal(signal.aborted, true);
+    return {
+      provisionalNativeCancellation: true,
+      errorCode: "WATCHBOUND_OPERATION_CANCELLED",
+      operation: "subscribe",
+    };
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+async function waitFor(predicate, message) {
+  await waitForInstalledSmokeCondition(predicate, message, {
+    timeoutMs: waitTimeoutMs,
+    onDeadline: reportSemanticDeadline,
+  });
+}
+
+function reportSemanticDeadline(message, timeoutMs) {
+  process.stderr.write(
+    `WATCHBOUND_INSTALLED_SMOKE_SEMANTIC_DEADLINE=${JSON.stringify({
+      elapsedMs: Date.now() - smokeStartedAt,
+      route: options.route,
+      timeoutMs,
+      message,
+    })}\n`,
+  );
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function parseOptions(args) {
+  const parsed = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      throw new Error(
+        "usage: check-signed-runtime.mjs --project <path> --wrapper <name> --package-version <version> --native-sha256 <digest> --route <route> [--native-target <id>] [--wrapper-path <path>] [--evidence <path>] [--wait-timeout-ms <milliseconds>]",
+      );
+    }
+    parsed[flag.slice(2)] = value;
+  }
+  for (const required of [
+    "project",
+    "wrapper",
+    "package-version",
+    "native-sha256",
+    "route",
+  ]) {
+    assert.ok(parsed[required], `--${required} is required`);
+  }
+  assert.match(parsed["native-sha256"], /^[0-9a-f]{64}$/u);
+  return parsed;
+}
+
+function readJson(source) {
+  return JSON.parse(fs.readFileSync(source, "utf8"));
+}
+
+function sha256(source) {
+  return crypto
+    .createHash("sha256")
+    .update(fs.readFileSync(source))
+    .digest("hex");
+}
+
+function deepEqual(left, right) {
+  try {
+    assert.deepEqual(left, right);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function bigintReplacer(_key, value) {
+  if (typeof value === "bigint") return `${value}n`;
+  if (value instanceof Uint8Array) return { type: "Uint8Array", hex: Buffer.from(value).toString("hex") };
+  return value;
+}
+
+function serializeCause(cause) {
+  if (cause === undefined) return null;
+  if (cause === null || typeof cause !== "object") return String(cause);
+  return {
+    name: cause.name ?? null,
+    code: cause.code ?? null,
+    message: cause.message ?? String(cause),
+    domain: cause.domain ?? null,
+    kind: cause.kind ?? null,
+  };
+}

--- a/linux-features/directory-only-working-tree-watch/patch.js
+++ b/linux-features/directory-only-working-tree-watch/patch.js
@@ -103,10 +103,10 @@ const PARCEL_FALLBACK_SYMBOL_KEY =
   "codex-linux.directory-only-working-tree-watch.parcel-fallback";
 const QUALIFICATION_WARNINGS_SYMBOL_KEY =
   "codex-linux.directory-only-working-tree-watch.qualification-warnings";
-const REPORT_SHIM_SYMBOL_KEY =
-  "codex-linux.directory-only-working-tree-watch.process-report-shim";
+const ESTABLISHMENT_LOGGED_SYMBOL_KEY =
+  "codex-linux.directory-only-working-tree-watch.establishment-logged";
 const WATCHBOUND_RESULT_NAME = "codexLinuxWatchboundWatcher";
-const WATCHBOUND_VERSION = "2.1.1";
+const WATCHBOUND_VERSION = "2.1.2";
 const DEFAULT_MAX_WATCHES = 8192;
 const DEFAULT_IGNORED_DIRECTORY_NAMES = [];
 const IDENTIFIER_PATTERN = "[A-Za-z_$][\\w$]*";
@@ -194,122 +194,44 @@ function codexLinuxStartDirectoryOnlyWorkingTreeWatch(
     const RETRY_MAX_MS = 30_000;
     const QUALIFICATION_WARNINGS_SYMBOL_KEY =
       "codex-linux.directory-only-working-tree-watch.qualification-warnings";
-    const WATCHBOUND_VERSION = "2.1.1";
+    const ESTABLISHMENT_LOGGED_SYMBOL_KEY =
+      "codex-linux.directory-only-working-tree-watch.establishment-logged";
+    const WATCHBOUND_VERSION = "2.1.2";
     const moduleOverrideKey = Symbol.for(
       "codex-linux.directory-only-working-tree-watch.test-module",
     );
     const moduleOverride = globalThis[moduleOverrideKey];
-    // process.report.getReport() dies in a fatal CHECK trap inside the official
-    // Electron binary (SIGILL; the openai/codex#38123 crash class), and both
-    // watchbound/capabilities.js and @gadicc/watchbound-node/load-native.cjs
-    // call it for libc detection. Replace it with the same facts from probes
-    // that stay in JavaScript before any Watchbound code can run. Probe order
-    // and matchers follow detect-libc (Apache-2.0, Lovell Fuller and others).
-    const reportShimMarker = Symbol.for(
-      "codex-linux.directory-only-working-tree-watch.process-report-shim",
-    );
-    if (process.report?.[reportShimMarker] !== true) {
-      const elfInterpreterPath = (image) => {
-        if (image.length < 64 || image.readUInt32LE(0) !== 0x464c457f) return null;
-        if (image[4] !== 2 || image[5] !== 1) return null;
-        const tableOffset = Number(image.readBigUInt64LE(32));
-        const entrySize = image.readUInt16LE(54);
-        const entryCount = image.readUInt16LE(56);
-        if (entrySize < 56) return null;
-        for (let index = 0; index < entryCount; index += 1) {
-          const entry = tableOffset + index * entrySize;
-          if (entry + 40 > image.length) break;
-          if (image.readUInt32LE(entry) !== 3) continue;
-          const interpOffset = Number(image.readBigUInt64LE(entry + 8));
-          const interpSize = Number(image.readBigUInt64LE(entry + 32));
-          if (interpSize < 2 || interpOffset + interpSize > image.length) return null;
-          const segment = image.subarray(interpOffset, interpOffset + interpSize);
-          const terminator = segment.indexOf(0);
-          return segment.toString("utf8", 0, terminator === -1 ? segment.length : terminator);
-        }
-        return null;
-      };
-      const readLeadingBytes = (filePath, length) => {
-        const descriptor = fs.openSync(filePath, "r");
-        try {
-          const buffer = Buffer.alloc(length);
-          return buffer.subarray(0, fs.readSync(descriptor, buffer, 0, length, 0));
-        } finally {
-          fs.closeSync(descriptor);
-        }
-      };
-      const probeExecutable =
-        moduleOverride != null && typeof moduleOverride.reportProbeExecutable === "string"
-          ? moduleOverride.reportProbeExecutable
-          : "/proc/self/exe";
-      let family = null;
-      let glibcVersion = null;
-      let interpreter = null;
-      try {
-        interpreter = elfInterpreterPath(readLeadingBytes(probeExecutable, 4096));
-        if (interpreter?.includes("/ld-musl-")) {
-          family = "musl";
-        } else if (interpreter?.includes("/ld-linux-")) {
-          family = "glibc";
-          // Closure-only Nix launches have no /usr/bin/ldd and no getconf on
-          // PATH, but the store path in PT_INTERP names the exact glibc.
-          glibcVersion = interpreter.match(/-glibc-(\d+\.\d+(?:\.\d+)?)/u)?.[1] ?? null;
-        }
-      } catch {}
-      try {
-        const ldd = fs.readFileSync("/usr/bin/ldd", "latin1");
-        if (family == null) {
-          if (ldd.includes("musl")) family = "musl";
-          else if (ldd.includes("GNU C Library")) family = "glibc";
-        }
-        if (family === "glibc" && glibcVersion == null) {
-          glibcVersion = ldd.match(/LIBC[a-z0-9 \-).]*?(\d+\.\d+)/iu)?.[1] ?? null;
-        }
-      } catch {}
-      if (family === "glibc" && glibcVersion == null) {
-        try {
-          glibcVersion = childProcess
-            .execFileSync("getconf", ["GNU_LIBC_VERSION"], {
-              encoding: "utf8",
-              timeout: 1000,
-              stdio: ["ignore", "pipe", "ignore"],
-            })
-            .match(/(\d+\.\d+(?:\.\d+)?)/u)?.[1] ?? null;
-        } catch {}
-      }
-      const reportHeader = family === "glibc" && glibcVersion != null
-        ? { glibcVersionRuntime: glibcVersion }
-        : {};
-      const reportSharedObjects = family === "musl" && interpreter != null
-        ? [interpreter]
-        : [];
-      // The native report object stays as the prototype so every other
-      // member keeps its accessor-backed behavior; only getReport is shadowed.
-      Object.defineProperty(process, "report", {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-        value: Object.create(process.report ?? null, {
-          [reportShimMarker]: { value: true },
-          getReport: {
-            configurable: true,
-            enumerable: true,
-            writable: true,
-            value: () => ({
-              header: { ...reportHeader },
-              sharedObjects: [...reportSharedObjects],
-            }),
-          },
-        }),
-      });
-    }
     let watchbound = moduleOverride;
     if (watchbound == null) {
       try {
         watchbound = await import("watchbound");
-      } catch {
-        // A refused loader (unsupported libc, missing package) must degrade to
-        // the preserved route, not reject the caller's file watch.
+      } catch (error) {
+        const runtimeRefusalCodes = new Set([
+          "WATCHBOUND_UNSUPPORTED_PLATFORM",
+          "WATCHBOUND_UNSUPPORTED_LIBC",
+          "WATCHBOUND_UNSUPPORTED_KERNEL",
+          "WATCHBOUND_UNSUPPORTED_NODE",
+          "WATCHBOUND_UNSUPPORTED_NODE_API",
+        ]);
+        if (!runtimeRefusalCodes.has(error?.code)) throw error;
+        // A supported loader refusal preserves the upstream route. Missing,
+        // corrupt, or API-incompatible enabled packages are packaging defects
+        // and must remain visible instead of silently selecting Parcel.
+        const warningStateKey = Symbol.for(QUALIFICATION_WARNINGS_SYMBOL_KEY);
+        const warningState = globalThis[warningStateKey] ??= new Set();
+        const fallbackName = typeof fallback === "function"
+          ? "upstream Parcel watcher"
+          : "upstream file watcher";
+        const message = error?.message ?? String(error);
+        const signature = `runtime\0${error.code}\0${message}\0${fallbackName}`;
+        if (!warningState.has(signature)) {
+          if (warningState.size >= 256) warningState.clear();
+          warningState.add(signature);
+          console.warn(
+            `WARN: directory-only working-tree watch runtime rejected Watchbound ` +
+              `${WATCHBOUND_VERSION} (${error.code}: ${message}); using the ${fallbackName}.`,
+          );
+        }
         return typeof fallback === "function" ? fallback() : null;
       }
     }
@@ -1461,6 +1383,25 @@ function codexLinuxStartDirectoryOnlyWorkingTreeWatch(
       scheduleRootRecovery();
     }
 
+    const establishmentLoggedKey = Symbol.for(ESTABLISHMENT_LOGGED_SYMBOL_KEY);
+    let establishmentLoggedRoots = globalThis[establishmentLoggedKey];
+    if (!(establishmentLoggedRoots instanceof Set)) {
+      establishmentLoggedRoots = new Set();
+      globalThis[establishmentLoggedKey] = establishmentLoggedRoots;
+    }
+    if (!establishmentLoggedRoots.has(root)) {
+      establishmentLoggedRoots.add(root);
+      const runtime = engine.runtimeStats();
+      const target = typeof qualification?.target?.packagedTargetId === "string"
+        ? qualification.target.packagedTargetId
+        : "unknown";
+      console.info(
+        `INFO: directory-only working-tree watch established with Watchbound ` +
+          `${WATCHBOUND_VERSION} for ${root} ` +
+          `(target=${target}, native=${runtime.nativeWatches}, limit=${requestedLimit}).`,
+      );
+    }
+
     return {
       // Watchbound is recursive for included paths. Reporting partial recursive
       // coverage deliberately preserves Codex's existing focus recovery.
@@ -1757,7 +1698,7 @@ function currentContractReason(records, bundleCount) {
   );
   const branches = relevant.reduce((count, record) => count + record.branchCallCount, 0);
   return (
-    "Current 26.803.41515 working-tree contract rejected: " +
+    "Current 26.814.41957 working-tree contract rejected: " +
     `Found ${relevant.length} current local startFileWatch bundles ` +
     `(${targetNames.join(", ") || "none"}), ${parcelContractCount} Parcel route contracts, ` +
     `and ${workerParcelContractCount} in worker.js across ${bundleCount} build bundles; ` +
@@ -2013,13 +1954,13 @@ const descriptors = [
 module.exports = {
   DEFAULT_IGNORED_DIRECTORY_NAMES,
   DEFAULT_MAX_WATCHES,
+  ESTABLISHMENT_LOGGED_SYMBOL_KEY,
   HELPER_NAME,
   LOCAL_FILE_WATCH_METHOD,
   PARCEL_FALLBACK_SYMBOL_KEY,
   PARCEL_WATCH_MARKER,
   PARCEL_WORKING_TREE_WATCH,
   QUALIFICATION_WARNINGS_SYMBOL_KEY,
-  REPORT_SHIM_SYMBOL_KEY,
   WATCHBOUND_VERSION,
   codexLinuxStartDirectoryOnlyWorkingTreeWatch,
   descriptors,

--- a/linux-features/directory-only-working-tree-watch/test.js
+++ b/linux-features/directory-only-working-tree-watch/test.js
@@ -20,12 +20,12 @@ const {
 
 const {
   DEFAULT_MAX_WATCHES,
+  ESTABLISHMENT_LOGGED_SYMBOL_KEY,
   HELPER_NAME,
   PARCEL_FALLBACK_SYMBOL_KEY,
   PARCEL_WATCH_MARKER,
   PARCEL_WORKING_TREE_WATCH,
   QUALIFICATION_WARNINGS_SYMBOL_KEY,
-  REPORT_SHIM_SYMBOL_KEY,
   WATCHBOUND_VERSION,
   codexLinuxStartDirectoryOnlyWorkingTreeWatch,
   descriptors,
@@ -36,7 +36,6 @@ const {
 } = require("./patch.js");
 const {
   commitPackageDirectoryNoReplace,
-  currentArtifactManifest,
   packageHelperExitCode,
   packageTarget,
   stageWatchboundPackages,
@@ -45,18 +44,6 @@ const {
   verifyControlledPackageRoot,
 } = require("./watchbound-package.js");
 
-test("Nix Node 24.14 compatibility keeps a separate exact loader hash", () => {
-  const original = process.env.CODEX_WATCHBOUND_NIX_NODE_24_14;
-  delete process.env.CODEX_WATCHBOUND_NIX_NODE_24_14;
-  const upstreamHash = currentArtifactManifest().packages.loader.files["native-matrix.json"];
-  process.env.CODEX_WATCHBOUND_NIX_NODE_24_14 = "1";
-  const nixHash = currentArtifactManifest().packages.loader.files["native-matrix.json"];
-  if (original === undefined) delete process.env.CODEX_WATCHBOUND_NIX_NODE_24_14;
-  else process.env.CODEX_WATCHBOUND_NIX_NODE_24_14 = original;
-  assert.equal(upstreamHash, "4f63e441d5fc05a80ede19d32aefc9c6b4b3309a28e3c225078224099ad07769");
-  assert.equal(nixHash, "8ea0c8101cc7d0f97a5d988ce30240914a1ae5fecce7f6c4d02a7b80359e6cf4");
-});
-
 const MODULE_OVERRIDE_KEY = Symbol.for(
   "codex-linux.directory-only-working-tree-watch.test-module",
 );
@@ -64,6 +51,7 @@ const ENGINE_KEY = Symbol.for(
   "codex-linux.directory-only-working-tree-watch.watchbound-engine",
 );
 const QUALIFICATION_WARNINGS_KEY = Symbol.for(QUALIFICATION_WARNINGS_SYMBOL_KEY);
+const ESTABLISHMENT_LOGGED_KEY = Symbol.for(ESTABLISHMENT_LOGGED_SYMBOL_KEY);
 
 function tempDirectory(t, prefix) {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -99,7 +87,7 @@ function currentBundleFixture() {
   ].join("");
 }
 
-// Exact relevant fragments from OpenAI Desktop 26.803.41515. Keep these
+// Exact relevant fragments from OpenAI Desktop 26.814.41957. Keep these
 // independent of patch.js so drift in the production contract cannot silently
 // rewrite the test fixture into a passing shape.
 const CURRENT_WORKER_LOCAL_FILE_WATCH = [
@@ -273,6 +261,8 @@ test("the worker patch injects one Watchbound adapter and is idempotent", () => 
     first.source,
     /defaultQualificationRetryDelays = \[250, 500, 1000, 2000\]/u,
   );
+  assert.match(first.source, /runtime rejected Watchbound/u);
+  assert.match(first.source, /established with Watchbound/u);
   assert.match(first.source, /"maxWatches":4096/u);
   assert.match(first.source, /"ignoredDirectoryNames":\["node_modules"\]/u);
 
@@ -285,7 +275,7 @@ test("the worker patch injects one Watchbound adapter and is idempotent", () => 
     settings,
   );
   assert.equal(legacy.matched, 0);
-  assert.match(legacy.reason, /current 26\.803\.41515 working-tree contract rejected/iu);
+  assert.match(legacy.reason, /current 26\.814\.41957 working-tree contract rejected/iu);
 });
 
 test("the current OpenAI Parcel route hands the working tree to the Watchbound host", () => {
@@ -369,7 +359,7 @@ test("feature patch reports drift instead of patching an ambiguous bundle", () =
 
   assert.equal(result.matched, 0);
   assert.equal(result.changed, 0);
-  assert.match(result.reason, /current 26\.803\.41515 working-tree contract rejected/iu);
+  assert.match(result.reason, /current 26\.814\.41957 working-tree contract rejected/iu);
   const descriptor = descriptors.find(({ id }) => id === "worker-directory-watch");
   assert.equal(descriptor.status(result, []).status, "skipped-optional");
 });
@@ -524,7 +514,7 @@ test("bundle discovery rejects copies outside the current src and worker pair", 
   assert.match(result.reason, /Found 3 current local startFileWatch bundles/u);
 });
 
-test("patches the pristine 26.803.41515 bundle contract and accepts only its exact completed state", (t) => {
+test("patches the pristine 26.814.41957 bundle contract and accepts only its exact completed state", (t) => {
   const candidate = currentBundlePair(t, {
     extra: { "unrelated.js": "const unrelatedWatch=host.startFileWatch(options);" },
   });
@@ -562,7 +552,7 @@ test("patches the pristine 26.803.41515 bundle contract and accepts only its exa
   assert.deepEqual(readBundlePair(candidate), completed);
 });
 
-test("rejects markers outside the exact 26.803.41515 Watchbound handoff", (t) => {
+test("rejects markers outside the exact 26.814.41957 Watchbound handoff", (t) => {
   const unmarkedHandoff = CURRENT_WATCHBOUND_ROUTE.replace(
     `/*${PARCEL_WATCH_MARKER}*/`,
     "",
@@ -1049,7 +1039,7 @@ test("reports failed-integrity when rollback cannot prove original current bundl
 });
 
 test("feature descriptors stage Watchbound before patching the worker", () => {
-  assert.equal(WATCHBOUND_VERSION, "2.1.1");
+  assert.equal(WATCHBOUND_VERSION, "2.1.2");
   assert.deepEqual(
     descriptors.map(({ id, phase, order, ciPolicy }) => ({
       id,
@@ -1145,7 +1135,7 @@ function createPackageFixture(t, name, version, files, metadataOverrides = {}) {
     name,
     version,
     license: "MIT",
-    engines: { node: ">=24.15.0 <25" },
+    engines: { node: ">=18.15.0" },
     watchbound: { delivery: "bundled-native-package" },
     ...metadataOverrides,
   };
@@ -1170,7 +1160,7 @@ const QUALIFIED_ELECTRON_VERSION = "42.3.0";
 function writeExtractedAppRuntime(extractedDir, electron = QUALIFIED_ELECTRON_VERSION) {
   writeJson(path.join(extractedDir, "package.json"), {
     name: "openai-codex-electron",
-    version: "26.803.41515",
+    version: "26.814.41957",
     devDependencies: { electron },
   });
 }
@@ -1260,7 +1250,7 @@ function packageFixtureManifest(t) {
       runtime: {
         electron: QUALIFIED_ELECTRON_VERSION,
         node: "24.15.0",
-        nodeRange: ">=24.15.0 <25",
+        nodeRange: ">=18.15.0",
       },
       packages: {
         wrapper: artifact("wrapper", "watchbound", wrapper),
@@ -1307,7 +1297,7 @@ function packageFixtureManifest(t) {
   };
 }
 
-test("the shipped artifact manifest pins the 2.1.1 source and four packages", () => {
+test("the shipped artifact manifest pins the 2.1.2 source and four packages", () => {
   const manifest = JSON.parse(
     fs.readFileSync(path.join(__dirname, "watchbound-artifacts.json"), "utf8"),
   );
@@ -1315,8 +1305,8 @@ test("the shipped artifact manifest pins the 2.1.1 source and four packages", ()
   assert.equal(manifest.version, WATCHBOUND_VERSION);
   assert.deepEqual(manifest.runtime, {
     electron: QUALIFIED_ELECTRON_VERSION,
-    node: "24.15.0",
-    nodeRange: ">=24.15.0 <25",
+    node: "24.14.0",
+    nodeRange: ">=18.15.0",
   });
   assert.equal(manifest.source.revision.length, 40);
   assert.equal(manifest.packages.wrapper.name, "watchbound");
@@ -1374,13 +1364,24 @@ test("Watchbound staging uses pinned runtime metadata without executing Electron
     qualification: "pinned-artifact-manifest",
   });
 
-  await assert.rejects(
-    stageWatchboundPackages(packageStageOptions(extractedDir, fixture, {
-      arch: "x64",
-      targetNodeVersion: "24.14.0",
-      materializePackage,
-    })),
-    /qualified for Electron 42\.3\.0 \/ Node\.js 24\.15\.0, got Node\.js 24\.14\.0/u,
+  assert.deepEqual(validateTargetRuntime(
+    extractedDir,
+    fixture.manifest,
+    QUALIFIED_ELECTRON_VERSION,
+    "24.14.0",
+  ), {
+    electron: QUALIFIED_ELECTRON_VERSION,
+    node: "24.14.0",
+    qualification: "pinned-artifact-manifest",
+  });
+  assert.throws(
+    () => validateTargetRuntime(
+      extractedDir,
+      fixture.manifest,
+      QUALIFIED_ELECTRON_VERSION,
+      "18.14.0",
+    ),
+    /requires Node\.js >=18\.15\.0, got Node\.js 18\.14\.0/u,
   );
   assert.equal(materializations, 0);
   assert.equal(fs.existsSync(path.join(extractedDir, "node_modules")), false);
@@ -1411,7 +1412,7 @@ test("Watchbound staging uses pinned runtime metadata without executing Electron
   assert.equal(materializations, 3);
 
   const unsupportedNodeManifest = structuredClone(fixture.manifest);
-  unsupportedNodeManifest.runtime.node = "24.14.0";
+  unsupportedNodeManifest.runtime.node = "18.14.0";
   assert.throws(
     () => validateArtifactManifest(unsupportedNodeManifest),
     /target runtime contract is invalid/u,
@@ -3258,6 +3259,12 @@ function fakeWatchbound(hooks = {}) {
         schemaVersion: 1,
         state: "qualified",
         reasons: [],
+        target: {
+          state: "qualified",
+          packagedTargetId: "linux-x64-gnu",
+          runtimeMatchesPackagedTarget: true,
+          qualification: "supported",
+        },
         root: {
           lexicalPath: root,
           lexicalPathBytes: Buffer.from(root),
@@ -3289,10 +3296,8 @@ async function waitFor(predicate, label, timeout = 3000) {
   assert.ok(predicate(), `timed out waiting for ${label}`);
 }
 
-test("the adapter fails closed on every Watchbound 2.1.1 contract mismatch", async (t) => {
-  const originalReport = Object.getOwnPropertyDescriptor(process, "report");
+test("the adapter fails closed on every Watchbound 2.1.2 contract mismatch", async (t) => {
   t.after(() => {
-    Object.defineProperty(process, "report", originalReport);
     delete globalThis[MODULE_OVERRIDE_KEY];
     delete globalThis[ENGINE_KEY];
   });
@@ -3350,25 +3355,26 @@ test("the adapter fails closed on every Watchbound 2.1.1 contract mismatch", asy
           ignoredDirectoryNames: [],
         },
       ),
-      /requires watchbound 2\.1\.1.*native exclusions/iu,
+      /requires watchbound 2\.1\.2.*native exclusions/iu,
       label,
     );
     assert.equal(fake.subscriptions.length, 0);
   }
 });
 
-test("the adapter replaces process.report before any Watchbound code runs", async (t) => {
+test("the adapter does not call or replace process.report", async (t) => {
   const originalReport = Object.getOwnPropertyDescriptor(process, "report");
   let poisonedCalls = 0;
+  const poisonedReport = {
+    getReport() {
+      poisonedCalls += 1;
+      throw new Error("getReport is fatal inside the packaged Electron binary");
+    },
+  };
   Object.defineProperty(process, "report", {
     configurable: true,
     enumerable: true,
-    value: {
-      getReport() {
-        poisonedCalls += 1;
-        throw new Error("getReport is fatal inside the packaged Electron binary");
-      },
-    },
+    value: poisonedReport,
   });
   const fake = fakeWatchbound();
   fake.capabilities.schemaVersion = 0;
@@ -3397,65 +3403,37 @@ test("the adapter replaces process.report before any Watchbound code runs", asyn
       ignoredDirectoryNames: [],
     },
   );
-  await assert.rejects(start(), /requires watchbound 2\.1\.1/u);
+  await assert.rejects(start(), /requires watchbound 2\.1\.2/u);
 
   assert.equal(poisonedCalls, 0);
-  const shim = process.report;
-  assert.equal(shim[Symbol.for(REPORT_SHIM_SYMBOL_KEY)], true);
-  const report = shim.getReport();
-  assert.equal(typeof report.header, "object");
-  assert.ok(Array.isArray(report.sharedObjects));
-  let expectGlibc = false;
-  try {
-    expectGlibc = fs.readFileSync("/usr/bin/ldd", "latin1").includes("GNU C Library");
-  } catch {}
-  if (expectGlibc) {
-    assert.match(report.header.glibcVersionRuntime, /^\d+\.\d+/u);
-  }
+  assert.equal(process.report, poisonedReport);
 
-  await assert.rejects(start(), /requires watchbound 2\.1\.1/u);
-  assert.equal(process.report, shim);
+  await assert.rejects(start(), /requires watchbound 2\.1\.2/u);
+  assert.equal(process.report, poisonedReport);
 });
 
-test("the report shim reads the glibc version from a Nix store interpreter", async (t) => {
-  const interpreterPath =
-    "/nix/store/6q3xi2h1a7lb0k5cm9dr8v4y5zj0wf2s-glibc-2.40-66/lib64/ld-linux-x86-64.so.2";
-  const interpreterBytes = Buffer.from(`${interpreterPath}\0`, "utf8");
-  const image = Buffer.alloc(512);
-  image.writeUInt32LE(0x464c457f, 0);
-  image[4] = 2;
-  image[5] = 1;
-  image.writeBigUInt64LE(64n, 32);
-  image.writeUInt16LE(56, 54);
-  image.writeUInt16LE(1, 56);
-  image.writeUInt32LE(3, 64);
-  image.writeBigUInt64LE(256n, 64 + 8);
-  image.writeBigUInt64LE(BigInt(interpreterBytes.length), 64 + 32);
-  interpreterBytes.copy(image, 256);
-  const executable = path.join(tempDirectory(t, "watchbound-nix-elf-"), "electron");
-  fs.writeFileSync(executable, image);
-
+test("a missing enabled Watchbound package fails instead of silently using Parcel", async (t) => {
   const originalReport = Object.getOwnPropertyDescriptor(process, "report");
+  let poisonedCalls = 0;
+  const poisonedReport = {
+    getReport() {
+      poisonedCalls += 1;
+      throw new Error("getReport is fatal inside the packaged Electron binary");
+    },
+  };
   Object.defineProperty(process, "report", {
     configurable: true,
     enumerable: true,
-    value: {
-      getReport() {
-        throw new Error("getReport is fatal inside the packaged Electron binary");
-      },
-    },
+    value: poisonedReport,
   });
-  const fake = fakeWatchbound();
-  fake.capabilities.schemaVersion = 0;
-  fake.reportProbeExecutable = executable;
-  globalThis[MODULE_OVERRIDE_KEY] = fake;
+  delete globalThis[MODULE_OVERRIDE_KEY];
   delete globalThis[ENGINE_KEY];
   t.after(() => {
-    delete globalThis[MODULE_OVERRIDE_KEY];
-    delete globalThis[ENGINE_KEY];
     Object.defineProperty(process, "report", originalReport);
   });
 
+  let fallbackCalls = 0;
+  const preserved = { dispose() {} };
   await assert.rejects(
     codexLinuxStartDirectoryOnlyWorkingTreeWatch(
       {
@@ -3473,62 +3451,72 @@ test("the report shim reads the glibc version from a Nix store interpreter", asy
         honorGitIgnore: false,
         ignoredDirectoryNames: [],
       },
+      () => {
+        fallbackCalls += 1;
+        return preserved;
+      },
     ),
-    /requires watchbound 2\.1\.1/u,
+    (error) => error?.code === "ERR_MODULE_NOT_FOUND",
   );
 
-  const report = process.report.getReport();
-  assert.equal(report.header.glibcVersionRuntime, "2.40");
-  assert.deepEqual(report.sharedObjects, []);
+  assert.equal(fallbackCalls, 0);
+  assert.equal(poisonedCalls, 0);
+  assert.equal(process.report, poisonedReport);
 });
 
-test("a failed Watchbound import degrades to the preserved fallback", async (t) => {
-  const originalReport = Object.getOwnPropertyDescriptor(process, "report");
-  let poisonedCalls = 0;
-  Object.defineProperty(process, "report", {
-    configurable: true,
-    enumerable: true,
-    value: {
-      getReport() {
-        poisonedCalls += 1;
-        throw new Error("getReport is fatal inside the packaged Electron binary");
-      },
-    },
-  });
-  delete globalThis[MODULE_OVERRIDE_KEY];
-  delete globalThis[ENGINE_KEY];
+test("bounded Watchbound runtime refusals log once and preserve the Parcel fallback", async (t) => {
+  const source = codexLinuxStartDirectoryOnlyWorkingTreeWatch.toString();
+  const importExpression = 'await import("watchbound")';
+  assert.equal(source.split(importExpression).length - 1, 1);
+
+  const codes = [
+    "WATCHBOUND_UNSUPPORTED_PLATFORM",
+    "WATCHBOUND_UNSUPPORTED_LIBC",
+    "WATCHBOUND_UNSUPPORTED_KERNEL",
+    "WATCHBOUND_UNSUPPORTED_NODE",
+    "WATCHBOUND_UNSUPPORTED_NODE_API",
+  ];
+  delete globalThis[QUALIFICATION_WARNINGS_KEY];
   t.after(() => {
-    Object.defineProperty(process, "report", originalReport);
+    delete globalThis[QUALIFICATION_WARNINGS_KEY];
   });
-
-  let fallbackCalls = 0;
-  const preserved = { dispose() {} };
-  const result = await codexLinuxStartDirectoryOnlyWorkingTreeWatch(
-    {
-      getFileSystemPath: () => "/qualified/root",
-      platformPath: async () => path.posix,
-    },
-    {
-      path: "/logical/root",
-      recursive: true,
-      renameEventHandling: "changed-path-with-parent-directory",
-      onChange() {},
-    },
-    {
-      maxWatches: 64,
-      honorGitIgnore: false,
-      ignoredDirectoryNames: [],
-    },
-    () => {
-      fallbackCalls += 1;
-      return preserved;
-    },
-  );
-
-  assert.equal(fallbackCalls, 1);
-  assert.equal(result, preserved);
-  assert.equal(poisonedCalls, 0);
-  assert.equal(process.report[Symbol.for(REPORT_SHIM_SYMBOL_KEY)], true);
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.map(String).join(" "));
+  try {
+    for (const code of codes) {
+      const refusingAdapter = Function(
+        "require",
+        `return (${source.replace(
+          importExpression,
+          `await Promise.reject(Object.assign(new Error("runtime refused"), { code: ${JSON.stringify(code)} }))`,
+        )});`,
+      )(require);
+      const preserved = { code };
+      let fallbackCalls = 0;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const result = await refusingAdapter({}, {}, {}, () => {
+          fallbackCalls += 1;
+          return preserved;
+        });
+        assert.equal(result, preserved);
+      }
+      assert.equal(fallbackCalls, 2);
+    }
+  } finally {
+    console.warn = originalWarn;
+  }
+  assert.equal(warnings.length, codes.length);
+  for (const code of codes) {
+    assert.equal(
+      warnings.filter((warning) => warning.includes(`(${code}: runtime refused)`)).length,
+      1,
+    );
+  }
+  assert.ok(warnings.every((warning) => (
+    warning.includes("runtime rejected Watchbound 2.1.2") &&
+    warning.includes("using the upstream Parcel watcher")
+  )));
 });
 
 test("the adapter preserves Codex policy around the Watchbound engine", async (t) => {
@@ -3941,44 +3929,72 @@ test("the adapter maps a symlinked workspace from Watchbound's physical namespac
   await watcher.dispose();
 });
 
-test("a qualified root uses Watchbound and disposes without invoking Parcel", async (t) => {
+test("qualified roots use Watchbound, log once per physical root, and dispose without Parcel", async (t) => {
   const root = tempDirectory(t, "watchbound-qualified-route-");
+  const rootAlias = `${root}-alias`;
+  const secondRoot = tempDirectory(t, "watchbound-second-qualified-route-");
+  fs.symlinkSync(root, rootAlias);
+  t.after(() => fs.rmSync(rootAlias, { force: true }));
   const fake = fakeWatchbound();
   globalThis[MODULE_OVERRIDE_KEY] = fake;
   delete globalThis[ENGINE_KEY];
   delete globalThis[QUALIFICATION_WARNINGS_KEY];
+  delete globalThis[ESTABLISHMENT_LOGGED_KEY];
   t.after(() => {
     delete globalThis[MODULE_OVERRIDE_KEY];
     delete globalThis[ENGINE_KEY];
     delete globalThis[QUALIFICATION_WARNINGS_KEY];
+    delete globalThis[ESTABLISHMENT_LOGGED_KEY];
   });
   let fallbackCalls = 0;
-  const watcher = await codexLinuxStartDirectoryOnlyWorkingTreeWatch(
-    {
-      getFileSystemPath: () => root,
-      platformPath: async () => path.posix,
-    },
-    {
-      path: "/logical/qualified",
-      recursive: true,
-      renameEventHandling: "changed-path-with-parent-directory",
-      onChange() {},
-    },
-    {
-      maxWatches: 64,
-      honorGitIgnore: false,
-      ignoredDirectoryNames: [],
-    },
-    () => {
-      fallbackCalls += 1;
-      throw new Error("qualified roots must not use Parcel");
-    },
-  );
+  const messages = [];
+  const originalInfo = console.info;
+  console.info = (...args) => messages.push(args.map(String).join(" "));
+  let watchers;
+  try {
+    watchers = [];
+    for (const currentRoot of [root, rootAlias, secondRoot]) {
+      watchers.push(await codexLinuxStartDirectoryOnlyWorkingTreeWatch(
+        {
+          getFileSystemPath: () => currentRoot,
+          platformPath: async () => path.posix,
+        },
+        {
+          path: "/logical/qualified",
+          recursive: true,
+          renameEventHandling: "changed-path-with-parent-directory",
+          onChange() {},
+        },
+        {
+          maxWatches: 64,
+          honorGitIgnore: false,
+          ignoredDirectoryNames: [],
+        },
+        () => {
+          fallbackCalls += 1;
+          throw new Error("qualified roots must not use Parcel");
+        },
+      ));
+    }
+  } finally {
+    console.info = originalInfo;
+  }
   assert.equal(fallbackCalls, 0);
-  assert.equal(fake.subscriptions.length, 1);
-  await watcher.dispose();
-  assert.equal(fake.subscriptions[0].disposed, true);
-  assert.equal(fake.subscriptions[0].disposeCalls, 1);
+  assert.equal(fake.subscriptions.length, 3);
+  assert.equal(messages.length, 2);
+  assert.ok(messages[0].includes(`for ${root} (`));
+  assert.match(
+    messages[0],
+    /established with Watchbound 2\.1\.2.*target=linux-x64-gnu, native=4, limit=64/u,
+  );
+  assert.ok(messages[1].includes(`for ${secondRoot} (`));
+  assert.match(
+    messages[1],
+    /established with Watchbound 2\.1\.2.*target=linux-x64-gnu, native=12, limit=64/u,
+  );
+  await Promise.all(watchers.map((watcher) => watcher.dispose()));
+  assert.ok(fake.subscriptions.every((subscription) => subscription.disposed));
+  assert.ok(fake.subscriptions.every((subscription) => subscription.disposeCalls === 1));
 });
 
 test("an unqualified root uses a deduplicated, disposable Parcel fallback", async (t) => {
@@ -5806,4 +5822,181 @@ test("metadata consumer exceptions trigger joined fatal disposal", async (t) => 
   assert.equal(closed.reason, "watch-error");
   assert.match(closed.error.message, /consumer rejected metadata event/u);
   assert.equal(fake.subscriptions[0].disposed, true);
+});
+
+test("the durable signed Owl acceptance record is passing and sanitized", () => {
+  const acceptanceRoot = path.join(__dirname, "acceptance");
+  const evidencePath = path.join(
+    acceptanceRoot,
+    "evidence",
+    "signed-runtime-2.1.2-x64.json",
+  );
+  const serialized = fs.readFileSync(evidencePath, "utf8");
+  const evidence = JSON.parse(serialized);
+  assert.equal(evidence.schemaVersion, 1);
+  assert.equal(evidence.kind, "codex-watchbound-signed-runtime-acceptance");
+  assert.equal(evidence.verdict, "passed");
+  assert.equal(evidence.watchbound.version, "2.1.2");
+  assert.equal(
+    evidence.watchbound.sourceCommit,
+    "fa188992ef2cc800f9e65b9395139f85ef945c45",
+  );
+  assert.equal(
+    evidence.watchbound.runtimeImplementationParent,
+    "4996ff1d027a95d6ffb677e41236399eae400a16",
+  );
+  assert.equal(
+    evidence.signedRuntime.executableSha256,
+    "85e03c4bb5814e943eb23ae7eb370ea8f7eeab67c646e46d17596a07eedfb5b6",
+  );
+  assert.equal(evidence.signedRuntime.officialPackage.version, "26.814.41957");
+  assert.equal(
+    evidence.signedRuntime.sourceAsarSha256,
+    "1a43bb2a6547cd2a4945a669fb14f0b15b6eddc1fc1177f51dffc554e3c5ad98",
+  );
+  assert.deepEqual(evidence.signedRuntime.processVersions, {
+    electron: "151.0.7922.137",
+    chrome: "151.0.7922.137",
+    node: "24.14.0",
+    napi: 10,
+  });
+  assert.equal(evidence.loaderAssertions.javascriptAdmission, ">=18.15.0");
+  assert.equal(evidence.loaderAssertions.javascriptAdmissionHasNoUpperBound, true);
+  assert.equal(evidence.loaderAssertions.processNodeApiSatisfied, true);
+  assert.equal(evidence.loaderAssertions.runtimeAdmissionSchema, 1);
+  assert.equal(evidence.loaderAssertions.runtimeLibcEvidence, "elf-interpreter-version");
+  assert.equal(evidence.runtimeAdmission.schemaVersion, 1);
+  assert.equal(evidence.runtimeAdmission.libc.family, "glibc");
+  assert.equal(
+    evidence.runtimeAdmission.libc.evidence,
+    "elf-interpreter-version",
+  );
+  assert.equal(evidence.native.exactSelectionWithoutFallback, true);
+  const repoRoot = path.resolve(__dirname, "../..");
+  assert.deepEqual(Object.keys(evidence.inputs.files), [
+    "linux-features/directory-only-working-tree-watch/acceptance/run-signed-runtime.mjs",
+    "linux-features/directory-only-working-tree-watch/acceptance/runtime-harness.mjs",
+    "linux-features/directory-only-working-tree-watch/acceptance/installed-package-smoke-helpers.mjs",
+    "linux-features/directory-only-working-tree-watch/acceptance/fixtures/exclusion-smoke-helpers.cjs",
+    "linux-features/directory-only-working-tree-watch/patch.js",
+    "linux-features/directory-only-working-tree-watch/watchbound-artifacts.json",
+    "nix/upstream-linux-packages.json",
+  ]);
+  for (const [relativePath, expectedSha256] of Object.entries(evidence.inputs.files)) {
+    assert.equal(
+      sha256(fs.readFileSync(path.join(repoRoot, relativePath))),
+      expectedSha256,
+      `${relativePath} changed after the signed acceptance was recorded`,
+    );
+  }
+  const generatedAdapter =
+    `"use strict";\nmodule.exports = ${codexLinuxStartDirectoryOnlyWorkingTreeWatch.toString()};\n`;
+  assert.equal(
+    sha256(generatedAdapter),
+    evidence.inputs.generatedProductionAdapterSha256,
+  );
+  const artifactManifest = JSON.parse(fs.readFileSync(
+    path.join(__dirname, "watchbound-artifacts.json"),
+    "utf8",
+  ));
+  for (const artifact of [
+    artifactManifest.packages.wrapper,
+    artifactManifest.packages.loader,
+    ...Object.values(artifactManifest.packages.targets),
+  ]) {
+    assert.deepEqual(evidence.inputs.watchboundArchives[artifact.name], {
+      sha256: artifact.sha256,
+      shasum: artifact.shasum,
+      integrity: artifact.integrity,
+    });
+  }
+  const upstreamPins = JSON.parse(fs.readFileSync(
+    path.join(repoRoot, "nix", "upstream-linux-packages.json"),
+    "utf8",
+  ));
+  assert.deepEqual(evidence.inputs.signedStablePackage, {
+    repositoryPath: upstreamPins.amd64.repositoryPath,
+    sha256: upstreamPins.amd64.sha256,
+    pinSource: "nix/upstream-linux-packages.json",
+  });
+  assert.equal(
+    evidence.signedRuntime.officialPackage.debSha256,
+    upstreamPins.amd64.sha256,
+  );
+  assert.match(
+    evidence.signedRuntime.officialPackage.dataPayloadInventorySha256,
+    /^[0-9a-f]{64}$/u,
+  );
+  assert.ok(evidence.signedRuntime.officialPackage.dataPayloadInventoryEntries > 0);
+  assert.equal(
+    evidence.signedRuntime.officialPackage.verifiedAgainstDebDataPayload,
+    true,
+  );
+  assert.deepEqual(evidence.productionAdapter, {
+    status: "passed",
+    exactInjectedSourceSha256: evidence.inputs.generatedProductionAdapterSha256,
+    bareSpecifierResolved: true,
+    moduleOverrideUsed: false,
+    fallbackCalls: 0,
+    watcherReturned: true,
+    nativeSubscriptionEstablished: true,
+    establishmentDiagnostic: {
+      emitted: true,
+      version: "2.1.2",
+      target: "linux-x64-gnu",
+      includedNativeBudget: true,
+    },
+    joinedDisposal: true,
+  });
+  assert.equal(evidence.iterations.length, 3);
+  for (const iteration of evidence.iterations) {
+    assert.equal(iteration.status, "passed");
+    assert.deepEqual(iteration.exit.signal, null);
+    assert.equal(iteration.exit.code, 0);
+    assert.equal(iteration.exit.timedOut, false);
+    assert.equal(iteration.exit.outputOverflow, false);
+    assert.equal(iteration.exit.terminationRequested, false);
+    assert.equal(iteration.exit.killEscalated, false);
+    assert.equal(iteration.lifecycleAssertions.resourcesReturnedToBaseline, true);
+    assert.deepEqual(iteration.runtime.baseline, iteration.runtime.final);
+  }
+  assert.equal(evidence.qualifyRoot.state, "qualified");
+  assert.equal(evidence.qualifyRoot.root.lexicalPath, "$CODEX_WORKSPACE");
+  assert.equal(evidence.negativeIntegrity.status, "passed");
+  assert.equal(evidence.negativeIntegrity.productionAdapter.fallbackCalls, 0);
+  assert.equal(
+    evidence.negativeIntegrity.error.code,
+    "WATCHBOUND_NATIVE_INTEGRITY_MISMATCH",
+  );
+  assert.equal(evidence.negativeIntegrity.fallbackAddonLoaded, false);
+  assert.equal(evidence.negativeIntegrity.exit.outputOverflow, false);
+  assert.equal(evidence.negativeIntegrity.exit.terminationRequested, false);
+  assert.equal(evidence.negativeIntegrity.exit.killEscalated, false);
+  assert.deepEqual(evidence.reportFreeAdmission, {
+    downstreamShimInstalled: false,
+    processReportUsed: false,
+    evidence: "elf-interpreter-version",
+    admissionSnapshotSharedWithCapabilities: true,
+  });
+  assert.deepEqual(evidence.arm64, {
+    status: "unavailable",
+    reason: "no signed ARM64 executable or ARM64 execution environment",
+  });
+  assert.doesNotMatch(serialized, /\/home\/|\/tmp\/|codex-watchbound-signed-acceptance-/u);
+  assert.ok(evidence.rawArtifacts.length > 0);
+  for (const artifact of evidence.rawArtifacts) {
+    assert.match(
+      artifact.filename,
+      /^reports\/watchbound-signed-runtime\/2\.1\.2-x64\//u,
+    );
+    assert.match(artifact.sha256, /^[0-9a-f]{64}$/u);
+  }
+  assert.match(evidence.reproduction.command, /--signed-deb <SIGNED_AMD64_DEB>/u);
+
+  const runtimeHarness = fs.readFileSync(
+    path.join(acceptanceRoot, "runtime-harness.mjs"),
+    "utf8",
+  );
+  assert.doesNotMatch(runtimeHarness, /42\.3\.0/u);
+  assert.doesNotMatch(runtimeHarness, /process\.report/u);
 });

--- a/linux-features/directory-only-working-tree-watch/watchbound-artifacts.json
+++ b/linux-features/directory-only-working-tree-watch/watchbound-artifacts.json
@@ -1,70 +1,70 @@
 {
-  "version": "2.1.1",
+  "version": "2.1.2",
   "source": {
-    "revision": "096c53174ba6ea6a2e2a065f01423deab09c9de4",
-    "url": "https://github.com/gadicc/watchbound/archive/096c53174ba6ea6a2e2a065f01423deab09c9de4.tar.gz",
-    "sha256": "5619c6d1887c02f3a554aa517a14bd58db8a73a6f2e31a856cf55b8807615270"
+    "revision": "fa188992ef2cc800f9e65b9395139f85ef945c45",
+    "url": "https://github.com/gadicc/watchbound/archive/fa188992ef2cc800f9e65b9395139f85ef945c45.tar.gz",
+    "sha256": "7b0b6dbde1cbd7543ac183d46927b708093f7d3fb21f5d3753946f820896d36b"
   },
   "runtime": {
     "electron": "42.3.0",
-    "node": "24.15.0",
-    "nodeRange": ">=24.15.0 <25"
+    "node": "24.14.0",
+    "nodeRange": ">=18.15.0"
   },
   "packages": {
     "wrapper": {
       "name": "watchbound",
       "license": "MIT",
-      "url": "https://registry.npmjs.org/watchbound/-/watchbound-2.1.1.tgz",
-      "integrity": "sha512-kysqjLk7rx8/Im5khevgiOP59adXPaCV2K9dEvWxyE3+u+LrTOakTLZqazD1TZS3fjJEpKLsFqxcydeSuXDzjg==",
-      "shasum": "4ff71453f1e7ce4cfe3829bf871934b156560d15",
-      "sha256": "29567421c1efee041658db4b50093f91558604d352178cb2e76dd331e7c5544d",
+      "url": "https://registry.npmjs.org/watchbound/-/watchbound-2.1.2.tgz",
+      "integrity": "sha512-1tk1bBZ+djRXVu6K31anpNCN0CUMe5Oft/ey955IHrPSFwtV3L66gi6mjwzyVz43+9p51RpUJSu7eP+F6kwE2A==",
+      "shasum": "6f762ffbf8376b66e4b054479c107d651a579a31",
+      "sha256": "f297d6753d847170433216c73b9787e322d0849d2c0582e3e557a0f332a20ba1",
       "archiveEnvironment": "CODEX_WATCHBOUND_ARCHIVE",
       "files": {
         "LICENSE.txt": "fa95ce16057358473c9c2fd682b37cda63c6190588663ca70f8e56e624de06cb",
-        "README.md": "7d6abc2d896522f805c15a9c991cec23b94af7f143e138b31cf8bf55ecfbff57",
+        "README.md": "afd1a679e88d5d601598bce75621ae4e05711f9e2f5a834d3225d13e4b3beb48",
         "automatic-reconciliation.js": "3841fc95f72ae44f528da94fba92165d1eae3e07dc661642875725284233d937",
-        "capabilities.js": "91618e33fc10212a0462105e21fe7a666bfbc11ddfa899a17448022fa74b67e7",
+        "capabilities.js": "52e8093f4ae869c74a8e8eeff0008cd2c1281f8b0ceef1a7f348a5274868a560",
         "errors.js": "5affc7fc40aba435772ef394be77103ebdcce1ba0b526b1ec4994b0cdd1c5fa6",
-        "index.d.ts": "08c56aa090aa78d279de4409d8d586c89fecc8ee1829ead2552d1be88b6f4efa",
-        "index.js": "82e1bb14939819633702dbd10ccc102c71b4d3bc45798d9c2cc479729c698bd1",
+        "index.d.ts": "24389a6b71b81172ca0f91b8178654174f27fd22284e46179f8b553f17c471b5",
+        "index.js": "603a76dc10ac001cec30a1f810ea8f6e016ced51eae0d7d70bcd7c709bf22b03",
         "native-establishment.js": "b211e6a0646cc1403d9e746ee757be084bb80ae8a29450affe2264527ac51cfa",
         "observed-state.js": "5d7d0289420a60124819d33598b68f9596754573ac9db88ff42bd1864fe15a3f",
-        "package.json": "bbf2cba9a19c4c31a95aaef02254335717b9f5fced29b6b928f2c6d290c9a8f4",
+        "package.json": "f02e8975d8710c805dd0181621481acb87545121f62c18a1dd1b161733005876",
         "path-delivery.js": "290a1108a6557f67acadccd1bbd0694408d6ba42fef5f80c96180482e7d57b9d"
       }
     },
     "loader": {
       "name": "@gadicc/watchbound-node",
       "license": "MIT",
-      "url": "https://registry.npmjs.org/@gadicc/watchbound-node/-/watchbound-node-2.1.1.tgz",
-      "integrity": "sha512-F5W25wl6olKXrhTZgAKBjEmChhBYdyranseL8IWVm3qcK4VfrSLg0AtJ2NTMZIg3IQCx0lvh6QVArQ793VSAJQ==",
-      "shasum": "409c1275b6d90d5a319c78d0c8efc665a7f7722e",
-      "sha256": "1f8241d08771f8cf00d50ef8953278934493e7712ae77dcb6418487e167f5284",
+      "url": "https://registry.npmjs.org/@gadicc/watchbound-node/-/watchbound-node-2.1.2.tgz",
+      "integrity": "sha512-h66Xgk2tNowLj1HfRn87whqsuzg4FJulusSrv3NsdIKE/89tONc2wGqHc2DDkn8j90C7XWYmRtZm0cIA0fok6Q==",
+      "shasum": "fecc1eeb7d5e2c27cde414bc1c3533d091973c00",
+      "sha256": "e12c138118990425892e606184f9cd9f96cd32c841254078747240c5942ba770",
       "archiveEnvironment": "CODEX_WATCHBOUND_NODE_ARCHIVE",
       "files": {
         "LICENSE.txt": "fa95ce16057358473c9c2fd682b37cda63c6190588663ca70f8e56e624de06cb",
-        "README.md": "7d6abc2d896522f805c15a9c991cec23b94af7f143e138b31cf8bf55ecfbff57",
-        "index.d.ts": "f87d6d862de33ce5f009cb1ffe427bc7ce26473cfbbba689135e7f2985157ddb",
+        "README.md": "afd1a679e88d5d601598bce75621ae4e05711f9e2f5a834d3225d13e4b3beb48",
+        "index.d.ts": "ff8aa793ef249ade0ca0744df1fe20d4ec32f762f0c3121d1070cc1640e6e106",
         "index.js": "fc2c5c40a79452034022cd09ec1bf25fb81c3c9b97de19bb45668534a5c05e62",
-        "load-native.cjs": "ebb82e79bf52deb8cc0b25f3f82f2a51aa14b36f4090a33e41f8a1a1749e8e56",
-        "native-matrix.json": "4f63e441d5fc05a80ede19d32aefc9c6b4b3309a28e3c225078224099ad07769",
-        "package.json": "945333b1a7bf91ef68a468d2c6df614098f0be438545ec5ffe9788319c6c8866"
+        "load-native.cjs": "981bcd17c519f073ee474d29d37c14c9eeb53c6447765b3cf173f1b81ee8314d",
+        "native-matrix.json": "d1ba83358e166e04e0655479315160bac416096b4c0821301c54f03922ced646",
+        "package.json": "20eb36b7ad735390c7ceeb9057c2fd8cded7acf6530b52d3dfd26037cedf70e4"
       }
     },
     "targets": {
       "x64": {
         "name": "@gadicc/watchbound-node-linux-x64-gnu",
         "license": "MIT",
-        "url": "https://registry.npmjs.org/@gadicc/watchbound-node-linux-x64-gnu/-/watchbound-node-linux-x64-gnu-2.1.1.tgz",
-        "integrity": "sha512-QqtfUeILJf8iKO9zxF6JxElVhoXnjxMFrtHKwTQgSK5+sSr7R+uOf4K8NO12ytR6+fI1T2J2yFPfzg5ll/gTRg==",
-        "shasum": "a3100b3d908d89ed4825233c4152abad6d24bda8",
-        "sha256": "0903c9eec6ebe127cb3aae7bce92ddb375c21503ef5438a132c28a19517e44c3",
+        "url": "https://registry.npmjs.org/@gadicc/watchbound-node-linux-x64-gnu/-/watchbound-node-linux-x64-gnu-2.1.2.tgz",
+        "integrity": "sha512-UuEIg6OrHcksCl/yR3JsX6SneEYvxDpT8n68AKPEWajLclj9+aSgCWHi6t2ihh+yC1a5qQbGYNkuUpjSkZh7Dg==",
+        "shasum": "80c76f8269df698fc146b6721428925da1c386cc",
+        "sha256": "2b4aff140baf6a512dab3fa0f14c12dfb1f785d60b3d2ba28e4144e7d275eded",
         "archiveEnvironment": "CODEX_WATCHBOUND_NODE_X64_ARCHIVE",
         "files": {
           "LICENSE.txt": "fa95ce16057358473c9c2fd682b37cda63c6190588663ca70f8e56e624de06cb",
-          "README.md": "7d6abc2d896522f805c15a9c991cec23b94af7f143e138b31cf8bf55ecfbff57",
-          "package.json": "4d24199c85d16719adfcc2b95e68693514ff0585252f296a2dfafc423cb373aa",
-          "watchbound.linux-x64-gnu.node": "45f40617c86c95e6f023f27891b09805d82e7dc21e295bf886ff5f6a7d541eac"
+          "README.md": "afd1a679e88d5d601598bce75621ae4e05711f9e2f5a834d3225d13e4b3beb48",
+          "package.json": "9b9ba9b2fb0bd2da0aac16d738ca989f5a0183e7145dec2f60f48904d969abe6",
+          "watchbound.linux-x64-gnu.node": "1f4713bb126bc8652d83e66d25219e0c0f3c354b3e0efeafcc2ec5e8b0bbec45"
         },
         "nativeBinding": {
           "path": "watchbound.linux-x64-gnu.node",
@@ -74,22 +74,22 @@
           "libc": "glibc",
           "elfClass": 64,
           "elfMachine": 62,
-          "sha256": "45f40617c86c95e6f023f27891b09805d82e7dc21e295bf886ff5f6a7d541eac"
+          "sha256": "1f4713bb126bc8652d83e66d25219e0c0f3c354b3e0efeafcc2ec5e8b0bbec45"
         }
       },
       "arm64": {
         "name": "@gadicc/watchbound-node-linux-arm64-gnu",
         "license": "MIT",
-        "url": "https://registry.npmjs.org/@gadicc/watchbound-node-linux-arm64-gnu/-/watchbound-node-linux-arm64-gnu-2.1.1.tgz",
-        "integrity": "sha512-2iSHBCBMxWe1X2Wg/mTDwDnJIw5HEHCpO8WCde2jPab9L1pMAKqPtevqW/ceEomUmY7GxfJSJhinJXHHEJQ0eA==",
-        "shasum": "f7bf85fdbbe7669812a0f946eb23a534a395a827",
-        "sha256": "a2acdc589d34499b979401b471f73173db33f7b82941f429bfdf4ea287f1e5e3",
+        "url": "https://registry.npmjs.org/@gadicc/watchbound-node-linux-arm64-gnu/-/watchbound-node-linux-arm64-gnu-2.1.2.tgz",
+        "integrity": "sha512-Eo/jJL+I1UKnxIeSZP1Vk6QIve4Oy9Ik2wcpfq+ifRQfxlyjClSm7KCt94tyYmDzpZUUGq92CjM+/DxiEhJZiA==",
+        "shasum": "a86224b5709f74ddb7aa8d57f5765aa865b3edf4",
+        "sha256": "8a016583cd3ad16bf627e314f72e515ab80c1e1415af7a1b65fdea0b1856d9e3",
         "archiveEnvironment": "CODEX_WATCHBOUND_NODE_ARM64_ARCHIVE",
         "files": {
           "LICENSE.txt": "fa95ce16057358473c9c2fd682b37cda63c6190588663ca70f8e56e624de06cb",
-          "README.md": "7d6abc2d896522f805c15a9c991cec23b94af7f143e138b31cf8bf55ecfbff57",
-          "package.json": "94f99b067d35618e461d0ac1c4c0b95fc3169fa282b5db9c41d8f6a9cf066e23",
-          "watchbound.linux-arm64-gnu.node": "9d7208e8fd961af3e26d4cc23403b593b2efdfd686af1ef6a70f462798357fb4"
+          "README.md": "afd1a679e88d5d601598bce75621ae4e05711f9e2f5a834d3225d13e4b3beb48",
+          "package.json": "e66c6f59107ad682070f866dd02a6e16f151e68d411d6cc1220f42da30c2fa69",
+          "watchbound.linux-arm64-gnu.node": "8929d81485731438afd66b732f4581f20cdf33bca5e36fb200ef7b2b67be74d2"
         },
         "nativeBinding": {
           "path": "watchbound.linux-arm64-gnu.node",
@@ -99,7 +99,7 @@
           "libc": "glibc",
           "elfClass": 64,
           "elfMachine": 183,
-          "sha256": "9d7208e8fd961af3e26d4cc23403b593b2efdfd686af1ef6a70f462798357fb4"
+          "sha256": "8929d81485731438afd66b732f4581f20cdf33bca5e36fb200ef7b2b67be74d2"
         }
       }
     }

--- a/linux-features/directory-only-working-tree-watch/watchbound-package.js
+++ b/linux-features/directory-only-working-tree-watch/watchbound-package.js
@@ -11,7 +11,7 @@ const {
   isPatchIntegrityError,
 } = require("../../scripts/patches/integrity-error.js");
 
-const WATCHBOUND_NODE_RANGE = ">=24.15.0 <25";
+const WATCHBOUND_NODE_RANGE = ">=18.15.0";
 const WATCHBOUND_TARGET_CONTRACTS = Object.freeze({
   x64: Object.freeze({
     packageName: "@gadicc/watchbound-node-linux-x64-gnu",
@@ -79,9 +79,7 @@ function nodeVersionSupportsWatchbound(version) {
     version,
     "Watchbound target Node.js version",
   ).split(".").map(Number);
-  return major === 24 && (
-    minor > 15 || (minor === 15 && patch >= 0)
-  );
+  return major > 18 || (major === 18 && (minor > 15 || (minor === 15 && patch >= 0)));
 }
 
 function extractedAppElectronVersion(extractedDir) {
@@ -134,15 +132,18 @@ function validateTargetRuntime(
         `${manifest.runtime.node}`,
     );
   }
-  if (
-    targetNodeVersion != null &&
-    targetNodeVersion !== "" &&
-    exactVersion(targetNodeVersion, "Target Node.js version") !== manifest.runtime.node
-  ) {
+  if (targetNodeVersion != null && targetNodeVersion !== "") {
+    const targetNode = exactVersion(targetNodeVersion, "Target Node.js version");
+    if (nodeVersionSupportsWatchbound(targetNode)) {
+      return {
+        electron: buildElectronVersion,
+        node: targetNode,
+        qualification: "pinned-artifact-manifest",
+      };
+    }
     throw new Error(
-      `Watchbound ${manifest.version} is qualified for Electron ` +
-        `${manifest.runtime.electron} / Node.js ${manifest.runtime.node}, got Node.js ` +
-        `${targetNodeVersion}`,
+      `Watchbound ${manifest.version} requires Node.js ${WATCHBOUND_NODE_RANGE}, ` +
+        `got Node.js ${targetNode}`,
     );
   }
   return {
@@ -1625,14 +1626,9 @@ function packageHelperExitCode(error) {
 }
 
 function currentArtifactManifest() {
-  const manifest = JSON.parse(
+  return JSON.parse(
     fs.readFileSync(path.join(__dirname, "watchbound-artifacts.json"), "utf8"),
   );
-  if (process.env.CODEX_WATCHBOUND_NIX_NODE_24_14 === "1") {
-    manifest.packages.loader.files["native-matrix.json"] =
-      "8ea0c8101cc7d0f97a5d988ce30240914a1ae5fecce7f6c4d02a7b80359e6cf4";
-  }
-  return manifest;
 }
 
 async function main() {
@@ -1680,7 +1676,6 @@ if (require.main === module) {
 }
 
 module.exports = {
-  currentArtifactManifest,
   defaultMaterializePackage,
   currentLibc,
   commitPackageDirectoryNoReplace,

--- a/nix/watchbound-Cargo.lock
+++ b/nix/watchbound-Cargo.lock
@@ -269,14 +269,14 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "watchbound-engine"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "watchbound-node"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "napi",
  "napi-build",

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -166,6 +166,9 @@ stage_update_builder_linux_features_tree() {
         [ -d "$source_root/$feature_id" ] || error "Missing enabled Linux feature: $feature_id"
         cp -a "$source_root/$feature_id" "$target/$feature_id"
         find "$target/$feature_id" -type d -name target -prune -exec rm -rf {} +
+        if [ "$feature_id" = "directory-only-working-tree-watch" ]; then
+            rm -rf "$target/$feature_id/acceptance"
+        fi
         if [ "$feature_id" = "mcp-helper-reaper" ]; then
             rm -rf \
                 "$target/$feature_id/reaper/src" \

--- a/scripts/lib/package-common.test.js
+++ b/scripts/lib/package-common.test.js
@@ -205,6 +205,36 @@ test("update-builder carries the shared feature compatibility registry", (t) => 
   );
 });
 
+test("update-builder omits directory-watch acceptance-only evidence", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-update-builder-watchbound-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const config = path.join(root, "features.json");
+  const builder = path.join(root, "builder");
+  fs.writeFileSync(
+    config,
+    `${JSON.stringify({ enabled: ["directory-only-working-tree-watch"] })}\n`,
+  );
+
+  runPackageCommon(
+    `CODEX_LINUX_FEATURES_CONFIG=${JSON.stringify(config)} stage_update_builder_linux_features_tree ${JSON.stringify(builder)}`,
+    root,
+  );
+
+  const stagedFeature = path.join(
+    builder,
+    "linux-features/directory-only-working-tree-watch",
+  );
+  for (const runtimeInput of [
+    "feature.json",
+    "patch.js",
+    "watchbound-artifacts.json",
+    "watchbound-package.js",
+  ]) {
+    assert.equal(fs.existsSync(path.join(stagedFeature, runtimeInput)), true);
+  }
+  assert.equal(fs.existsSync(path.join(stagedFeature, "acceptance")), false);
+});
+
 test("update-builder stages only plugin templates consumed by enabled feature hooks", (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-update-builder-plugins-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));


### PR DESCRIPTION
This PR addresses issues that arose after the port to the native OpenAI Linux binary.  It pins to the latest `watchbound` version which itself includes changes that made various local shims unnecessary.

## Summary

Follow-up to #1283, merged in [88175033](https://github.com/ilysenko/codex-desktop-linux/commit/8817503316db747a8932ce1317dd35d5ee17ec2f).

Watchbound 2.1.1 required Node 24.15–24.x, while the latest signed stable OpenAI Linux package (`26.810.52044`) bundles Node 24.14. Nix rewrote the minimum-version metadata, but other package paths allowed Watchbound to refuse the runtime and fall back to Parcel.

This change:

- Pins the published Watchbound 2.1.2 wrapper, loader, x64 and ARM64 native packages, source commit, and exact artifact digests.
- Adopts Watchbound 2.1.2’s `>=18.15.0` Node admission and ELF-interpreter libc detection.
- Removes the obsolete `process.report` compatibility shim from #1336.
- Removes the Nix-only Node metadata rewrite from #1340.
- Retains the Nix runtime relocation from #1332 because upstream Parcel remains the default and unsupported-runtime fallback.
- Refreshes the directory-watch drift contract for OpenAI Linux `26.810.52044`.
- Makes missing, corrupt, or API-incompatible enabled Watchbound packages fail visibly; only explicit unsupported-runtime errors may fall back to Parcel.
- Adds signed x64 acceptance evidence exercising the exact production adapter, bare `watchbound` import, three cold starts, resource cleanup, and corrupted-addon rejection.
- Binds that evidence to the signed deb, complete deb payload inventory, official executable and ASAR, npm archives, manifest, adapter, runner, and harness hashes.
- Excludes developer-only acceptance fixtures from native update-builder payloads.

The feature remains disabled by default. Builds without it preserve the official ASAR unchanged.

Affected scope:

- Feature: `directory-only-working-tree-watch`
- Architectures: amd64 and arm64 pins; signed runtime execution validated on amd64
- Formats: shared deb/RPM/pacman/AppImage feature staging, native update-builder payloads, and Nix

Related: #1283, #1332, #1336, #1340 and [Watchbound source commit fa18899](https://github.com/gadicc/watchbound/commit/fa188992ef2cc800f9e65b9395139f85ef945c45).

## Validation

Passed:

- `node linux-features/directory-only-working-tree-watch/test.js` — 119/119
- `node scripts/lib/package-common.test.js` — 11/11
- `node --test scripts/patch-linux-window-ui.test.js scripts/lib/linux-features.test.js linux-features/*/test.js` — 753/753
- `bash tests/scripts_smoke.sh` — 51/51
- Signed OpenAI x64 runtime acceptance — three cold starts and corrupted-addon rejection
- `nix --extra-experimental-features 'nix-command flakes' build --no-link .#checks.x86_64-linux.nix-runtime-maximal-directory-watch`
- `bash -n scripts/lib/package-common.sh`
- `git diff --check`

Not covered locally:

- Signed ARM64 runtime execution; ARM64 manifests and package staging are covered, but no real ARM64 execution environment was available.
- Full deb, RPM, pacman, and AppImage artifact builds.
- Full `nix flake check`; the targeted maximal directory-watch derivation passed.
- npm provenance/DSSE verification beyond the pinned integrity, shasum, SHA-256, and per-file inventory checks.

Required GitHub CI is pending.

### Runtime observability

Each fully established Watchbound route now emits one `INFO` message per resolved physical working-tree root per app process, including the Watchbound version, qualified root, packaged target, active native-watch count, and configured budget. Reopening the same project—including through an alias of the same physical root—does not repeat the message, while each separately opened project receives its own confirmation.

Supported runtime refusals and roots that remain unqualified or unknown emit deduplicated `WARN` messages before preserving the upstream Parcel watcher. Partial or uncertain coverage warns once per incomplete episode, and a subsequent `INFO` message confirms recovery.

The focused tests cover repeated subscriptions, aliases, and distinct physical roots. The refreshed signed `26.814.41957` acceptance evidence also asserts that the positive establishment diagnostic is emitted by the exact production adapter while retaining the existing no-fallback, joined-disposal, and tampered-native failure checks.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest signed stable OpenAI Linux package and removes obsolete fallback code and tests.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.