### PR TITLE
Fix empty helper workspace source for feature helpers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,10 @@
           src = sourceRoot;
           filter = path: type:
             let
-              relative = lib.removePrefix "${toString sourceRoot}/" (toString path);
+              # Relative to ./. and not sourceRoot: cleanSourceWith composes
+              # filters onto the original source root, so this filter is called
+              # with paths under ./., never under sourceRoot's own store path.
+              relative = lib.removePrefix "${toString ./.}/" (toString path);
               workspacePaths = [
                 "computer-use-linux"
                 "read-aloud-linux"
@@ -875,6 +878,16 @@
           touch "$out"
         '';
         checks.modules = import ./nix/modules-test.nix { inherit pkgs self system; };
+        checks.helper-workspace-source =
+          pkgs.runCommand "helper-workspace-source-check" { } ''
+            test -f ${helperWorkspaceSource}/Cargo.lock
+            test -f ${helperWorkspaceSource}/Cargo.toml
+            test -d ${helperWorkspaceSource}/computer-use-linux
+            test -d ${helperWorkspaceSource}/read-aloud-linux
+            test -d ${helperWorkspaceSource}/record-replay-linux
+            test -d ${helperWorkspaceSource}/updater
+            touch "$out"
+          '';
         checks.nix-runtime = mkRuntimeCheck "nix-runtime-check" codexDesktop true false;
         checks.nix-runtime-chronicle-skysight =
           mkRuntimeCheck "nix-runtime-chronicle-skysight" chronicleSkysight false false;


### PR DESCRIPTION
## Problem

`helperWorkspaceSource` derives its relative path with:

```nix
relative = lib.removePrefix "${toString sourceRoot}/" (toString path);
```

but `sourceRoot` is itself a `lib.cleanSourceWith` result. `cleanSourceWith` composes filters onto `orig.origSrc` rather than materialising the intermediate source (see `lib/sources.nix`), so this filter is invoked with paths under `./.`, while `toString sourceRoot` is the intermediate store path. The prefix never strips, `relative` stays absolute, no branch of the predicate matches, and every path is excluded.

## User-visible behavior

The resulting `src` is an empty directory, so any build that reaches `mkWorkspaceHelpers` fails at the Cargo lock consistency hook:

```
Validating consistency between /build/source/Cargo.lock and /build/cargo-vendor-dir/Cargo.lock
/nix/store/...-diffutils-3.12/bin/diff: /build/source/Cargo.lock: No such file or directory
ERROR: Missing Cargo.lock from src. Expected to find it at: /build/source/Cargo.lock
```

This affects every configuration that enables `computer-use-linux`, `read-aloud-mcp`, `chronicle-skysight`, or `record-and-replay`.

## Affected formats / features

Nix only — deb, RPM, pacman and AppImage build these helpers through the Makefile and are unaffected. Features: computer-use, read-aloud, record/replay.

## Change

Take the prefix from `./.` so it matches the paths the composed filter actually receives, and add a `checks.helper-workspace-source` flake check asserting the workspace source contains `Cargo.lock`, `Cargo.toml` and the four crate directories.

## Validation

On x86_64-linux:

- `nix build .#checks.x86_64-linux.helper-workspace-source` — fails on the unfixed tree (this is the regression test), passes with the fix.
- `nix build .#checks.x86_64-linux.nix-runtime-computer-use` — builds `codex-desktop-feature-helpers-0.1.0` and passes.

Not run: the full `nix flake check`, the non-Nix package formats, and `arm64`.

---

*Disclosure: this change and description were produced with Claude Code (Claude Opus 5) and reviewed by me before submission. The commit carries an `Assisted-by:` trailer.*
