### PR TITLE
Fix remote-control provider alias capture

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -3,12 +3,6 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
-function requireName(source, moduleName) {
-  const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = source.match(new RegExp(`([A-Za-z_$][\\w$]*)=require\\("${escaped}"\\)`));
-  return match?.[1] ?? null;
-}
-
 const DEVICE_KEY_CLIENT_MARKER = "codexLinuxRemoteControlDeviceKeyClient";
 const DEVICE_KEY_GUARD =
   "if(process.platform!==`darwin`&&process.platform!==`win32`)throw Error(`Remote control device keys are only available on macOS and Windows`);";
@@ -89,6 +83,7 @@ function replaceOnce(source, needle, replacement) {
 
 function linuxDeviceKeyProviderSource({ childProcessVar, cryptoVar, fsVar, pathVar }) {
   return [
+    `const ${pathVar}=require(\`node:path\`),${fsVar}=require(\`node:fs\`),${cryptoVar}=require(\`node:crypto\`),${childProcessVar}=require(\`node:child_process\`);`,
     "const codexLinuxRemoteControlKeyStoreVersion=2,codexLinuxRemoteControlKeyStoreMaxBytes=1048576,codexLinuxRemoteControlKeyStoreMaxKeys=64;",
     "function codexLinuxRemoteControlAssertOwnedRegularStat(e){if(!e.isFile())throw Error(`Linux remote control key state must be a regular file`);if(typeof process.getuid==`function`&&e.uid!==process.getuid())throw Error(`Linux remote control key state is owned by another user`);if((e.mode&511)!==384)throw Error(`Linux remote control key state permissions must be 0600`);return e}",
     "function codexLinuxRemoteControlAssertOwnedRegularFile(e,t){let n=t.lstatSync(e);if(n.isSymbolicLink())throw Error(`Linux remote control key state must be a regular file`);return codexLinuxRemoteControlAssertOwnedRegularStat(n)}",
@@ -164,14 +159,10 @@ function applyLinuxRemoteControlDeviceKeyPatch(source) {
     return source;
   }
 
-  const cryptoVar = requireName(source, "node:crypto");
-  const fsVar = requireName(source, "node:fs");
-  const pathVar = requireName(source, "node:path");
-  const childProcessVar = "require(`node:child_process`)";
-  if (cryptoVar == null || fsVar == null || pathVar == null) {
-    console.warn("WARN: Could not find Node module aliases - skipping Linux remote-control device-key patch");
-    return source;
-  }
+  const cryptoVar = "codexLinuxRemoteControlCrypto";
+  const fsVar = "codexLinuxRemoteControlFs";
+  const pathVar = "codexLinuxRemoteControlPath";
+  const childProcessVar = "codexLinuxRemoteControlChildProcess";
 
   const insertionNeedle = source.match(DEVICE_KEY_REQUIRE_NEEDLE)?.[0] ?? null;
   if (insertionNeedle == null || !source.includes(DEVICE_KEY_GUARD)) {

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -1088,15 +1088,23 @@ test("Linux remote-control device-key provider does not capture a function-local
   const source = `function injectedFeature(){let __codexChild=require(\`node:child_process\`);return __codexChild}${syntheticMainBundle()}`;
   const patched = applyLinuxRemoteControlDeviceKeyPatch(source);
 
-  assert.match(patched, /require\(`node:child_process`\)\.spawn\(/);
+  assert.match(patched, /codexLinuxRemoteControlChildProcess\.spawn\(/);
   assert.doesNotMatch(patched, /__codexChild\.spawn\(/);
+});
+
+test("Linux remote-control device-key provider does not capture a function-local path alias", () => {
+  const source = `function injectedFeature(){let n=require("node:path");return n}${syntheticMainBundle()}`;
+  const patched = applyLinuxRemoteControlDeviceKeyPatch(source);
+
+  assert.match(patched, /codexLinuxRemoteControlPath\.isAbsolute\(/);
+  assert.doesNotMatch(patched, /n\.isAbsolute\(codexLinuxRemoteControlConfigRoot\)/);
 });
 
 test("Linux remote-control device-key provider avoids upstream minified alias collisions", async () => {
   const configHome = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-key-collision-"));
   try {
     const patched = applyLinuxRemoteControlDeviceKeyPatch(syntheticCryptoAliasCollisionMainBundle());
-    assert.match(patched, /\(0,c\.generateKeyPairSync\)\(`/);
+    assert.match(patched, /\(0,codexLinuxRemoteControlCrypto\.generateKeyPairSync\)\(`/);
     assert.match(patched, /codexLinuxRemoteControlKeyRecord/);
     assert.doesNotMatch(patched, /let c=\{algorithm:`ecdsa_p256_sha256`/);
 


### PR DESCRIPTION
## Problem

Outbound remote-control authorization can fail after the enrollment-start response with:

```text
n.isAbsolute is not a function
```

The device-key patch searched the entire minified main bundle for existing Node module aliases. On the current official `26.818.41705` bundle, that search can capture a function-local `node:path` alias and then reference it from the separately injected provider, where it resolves to an unrelated value.

This is a follow-up to #919: the dedicated private key directory remains unchanged, but the provider no longer relies on drift-prone aliases from the upstream bundle.

## Solution

- import `node:path`, `node:fs`, `node:crypto`, and `node:child_process` through provider-scoped, feature-owned names
- remove the whole-bundle alias scanner
- add a regression fixture with an earlier function-local `node:path` alias
- keep the existing child-process and crypto collision coverage aligned with the owned module names

## User-visible behavior

Clicking **Authorize on chatgpt.com** no longer crashes locally while preparing the Linux device key. This affects the disabled-by-default `remote-mobile-control` feature across package formats and architectures.

## Validation

- `node --test linux-features/remote-mobile-control/test.js` — 101 passed
- `node --test scripts/patch-linux-window-ui.test.js scripts/lib/linux-features.test.js linux-features/remote-mobile-control/test.js` — 136 passed
- `bash tests/scripts_smoke.sh` — 51 passed
- feature-only inspection against official Linux package `26.818.41705` — 15 descriptors applied, 3 already applied, no failures
- `git diff --check`

Runtime reproduction and patched-package launch were verified on Arch Linux x86_64 with Hyprland. Other architectures and package formats were not manually exercised; the changed code is format-independent injected JavaScript.
