### PR TITLE
fix(browser): preserve proxy env for Browser Use helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ requirements, known limitations, configuration, and tests.
 | `appshots` | Capture and crop the focused Linux window from the composer | [Docs](linux-features/appshots/README.md) |
 | `authenticated-proxy` | Username/password support for HTTP proxies | [Docs](linux-features/authenticated-proxy/README.md) |
 | `automation-extensions` | Multi-time schedules and eager `automation_update` exposure | [Docs](linux-features/automation-extensions/README.md) |
+| `browser-proxy` | Pass explicit proxy settings to Browser Use network helpers | [Docs](linux-features/browser-proxy/README.md) |
 | `chronicle-skysight` | Opt-in Linux desktop activity memory and restricted Skysight MCP tools | [Docs](linux-features/chronicle-skysight/README.md) |
 | `codex-micro` | Work Louder Codex Micro hotplug and hidraw policy using upstream `node-hid` | [Docs](linux-features/codex-micro/README.md) |
 | `computer-use-linux` | Linux desktop-control UI and native MCP backend | [Docs](linux-features/computer-use-linux/README.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -203,6 +203,7 @@ Nix 用户应从 profile、Home Manager 配置或 NixOS module 中删除该包�
 | `appshots` | 从 composer 捕获并裁剪当前 Linux 窗口 | [文档](linux-features/appshots/README.md) |
 | `authenticated-proxy` | 带用户名和密码的 HTTP proxy | [文档](linux-features/authenticated-proxy/README.md) |
 | `automation-extensions` | 多时间调度和 eager `automation_update` | [文档](linux-features/automation-extensions/README.md) |
+| `browser-proxy` | 让 Browser Use 的网络辅助进程继承显式代理设置 | [文档](linux-features/browser-proxy/README.zh-CN.md) |
 | `chronicle-skysight` | 可选的 Linux 桌面活动记忆与受限 Skysight MCP 工具 | [文档](linux-features/chronicle-skysight/README.md) |
 | `codex-micro` | 使用上游 `node-hid` 的 Codex Micro hotplug/hidraw policy | [文档](linux-features/codex-micro/README.md) |
 | `computer-use-linux` | Linux desktop-control UI 与原生 MCP backend | [文档](linux-features/computer-use-linux/README.md) |

--- a/linux-features/browser-proxy/README.md
+++ b/linux-features/browser-proxy/README.md
@@ -1,0 +1,77 @@
+# Browser Runtime Proxy
+
+Browser Use runs its network and DOM helpers in a separate `node_repl`
+process. Some desktop releases start that helper with a filtered environment,
+even when the Codex app-server has explicit proxy variables. Chrome can remain
+connected while navigation and DOM commands then wait on Browser Use network
+checks that cannot reach their endpoint.
+
+This opt-in feature wraps the bundled helper and copies only these variables
+from its immediate app-server parent when the helper did not receive a member
+of the corresponding proxy family:
+
+- `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY`
+- their lower-case equivalents
+- `NODE_USE_ENV_PROXY`
+
+Upper- and lower-case spellings are treated as one proxy family for HTTP,
+HTTPS, ALL, and NO_PROXY. If the helper already has either spelling in a
+family, neither spelling is imported from the parent. This preserves an
+explicit child route and avoids exposing an unnecessary alternate-case proxy
+URL that may contain credentials.
+
+When a non-empty proxy variable is recovered and `NODE_USE_ENV_PROXY` is not
+set, the wrapper sets it to `1`. The original helper is then executed without
+changing Browser Use URL-policy or user-consent checks.
+
+## Enable
+
+Add the feature to `linux-features/features.json`:
+
+```json
+{
+  "enabled": ["browser-proxy"]
+}
+```
+
+Then rebuild the app/package. Launch Codex with standard proxy variables in
+its environment, for example:
+
+```bash
+HTTP_PROXY='http://127.0.0.1:10809' \
+HTTPS_PROXY='http://127.0.0.1:10809' \
+NO_PROXY='127.0.0.1,localhost' \
+NODE_USE_ENV_PROXY=1 \
+./codex-app/start.sh
+```
+
+The launcher, desktop entry, or service that starts Codex must export these
+variables. Desktop proxy settings alone may not add them to the process
+environment.
+
+## Scope and security
+
+This feature affects Browser Use `node_repl` network requests. It does not
+select the proxy used by Chrome page traffic; configure that separately in
+Chrome, Electron, or the proxy application's routing rules.
+
+Proxy URLs can contain credentials. Enabling this feature makes the selected
+proxy variables available to the same-user Browser Use helper, just as they
+are already available to its Codex app-server parent. Values are never logged.
+If `/proc/<parent>/environ` cannot be read, the wrapper runs the original
+helper with its existing environment.
+
+The feature does not set `BROWSER_USE_SECURITY_MODE`, disable ambient network
+controls, or bypass Browser Use site-status, URL-policy, or consent checks.
+
+## Disable and test
+
+Remove `browser-proxy` from `linux-features/features.json` and rebuild. Its
+cleanup hook restores the original `node_repl` entrypoint when it owns the
+wrapper.
+
+Run the regression tests with:
+
+```bash
+node --test linux-features/browser-proxy/test.js
+```

--- a/linux-features/browser-proxy/README.zh-CN.md
+++ b/linux-features/browser-proxy/README.zh-CN.md
@@ -1,0 +1,66 @@
+# Browser Runtime Proxy
+
+Browser Use 会在独立的 `node_repl` 进程中执行网络和 DOM 辅助操作。
+某些桌面版本启动该进程时会过滤环境变量：即使 Codex app-server
+已经获得明确的代理配置，`node_repl` 也可能没有。这会造成 Chrome
+连接和标签页列表正常，但导航或 DOM 命令在 Browser Use 网络检查上超时。
+
+这个默认关闭的功能仅会在子进程未显式设置对应代理族时，
+从直接父进程继承：
+
+- `HTTP_PROXY`、`HTTPS_PROXY`、`ALL_PROXY` 和 `NO_PROXY`
+- 上述变量的小写形式
+- `NODE_USE_ENV_PROXY`
+
+对于 HTTP、HTTPS、ALL 和 NO_PROXY，大小写名称按同一个代理族处理。
+只要子进程已经设置该族中的任意一种写法，wrapper 就不会从父进程
+导入该族的任何变量。这会保留子进程明确指定的路由，也避免暴露
+可能包含凭据的多余代理 URL。
+
+如果继承到了非空代理变量，且没有设置 `NODE_USE_ENV_PROXY`，wrapper
+会将它设为 `1`，然后原样执行官方 `node_repl`。
+
+## 启用
+
+在 `linux-features/features.json` 中加入：
+
+```json
+{
+  "enabled": ["browser-proxy"]
+}
+```
+
+重新构建后，请让启动 Codex 的桌面图标、脚本或服务导出标准代理变量，
+例如 v2rayN 的 HTTP 代理：
+
+```bash
+HTTP_PROXY='http://127.0.0.1:10809' \
+HTTPS_PROXY='http://127.0.0.1:10809' \
+NO_PROXY='127.0.0.1,localhost' \
+NODE_USE_ENV_PROXY=1 \
+./codex-app/start.sh
+```
+
+只设置 GNOME 等桌面环境的系统代理，不一定会把这些变量加入 Codex
+进程环境。
+
+## 影响范围与安全性
+
+该功能只影响 Browser Use `node_repl` 的网络请求，不会决定 Chrome 网页流量
+走哪条路由；Chrome、Electron 或 v2rayN 的分流规则仍需单独配置。
+
+代理 URL 可能包含凭据。启用后，同一用户下的 Browser Use 辅助进程会获得
+父 app-server 已经拥有的这些变量，wrapper 不会记录变量值。如果无法
+读取 `/proc/<parent>/environ`，将直接使用子进程原有环境运行官方程序。
+
+该功能不会设置 `BROWSER_USE_SECURITY_MODE`，也不会关闭或绕过 site-status、
+URL policy 和用户授权检查。
+
+## 关闭与测试
+
+从 `linux-features/features.json` 中移除 `browser-proxy` 后重新构建。如果
+wrapper 确实属于该功能，cleanup hook 会恢复原始 `node_repl`。
+
+```bash
+node --test linux-features/browser-proxy/test.js
+```

--- a/linux-features/browser-proxy/cleanup.sh
+++ b/linux-features/browser-proxy/cleanup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+: "${INSTALL_DIR:?INSTALL_DIR is required}"
+
+bin_dir="$INSTALL_DIR/resources/cua_node/bin"
+node_repl="$bin_dir/node_repl"
+original_node_repl="$bin_dir/node_repl.codex-linux-original"
+wrapper_marker="browser-proxy-node-repl-wrapper"
+
+is_browser_proxy_wrapper() {
+    local candidate="$1"
+    [ -f "$candidate" ] || return 1
+    LC_ALL=C grep -a -Fq -- "$wrapper_marker" < <(head -c 512 -- "$candidate")
+}
+
+[ -e "$original_node_repl" ] || exit 0
+
+if [ ! -e "$node_repl" ]; then
+    mv -- "$original_node_repl" "$node_repl"
+    exit 0
+fi
+
+if ! is_browser_proxy_wrapper "$node_repl"; then
+    echo "browser-proxy cleanup: current node_repl is not this feature's wrapper; leaving both files unchanged" >&2
+    exit 1
+fi
+
+mv -f -- "$original_node_repl" "$node_repl"

--- a/linux-features/browser-proxy/feature.json
+++ b/linux-features/browser-proxy/feature.json
@@ -1,0 +1,10 @@
+{
+  "id": "browser-proxy",
+  "title": "Browser Runtime Proxy",
+  "description": "Passes explicit standard proxy environment variables from the Codex app-server to Browser Use node_repl helpers.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "stageHook": "./stage.sh",
+    "cleanupHook": "./cleanup.sh"
+  }
+}

--- a/linux-features/browser-proxy/node-repl-proxy-wrapper.sh
+++ b/linux-features/browser-proxy/node-repl-proxy-wrapper.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# browser-proxy-node-repl-wrapper
+set -euo pipefail
+
+bin_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+original="$bin_dir/node_repl.codex-linux-original"
+
+if [ ! -x "$original" ]; then
+    echo "browser-proxy: original node_repl is missing or not executable" >&2
+    exit 126
+fi
+
+# Browser Use helpers are launched with a deliberately filtered environment.
+# Recover only the standard proxy variables that the immediate app-server
+# parent already received. Upper- and lower-case spellings form one family, so
+# either spelling in the helper environment blocks both parent spellings.
+child_has_http_proxy_family=0
+child_has_https_proxy_family=0
+child_has_all_proxy_family=0
+child_has_no_proxy_family=0
+if [[ -v HTTP_PROXY || -v http_proxy ]]; then
+    child_has_http_proxy_family=1
+fi
+if [[ -v HTTPS_PROXY || -v https_proxy ]]; then
+    child_has_https_proxy_family=1
+fi
+if [[ -v ALL_PROXY || -v all_proxy ]]; then
+    child_has_all_proxy_family=1
+fi
+if [[ -v NO_PROXY || -v no_proxy ]]; then
+    child_has_no_proxy_family=1
+fi
+
+parent_environment="/proc/$PPID/environ"
+if [ -r "$parent_environment" ]; then
+    while IFS= read -r -d '' entry; do
+        name="${entry%%=*}"
+        case "$name" in
+            HTTP_PROXY|http_proxy)
+                if [ "$child_has_http_proxy_family" -eq 0 ]; then
+                    export "$entry"
+                fi
+                ;;
+            HTTPS_PROXY|https_proxy)
+                if [ "$child_has_https_proxy_family" -eq 0 ]; then
+                    export "$entry"
+                fi
+                ;;
+            ALL_PROXY|all_proxy)
+                if [ "$child_has_all_proxy_family" -eq 0 ]; then
+                    export "$entry"
+                fi
+                ;;
+            NO_PROXY|no_proxy)
+                if [ "$child_has_no_proxy_family" -eq 0 ]; then
+                    export "$entry"
+                fi
+                ;;
+            NODE_USE_ENV_PROXY)
+                if [[ ! -v NODE_USE_ENV_PROXY ]]; then
+                    export "$entry"
+                fi
+                ;;
+        esac
+    done < "$parent_environment" 2>/dev/null || true
+fi
+
+if [[ ! -v NODE_USE_ENV_PROXY ]]; then
+    for name in HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy; do
+        if [[ -v $name && -n ${!name} ]]; then
+            export NODE_USE_ENV_PROXY=1
+            break
+        fi
+    done
+fi
+
+exec "$original" "$@"

--- a/linux-features/browser-proxy/stage.sh
+++ b/linux-features/browser-proxy/stage.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+: "${SCRIPT_DIR:?SCRIPT_DIR is required}"
+: "${INSTALL_DIR:?INSTALL_DIR is required}"
+
+feature_dir="$SCRIPT_DIR/linux-features/browser-proxy"
+bin_dir="$INSTALL_DIR/resources/cua_node/bin"
+node_repl="$bin_dir/node_repl"
+original_node_repl="$bin_dir/node_repl.codex-linux-original"
+wrapper_source="$feature_dir/node-repl-proxy-wrapper.sh"
+wrapper_marker="browser-proxy-node-repl-wrapper"
+temporary_wrapper="$bin_dir/.node_repl.browser-proxy.$$"
+
+is_browser_proxy_wrapper() {
+    local candidate="$1"
+    [ -f "$candidate" ] || return 1
+    LC_ALL=C grep -a -Fq -- "$wrapper_marker" < <(head -c 512 -- "$candidate")
+}
+
+cleanup_temporary_wrapper() {
+    rm -f -- "$temporary_wrapper"
+    if [ ! -e "$node_repl" ] && [ -e "$original_node_repl" ]; then
+        mv -- "$original_node_repl" "$node_repl" || true
+    fi
+}
+trap cleanup_temporary_wrapper EXIT
+
+[ -x "$wrapper_source" ] || {
+    echo "browser-proxy wrapper is missing or not executable: $wrapper_source" >&2
+    exit 1
+}
+
+[ -d "$bin_dir" ] || {
+    echo "browser-proxy cannot find the Browser Use runtime directory: $bin_dir" >&2
+    exit 1
+}
+
+if [ -e "$original_node_repl" ]; then
+    if [ ! -e "$node_repl" ]; then
+        mv -- "$original_node_repl" "$node_repl"
+    elif ! is_browser_proxy_wrapper "$node_repl"; then
+        echo "browser-proxy found an existing node_repl backup but does not own the current entrypoint" >&2
+        echo "leaving both files unchanged: $node_repl" >&2
+        exit 1
+    fi
+fi
+
+if [ ! -e "$original_node_repl" ]; then
+    [ -x "$node_repl" ] || {
+        echo "browser-proxy cannot find an executable Browser Use node_repl: $node_repl" >&2
+        exit 1
+    }
+    mv -- "$node_repl" "$original_node_repl"
+fi
+
+[ -x "$original_node_repl" ] || {
+    echo "browser-proxy original node_repl is not executable: $original_node_repl" >&2
+    exit 1
+}
+
+install -m 0755 -- "$wrapper_source" "$temporary_wrapper"
+mv -f -- "$temporary_wrapper" "$node_repl"
+trap - EXIT
+
+echo "browser-proxy staged: Browser Use node_repl will inherit explicit proxy variables from its app-server parent" >&2

--- a/linux-features/browser-proxy/test.js
+++ b/linux-features/browser-proxy/test.js
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const {
+  disabledLinuxFeatureCleanupHooks,
+  enabledLinuxFeatureIds,
+  enabledLinuxFeatureStageHooks,
+} = require("../../scripts/lib/linux-features.js");
+
+const FEATURE_DIR = __dirname;
+const REPO_ROOT = path.resolve(FEATURE_DIR, "../..");
+const STAGE = path.join(FEATURE_DIR, "stage.sh");
+const CLEANUP = path.join(FEATURE_DIR, "cleanup.sh");
+const WRAPPER = path.join(FEATURE_DIR, "node-repl-proxy-wrapper.sh");
+const PROXY_NAMES = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+  "no_proxy",
+  "NODE_USE_ENV_PROXY",
+];
+
+function cleanProxyEnvironment(extra = {}) {
+  const environment = { ...process.env };
+  for (const name of PROXY_NAMES) delete environment[name];
+  return { ...environment, ...extra };
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    ...options,
+  });
+  assert.equal(
+    result.status,
+    0,
+    `${command} ${args.join(" ")} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  return result;
+}
+
+function withTempFeatureRoot(enabled, callback) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-browser-proxy-features-"));
+  try {
+    fs.writeFileSync(path.join(root, "features.example.json"), '{"enabled":[]}\n');
+    fs.writeFileSync(path.join(root, "features.json"), `${JSON.stringify({ enabled }, null, 2)}\n`);
+    fs.cpSync(FEATURE_DIR, path.join(root, "browser-proxy"), { recursive: true });
+    return callback(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function writeExecutable(file, contents) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, contents, { mode: 0o755 });
+}
+
+function makeFakeInstall() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-browser-proxy-install-"));
+  const installDir = path.join(root, "app");
+  const binDir = path.join(installDir, "resources", "cua_node", "bin");
+  const nodeRepl = path.join(binDir, "node_repl");
+  const originalNodeRepl = path.join(binDir, "node_repl.codex-linux-original");
+  const originalContents = `#!/usr/bin/env bash
+set -euo pipefail
+for name in HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY http_proxy https_proxy all_proxy no_proxy NODE_USE_ENV_PROXY; do
+  if [[ -v $name ]]; then
+    printf '%s=%s\\n' "$name" "\${!name}"
+  else
+    printf '%s=<unset>\\n' "$name"
+  fi
+done
+if [[ -v UNRELATED_SECRET ]]; then
+  printf 'UNRELATED_SECRET=%s\\n' "$UNRELATED_SECRET"
+else
+  printf 'UNRELATED_SECRET=<unset>\\n'
+fi
+printf 'args=%s\\n' "$*"
+`;
+  writeExecutable(nodeRepl, originalContents);
+  return { root, installDir, nodeRepl, originalNodeRepl, originalContents };
+}
+
+function featureEnvironment(installDir) {
+  return {
+    ...process.env,
+    SCRIPT_DIR: REPO_ROOT,
+    INSTALL_DIR: installDir,
+    WORK_DIR: path.join(installDir, ".work"),
+    ARCH: process.arch,
+  };
+}
+
+function runWithFilteredChild(wrapper, parentEnvironment, childEnvironment = {}) {
+  const childAssignments = Object.entries(childEnvironment).map(
+    ([name, value]) => `${name}=${value}`,
+  );
+  // Keep Bash alive as the wrapper's parent. Otherwise Bash may replace itself
+  // with the final command and the wrapper would inspect the Node test runner.
+  const script = `wrapper="$1"; shift; env -i -- PATH="$PATH" HOME="\${HOME:-/tmp}" "$@" "$wrapper" alpha beta; status=$?; :; exit $status`;
+  return run(
+    "bash",
+    ["-c", script, "browser-proxy-parent", wrapper, ...childAssignments],
+    { env: parentEnvironment },
+  );
+}
+
+function reportedEnvironment(stdout) {
+  const environment = new Map();
+  for (const line of stdout.split("\n")) {
+    const separator = line.indexOf("=");
+    if (separator > 0) environment.set(line.slice(0, separator), line.slice(separator + 1));
+  }
+  return environment;
+}
+
+test("browser-proxy is disabled by default and exposes cleanup only while disabled", () => {
+  withTempFeatureRoot([], (root) => {
+    assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot: root }), []);
+    assert.deepEqual(enabledLinuxFeatureStageHooks({ featuresRoot: root }), []);
+    assert.deepEqual(
+      disabledLinuxFeatureCleanupHooks({ featuresRoot: root }).map((hook) => hook.id),
+      ["browser-proxy"],
+    );
+  });
+});
+
+test("browser-proxy exposes one stage hook only when explicitly enabled", () => {
+  withTempFeatureRoot(["browser-proxy"], (root) => {
+    assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot: root }), ["browser-proxy"]);
+    assert.deepEqual(
+      enabledLinuxFeatureStageHooks({ featuresRoot: root }).map((hook) => hook.id),
+      ["browser-proxy"],
+    );
+    assert.deepEqual(disabledLinuxFeatureCleanupHooks({ featuresRoot: root }), []);
+  });
+});
+
+test("feature shell entrypoints pass bash syntax validation", () => {
+  for (const script of [STAGE, CLEANUP, WRAPPER]) run("bash", ["-n", script]);
+});
+
+test("stage is idempotent and the wrapper recovers only proxy variables from its parent", () => {
+  const fixture = makeFakeInstall();
+  try {
+    const env = featureEnvironment(fixture.installDir);
+    run("bash", [STAGE], { env });
+    run("bash", [STAGE], { env });
+
+    assert.equal(fs.readFileSync(fixture.originalNodeRepl, "utf8"), fixture.originalContents);
+    assert.match(fs.readFileSync(fixture.nodeRepl, "utf8"), /browser-proxy-node-repl-wrapper/);
+    assert.equal(fs.statSync(fixture.nodeRepl).mode & 0o777, 0o755);
+    assert.equal(fs.statSync(fixture.originalNodeRepl).mode & 0o111, 0o111);
+
+    const result = runWithFilteredChild(
+      fixture.nodeRepl,
+      cleanProxyEnvironment({
+        HTTP_PROXY: "http://127.0.0.1:18080",
+        https_proxy: "http://127.0.0.1:18443",
+        NO_PROXY: "127.0.0.1,localhost",
+        UNRELATED_SECRET: "must-not-be-copied",
+      }),
+    );
+    assert.match(result.stdout, /^HTTP_PROXY=http:\/\/127\.0\.0\.1:18080$/m);
+    assert.match(result.stdout, /^https_proxy=http:\/\/127\.0\.0\.1:18443$/m);
+    assert.match(result.stdout, /^NO_PROXY=127\.0\.0\.1,localhost$/m);
+    assert.match(result.stdout, /^NODE_USE_ENV_PROXY=1$/m);
+    assert.match(result.stdout, /^HTTPS_PROXY=<unset>$/m);
+    assert.match(result.stdout, /^UNRELATED_SECRET=<unset>$/m);
+    assert.doesNotMatch(result.stdout, /must-not-be-copied/);
+    assert.match(result.stdout, /^args=alpha beta$/m);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("an explicit child proxy value wins over the parent value", () => {
+  const fixture = makeFakeInstall();
+  try {
+    run("bash", [STAGE], { env: featureEnvironment(fixture.installDir) });
+    const result = runWithFilteredChild(
+      fixture.nodeRepl,
+      cleanProxyEnvironment({ HTTP_PROXY: "http://parent.invalid:8080" }),
+      { HTTP_PROXY: "http://child.invalid:9090" },
+    );
+    assert.match(result.stdout, /^HTTP_PROXY=http:\/\/child\.invalid:9090$/m);
+    assert.match(result.stdout, /^NODE_USE_ENV_PROXY=1$/m);
+    assert.doesNotMatch(result.stdout, /parent\.invalid/);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("an explicit child proxy family blocks cross-case parent values", () => {
+  const fixture = makeFakeInstall();
+  try {
+    run("bash", [STAGE], { env: featureEnvironment(fixture.installDir) });
+    const families = [
+      ["HTTP_PROXY", "http_proxy", "http://child-http.invalid:8080"],
+      ["HTTPS_PROXY", "https_proxy", "http://child-https.invalid:8443"],
+      ["ALL_PROXY", "all_proxy", "socks://child-all.invalid:1080"],
+      ["NO_PROXY", "no_proxy", "child.internal,localhost"],
+    ];
+
+    for (const [upperName, lowerName, childValue] of families) {
+      for (const [childName, parentName] of [
+        [upperName, lowerName],
+        [lowerName, upperName],
+      ]) {
+        const parentValue = parentName.toLowerCase() === "no_proxy"
+          ? "parent.internal"
+          : "http://parent-user:parent-secret@parent.invalid:8080";
+        const result = runWithFilteredChild(
+          fixture.nodeRepl,
+          cleanProxyEnvironment({ [parentName]: parentValue }),
+          { [childName]: childValue },
+        );
+        const environment = reportedEnvironment(result.stdout);
+
+        assert.equal(environment.get(childName), childValue);
+        assert.equal(environment.get(parentName), "<unset>");
+        assert.doesNotMatch(result.stdout, /parent-user|parent-secret|parent\.invalid/);
+      }
+    }
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("the wrapper leaves NODE_USE_ENV_PROXY unset when no proxy exists", () => {
+  const fixture = makeFakeInstall();
+  try {
+    run("bash", [STAGE], { env: featureEnvironment(fixture.installDir) });
+    const result = runWithFilteredChild(fixture.nodeRepl, cleanProxyEnvironment());
+    assert.match(result.stdout, /^HTTP_PROXY=<unset>$/m);
+    assert.match(result.stdout, /^https_proxy=<unset>$/m);
+    assert.match(result.stdout, /^NODE_USE_ENV_PROXY=<unset>$/m);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("cleanup restores the original entrypoint byte-for-byte", () => {
+  const fixture = makeFakeInstall();
+  try {
+    const env = featureEnvironment(fixture.installDir);
+    run("bash", [STAGE], { env });
+    run("bash", [CLEANUP], { env });
+    run("bash", [CLEANUP], { env });
+
+    assert.equal(fs.readFileSync(fixture.nodeRepl, "utf8"), fixture.originalContents);
+    assert.equal(fs.existsSync(fixture.originalNodeRepl), false);
+    assert.equal(fs.statSync(fixture.nodeRepl).mode & 0o111, 0o111);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("a staging failure restores the original entrypoint", () => {
+  const fixture = makeFakeInstall();
+  try {
+    const fakeBin = path.join(fixture.root, "fake-bin");
+    writeExecutable(path.join(fakeBin, "install"), "#!/usr/bin/env bash\nexit 73\n");
+    const env = {
+      ...featureEnvironment(fixture.installDir),
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+    };
+    const result = spawnSync("bash", [STAGE], { cwd: REPO_ROOT, encoding: "utf8", env });
+
+    assert.notEqual(result.status, 0, "stage unexpectedly succeeded with a failing install command");
+    assert.equal(fs.readFileSync(fixture.nodeRepl, "utf8"), fixture.originalContents);
+    assert.equal(fs.existsSync(fixture.originalNodeRepl), false);
+    assert.deepEqual(
+      fs.readdirSync(path.dirname(fixture.nodeRepl)).filter((name) => name.startsWith(".node_repl.")),
+      [],
+    );
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("stage and cleanup preserve files when an unknown wrapper owns the entrypoint", () => {
+  const fixture = makeFakeInstall();
+  try {
+    const foreignContents = "#!/usr/bin/env bash\necho foreign wrapper\n";
+    const backupContents = "#!/usr/bin/env bash\necho existing backup\n";
+    writeExecutable(fixture.nodeRepl, foreignContents);
+    writeExecutable(fixture.originalNodeRepl, backupContents);
+    const env = featureEnvironment(fixture.installDir);
+
+    for (const script of [STAGE, CLEANUP]) {
+      const result = spawnSync("bash", [script], { cwd: REPO_ROOT, encoding: "utf8", env });
+      assert.notEqual(result.status, 0, `${path.basename(script)} unexpectedly succeeded`);
+      assert.match(result.stderr, /does not own|not this feature's wrapper/);
+      assert.equal(fs.readFileSync(fixture.nodeRepl, "utf8"), foreignContents);
+      assert.equal(fs.readFileSync(fixture.originalNodeRepl, "utf8"), backupContents);
+    }
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
**IMPORTANT: This is my only open pull request to this repository.**

## Summary

The latest signed Linux package (26.818.22352) can start Browser Use `node_repl` helpers with a filtered environment. On systems where the direct route cannot reach ChatGPT but the Codex app-server has explicit proxy variables, Chrome can still connect, list, and claim tabs while navigation and DOM commands hang during the Browser Use site-status security check.

This adds a disabled-by-default `browser-proxy` Linux feature that:

- wraps the bundled helper and recovers only missing standard proxy variables from its immediate app-server parent;
- preserves explicit child values and enables Node environment-proxy support only when a non-empty proxy exists;
- retains the official helper byte-for-byte as `node_repl.codex-linux-original`, with ownership checks, atomic replacement, rollback, and cleanup;
- documents configuration, scope, and credential exposure in English and Chinese.

The feature does not patch `app.asar`, log proxy values, alter Chrome page routing, set `BROWSER_USE_SECURITY_MODE`, or bypass site-status, URL-policy, or consent checks.

The cross-platform connect/list-but-DOM-timeout symptom also appears in [openai/codex#36278](https://github.com/openai/codex/issues/36278).

## Validation

- `node --test linux-features/browser-proxy/test.js`: 9 passed.
- `node --test scripts/lib/linux-features.test.js linux-features/browser-proxy/test.js`: 39 passed.
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template`
- `bash tests/scripts_smoke.sh`
- `node --test scripts/patch-linux-window-ui.test.js scripts/lib/linux-features.test.js linux-features/*/test.js`: 751 passed, 1 skipped, 0 failed.
- Feature-only build from signed `chatgpt 26.818.22352` on Ubuntu 24.04 / GNOME X11 / amd64; official `app.asar` preserved byte-for-byte.
- Installed and inspected a Debian package built with `PACKAGE_WITH_UPDATER=0`.
- Real Chrome extension validation:
  - Baidu navigation completed in 1.48 s.
  - visible DOM and full DOM snapshot completed in 51 ms and 68 ms.
  - five consecutive DOM + fill/read/clear rounds completed in 212–250 ms each with no timeout.
  - running helpers contained the expected proxy variable names; values and credentials were not printed.

Not tested: arm64, RPM, pacman, AppImage, or Nix runtime packaging. The stage hook is format-independent, but only the Debian payload was built and installed manually.

Security/rollback notes: proxy URLs may contain credentials, so the feature is opt-in and exposes them only to the same-user helper whose immediate parent already has them. Unreadable parent environment leaves the helper environment unchanged. Tests cover idempotency, explicit-child precedence, no-proxy behavior, failed-stage rollback, cleanup restoration, and foreign-wrapper collision preservation.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest signed stable OpenAI Linux package and removes obsolete fallback code and tests.
- [ ] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass. (Relevant local validation passed; GitHub CI is pending.)
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
