### PR TITLE
Allow configurable UI font sizes above 16 px

### DIFF
--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -18,6 +18,7 @@ Enable it in the local, gitignored feature config:
 | Tweak | Patch module | What it does | Settings |
 | --- | --- | --- | --- |
 | `appearance.dockIcon` | `patches/dock-icon.js` | Exposes the upstream Dock icon selector and synchronizes the selected icon across Linux windows, tray, and supported desktop launchers. | `tweaks.appearance.dockIcon.enabled` |
+| `appearance.uiFontSize` | `patches/ui-font-size.js` | Raises the upstream 16 px UI font-size maximum to a configurable value. | `tweaks.appearance.uiFontSize.enabled`, `tweaks.appearance.uiFontSize.max` |
 | `home.suggestedPrompts` | `patches/suggested-prompts.js` | Exposes the upstream Suggested Prompts setting and enables generated project-aware cards on Home. | `tweaks.home.suggestedPrompts.enabled` |
 | `modelPicker.showModelsByDefault` | `patches/model-picker-model-list.js` | Opens the advanced picker by default and shows model choices inline instead of hiding them behind the compact Power slider and a nested Model submenu. | `tweaks.modelPicker.showModelsByDefault.enabled` |
 | `reasoning.keepEffortLabelsEnglish` | `patches/reasoning-effort-labels.js` | Keeps reasoning effort values in English in the Simplified Chinese UI while leaving the surrounding interface translated. | `tweaks.reasoning.keepEffortLabelsEnglish.enabled` |
@@ -102,6 +103,41 @@ launch the app once. That launch lets the marker-safe prelaunch hook remove its
 managed desktop override and icons. The feature can then be removed from the
 next rebuild. Removing `ui-tweaks` directly does not run feature-owned local
 cleanup, by design.
+
+### `appearance.uiFontSize`
+
+Raises the official app's hard-coded UI font-size maximum from 16 px. The same
+upstream limit feeds both the numeric input and the persisted-setting schema, so
+the patch changes their shared limit instead of bypassing only the visible
+control. Code font sizing is unchanged.
+
+This tweak is independently disabled by default. Its default extended maximum
+is 24 px and can be configured from 17 through 64 px:
+
+```json
+{
+  "enabled": ["ui-tweaks"],
+  "settings": {
+    "ui-tweaks": {
+      "tweaks": {
+        "appearance": {
+          "uiFontSize": {
+            "enabled": true,
+            "max": 24
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Config keys:
+
+- `enabled`: `true` raises the UI font-size maximum; `false` preserves the
+  official 11–16 px range.
+- `max`: integer from `17` through `64`; invalid values warn and fall back to
+  `24`.
 
 ### `home.suggestedPrompts`
 
@@ -209,6 +245,8 @@ remove only the incomplete Dock icon payload, and reject candidate promotion.
 Suggested Prompts validates every current insertion point
 before changing an asset and leaves mixed or drifted input byte-identical.
 Invalid style values warn and fall back to the default bold style.
+The UI font-size tweak requires one unique current settings-registry contract
+and leaves a drifted or ambiguous asset unchanged.
 
 ## Adding Tweaks
 

--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -107,9 +107,10 @@ cleanup, by design.
 ### `appearance.uiFontSize`
 
 Raises the official app's hard-coded UI font-size maximum from 16 px. The same
-upstream limit feeds both the numeric input and the persisted-setting schema, so
-the patch changes their shared limit instead of bypassing only the visible
-control. Code font sizing is unchanged.
+upstream limit feeds both the numeric input and the persisted-setting schema.
+That registry is compiled into the renderer, main-process support bundle, and
+worker, so the patch requires and updates all three copies atomically instead of
+bypassing only the visible control. Code font sizing is unchanged.
 
 This tweak is independently disabled by default. Its default extended maximum
 is 24 px and can be configured from 17 through 64 px:
@@ -245,8 +246,9 @@ remove only the incomplete Dock icon payload, and reject candidate promotion.
 Suggested Prompts validates every current insertion point
 before changing an asset and leaves mixed or drifted input byte-identical.
 Invalid style values warn and fall back to the default bold style.
-The UI font-size tweak requires one unique current settings-registry contract
-and leaves a drifted or ambiguous asset unchanged.
+The UI font-size tweak requires the three current settings-registry contracts
+and leaves every target unchanged when any copy is missing, mixed, drifted, or
+ambiguous.
 
 ## Adding Tweaks
 

--- a/linux-features/ui-tweaks/feature.json
+++ b/linux-features/ui-tweaks/feature.json
@@ -18,6 +18,10 @@
     "appearance": {
       "dockIcon": {
         "enabled": false
+      },
+      "uiFontSize": {
+        "enabled": false,
+        "max": 24
       }
     },
     "home": {

--- a/linux-features/ui-tweaks/patch.js
+++ b/linux-features/ui-tweaks/patch.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const sidebarProjectName = require("./patches/sidebar-project-name.js");
+const uiFontSize = require("./patches/ui-font-size.js");
 const modelPickerModelList = require("./patches/model-picker-model-list.js");
 const reasoningEffortLabels = require("./patches/reasoning-effort-labels.js");
 const dockIcon = require("./patches/dock-icon.js");
@@ -15,6 +16,7 @@ function patchesFrom(...modules) {
 module.exports = {
   descriptors: patchesFrom(
     sidebarProjectName,
+    uiFontSize,
     modelPickerModelList,
     reasoningEffortLabels,
     dockIcon,

--- a/linux-features/ui-tweaks/patches/ui-font-size.js
+++ b/linux-features/ui-tweaks/patches/ui-font-size.js
@@ -1,0 +1,103 @@
+"use strict";
+
+const DEFAULT_MAX_UI_FONT_SIZE = 24;
+const MAX_CONFIGURABLE_UI_FONT_SIZE = 64;
+const MIN_EXTENDED_UI_FONT_SIZE = 17;
+const UI_FONT_SIZE_ASSET_PATTERN = /^app-initial-[^.]+\.js$/;
+const RUNTIME_MARKER = "codex-linux-ui-font-size-max";
+const UPSTREAM_FONT_SIZE_LIMITS_PATTERN =
+  /([A-Za-z_$][\w$]*)=\{sans:\{min:(11),max:(16)\},code:\{min:(8),max:(24)\}\}/g;
+
+function warn(message) {
+  console.warn(`WARN: ${message} - skipping ui-tweaks UI font size patch`);
+}
+
+function uiFontSizeConfig(context) {
+  const defaults = context?.feature?.manifest?.tweaks?.appearance?.uiFontSize;
+  const settings = context?.feature?.settings?.tweaks?.appearance?.uiFontSize;
+  return {
+    ...(defaults != null && typeof defaults === "object" && !Array.isArray(defaults) ? defaults : {}),
+    ...(settings != null && typeof settings === "object" && !Array.isArray(settings) ? settings : {}),
+  };
+}
+
+function enabled(context) {
+  return uiFontSizeConfig(context).enabled === true;
+}
+
+function normalizedMaxUiFontSize(context) {
+  const configured = uiFontSizeConfig(context).max;
+  if (configured == null) {
+    return DEFAULT_MAX_UI_FONT_SIZE;
+  }
+  if (
+    !Number.isInteger(configured) ||
+    configured < MIN_EXTENDED_UI_FONT_SIZE ||
+    configured > MAX_CONFIGURABLE_UI_FONT_SIZE
+  ) {
+    console.warn(
+      `WARN: ui-tweaks appearance.uiFontSize.max must be an integer from ` +
+        `${MIN_EXTENDED_UI_FONT_SIZE} to ${MAX_CONFIGURABLE_UI_FONT_SIZE} - ` +
+        `using ${DEFAULT_MAX_UI_FONT_SIZE}`,
+    );
+    return DEFAULT_MAX_UI_FONT_SIZE;
+  }
+  return configured;
+}
+
+function applyUiFontSizePatch(source, context = {}) {
+  try {
+    if (typeof source !== "string") {
+      warn("Asset source is not a string");
+      return source;
+    }
+    if (!enabled(context) || source.includes(RUNTIME_MARKER)) {
+      return source;
+    }
+
+    const matches = [...source.matchAll(UPSTREAM_FONT_SIZE_LIMITS_PATTERN)];
+    if (matches.length !== 1) {
+      if (context.warnOnMissingMarkers === true) {
+        warn("Could not find the unique current UI and code font size limits");
+      }
+      return source;
+    }
+
+    const max = normalizedMaxUiFontSize(context);
+    const [original, registry, sansMin, _sansMax, codeMin, codeMax] = matches[0];
+    const replacement =
+      `${registry}={sans:{min:${sansMin},max:${max}/*${RUNTIME_MARKER}*/},` +
+      `code:{min:${codeMin},max:${codeMax}}}`;
+    return source.replace(original, replacement);
+  } catch (error) {
+    warn(`Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
+    return source;
+  }
+}
+
+const descriptors = [
+  {
+    id: "extended-ui-font-size",
+    phase: "webview-asset",
+    order: 20_792,
+    ciPolicy: "optional",
+    enabled,
+    pattern: UI_FONT_SIZE_ASSET_PATTERN,
+    missingDescription: "appearance settings registry bundle",
+    skipDescription: "ui-tweaks extended UI font size patch",
+    apply: (source, context = {}) =>
+      applyUiFontSizePatch(source, { ...context, warnOnMissingMarkers: true }),
+  },
+];
+
+module.exports = {
+  DEFAULT_MAX_UI_FONT_SIZE,
+  MAX_CONFIGURABLE_UI_FONT_SIZE,
+  MIN_EXTENDED_UI_FONT_SIZE,
+  RUNTIME_MARKER,
+  UI_FONT_SIZE_ASSET_PATTERN,
+  UPSTREAM_FONT_SIZE_LIMITS_PATTERN,
+  applyUiFontSizePatch,
+  descriptors,
+  normalizedMaxUiFontSize,
+};

--- a/linux-features/ui-tweaks/patches/ui-font-size.js
+++ b/linux-features/ui-tweaks/patches/ui-font-size.js
@@ -11,7 +11,7 @@ const EXPECTED_FONT_SIZE_BUNDLE_COUNT = 3;
 const UPSTREAM_FONT_SIZE_LIMITS_PATTERN =
   /([A-Za-z_$][\w$]*)=\{sans:\{min:(11),max:(16)\},code:\{min:(8),max:(24)\}\}/g;
 const APPLIED_FONT_SIZE_LIMITS_PATTERN =
-  /[A-Za-z_$][\w$]*=\{sans:\{min:11,max:(?:1[7-9]|[2-5]\d|6[0-4])\/\*codex-linux-ui-font-size-max\*\/\},code:\{min:8,max:24\}\}/g;
+  /[A-Za-z_$][\w$]*=\{sans:\{min:11,max:(1[7-9]|[2-5]\d|6[0-4])\/\*codex-linux-ui-font-size-max\*\/\},code:\{min:8,max:24\}\}/g;
 
 function warn(message) {
   console.warn(`WARN: ${message} - skipping ui-tweaks UI font size patch`);
@@ -69,6 +69,12 @@ function fontSizeLimitContract(source) {
     return "applied";
   }
   return "drifted";
+}
+
+function appliedUiFontSizeMax(source) {
+  APPLIED_FONT_SIZE_LIMITS_PATTERN.lastIndex = 0;
+  const matches = [...source.matchAll(APPLIED_FONT_SIZE_LIMITS_PATTERN)];
+  return matches.length === 1 ? Number(matches[0][1]) : null;
 }
 
 function applyUiFontSizePatch(source, context = {}) {
@@ -129,7 +135,12 @@ function findUiFontSizeBundles(extractedDir) {
     const source = fs.readFileSync(filePath, "utf8");
     const state = fontSizeLimitContract(source);
     if (state !== "absent") {
-      candidates.push({ filePath, source, state });
+      candidates.push({
+        filePath,
+        source,
+        state,
+        appliedMax: state === "applied" ? appliedUiFontSizeMax(source) : null,
+      });
     }
   }
 
@@ -138,18 +149,23 @@ function findUiFontSizeBundles(extractedDir) {
   ).length;
   const webviewCount = candidates.length - buildCount;
   const states = new Set(candidates.map(({ state }) => state));
+  const appliedMaxes = new Set(
+    candidates.filter(({ state }) => state === "applied").map(({ appliedMax }) => appliedMax),
+  );
   if (
     candidates.length !== EXPECTED_FONT_SIZE_BUNDLE_COUNT ||
     buildCount !== 2 ||
     webviewCount !== 1 ||
     states.has("drifted") ||
-    states.size !== 1
+    states.size !== 1 ||
+    appliedMaxes.size > 1
   ) {
     return {
       candidates: [],
       reason:
         `Found ${buildCount} build and ${webviewCount} webview UI font-size contracts ` +
-        `with states ${JSON.stringify([...states].sort())}`,
+        `with states ${JSON.stringify([...states].sort())} and applied maxima ` +
+        `${JSON.stringify([...appliedMaxes].sort((left, right) => left - right))}`,
     };
   }
   return { candidates, reason: null };
@@ -163,6 +179,14 @@ function applyUiFontSizeAppPatch(extractedDir, context = {}) {
     return { matched: 0, changed: 0, reason };
   }
   if (discovery.candidates[0].state === "applied") {
+    const configuredMax = normalizedMaxUiFontSize(context);
+    if (discovery.candidates[0].appliedMax !== configuredMax) {
+      const reason =
+        `Applied UI font-size maximum ${discovery.candidates[0].appliedMax} ` +
+        `does not match configured maximum ${configuredMax}`;
+      warn(reason);
+      return { matched: 0, changed: 0, reason };
+    }
     return {
       matched: EXPECTED_FONT_SIZE_BUNDLE_COUNT,
       changed: 0,
@@ -215,6 +239,7 @@ module.exports = {
   MIN_EXTENDED_UI_FONT_SIZE,
   RUNTIME_MARKER,
   UPSTREAM_FONT_SIZE_LIMITS_PATTERN,
+  appliedUiFontSizeMax,
   applyUiFontSizeAppPatch,
   applyUiFontSizePatch,
   descriptors,

--- a/linux-features/ui-tweaks/patches/ui-font-size.js
+++ b/linux-features/ui-tweaks/patches/ui-font-size.js
@@ -1,12 +1,17 @@
 "use strict";
 
+const fs = require("node:fs");
+const path = require("node:path");
+
 const DEFAULT_MAX_UI_FONT_SIZE = 24;
 const MAX_CONFIGURABLE_UI_FONT_SIZE = 64;
 const MIN_EXTENDED_UI_FONT_SIZE = 17;
-const UI_FONT_SIZE_ASSET_PATTERN = /^app-initial-[^.]+\.js$/;
 const RUNTIME_MARKER = "codex-linux-ui-font-size-max";
+const EXPECTED_FONT_SIZE_BUNDLE_COUNT = 3;
 const UPSTREAM_FONT_SIZE_LIMITS_PATTERN =
   /([A-Za-z_$][\w$]*)=\{sans:\{min:(11),max:(16)\},code:\{min:(8),max:(24)\}\}/g;
+const APPLIED_FONT_SIZE_LIMITS_PATTERN =
+  /[A-Za-z_$][\w$]*=\{sans:\{min:11,max:(?:1[7-9]|[2-5]\d|6[0-4])\/\*codex-linux-ui-font-size-max\*\/\},code:\{min:8,max:24\}\}/g;
 
 function warn(message) {
   console.warn(`WARN: ${message} - skipping ui-tweaks UI font size patch`);
@@ -45,6 +50,27 @@ function normalizedMaxUiFontSize(context) {
   return configured;
 }
 
+function countMatches(source, pattern) {
+  pattern.lastIndex = 0;
+  return [...source.matchAll(pattern)].length;
+}
+
+function fontSizeLimitContract(source) {
+  const markerCount = source.split(RUNTIME_MARKER).length - 1;
+  const upstreamCount = countMatches(source, UPSTREAM_FONT_SIZE_LIMITS_PATTERN);
+  const appliedCount = countMatches(source, APPLIED_FONT_SIZE_LIMITS_PATTERN);
+  if (markerCount === 0 && upstreamCount === 0 && appliedCount === 0) {
+    return "absent";
+  }
+  if (markerCount === 0 && upstreamCount === 1 && appliedCount === 0) {
+    return "current";
+  }
+  if (markerCount === 1 && upstreamCount === 0 && appliedCount === 1) {
+    return "applied";
+  }
+  return "drifted";
+}
+
 function applyUiFontSizePatch(source, context = {}) {
   try {
     if (typeof source !== "string") {
@@ -55,6 +81,7 @@ function applyUiFontSizePatch(source, context = {}) {
       return source;
     }
 
+    UPSTREAM_FONT_SIZE_LIMITS_PATTERN.lastIndex = 0;
     const matches = [...source.matchAll(UPSTREAM_FONT_SIZE_LIMITS_PATTERN)];
     if (matches.length !== 1) {
       if (context.warnOnMissingMarkers === true) {
@@ -75,29 +102,123 @@ function applyUiFontSizePatch(source, context = {}) {
   }
 }
 
+function fontSizeBundlePaths(extractedDir) {
+  const buildDir = path.join(extractedDir, ".vite", "build");
+  const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
+  const paths = [];
+  if (fs.existsSync(buildDir)) {
+    paths.push(
+      ...fs.readdirSync(buildDir, { withFileTypes: true })
+        .filter((entry) => entry.isFile() && entry.name.endsWith(".js"))
+        .map((entry) => path.join(buildDir, entry.name)),
+    );
+  }
+  if (fs.existsSync(webviewAssetsDir)) {
+    paths.push(
+      ...fs.readdirSync(webviewAssetsDir, { withFileTypes: true })
+        .filter((entry) => entry.isFile() && /^app-initial-[^.]+\.js$/.test(entry.name))
+        .map((entry) => path.join(webviewAssetsDir, entry.name)),
+    );
+  }
+  return paths.sort();
+}
+
+function findUiFontSizeBundles(extractedDir) {
+  const candidates = [];
+  for (const filePath of fontSizeBundlePaths(extractedDir)) {
+    const source = fs.readFileSync(filePath, "utf8");
+    const state = fontSizeLimitContract(source);
+    if (state !== "absent") {
+      candidates.push({ filePath, source, state });
+    }
+  }
+
+  const buildCount = candidates.filter(({ filePath }) =>
+    filePath.startsWith(`${path.join(extractedDir, ".vite", "build")}${path.sep}`),
+  ).length;
+  const webviewCount = candidates.length - buildCount;
+  const states = new Set(candidates.map(({ state }) => state));
+  if (
+    candidates.length !== EXPECTED_FONT_SIZE_BUNDLE_COUNT ||
+    buildCount !== 2 ||
+    webviewCount !== 1 ||
+    states.has("drifted") ||
+    states.size !== 1
+  ) {
+    return {
+      candidates: [],
+      reason:
+        `Found ${buildCount} build and ${webviewCount} webview UI font-size contracts ` +
+        `with states ${JSON.stringify([...states].sort())}`,
+    };
+  }
+  return { candidates, reason: null };
+}
+
+function applyUiFontSizeAppPatch(extractedDir, context = {}) {
+  const discovery = findUiFontSizeBundles(extractedDir);
+  if (discovery.candidates.length !== EXPECTED_FONT_SIZE_BUNDLE_COUNT) {
+    const reason = discovery.reason ?? "Current UI font-size contracts not found";
+    warn(reason);
+    return { matched: 0, changed: 0, reason };
+  }
+  if (discovery.candidates[0].state === "applied") {
+    return {
+      matched: EXPECTED_FONT_SIZE_BUNDLE_COUNT,
+      changed: 0,
+      reason: null,
+      targets: discovery.candidates.map(({ filePath }) => path.relative(extractedDir, filePath)),
+    };
+  }
+
+  const results = discovery.candidates.map((candidate) => ({
+    ...candidate,
+    patchedSource: applyUiFontSizePatch(candidate.source, context),
+  }));
+  if (results.some(({ patchedSource, source }) => patchedSource === source)) {
+    const reason = "Could not patch every current UI font-size contract";
+    warn(reason);
+    return { matched: 0, changed: 0, reason };
+  }
+  for (const { filePath, patchedSource } of results) {
+    fs.writeFileSync(filePath, patchedSource, "utf8");
+  }
+  return {
+    matched: EXPECTED_FONT_SIZE_BUNDLE_COUNT,
+    changed: EXPECTED_FONT_SIZE_BUNDLE_COUNT,
+    reason: null,
+    targets: results.map(({ filePath }) => path.relative(extractedDir, filePath)),
+  };
+}
+
 const descriptors = [
   {
     id: "extended-ui-font-size",
-    phase: "webview-asset",
+    phase: "extracted-app:post-webview",
     order: 20_792,
     ciPolicy: "optional",
     enabled,
-    pattern: UI_FONT_SIZE_ASSET_PATTERN,
-    missingDescription: "appearance settings registry bundle",
-    skipDescription: "ui-tweaks extended UI font size patch",
-    apply: (source, context = {}) =>
-      applyUiFontSizePatch(source, { ...context, warnOnMissingMarkers: true }),
+    apply: applyUiFontSizeAppPatch,
+    status: (result, warnings) => {
+      if (result?.matched !== EXPECTED_FONT_SIZE_BUNDLE_COUNT) {
+        return { status: "skipped-optional", reason: result?.reason ?? warnings[0] ?? null };
+      }
+      return result.changed > 0 ? "applied" : "already-applied";
+    },
   },
 ];
 
 module.exports = {
   DEFAULT_MAX_UI_FONT_SIZE,
+  EXPECTED_FONT_SIZE_BUNDLE_COUNT,
   MAX_CONFIGURABLE_UI_FONT_SIZE,
   MIN_EXTENDED_UI_FONT_SIZE,
   RUNTIME_MARKER,
-  UI_FONT_SIZE_ASSET_PATTERN,
   UPSTREAM_FONT_SIZE_LIMITS_PATTERN,
+  applyUiFontSizeAppPatch,
   applyUiFontSizePatch,
   descriptors,
+  findUiFontSizeBundles,
+  fontSizeLimitContract,
   normalizedMaxUiFontSize,
 };

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -43,11 +43,13 @@ const {
 } = require("./patches/reasoning-effort-labels.js");
 const {
   DEFAULT_MAX_UI_FONT_SIZE,
+  EXPECTED_FONT_SIZE_BUNDLE_COUNT,
   MAX_CONFIGURABLE_UI_FONT_SIZE,
   MIN_EXTENDED_UI_FONT_SIZE,
   RUNTIME_MARKER: UI_FONT_SIZE_RUNTIME_MARKER,
-  UI_FONT_SIZE_ASSET_PATTERN,
+  applyUiFontSizeAppPatch,
   applyUiFontSizePatch,
+  findUiFontSizeBundles,
   normalizedMaxUiFontSize,
 } = require("./patches/ui-font-size.js");
 
@@ -174,6 +176,24 @@ function uiFontSizeContext(overrides = {}) {
   };
 }
 
+function createUiFontSizeExtractedApp() {
+  const extractedDir = fs.mkdtempSync(path.join(os.tmpdir(), "ui-font-size-app-"));
+  const buildDir = path.join(extractedDir, ".vite", "build");
+  const webviewDir = path.join(extractedDir, "webview", "assets");
+  fs.mkdirSync(buildDir, { recursive: true });
+  fs.mkdirSync(webviewDir, { recursive: true });
+  const targets = [
+    path.join(buildDir, "src-fixture.js"),
+    path.join(buildDir, "worker.js"),
+    path.join(webviewDir, "app-initial-fixture.js"),
+  ];
+  for (const target of targets) {
+    fs.writeFileSync(target, uiFontSizeBundleFixture());
+  }
+  fs.writeFileSync(path.join(buildDir, "unrelated.js"), "console.log('unrelated');");
+  return { extractedDir, targets };
+}
+
 function applyPatchTwice(source, context) {
   const patched = applySidebarProjectNameStylePatch(source, context);
   assert.equal(applySidebarProjectNameStylePatch(patched, context), patched);
@@ -220,7 +240,11 @@ test("ui-tweaks is discoverable and disabled until listed in features.json", () 
       descriptors.map((descriptor) => [descriptor.id, descriptor.phase, descriptor.ciPolicy]),
       [
         ["feature:ui-tweaks:sidebar-project-name-style", "webview-asset", "optional"],
-        ["feature:ui-tweaks:extended-ui-font-size", "webview-asset", "optional"],
+        [
+          "feature:ui-tweaks:extended-ui-font-size",
+          "extracted-app:post-webview",
+          "optional",
+        ],
         ["feature:ui-tweaks:model-picker-default-advanced-view", "webview-asset", "optional"],
         ["feature:ui-tweaks:model-picker-inline-model-list", "webview-asset", "optional"],
         [
@@ -289,8 +313,70 @@ test("UI font size tweak raises the shared input and schema maximum", () => {
   assert.match(patched, new RegExp(UI_FONT_SIZE_RUNTIME_MARKER));
   assert.equal((patched.match(new RegExp(UI_FONT_SIZE_RUNTIME_MARKER, "g")) ?? []).length, 1);
   assert.equal(applyUiFontSizePatch(patched, uiFontSizeContext()), patched);
-  assert.match("app-initial-BOhZp99F.js", UI_FONT_SIZE_ASSET_PATTERN);
-  assert.doesNotMatch("general-settings-C9tRVDyl.js", UI_FONT_SIZE_ASSET_PATTERN);
+});
+
+test("UI font size tweak atomically patches all three runtime registries", () => {
+  const { extractedDir, targets } = createUiFontSizeExtractedApp();
+  try {
+    const discovery = findUiFontSizeBundles(extractedDir);
+    assert.equal(discovery.candidates.length, EXPECTED_FONT_SIZE_BUNDLE_COUNT);
+
+    const result = applyUiFontSizeAppPatch(extractedDir, uiFontSizeContext({ max: 32 }));
+    assert.equal(result.matched, EXPECTED_FONT_SIZE_BUNDLE_COUNT);
+    assert.equal(result.changed, EXPECTED_FONT_SIZE_BUNDLE_COUNT);
+    for (const target of targets) {
+      const source = fs.readFileSync(target, "utf8");
+      assert.match(source, /sans:\{min:11,max:32\/\*/);
+      assert.match(source, new RegExp(UI_FONT_SIZE_RUNTIME_MARKER));
+    }
+
+    const repeated = applyUiFontSizeAppPatch(extractedDir, uiFontSizeContext({ max: 32 }));
+    assert.equal(repeated.matched, EXPECTED_FONT_SIZE_BUNDLE_COUNT);
+    assert.equal(repeated.changed, 0);
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
+});
+
+test("UI font size app patch rejects missing, duplicate, and mixed registries byte-identically", () => {
+  for (const mutate of [
+    ({ targets }) => fs.rmSync(targets[1]),
+    ({ extractedDir }) =>
+      fs.writeFileSync(
+        path.join(extractedDir, ".vite", "build", "duplicate.js"),
+        uiFontSizeBundleFixture(),
+      ),
+    ({ targets }) =>
+      fs.writeFileSync(
+        targets[0],
+        applyUiFontSizePatch(fs.readFileSync(targets[0], "utf8"), uiFontSizeContext()),
+      ),
+    ({ targets }) =>
+      fs.writeFileSync(
+        targets[0],
+        fs.readFileSync(targets[0], "utf8") + `/*${UI_FONT_SIZE_RUNTIME_MARKER}*/`,
+      ),
+  ]) {
+    const fixture = createUiFontSizeExtractedApp();
+    try {
+      mutate(fixture);
+      const before = fixture.targets
+        .filter((target) => fs.existsSync(target))
+        .map((target) => [target, fs.readFileSync(target, "utf8")]);
+      const { value: result, warnings } = withCapturedWarns(() =>
+        applyUiFontSizeAppPatch(fixture.extractedDir, uiFontSizeContext()),
+      );
+
+      assert.equal(result.matched, 0);
+      assert.equal(result.changed, 0);
+      assert.equal(warnings.length, 1);
+      for (const [target, source] of before) {
+        assert.equal(fs.readFileSync(target, "utf8"), source);
+      }
+    } finally {
+      fs.rmSync(fixture.extractedDir, { recursive: true, force: true });
+    }
+  }
 });
 
 test("UI font size tweak is disabled by default and accepts a custom maximum", () => {
@@ -776,7 +862,16 @@ test("feature settings override the tracked defaults through features.json", () 
       candidate.id.endsWith(":extended-ui-font-size"),
     );
     assert.equal(uiFontSizeDescriptor.enabled({}), true);
-    assert.match(uiFontSizeDescriptor.apply(uiFontSizeBundleFixture(), {}), /max:32\/\*/);
+    const fontSizeFixture = createUiFontSizeExtractedApp();
+    try {
+      const result = uiFontSizeDescriptor.apply(fontSizeFixture.extractedDir, {});
+      assert.equal(result.changed, EXPECTED_FONT_SIZE_BUNDLE_COUNT);
+      for (const target of fontSizeFixture.targets) {
+        assert.match(fs.readFileSync(target, "utf8"), /max:32\/\*/);
+      }
+    } finally {
+      fs.rmSync(fontSizeFixture.extractedDir, { recursive: true, force: true });
+    }
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -356,6 +356,18 @@ test("UI font size app patch rejects missing, duplicate, and mixed registries by
         targets[0],
         fs.readFileSync(targets[0], "utf8") + `/*${UI_FONT_SIZE_RUNTIME_MARKER}*/`,
       ),
+    ({ targets }) => {
+      for (const target of targets) {
+        fs.writeFileSync(
+          target,
+          applyUiFontSizePatch(fs.readFileSync(target, "utf8"), uiFontSizeContext()),
+        );
+      }
+      fs.writeFileSync(
+        targets[0],
+        applyUiFontSizePatch(uiFontSizeBundleFixture(), uiFontSizeContext({ max: 32 })),
+      );
+    },
   ]) {
     const fixture = createUiFontSizeExtractedApp();
     try {

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -41,6 +41,15 @@ const {
   ZH_CN_LOCALE_ASSET_PATTERN,
   applyEnglishReasoningLabels,
 } = require("./patches/reasoning-effort-labels.js");
+const {
+  DEFAULT_MAX_UI_FONT_SIZE,
+  MAX_CONFIGURABLE_UI_FONT_SIZE,
+  MIN_EXTENDED_UI_FONT_SIZE,
+  RUNTIME_MARKER: UI_FONT_SIZE_RUNTIME_MARKER,
+  UI_FONT_SIZE_ASSET_PATTERN,
+  applyUiFontSizePatch,
+  normalizedMaxUiFontSize,
+} = require("./patches/ui-font-size.js");
 
 function projectBundleFixture() {
   return [
@@ -127,6 +136,44 @@ function simplifiedChineseLocaleFixture() {
     .join(",");
 }
 
+function uiFontSizeBundleFixture() {
+  return [
+    "var Wu,Gu,Input,Aje=setup(()=>{",
+    "Wu={sans:{min:11,max:16},code:{min:8,max:24}},",
+    "Gu={sansFontSize:setting({default:14,schema:number().min(Wu.sans.min).max(Wu.sans.max)})},",
+    "Input=input({min:Wu.sans.min,max:Wu.sans.max})",
+    "});",
+    "function fontSizeState(){return {input:Input,limits:Wu,setting:Gu.sansFontSize}}",
+  ].join("");
+}
+
+function uiFontSizeContext(overrides = {}) {
+  return {
+    feature: {
+      manifest: {
+        tweaks: {
+          appearance: {
+            uiFontSize: {
+              enabled: false,
+              max: DEFAULT_MAX_UI_FONT_SIZE,
+            },
+          },
+        },
+      },
+      settings: {
+        tweaks: {
+          appearance: {
+            uiFontSize: {
+              enabled: true,
+              ...overrides,
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
 function applyPatchTwice(source, context) {
   const patched = applySidebarProjectNameStylePatch(source, context);
   assert.equal(applySidebarProjectNameStylePatch(patched, context), patched);
@@ -173,6 +220,7 @@ test("ui-tweaks is discoverable and disabled until listed in features.json", () 
       descriptors.map((descriptor) => [descriptor.id, descriptor.phase, descriptor.ciPolicy]),
       [
         ["feature:ui-tweaks:sidebar-project-name-style", "webview-asset", "optional"],
+        ["feature:ui-tweaks:extended-ui-font-size", "webview-asset", "optional"],
         ["feature:ui-tweaks:model-picker-default-advanced-view", "webview-asset", "optional"],
         ["feature:ui-tweaks:model-picker-inline-model-list", "webview-asset", "optional"],
         [
@@ -197,8 +245,101 @@ test("ui-tweaks is discoverable and disabled until listed in features.json", () 
       modelPickerDescriptors.every((descriptor) => typeof descriptor.enabled === "function"),
     );
     assert.ok(modelPickerDescriptors.every((descriptor) => descriptor.enabled({}) === false));
+    const uiFontSizeDescriptor = descriptors.find((descriptor) =>
+      descriptor.id.endsWith(":extended-ui-font-size"),
+    );
+    assert.equal(typeof uiFontSizeDescriptor?.enabled, "function");
+    assert.equal(uiFontSizeDescriptor.enabled({}), false);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("UI font size tweak raises the shared input and schema maximum", () => {
+  const source = uiFontSizeBundleFixture();
+  const patched = applyUiFontSizePatch(source, uiFontSizeContext());
+  const state = Function(
+    "setup",
+    "setting",
+    "number",
+    "input",
+    `${patched};return fontSizeState();`,
+  )(
+    (callback) => callback(),
+    (value) => value,
+    () => ({
+      min(value) {
+        this.minValue = value;
+        return this;
+      },
+      max(value) {
+        this.maxValue = value;
+        return this;
+      },
+    }),
+    (value) => value,
+  );
+
+  assert.deepEqual(state.limits, {
+    sans: { min: 11, max: DEFAULT_MAX_UI_FONT_SIZE },
+    code: { min: 8, max: 24 },
+  });
+  assert.equal(state.input.max, DEFAULT_MAX_UI_FONT_SIZE);
+  assert.equal(state.setting.schema.maxValue, DEFAULT_MAX_UI_FONT_SIZE);
+  assert.match(patched, new RegExp(UI_FONT_SIZE_RUNTIME_MARKER));
+  assert.equal((patched.match(new RegExp(UI_FONT_SIZE_RUNTIME_MARKER, "g")) ?? []).length, 1);
+  assert.equal(applyUiFontSizePatch(patched, uiFontSizeContext()), patched);
+  assert.match("app-initial-BOhZp99F.js", UI_FONT_SIZE_ASSET_PATTERN);
+  assert.doesNotMatch("general-settings-C9tRVDyl.js", UI_FONT_SIZE_ASSET_PATTERN);
+});
+
+test("UI font size tweak is disabled by default and accepts a custom maximum", () => {
+  const source = uiFontSizeBundleFixture();
+  const featureJson = JSON.parse(fs.readFileSync(path.join(__dirname, "feature.json"), "utf8"));
+  const defaultContext = { feature: { manifest: featureJson } };
+  const customContext = uiFontSizeContext({ max: 32 });
+
+  assert.equal(featureJson.tweaks.appearance.uiFontSize.enabled, false);
+  assert.equal(featureJson.tweaks.appearance.uiFontSize.max, DEFAULT_MAX_UI_FONT_SIZE);
+  assert.equal(applyUiFontSizePatch(source, defaultContext), source);
+  assert.match(applyUiFontSizePatch(source, customContext), /sans:\{min:11,max:32\/\*/);
+  assert.equal(normalizedMaxUiFontSize(customContext), 32);
+});
+
+test("invalid UI font size maxima warn and fall back to the safe default", () => {
+  for (const max of [16, 24.5, MAX_CONFIGURABLE_UI_FONT_SIZE + 1, "32"]) {
+    const context = uiFontSizeContext({ max });
+    const { value, warnings } = withCapturedWarns(() =>
+      applyUiFontSizePatch(uiFontSizeBundleFixture(), context),
+    );
+
+    assert.match(value, new RegExp(`sans:\\{min:11,max:${DEFAULT_MAX_UI_FONT_SIZE}\\/\\*`));
+    assert.equal(warnings.length, 1);
+    assert.match(
+      warnings[0],
+      new RegExp(
+        `must be an integer from ${MIN_EXTENDED_UI_FONT_SIZE} ` +
+          `to ${MAX_CONFIGURABLE_UI_FONT_SIZE}`,
+      ),
+    );
+  }
+});
+
+test("UI font size drift and duplicate contracts fail closed", () => {
+  for (const source of [
+    "var limits={sans:{min:11,max:17},code:{min:8,max:24}};",
+    uiFontSizeBundleFixture() + uiFontSizeBundleFixture(),
+  ]) {
+    const { value, warnings } = withCapturedWarns(() =>
+      applyUiFontSizePatch(source, {
+        ...uiFontSizeContext(),
+        warnOnMissingMarkers: true,
+      }),
+    );
+
+    assert.equal(value, source);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /unique current UI and code font size limits/);
   }
 });
 
@@ -596,6 +737,12 @@ test("feature settings override the tracked defaults through features.json", () 
           settings: {
             "ui-tweaks": {
               tweaks: {
+                appearance: {
+                  uiFontSize: {
+                    enabled: true,
+                    max: 32,
+                  },
+                },
                 sidebar: {
                   projectName: {
                     style: "font-weight: 800 !important; color: red;",
@@ -625,6 +772,11 @@ test("feature settings override the tracked defaults through features.json", () 
         .filter((candidate) => candidate.id.includes(":model-picker-"))
         .every((candidate) => candidate.enabled({}) === true),
     );
+    const uiFontSizeDescriptor = descriptors.find((candidate) =>
+      candidate.id.endsWith(":extended-ui-font-size"),
+    );
+    assert.equal(uiFontSizeDescriptor.enabled({}), true);
+    assert.match(uiFontSizeDescriptor.apply(uiFontSizeBundleFixture(), {}), /max:32\/\*/);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Summary
- add a disabled-by-default `ui-tweaks` option that raises the UI font-size maximum (24 px by default, configurable from 17–64)
- patch the settings registry atomically in the renderer, main-process support bundle, and worker
- fail closed without modifying assets when any expected runtime contract is missing, duplicated, mixed, or drifted

Tests/checks
- `node --test linux-features/ui-tweaks/test.js` (66 passed)
- `node --test scripts/patch-linux-window-ui.test.js scripts/lib/linux-features.test.js linux-features/ui-tweaks/test.js` (101 passed)
- `bash tests/scripts_smoke.sh` (51 passed)
- signed official-package feature-only inspection (patch applied to all three runtime bundles)
- `git diff --check`

Notes
- disabled in committed configuration; users opt in through `linux-features/features.json`
- code font sizing is unchanged