### PR TITLE
Fix NixOS sandbox and workspace runtimes

### DIFF
--- a/docs/nix.md
+++ b/docs/nix.md
@@ -114,13 +114,18 @@ The Nix package follows the standard `NIXOS_OZONE_WL` convention. When both
 `NIXOS_OZONE_WL` and `WAYLAND_DISPLAY` are set, its wrapper starts Electron with
 native Wayland rendering and text-input-v3 IME support.
 
-On NixOS the launcher includes Bubblewrap on `PATH` for the Codex Linux command
-sandbox and enters a package-local FHS compatibility environment before
-starting the app. Generic Linux Git, Node.js, Python, and pnpm runtimes
-downloaded into the user cache therefore have their expected dynamic linker
-and libraries; enabling the system-wide `programs.nix-ld` module is not
-required. Other Nix systems keep the normal launcher path and use their system
-Bubblewrap integration.
+On NixOS the launcher includes a package-local Bubblewrap adapter on `PATH` for
+the Codex Linux command sandbox. The adapter preserves the sandbox policy and
+adds the packaged `nix-ld` interpreter and runtime libraries inside that mount
+namespace. Generic Linux Git, Node.js, Python, and pnpm runtimes downloaded into
+the user cache therefore work in sandboxed workspace commands without enabling
+the system-wide `programs.nix-ld` module. Other Nix systems keep the normal
+launcher path and use their system Bubblewrap integration.
+
+The adapter uses the generic loader symlink that NixOS provides through
+`environment.stub-ld` by default. A system that explicitly disables both that
+stub and `programs.nix-ld` keeps the packaged Bubblewrap integration, but its
+generic cached runtimes remain unavailable.
 
 The wrapper uses the NixOS OpenGL driver path when it is present and retains
 Mesa as a fallback. Proprietary drivers on non-NixOS distributions may still

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -114,12 +114,13 @@ The Nix package follows the standard `NIXOS_OZONE_WL` convention. When both
 `NIXOS_OZONE_WL` and `WAYLAND_DISPLAY` are set, its wrapper starts Electron with
 native Wayland rendering and text-input-v3 IME support.
 
-The launcher includes Bubblewrap on `PATH` for the Codex Linux command sandbox.
-On NixOS it also enters a package-local FHS compatibility environment before
+On NixOS the launcher includes Bubblewrap on `PATH` for the Codex Linux command
+sandbox and enters a package-local FHS compatibility environment before
 starting the app. Generic Linux Git, Node.js, Python, and pnpm runtimes
 downloaded into the user cache therefore have their expected dynamic linker
 and libraries; enabling the system-wide `programs.nix-ld` module is not
-required. Other Nix systems keep the normal launcher path.
+required. Other Nix systems keep the normal launcher path and use their system
+Bubblewrap integration.
 
 The wrapper uses the NixOS OpenGL driver path when it is present and retains
 Mesa as a fallback. Proprietary drivers on non-NixOS distributions may still

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -114,6 +114,13 @@ The Nix package follows the standard `NIXOS_OZONE_WL` convention. When both
 `NIXOS_OZONE_WL` and `WAYLAND_DISPLAY` are set, its wrapper starts Electron with
 native Wayland rendering and text-input-v3 IME support.
 
+The launcher includes Bubblewrap on `PATH` for the Codex Linux command sandbox.
+On NixOS it also enters a package-local FHS compatibility environment before
+starting the app. Generic Linux Git, Node.js, Python, and pnpm runtimes
+downloaded into the user cache therefore have their expected dynamic linker
+and libraries; enabling the system-wide `programs.nix-ld` module is not
+required. Other Nix systems keep the normal launcher path.
+
 The wrapper uses the NixOS OpenGL driver path when it is present and retains
 Mesa as a fallback. Proprietary drivers on non-NixOS distributions may still
 need that distribution's usual Nix/OpenGL integration; the flake deliberately

--- a/flake.nix
+++ b/flake.nix
@@ -82,17 +82,24 @@
           "${pkgs.addDriverRunpath.driverLink}/lib"
           (lib.makeLibraryPath runtimeLibraries)
         ];
-        curlWithGnuTls = pkgs.curl.override {
+        curlWithGnuTlsCompat = (pkgs.curl.override {
           gnutlsSupport = true;
           opensslSupport = false;
-        };
+        }).overrideAttrs (previousAttrs: {
+          postPatch = (previousAttrs.postPatch or "") + ''
+            substituteInPlace lib/libcurl.vers.in \
+              --replace-fail \
+                'CURL_@CURL_LIBCURL_VERSIONED_SYMBOLS_PREFIX@@CURL_LIBCURL_VERSIONED_SYMBOLS_SONAME@' \
+                'CURL_GNUTLS_3'
+          '';
+        });
         workspaceRuntimeLibraries = runtimeLibraries ++ [
           pkgs.fontconfig
-          curlWithGnuTls.out
+          curlWithGnuTlsCompat.out
         ];
         baseRuntimePackages = with pkgs; [
-          bash bubblewrap coreutils curl findutils gawk gnugrep gnused libnotify
-          nodejs procps python3 systemd util-linux xdg-utils
+          bash coreutils curl findutils gawk gnugrep gnused libnotify nodejs procps
+          python3 systemd util-linux xdg-utils
         ];
         featureRuntimePackages = featureIds:
           lib.optionals (lib.elem "appshots" featureIds) [ pkgs.xinput pkgs.xmodmap ]
@@ -107,36 +114,69 @@
           lib.makeBinPath (lib.unique (
             baseRuntimePackages ++ featureRuntimePackages featureIds
           ));
+        fhsProfileVariables = [
+          "PATH"
+          "PS1"
+          "LOCALE_ARCHIVE"
+          "TZDIR"
+          "XDG_DATA_DIRS"
+          "NIX_ENFORCE_PURITY"
+          "NIX_BINTOOLS_WRAPPER_TARGET_HOST_${pkgs.stdenv.cc.suffixSalt}"
+          "NIX_CC_WRAPPER_TARGET_HOST_${pkgs.stdenv.cc.suffixSalt}"
+          "NIX_CFLAGS_COMPILE"
+          "NIX_CFLAGS_LINK"
+          "NIX_LDFLAGS"
+          "PKG_CONFIG_PATH"
+          "ACLOCAL_PATH"
+          "GST_PLUGIN_SYSTEM_PATH_1_0"
+        ];
+        fhsProfileCallerVariables =
+          lib.remove "PATH" (lib.remove "XDG_DATA_DIRS" fhsProfileVariables);
         nixRuntimeEnv = pkgs.buildFHSEnv {
           name = "codex-desktop-runtime";
           targetPkgs = _pkgs: workspaceRuntimeLibraries;
           runScript = "${pkgs.coreutils}/bin/env";
           profile = ''
-            if [[ -n "''${CODEX_NIX_RUNTIME_PATH-}" ]]; then
-              export PATH="$CODEX_NIX_RUNTIME_PATH"
-              unset CODEX_NIX_RUNTIME_PATH
-            fi
-            if [[ -n "''${CODEX_NIX_RUNTIME_XDG_DATA_DIRS_SET-}" ]]; then
-              export XDG_DATA_DIRS="$CODEX_NIX_RUNTIME_XDG_DATA_DIRS"
-            else
-              unset XDG_DATA_DIRS
-            fi
-            unset CODEX_NIX_RUNTIME_XDG_DATA_DIRS
-            unset CODEX_NIX_RUNTIME_XDG_DATA_DIRS_SET
+            restore_codex_nix_runtime_variable() {
+              local variable_name="$1"
+              local value_name="CODEX_NIX_RUNTIME_VALUE_$variable_name"
+              local set_name="CODEX_NIX_RUNTIME_SET_$variable_name"
+              if [[ -v $set_name ]]; then
+                printf -v "$variable_name" '%s' "''${!value_name}"
+                export "$variable_name"
+              else
+                unset "$variable_name"
+              fi
+              unset "$value_name" "$set_name"
+            }
+            ${lib.concatMapStringsSep "\n" (name:
+              "restore_codex_nix_runtime_variable ${lib.escapeShellArg name}"
+            ) fhsProfileVariables}
+            unset -f restore_codex_nix_runtime_variable
           '';
         };
         nixRuntimeLauncher = pkgs.writeShellScript "codex-desktop-nix-runtime-launcher" ''
           set -euo pipefail
           [ "$#" -gt 0 ]
           if [[ -e /etc/NIXOS ]]; then
-            export CODEX_NIX_RUNTIME_PATH="$PATH"
-            if [[ -v XDG_DATA_DIRS ]]; then
-              export CODEX_NIX_RUNTIME_XDG_DATA_DIRS="$XDG_DATA_DIRS"
-              export CODEX_NIX_RUNTIME_XDG_DATA_DIRS_SET=1
-            else
-              unset CODEX_NIX_RUNTIME_XDG_DATA_DIRS
-              unset CODEX_NIX_RUNTIME_XDG_DATA_DIRS_SET
-            fi
+            capture_codex_nix_runtime_variable() {
+              local variable_name="$1"
+              local value_name="CODEX_NIX_RUNTIME_VALUE_$variable_name"
+              local set_name="CODEX_NIX_RUNTIME_SET_$variable_name"
+              if [[ -v $variable_name ]]; then
+                printf -v "$value_name" '%s' "''${!variable_name}"
+                export "$value_name"
+                printf -v "$set_name" 1
+                export "$set_name"
+              else
+                unset "$value_name" "$set_name"
+              fi
+            }
+            ${lib.concatMapStringsSep "\n" (name:
+              "capture_codex_nix_runtime_variable ${lib.escapeShellArg name}"
+            ) fhsProfileVariables}
+            export CODEX_NIX_RUNTIME_VALUE_PATH="${pkgs.bubblewrap}/bin:$CODEX_NIX_RUNTIME_VALUE_PATH"
+            unset -f capture_codex_nix_runtime_variable
             exec ${nixRuntimeEnv}/bin/codex-desktop-runtime "$@"
           fi
           exec "$@"
@@ -146,8 +186,8 @@
           aarch64-linux = "/lib/ld-linux-aarch64.so.1";
         }.${system};
         genericRuntimeProbe = pkgs.runCommandCC "codex-generic-runtime-probe" {
-          nativeBuildInputs = [ pkgs.patchelf pkgs.pkg-config ];
-          buildInputs = [ curlWithGnuTls ];
+          nativeBuildInputs = [ pkgs.binutils pkgs.gnugrep pkgs.patchelf pkgs.pkg-config ];
+          buildInputs = [ curlWithGnuTlsCompat ];
         } ''
           mkdir -p "$out/bin"
           printf '%s\n' \
@@ -168,6 +208,10 @@
             "$out/bin/generic-runtime-probe"
           patchelf --print-needed "$out/bin/generic-runtime-probe" \
             | grep -Fx libcurl-gnutls.so.4
+          readelf --version-info "$out/bin/generic-runtime-probe" \
+            | grep -F CURL_GNUTLS_3
+          readelf --version-info ${curlWithGnuTlsCompat.out}/lib/libcurl.so.4 \
+            | grep -F 'Name: CURL_GNUTLS_3'
         '';
         gsettingsSchemaPackages = with pkgs; [ gsettings-desktop-schemas gtk3 ];
         gsettingsSchemaRoot = package:
@@ -749,6 +793,15 @@
         wrapperEnvironmentProbe = pkgs.writeText "codex-nix-wrapper-environment-probe" ''
           case "$0" in
             */opt/codex-desktop/start.sh)
+              if [[ -n "''${CODEX_NIX_PROFILE_ENV_EXPECTED-}" ]]; then
+                for variable_name in ${lib.escapeShellArgs fhsProfileCallerVariables}; do
+                  expected="caller-$variable_name"
+                  if [[ ! -v $variable_name || "''${!variable_name}" != "$expected" ]]; then
+                    printf 'FHS profile changed %s\n' "$variable_name" >&2
+                    exit 90
+                  fi
+                done
+              fi
               {
                 printf 'alsa=%s:%s\n' "''${ALSA_PLUGIN_DIR+x}" "''${ALSA_PLUGIN_DIR-}"
                 printf 'xdg=%s:%s\n' "''${XDG_DATA_DIRS+x}" "''${XDG_DATA_DIRS-}"
@@ -764,7 +817,8 @@
               ;;
           esac
         '';
-        mkWrapperContractCheck = package: pkgs.writeShellScript "codex-nix-wrapper-contract" ''
+        mkWrapperContractCheck = package: expectNixBwrap:
+          pkgs.writeShellScript "codex-nix-wrapper-contract" ''
           set -euo pipefail
           capture="$(${pkgs.coreutils}/bin/mktemp)"
           trap '${pkgs.coreutils}/bin/rm -f "$capture"' EXIT
@@ -774,7 +828,9 @@
             ${package}/bin/codex-desktop --diagnose
           ${pkgs.gnugrep}/bin/grep -Fx 'alsa=x:${pkgs.pipewire}/lib/alsa-lib' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'xdg=x:${gsettingsSchemaDataDirs}:${xdgDefaultDataDirs}' "$capture"
-          ${pkgs.gnugrep}/bin/grep -Fx 'bwrap=${pkgs.bubblewrap}/bin/bwrap' "$capture"
+          ${pkgs.gnugrep}/bin/grep -Fx \
+            'bwrap=${lib.optionalString expectNixBwrap "${pkgs.bubblewrap}/bin/bwrap"}' \
+            "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'ld=:' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'bamf=${package}/share/applications/codex-desktop.desktop' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'args=<--diagnose>' "$capture"
@@ -792,7 +848,9 @@
             ${package}/bin/codex-desktop --diagnose
           ${pkgs.gnugrep}/bin/grep -Fx 'alsa=x:' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'xdg=x:${gsettingsSchemaDataDirs}:${xdgDefaultDataDirs}' "$capture"
-          ${pkgs.gnugrep}/bin/grep -Fx 'path=${runtimePathFor package.passthru.effectiveLinuxFeatureIds}:/caller/bin' "$capture"
+          ${pkgs.gnugrep}/bin/grep -Fx \
+            'path=${lib.optionalString expectNixBwrap "${pkgs.bubblewrap}/bin:"}${runtimePathFor package.passthru.effectiveLinuxFeatureIds}:/caller/bin' \
+            "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'ld=x:/caller/lib' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx \
             'args=<--ozone-platform=wayland><--enable-wayland-ime=true><--wayland-text-input-version=3><--diagnose>' \
@@ -805,6 +863,17 @@
           ${pkgs.gnugrep}/bin/grep -Fx 'xdg=x:${gsettingsSchemaDataDirs}:/caller/share' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'ld=x:' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'bamf=/caller/desktop' "$capture"
+          ${lib.optionalString expectNixBwrap ''
+          profile_environment=()
+          for variable_name in ${lib.escapeShellArgs fhsProfileCallerVariables}; do
+            profile_environment+=("$variable_name=caller-$variable_name")
+          done
+          ${pkgs.coreutils}/bin/env "''${profile_environment[@]}" \
+            BASH_ENV=${wrapperEnvironmentProbe} \
+            CODEX_NIX_ENV_CAPTURE="$capture" \
+            CODEX_NIX_PROFILE_ENV_EXPECTED=1 \
+            ${package}/bin/codex-desktop --diagnose
+          ''}
         '';
         mkRuntimeCheck = name: package: verifyBundledMarketplacePermissions: verifyWatchbound:
           pkgs.runCommand name {
@@ -819,7 +888,7 @@
               --dynamic-linker "$dynamic_linker" \
               --runtime-library-path "${runtimeLibraryPath}" \
               --patchelf ${pkgs.patchelf}/bin/patchelf
-            ${mkWrapperContractCheck package}
+            ${mkWrapperContractCheck package false}
             test "$(
               ${nixRuntimeEnv}/bin/codex-desktop-runtime \
                 ${genericRuntimeProbe}/bin/generic-runtime-probe
@@ -885,7 +954,7 @@
           export XDG_CACHE_HOME="$HOME/.cache"
           export DISPLAY=:99
           mkdir -p "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$XDG_CACHE_HOME"
-          ${mkWrapperContractCheck codexDesktop}
+          ${mkWrapperContractCheck codexDesktop true}
           test "$(
             ${nixRuntimeEnv}/bin/codex-desktop-runtime \
               ${genericRuntimeProbe}/bin/generic-runtime-probe

--- a/flake.nix
+++ b/flake.nix
@@ -82,9 +82,17 @@
           "${pkgs.addDriverRunpath.driverLink}/lib"
           (lib.makeLibraryPath runtimeLibraries)
         ];
+        curlWithGnuTls = pkgs.curl.override {
+          gnutlsSupport = true;
+          opensslSupport = false;
+        };
+        workspaceRuntimeLibraries = runtimeLibraries ++ [
+          pkgs.fontconfig
+          curlWithGnuTls.out
+        ];
         baseRuntimePackages = with pkgs; [
-          bash coreutils curl findutils gawk gnugrep gnused libnotify nodejs procps
-          python3 systemd util-linux xdg-utils
+          bash bubblewrap coreutils curl findutils gawk gnugrep gnused libnotify
+          nodejs procps python3 systemd util-linux xdg-utils
         ];
         featureRuntimePackages = featureIds:
           lib.optionals (lib.elem "appshots" featureIds) [ pkgs.xinput pkgs.xmodmap ]
@@ -99,6 +107,68 @@
           lib.makeBinPath (lib.unique (
             baseRuntimePackages ++ featureRuntimePackages featureIds
           ));
+        nixRuntimeEnv = pkgs.buildFHSEnv {
+          name = "codex-desktop-runtime";
+          targetPkgs = _pkgs: workspaceRuntimeLibraries;
+          runScript = "${pkgs.coreutils}/bin/env";
+          profile = ''
+            if [[ -n "''${CODEX_NIX_RUNTIME_PATH-}" ]]; then
+              export PATH="$CODEX_NIX_RUNTIME_PATH"
+              unset CODEX_NIX_RUNTIME_PATH
+            fi
+            if [[ -n "''${CODEX_NIX_RUNTIME_XDG_DATA_DIRS_SET-}" ]]; then
+              export XDG_DATA_DIRS="$CODEX_NIX_RUNTIME_XDG_DATA_DIRS"
+            else
+              unset XDG_DATA_DIRS
+            fi
+            unset CODEX_NIX_RUNTIME_XDG_DATA_DIRS
+            unset CODEX_NIX_RUNTIME_XDG_DATA_DIRS_SET
+          '';
+        };
+        nixRuntimeLauncher = pkgs.writeShellScript "codex-desktop-nix-runtime-launcher" ''
+          set -euo pipefail
+          [ "$#" -gt 0 ]
+          if [[ -e /etc/NIXOS ]]; then
+            export CODEX_NIX_RUNTIME_PATH="$PATH"
+            if [[ -v XDG_DATA_DIRS ]]; then
+              export CODEX_NIX_RUNTIME_XDG_DATA_DIRS="$XDG_DATA_DIRS"
+              export CODEX_NIX_RUNTIME_XDG_DATA_DIRS_SET=1
+            else
+              unset CODEX_NIX_RUNTIME_XDG_DATA_DIRS
+              unset CODEX_NIX_RUNTIME_XDG_DATA_DIRS_SET
+            fi
+            exec ${nixRuntimeEnv}/bin/codex-desktop-runtime "$@"
+          fi
+          exec "$@"
+        '';
+        genericRuntimeInterpreter = {
+          x86_64-linux = "/lib64/ld-linux-x86-64.so.2";
+          aarch64-linux = "/lib/ld-linux-aarch64.so.1";
+        }.${system};
+        genericRuntimeProbe = pkgs.runCommandCC "codex-generic-runtime-probe" {
+          nativeBuildInputs = [ pkgs.patchelf pkgs.pkg-config ];
+          buildInputs = [ curlWithGnuTls ];
+        } ''
+          mkdir -p "$out/bin"
+          printf '%s\n' \
+            '#include <stdio.h>' \
+            '#include <curl/curl.h>' \
+            'int main(void) {' \
+            '  if (curl_version() == NULL) return 1;' \
+            '  puts("workspace-runtime-ok");' \
+            '  return 0;' \
+            '}' \
+            > probe.c
+          "$CC" -o "$out/bin/generic-runtime-probe" probe.c \
+            $(pkg-config --cflags --libs libcurl)
+          patchelf --remove-rpath "$out/bin/generic-runtime-probe"
+          patchelf --replace-needed libcurl.so.4 libcurl-gnutls.so.4 \
+            "$out/bin/generic-runtime-probe"
+          patchelf --set-interpreter "${genericRuntimeInterpreter}" \
+            "$out/bin/generic-runtime-probe"
+          patchelf --print-needed "$out/bin/generic-runtime-probe" \
+            | grep -Fx libcurl-gnutls.so.4
+        '';
         gsettingsSchemaPackages = with pkgs; [ gsettings-desktop-schemas gtk3 ];
         gsettingsSchemaRoot = package:
           lib.removeSuffix "/glib-2.0/schemas" (pkgs.glib.getSchemaPath package);
@@ -389,13 +459,14 @@
               substituteInPlace "$out/share/applications/codex-desktop.desktop" \
                 --replace-fail "/usr/bin/codex-desktop" "$out/bin/codex-desktop" \
                 --replace-fail "/usr/share/applications/codex-desktop.desktop" "$out/share/applications/codex-desktop.desktop"
-              makeWrapper "$app/start.sh" "$out/bin/codex-desktop" \
+              makeWrapper "${nixRuntimeLauncher}" "$out/bin/codex-desktop" \
                 --prefix PATH : "${runtimePathFor effectiveFeatureIds}" \
                 --set-default ALSA_PLUGIN_DIR "${pkgs.pipewire}/lib/alsa-lib" \
                 --run 'export XDG_DATA_DIRS="''${XDG_DATA_DIRS:-${xdgDefaultDataDirs}}"' \
                 --prefix XDG_DATA_DIRS : "${gsettingsSchemaDataDirs}" \
                 --set-default BAMF_DESKTOP_FILE_HINT "$out/share/applications/codex-desktop.desktop" \
                 --set-default CODEX_CLI_PATH "$app/resources/codex" \
+                --add-flags "$app/start.sh" \
                 --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-wayland-ime=true --wayland-text-input-version=3}}"
               node "$source_dir/nix/elf-runtime.cjs" audit \
                 --root "$app" \
@@ -457,7 +528,8 @@
               --wayland-text-input-version=3
             )
           fi
-          exec "$app_dir/.start.sh-nix" "$@" "''${extra_flags[@]}"
+          exec ${nixRuntimeLauncher} \
+            "$app_dir/.start.sh-nix" "$@" "''${extra_flags[@]}"
         '';
         installerWorkspaceHelpers = mkWorkspaceHelpers maximalDirectoryFeatureIds;
         installerRuntimeClosure = pkgs.writeText "codex-desktop-installer-runtime-closure" (
@@ -681,6 +753,7 @@
                 printf 'alsa=%s:%s\n' "''${ALSA_PLUGIN_DIR+x}" "''${ALSA_PLUGIN_DIR-}"
                 printf 'xdg=%s:%s\n' "''${XDG_DATA_DIRS+x}" "''${XDG_DATA_DIRS-}"
                 printf 'path=%s\n' "$PATH"
+                printf 'bwrap=%s\n' "$(command -v bwrap || true)"
                 printf 'ld=%s:%s\n' "''${LD_LIBRARY_PATH+x}" "''${LD_LIBRARY_PATH-}"
                 printf 'bamf=%s\n' "''${BAMF_DESKTOP_FILE_HINT-}"
                 printf 'args='
@@ -701,6 +774,7 @@
             ${package}/bin/codex-desktop --diagnose
           ${pkgs.gnugrep}/bin/grep -Fx 'alsa=x:${pkgs.pipewire}/lib/alsa-lib' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'xdg=x:${gsettingsSchemaDataDirs}:${xdgDefaultDataDirs}' "$capture"
+          ${pkgs.gnugrep}/bin/grep -Fx 'bwrap=${pkgs.bubblewrap}/bin/bwrap' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'ld=:' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'bamf=${package}/share/applications/codex-desktop.desktop' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'args=<--diagnose>' "$capture"
@@ -746,6 +820,10 @@
               --runtime-library-path "${runtimeLibraryPath}" \
               --patchelf ${pkgs.patchelf}/bin/patchelf
             ${mkWrapperContractCheck package}
+            test "$(
+              ${nixRuntimeEnv}/bin/codex-desktop-runtime \
+                ${genericRuntimeProbe}/bin/generic-runtime-probe
+            )" = workspace-runtime-ok
             "$app/start.sh" --diagnose
             timeout 10 "$app/browser_crashpad_handler" --version
             "$app/resources/cua_node/bin/node" --version
@@ -808,6 +886,14 @@
           export DISPLAY=:99
           mkdir -p "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$XDG_CACHE_HOME"
           ${mkWrapperContractCheck codexDesktop}
+          test "$(
+            ${nixRuntimeEnv}/bin/codex-desktop-runtime \
+              ${genericRuntimeProbe}/bin/generic-runtime-probe
+          )" = workspace-runtime-ok
+          ${nixRuntimeEnv}/bin/codex-desktop-runtime \
+            ${pkgs.bubblewrap}/bin/bwrap \
+            --unshare-user --unshare-net --ro-bind / / --dev /dev --proc /proc \
+            -- ${pkgs.coreutils}/bin/true
           ${pkgs.xvfb}/bin/Xvfb "$DISPLAY" -screen 0 1280x800x24 >"$HOME/xvfb.log" 2>&1 &
           xvfb_pid=$!
           trap 'kill "$xvfb_pid" 2>/dev/null || true' EXIT

--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,10 @@
           pkgs.fontconfig
           curlWithGnuTlsCompat.out
         ];
+        workspaceRuntimeLibraryPath = lib.concatStringsSep ":" [
+          "${pkgs.addDriverRunpath.driverLink}/lib"
+          (lib.makeLibraryPath workspaceRuntimeLibraries)
+        ];
         baseRuntimePackages = with pkgs; [
           bash coreutils curl findutils gawk gnugrep gnused libnotify nodejs procps
           python3 systemd util-linux xdg-utils
@@ -115,77 +119,102 @@
           lib.makeBinPath (lib.unique (
             baseRuntimePackages ++ featureRuntimePackages featureIds
           ));
-        fhsProfileVariables = [
-          "PATH"
-          "PS1"
-          "LOCALE_ARCHIVE"
-          "TZDIR"
-          "XDG_DATA_DIRS"
-          "NIX_ENFORCE_PURITY"
-          "NIX_BINTOOLS_WRAPPER_TARGET_HOST_${pkgs.stdenv.cc.suffixSalt}"
-          "NIX_CC_WRAPPER_TARGET_HOST_${pkgs.stdenv.cc.suffixSalt}"
-          "NIX_CFLAGS_COMPILE"
-          "NIX_CFLAGS_LINK"
-          "NIX_LDFLAGS"
-          "PKG_CONFIG_PATH"
-          "ACLOCAL_PATH"
-          "GST_PLUGIN_SYSTEM_PATH_1_0"
-        ];
-        fhsProfileCallerVariables =
-          lib.remove "PATH" (lib.remove "XDG_DATA_DIRS" fhsProfileVariables);
-        nixRuntimeEnv = pkgs.buildFHSEnv {
-          name = "codex-desktop-runtime";
-          targetPkgs = _pkgs: workspaceRuntimeLibraries;
-          runScript = "${pkgs.coreutils}/bin/env";
-          profile = ''
-            restore_codex_nix_runtime_variable() {
-              local variable_name="$1"
-              local value_name="CODEX_NIX_RUNTIME_VALUE_$variable_name"
-              local set_name="CODEX_NIX_RUNTIME_SET_$variable_name"
-              if [[ -v $set_name ]]; then
-                printf -v "$variable_name" '%s' "''${!value_name}"
-                export "$variable_name"
-              else
-                unset "$variable_name"
-              fi
-              unset "$value_name" "$set_name"
-            }
-            ${lib.concatMapStringsSep "\n" (name:
-              "restore_codex_nix_runtime_variable ${lib.escapeShellArg name}"
-            ) fhsProfileVariables}
-            unset -f restore_codex_nix_runtime_variable
+        genericRuntimeInterpreter = {
+          x86_64-linux = "/lib64/ld-linux-x86-64.so.2";
+          aarch64-linux = "/lib/ld-linux-aarch64.so.1";
+        }.${system};
+        dynamicLinker = pkgs.stdenv.cc.bintools.dynamicLinker;
+        mkNixosBwrap = { realBwrap, runtimeInterpreter ? genericRuntimeInterpreter }:
+          let
+            source = pkgs.writeText "codex-desktop-nixos-bwrap.c" ''
+              #define _XOPEN_SOURCE 700
+              #include <errno.h>
+              #include <stdio.h>
+              #include <stdlib.h>
+              #include <string.h>
+              #include <unistd.h>
+
+              static const char *real_bwrap = "${realBwrap}";
+              static const char *generic_interpreter = "${runtimeInterpreter}";
+              static const char *nix_ld = "${pkgs.nix-ld}/libexec/nix-ld";
+              static const char *dynamic_linker = "${dynamicLinker}";
+              static const char *runtime_library_path = "${workspaceRuntimeLibraryPath}";
+
+              int main(int argc, char **argv) {
+                int separator = -1;
+                for (int index = 1; index < argc; index++) {
+                  if (strcmp(argv[index], "--") == 0) {
+                    separator = index;
+                    break;
+                  }
+                }
+                if (separator < 0) {
+                  execv(real_bwrap, argv);
+                  perror("execv real bubblewrap");
+                  return 127;
+                }
+
+                char *mount_destination = realpath(generic_interpreter, NULL);
+                if (mount_destination == NULL) {
+                  if (errno == ENOENT) {
+                    fprintf(stderr,
+                            "codex-desktop: generic interpreter %s is unavailable; "
+                            "cached generic runtimes remain disabled\n",
+                            generic_interpreter);
+                    execv(real_bwrap, argv);
+                    perror("execv real bubblewrap");
+                    return 127;
+                  }
+                  perror("resolve generic interpreter");
+                  return 127;
+                }
+
+                const int extra_count = 9;
+                char **rewritten = calloc((size_t)argc + (size_t)extra_count + 1,
+                                          sizeof(*rewritten));
+                if (rewritten == NULL) {
+                  perror("allocate bubblewrap arguments");
+                  return 127;
+                }
+
+                int output = 0;
+                for (int index = 0; index < separator; index++) {
+                  rewritten[output++] = argv[index];
+                }
+                rewritten[output++] = "--ro-bind";
+                rewritten[output++] = (char *)nix_ld;
+                rewritten[output++] = mount_destination;
+                rewritten[output++] = "--setenv";
+                rewritten[output++] = "NIX_LD";
+                rewritten[output++] = (char *)dynamic_linker;
+                rewritten[output++] = "--setenv";
+                rewritten[output++] = "NIX_LD_LIBRARY_PATH";
+                rewritten[output++] = (char *)runtime_library_path;
+                for (int index = separator; index < argc; index++) {
+                  rewritten[output++] = argv[index];
+                }
+                rewritten[output] = NULL;
+                execv(real_bwrap, rewritten);
+                perror("execv real bubblewrap");
+                return 127;
+              }
+            '';
+          in pkgs.runCommandCC "codex-desktop-nixos-bwrap" { } ''
+            mkdir -p "$out/bin"
+            "$CC" -std=c11 -O2 -Wall -Wextra -Werror \
+              -o "$out/bin/bwrap" ${source}
           '';
+        nixosBwrap = mkNixosBwrap {
+          realBwrap = "${pkgs.bubblewrap}/bin/bwrap";
         };
         nixRuntimeLauncher = pkgs.writeShellScript "codex-desktop-nix-runtime-launcher" ''
           set -euo pipefail
           [ "$#" -gt 0 ]
           if [[ -e /etc/NIXOS ]]; then
-            capture_codex_nix_runtime_variable() {
-              local variable_name="$1"
-              local value_name="CODEX_NIX_RUNTIME_VALUE_$variable_name"
-              local set_name="CODEX_NIX_RUNTIME_SET_$variable_name"
-              if [[ -v $variable_name ]]; then
-                printf -v "$value_name" '%s' "''${!variable_name}"
-                export "$value_name"
-                printf -v "$set_name" 1
-                export "$set_name"
-              else
-                unset "$value_name" "$set_name"
-              fi
-            }
-            ${lib.concatMapStringsSep "\n" (name:
-              "capture_codex_nix_runtime_variable ${lib.escapeShellArg name}"
-            ) fhsProfileVariables}
-            export CODEX_NIX_RUNTIME_VALUE_PATH="${pkgs.bubblewrap}/bin:$CODEX_NIX_RUNTIME_VALUE_PATH"
-            unset -f capture_codex_nix_runtime_variable
-            exec ${nixRuntimeEnv}/bin/codex-desktop-runtime "$@"
+            export PATH="${nixosBwrap}/bin:''${PATH-}"
           fi
           exec "$@"
         '';
-        genericRuntimeInterpreter = {
-          x86_64-linux = "/lib64/ld-linux-x86-64.so.2";
-          aarch64-linux = "/lib/ld-linux-aarch64.so.1";
-        }.${system};
         genericRuntimeProbe = pkgs.runCommandCC "codex-generic-runtime-probe" {
           nativeBuildInputs = [ pkgs.binutils pkgs.gnugrep pkgs.patchelf pkgs.pkg-config ];
           buildInputs = [ curlWithGnuTlsCompat ];
@@ -203,6 +232,7 @@
           "$CC" -o "$out/bin/generic-runtime-probe" probe.c \
             $(pkg-config --cflags --libs libcurl)
           patchelf --remove-rpath "$out/bin/generic-runtime-probe"
+          test -e ${curlWithGnuTlsCompat.out}/lib/libcurl-gnutls.so.4
           patchelf --replace-needed libcurl.so.4 libcurl-gnutls.so.4 \
             "$out/bin/generic-runtime-probe"
           patchelf --set-interpreter "${genericRuntimeInterpreter}" \
@@ -794,15 +824,6 @@
         wrapperEnvironmentProbe = pkgs.writeText "codex-nix-wrapper-environment-probe" ''
           case "$0" in
             */opt/codex-desktop/start.sh)
-              if [[ -n "''${CODEX_NIX_PROFILE_ENV_EXPECTED-}" ]]; then
-                for variable_name in ${lib.escapeShellArgs fhsProfileCallerVariables}; do
-                  expected="caller-$variable_name"
-                  if [[ ! -v $variable_name || "''${!variable_name}" != "$expected" ]]; then
-                    printf 'FHS profile changed %s\n' "$variable_name" >&2
-                    exit 90
-                  fi
-                done
-              fi
               {
                 printf 'alsa=%s:%s\n' "''${ALSA_PLUGIN_DIR+x}" "''${ALSA_PLUGIN_DIR-}"
                 printf 'xdg=%s:%s\n' "''${XDG_DATA_DIRS+x}" "''${XDG_DATA_DIRS-}"
@@ -830,7 +851,7 @@
           ${pkgs.gnugrep}/bin/grep -Fx 'alsa=x:${pkgs.pipewire}/lib/alsa-lib' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'xdg=x:${gsettingsSchemaDataDirs}:${xdgDefaultDataDirs}' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx \
-            'bwrap=${lib.optionalString expectNixBwrap "${pkgs.bubblewrap}/bin/bwrap"}' \
+            'bwrap=${lib.optionalString expectNixBwrap "${nixosBwrap}/bin/bwrap"}' \
             "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'ld=:' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'bamf=${package}/share/applications/codex-desktop.desktop' "$capture"
@@ -850,7 +871,7 @@
           ${pkgs.gnugrep}/bin/grep -Fx 'alsa=x:' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'xdg=x:${gsettingsSchemaDataDirs}:${xdgDefaultDataDirs}' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx \
-            'path=${lib.optionalString expectNixBwrap "${pkgs.bubblewrap}/bin:"}${runtimePathFor package.passthru.effectiveLinuxFeatureIds}:/caller/bin' \
+            'path=${lib.optionalString expectNixBwrap "${nixosBwrap}/bin:"}${runtimePathFor package.passthru.effectiveLinuxFeatureIds}:/caller/bin' \
             "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'ld=x:/caller/lib' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx \
@@ -864,17 +885,63 @@
           ${pkgs.gnugrep}/bin/grep -Fx 'xdg=x:${gsettingsSchemaDataDirs}:/caller/share' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'ld=x:' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'bamf=/caller/desktop' "$capture"
-          ${lib.optionalString expectNixBwrap ''
-          profile_environment=()
-          for variable_name in ${lib.escapeShellArgs fhsProfileCallerVariables}; do
-            profile_environment+=("$variable_name=caller-$variable_name")
-          done
-          ${pkgs.coreutils}/bin/env "''${profile_environment[@]}" \
-            BASH_ENV=${wrapperEnvironmentProbe} \
-            CODEX_NIX_ENV_CAPTURE="$capture" \
-            CODEX_NIX_PROFILE_ENV_EXPECTED=1 \
-            ${package}/bin/codex-desktop --diagnose
-          ''}
+        '';
+        bwrapArgumentProbeSource = pkgs.writeText "codex-nix-bwrap-argument-probe.c" ''
+          #include <stdio.h>
+          #include <stdlib.h>
+
+          int main(int argc, char **argv) {
+            const char *capture = getenv("CODEX_NIX_BWRAP_CAPTURE");
+            if (capture == NULL) return 2;
+            FILE *output = fopen(capture, "w");
+            if (output == NULL) return 3;
+            for (int index = 1; index < argc; index++) {
+              if (fprintf(output, "<%s>", argv[index]) < 0) return 4;
+            }
+            return fclose(output) == 0 ? 0 : 5;
+          }
+        '';
+        bwrapArgumentProbe = pkgs.runCommandCC "codex-nix-bwrap-argument-probe" { } ''
+          "$CC" -std=c11 -O2 -Wall -Wextra -Werror \
+            -o "$out" ${bwrapArgumentProbeSource}
+        '';
+        bwrapInterpreterTarget = pkgs.writeText "codex-bwrap-interpreter-target" "";
+        bwrapInterpreterLink = pkgs.runCommand "codex-bwrap-interpreter-link" { } ''
+          ln -s ${bwrapInterpreterTarget} "$out"
+        '';
+        nixosBwrapProbe = mkNixosBwrap {
+          realBwrap = bwrapArgumentProbe;
+          runtimeInterpreter = bwrapInterpreterLink;
+        };
+        missingBwrapInterpreter = "/codex-desktop-missing-runtime/ld-linux.so";
+        nixosBwrapMissingProbe = mkNixosBwrap {
+          realBwrap = bwrapArgumentProbe;
+          runtimeInterpreter = missingBwrapInterpreter;
+        };
+        nixosBwrapContractCheck = pkgs.writeShellScript "codex-nix-bwrap-contract" ''
+          set -euo pipefail
+          capture="$(${pkgs.coreutils}/bin/mktemp)"
+          hostile_bash_env="$(${pkgs.coreutils}/bin/mktemp)"
+          trap '${pkgs.coreutils}/bin/rm -f "$capture" "$hostile_bash_env"' EXIT
+          printf 'exit 91\n' > "$hostile_bash_env"
+          BASH_ENV="$hostile_bash_env" CODEX_NIX_BWRAP_CAPTURE="$capture" \
+            ${nixosBwrapProbe}/bin/bwrap --help
+          ${pkgs.gnugrep}/bin/grep -Fx '<--help>' "$capture"
+          BASH_ENV="$hostile_bash_env" CODEX_NIX_BWRAP_CAPTURE="$capture" \
+            ${nixosBwrapProbe}/bin/bwrap --version
+          ${pkgs.gnugrep}/bin/grep -Fx '<--version>' "$capture"
+          BASH_ENV="$hostile_bash_env" CODEX_NIX_BWRAP_CAPTURE="$capture" \
+            ${nixosBwrapProbe}/bin/bwrap \
+              --ro-bind /source /target --unshare-user -- /bin/tool --flag
+          ${pkgs.gnugrep}/bin/grep -Fx \
+            '<--ro-bind></source></target><--unshare-user><--ro-bind><${pkgs.nix-ld}/libexec/nix-ld><${bwrapInterpreterTarget}><--setenv><NIX_LD><${dynamicLinker}><--setenv><NIX_LD_LIBRARY_PATH><${workspaceRuntimeLibraryPath}><--></bin/tool><--flag>' \
+            "$capture"
+          BASH_ENV="$hostile_bash_env" CODEX_NIX_BWRAP_CAPTURE="$capture" \
+            ${nixosBwrapMissingProbe}/bin/bwrap \
+              --ro-bind /source /target --unshare-user -- /bin/tool --flag
+          ${pkgs.gnugrep}/bin/grep -Fx \
+            '<--ro-bind></source></target><--unshare-user><--></bin/tool><--flag>' \
+            "$capture"
         '';
         mkRuntimeCheck = name: package: verifyBundledMarketplacePermissions: verifyWatchbound:
           pkgs.runCommand name {
@@ -890,9 +957,12 @@
               --runtime-library-path "${runtimeLibraryPath}" \
               --patchelf ${pkgs.patchelf}/bin/patchelf
             ${mkWrapperContractCheck package false}
+            ${nixosBwrapContractCheck}
             test "$(
-              ${nixRuntimeEnv}/bin/codex-desktop-runtime \
-                ${genericRuntimeProbe}/bin/generic-runtime-probe
+              NIX_LD=${lib.escapeShellArg dynamicLinker} \
+              NIX_LD_LIBRARY_PATH=${lib.escapeShellArg workspaceRuntimeLibraryPath} \
+                ${pkgs.nix-ld}/libexec/nix-ld \
+                  ${genericRuntimeProbe}/bin/generic-runtime-probe
             )" = workspace-runtime-ok
             "$app/start.sh" --diagnose
             timeout 10 "$app/browser_crashpad_handler" --version
@@ -956,14 +1026,9 @@
           export DISPLAY=:99
           mkdir -p "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$XDG_CACHE_HOME"
           ${mkWrapperContractCheck codexDesktop true}
-          test "$(
-            ${nixRuntimeEnv}/bin/codex-desktop-runtime \
-              ${genericRuntimeProbe}/bin/generic-runtime-probe
-          )" = workspace-runtime-ok
-          ${nixRuntimeEnv}/bin/codex-desktop-runtime \
-            ${pkgs.bubblewrap}/bin/bwrap \
+          test "$(${nixosBwrap}/bin/bwrap \
             --unshare-user --unshare-net --ro-bind / / --dev /dev --proc /proc \
-            -- ${pkgs.coreutils}/bin/true
+            -- ${genericRuntimeProbe}/bin/generic-runtime-probe)" = workspace-runtime-ok
           ${pkgs.xvfb}/bin/Xvfb "$DISPLAY" -screen 0 1280x800x24 >"$HOME/xvfb.log" 2>&1 &
           xvfb_pid=$!
           trap 'kill "$xvfb_pid" 2>/dev/null || true' EXIT

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,7 @@
         ];
         curlWithGnuTlsCompat = (pkgs.curl.override {
           gnutlsSupport = true;
+          http3Support = false;
           opensslSupport = false;
         }).overrideAttrs (previousAttrs: {
           postPatch = (previousAttrs.postPatch or "") + ''


### PR DESCRIPTION
## Summary

- add a NixOS-only package-local Bubblewrap adapter without nesting the app in another sandbox
- preserve the Codex sandbox policy while making cached generic Git, Node.js, Python, and pnpm runtimes use packaged `nix-ld` and runtime libraries
- provide the `CURL_GNUTLS_3` ABI and Debian curl SONAME required by the cached Git runtime
- keep non-NixOS launch behavior unchanged and safely pass through Bubblewrap when a custom NixOS configuration removes the generic loader symlink
- add x86_64/aarch64 runtime probes, adapter contracts, and a real NixOS VM integration check
- document the NixOS runtime behavior and its explicit loader-symlink edge case

Fixes #1394

## Tests

Not run locally per maintainer request. The complete diff received two clean read-only code-review passes; GitHub Actions validates the implementation.

## Notes

The adapter is enabled only when `/etc/NIXOS` is present. Standard NixOS systems use the default `environment.stub-ld` symlink as a namespace-local mount point, so system-wide `programs.nix-ld` is not required. Systems that explicitly disable both loader integrations retain Bubblewrap but not generic cached-runtime compatibility.