### PR TITLE
Fix shared app-server config override forwarding

### DIFF
--- a/linux-features/shared-app-server-socket/README.md
+++ b/linux-features/shared-app-server-socket/README.md
@@ -17,6 +17,14 @@ PATH` byte tunnel and its existing WebSocket transport. Other local clients use
 the same stock proxy command to attach to the Unix socket and receive the normal
 WebSocket `/rpc` byte stream. Closing Desktop stops the authority.
 
+The feature preserves the configuration overrides supplied by the official
+local transport. It forwards each opaque override as an ordered `-c` argument
+before the `app-server` subcommand when it starts the shared authority. It does
+not inspect or reconstruct bundled MCP server configuration. Desktop is the
+only authority owner. Other clients attach through the stock proxy and use the
+configuration of that Desktop-owned authority; they do not supply a second
+override list.
+
 The launcher uses the official CLI bundled in `resources/codex` by default.
 An explicit `CODEX_CLI_PATH` remains supported and is preserved by the feature
 hook.
@@ -129,5 +137,7 @@ CODEX_CLI_PATH="/absolute/path/to/real/codex" node --test linux-features/shared-
 ```
 
 The feature depends on upstream's current local transport factory, WebSocket
-adapter, and `app-server proxy` command. Bundle drift causes the optional patch
-to warn and skip instead of modifying an unknown surface.
+adapter, configuration-override callback, and `app-server proxy` command. The
+descriptor leaves an unknown bundle byte-identical and reports a warning. When
+the feature is enabled, candidate acceptance treats that warning as a failure
+and rejects the build instead of installing a partial patch.

--- a/linux-features/shared-app-server-socket/patch.js
+++ b/linux-features/shared-app-server-socket/patch.js
@@ -37,7 +37,7 @@ function sharedTransportClassSource(symbols) {
   return (
     "class CodexLinuxSharedAppServerSocketTransport{" +
     "kind=`websocket`;proxyStreams=new Set;authority=null;authorityError=null;authorityReady=null;lockIdentity=null;ownerStartTime=null;socketIdentity=null;disposed=!1;" +
-    "constructor(e){this.socketPath=e;this.lockPath=`${e}.lock`}" +
+    "constructor(e,t){if(typeof t!==`function`)throw Error(`shared app-server socket requires a config override callback`);this.socketPath=e;this.lockPath=`${e}.lock`;this.getConfigOverrides=t}" +
     "supportsReconnect(){return!0}" +
     "sameIdentity(e,t){return e!=null&&t.dev===e.dev&&t.ino===e.ino}" +
     "processIdentity(e){let t=require(`node:fs`);try{let n=t.readFileSync(`/proc/${e}/stat`,`utf8`),r=n.lastIndexOf(`)`);if(r<0)return null;return n.slice(r+2).trim().split(/\\s+/)[19]??null}catch(e){return null}}" +
@@ -49,7 +49,7 @@ function sharedTransportClassSource(symbols) {
     "async acquireOwnership(){let e=require(`node:fs`),t=require(`node:path`);e.mkdirSync(t.dirname(this.socketPath),{recursive:!0,mode:448});for(let t=0;t<2;t++){let n;try{n=e.openSync(this.lockPath,`wx`,384),this.lockIdentity=e.fstatSync(n);let t=this.processIdentity(process.pid);if(t==null)throw Error(`shared app-server socket could not identify its owner`);this.ownerStartTime=t,e.writeSync(n,`${process.pid} ${t}\\n`),e.fsyncSync(n)}catch(e){if(e?.code===`EEXIST`&&t===0&&await this.reclaimStaleLock())continue;if(e?.code===`EEXIST`)throw Error(`shared app-server socket is already owned: ${this.socketPath}`);this.releaseOwnedPaths(!0);throw e}finally{n!=null&&e.closeSync(n)}try{e.lstatSync(this.socketPath);throw Error(`shared app-server socket path already exists: ${this.socketPath}`)}catch(e){if(e?.code!==`ENOENT`){this.releaseOwnedPaths();throw e}}return}}" +
     "stopAuthority(e){return new Promise(t=>{if(!e||e.exitCode!=null||e.signalCode!=null)return t(!0);let n=!1,r=i=>{if(n)return;n=!0,clearTimeout(a),e.off(`close`,o),e.off(`exit`,o),e.off(`error`,s),t(i)},o=()=>r(!0),s=e=>{this.authorityError??=e},a=setTimeout(()=>r(!1),2e3);a.unref?.(),e.once(`close`,o),e.once(`exit`,o),e.on(`error`,s);try{e.kill()}catch(e){this.authorityError??=e,r(!1)}})}" +
     "async ensureAuthority(){if(this.disposed)throw Error(`shared app-server socket transport is disposed`);if(this.authorityReady)return this.authorityReady;if(this.authority&&this.authority.exitCode==null&&this.authority.signalCode==null){if(this.authorityError)throw this.authorityError;return}let e=this.startAuthority();this.authorityReady=e;try{return await e}finally{this.authorityReady===e&&(this.authorityReady=null)}}" +
-    "async startAuthority(){let e=process.env.CODEX_CLI_PATH;if(!e)throw Error(`shared app-server socket requires CODEX_CLI_PATH`);this.authorityError=null,await this.acquireOwnership();if(this.disposed){this.releaseOwnedPaths(!0);throw Error(`shared app-server socket transport was disposed during startup`)}let t=require(`node:fs`),n;try{n=require(`node:child_process`).spawn(e,[`app-server`,`--listen`,`unix://${this.socketPath}`],{env:process.env,stdio:`ignore`}),this.authority=n}catch(e){this.releaseOwnedPaths();throw e}try{this.recordAuthorityIdentity(n),await new Promise((e,r)=>{let i=!1,a,o=()=>{clearTimeout(a),clearTimeout(u),n.off(`error`,s),n.off(`exit`,l),n.off(`close`,l)},c=(t,u)=>{if(i)return;i=!0,o(),t?r(t):e(u)},s=e=>{this.authorityError=e,c(e)},l=()=>c(Error(`shared app-server authority exited before socket creation`)),h=()=>{if(i)return;try{let e=t.lstatSync(this.socketPath);if(e.isSocket()){if(typeof process.getuid==`function`&&e.uid!==process.getuid())return c(Error(`shared app-server socket has unexpected owner`));this.socketIdentity={dev:e.dev,ino:e.ino};return c(null)}}catch(e){if(e?.code!==`ENOENT`)return c(e)}a=setTimeout(h,100),a.unref?.()},u=setTimeout(()=>c(Error(`shared app-server socket creation timed out`)),1e4);n.once(`error`,s),n.once(`exit`,l),n.once(`close`,l),h(),u.unref?.()}),n.on(`error`,e=>{this.authorityError=e;for(let t of this.proxyStreams)t.destroy(e)}),n.once(`exit`,()=>{this.authority===n&&(this.authority=null,this.releaseOwnedPaths(!0))})}catch(e){this.authority=null;(await this.stopAuthority(n))&&this.releaseOwnedPaths();throw e}}" +
+    "async startAuthority(){let e=process.env.CODEX_CLI_PATH;if(!e)throw Error(`shared app-server socket requires CODEX_CLI_PATH`);this.authorityError=null;let t=await this.getConfigOverrides();if(this.disposed)throw Error(`shared app-server socket transport was disposed during startup`);if(!Array.isArray(t)||t.some(e=>typeof e!==`string`))throw Error(`shared app-server socket received invalid config overrides`);await this.acquireOwnership();if(this.disposed){this.releaseOwnedPaths(!0);throw Error(`shared app-server socket transport was disposed during startup`)}let n=require(`node:fs`),r;try{r=require(`node:child_process`).spawn(e,[...t.flatMap(e=>[`-c`,e]),`app-server`,`--listen`,`unix://${this.socketPath}`],{env:process.env,stdio:`ignore`}),this.authority=r}catch(e){this.releaseOwnedPaths();throw e}try{this.recordAuthorityIdentity(r),await new Promise((e,t)=>{let i=!1,a,o=()=>{clearTimeout(a),clearTimeout(u),r.off(`error`,s),r.off(`exit`,l),r.off(`close`,l)},c=(n,u)=>{if(i)return;i=!0,o(),n?t(n):e(u)},s=e=>{this.authorityError=e,c(e)},l=()=>c(Error(`shared app-server authority exited before socket creation`)),h=()=>{if(i)return;try{let e=n.lstatSync(this.socketPath);if(e.isSocket()){if(typeof process.getuid==`function`&&e.uid!==process.getuid())return c(Error(`shared app-server socket has unexpected owner`));this.socketIdentity={dev:e.dev,ino:e.ino};return c(null)}}catch(e){if(e?.code!==`ENOENT`)return c(e)}a=setTimeout(h,100),a.unref?.()},u=setTimeout(()=>c(Error(`shared app-server socket creation timed out`)),1e4);r.once(`error`,s),r.once(`exit`,l),r.once(`close`,l),h(),u.unref?.()}),r.on(`error`,e=>{this.authorityError=e;for(let t of this.proxyStreams)t.destroy(e)}),r.once(`exit`,()=>{this.authority===r&&(this.authority=null,this.releaseOwnedPaths(!0))})}catch(e){this.authority=null;(await this.stopAuthority(r))&&this.releaseOwnedPaths();throw e}}" +
     "createProxyStream(){let c=process.env.CODEX_CLI_PATH;if(!c)throw Error(`shared app-server socket requires CODEX_CLI_PATH`);let e=require(`node:child_process`).spawn(c,[`app-server`,`proxy`,`--sock`,this.socketPath],{env:process.env,stdio:[`pipe`,`pipe`,`pipe`]}),t=e.stdin,n=e.stdout,r=e.stderr;if(t==null||n==null||r==null)throw e.kill(),Error(`shared app-server proxy stdio was unavailable`);let i=``;r.on(`data`,e=>{i=`${i}${e.toString(`utf8`)}`.slice(-4000)});let a=new(require(`node:stream`).Duplex)({read(){n.resume()},write(e,n,r){t.write(e,n,r)},final(e){t.end(),e()},destroy(t,n){e.kill(),n(t)}});Object.assign(a,{setKeepAlive:()=>a,setNoDelay:()=>a,setTimeout:()=>a});let o=e=>a.destroy(e);t.on(`error`,o),n.on(`data`,e=>{a.push(e)||n.pause()}),n.on(`end`,()=>a.push(null)),e.on(`error`,o),e.on(`close`,(e,n)=>{t.removeListener(`error`,o),e===0?a.push(null):a.destroy(Error(`shared app-server proxy exited (${e??n??`unknown`}): ${i.trim()}`))}),this.proxyStreams.add(a),a.once(`close`,()=>this.proxyStreams.delete(a));return a}" +
     `async connect(){await this.ensureAuthority();let e={current:null},t=new ${symbols.namespace}.${symbols.webSocketClass}(${symbols.webSocketUrl},{perMessageDeflate:!1,createConnection:()=>(e.current=this.createProxyStream(),e.current)});t.once(\`close\`,()=>e.current?.destroy());try{await new Promise((n,r)=>{let i=setTimeout(()=>o(Error(\`shared app-server websocket open timed out\`)),3e4);i.unref();let a=()=>{clearTimeout(i),t.off(\`error\`,o),t.off(\`close\`,s)},o=e=>{a(),r(e)},s=()=>o(Error(\`shared app-server websocket closed before opening\`));t.once(\`open\`,()=>{a(),n()}),t.once(\`error\`,o),t.once(\`close\`,s)})}catch(n){e.current?.destroy(),t.terminate(),await new Promise(e=>setTimeout(e,0));throw n}${symbols.namespace}.${symbols.keepAlive}(t,{onPongTimeout:()=>t.terminate()});return new ${symbols.namespace}.${symbols.adapterClass}(t)}}`
   );
@@ -72,22 +72,38 @@ function applySharedAppServerSocketPatch(source) {
     return source;
   }
   const factorySource = source.slice(factoryStart, factoryEnd);
-  const localFallbackPattern = new RegExp(
+  const insertionPattern = new RegExp(
     `(if\\(${symbols.namespace}\\.(${IDENT})\\(e\\.hostConfig\\)\\)return new (${IDENT})\\(\\{hostConfig:e\\.hostConfig,repoRoot:e\\.repoRoot,resourcesPath:e\\.resourcesPath,defaultOriginator:e\\.defaultOriginator\\}\\);)(?=let (${IDENT})=(${IDENT})\\(e\\.hostConfig\\);if\\(\\4\\)\\{)`,
+    "g",
   );
-  const localFallbackMatch = factorySource.match(localFallbackPattern);
-  if (localFallbackMatch == null) {
-    console.warn("WARN: Could not find local transport fallback for shared app-server socket patch");
+  const insertionMatches = [...factorySource.matchAll(insertionPattern)];
+  if (insertionMatches.length !== 1) {
+    console.warn(
+      `WARN: Expected one local transport insertion point for shared app-server socket patch, found ${insertionMatches.length}`,
+    );
     return source;
   }
+  const configOverridesPattern = new RegExp(
+    `return new ${symbols.namespace}\\.(${IDENT})\\(\\{hostConfig:e\\.hostConfig,repoRoot:e\\.repoRoot,resourcesPath:e\\.resourcesPath,defaultOriginator:e\\.defaultOriginator,getConfigOverrides:((?:async)?\\(\\)=>${IDENT}\\(e\\))\\}\\)`,
+    "g",
+  );
+  const configOverridesMatches = [...factorySource.matchAll(configOverridesPattern)];
+  if (configOverridesMatches.length !== 1) {
+    console.warn(
+      `WARN: Expected one local transport config override callback for shared app-server socket patch, found ${configOverridesMatches.length}`,
+    );
+    return source;
+  }
+  const [insertionMatch] = insertionMatches;
+  const getConfigOverrides = configOverridesMatches[0][2];
 
   const classSource = sharedTransportClassSource(symbols);
 
-  const patchedFactory = factorySource.replace(
-    localFallbackPattern,
-    (match) =>
-      `${match}if(process.env.CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET&&e.hostConfig.kind===\`local\`)return new CodexLinuxSharedAppServerSocketTransport(process.env.CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET);`,
-  );
+  const insertionIndex = insertionMatch.index + insertionMatch[0].length;
+  const patchedFactory =
+    factorySource.slice(0, insertionIndex) +
+    `if(process.env.CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET&&e.hostConfig.kind===\`local\`)return new CodexLinuxSharedAppServerSocketTransport(process.env.CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET,${getConfigOverrides});` +
+    factorySource.slice(insertionIndex);
   return source.slice(0, factoryStart) + classSource + patchedFactory + source.slice(factoryEnd);
 }
 

--- a/linux-features/shared-app-server-socket/test.js
+++ b/linux-features/shared-app-server-socket/test.js
@@ -374,7 +374,13 @@ function loadInjectedTransport({ spawnImpl, WebSocketImpl = null, fsImpl = fs, t
     clearTimeout,
   };
   vm.runInNewContext(`${source};globalThis.Transport=CodexLinuxSharedAppServerSocketTransport`, context);
-  return { Transport: context.Transport, namespace };
+  const InjectedTransport = context.Transport;
+  class Transport extends InjectedTransport {
+    constructor(socketPath, getConfigOverrides = async () => []) {
+      super(socketPath, getConfigOverrides);
+    }
+  }
+  return { InjectedTransport, Transport, namespace };
 }
 
 async function listenUnix(socketPath) {
@@ -494,7 +500,7 @@ function syntheticBundle() {
     "if(e.transportKind===`remote-control`)return new Remote(e);",
     "if(n.no(e.hostConfig))return new hoe({hostConfig:e.hostConfig,repoRoot:e.repoRoot,resourcesPath:e.resourcesPath,defaultOriginator:e.defaultOriginator});",
     "let r=x5(e.hostConfig);if(r){e.desktopAuthAppServerClient;let t=vbe(e.hostConfig,r);return new n.Tn({hostConfig:e.hostConfig,websocketUrl:r,getWebsocketProtocols:void 0,...t==null?{}:{socksProxyUrl:t}})}",
-    "return new n.Cn({hostConfig:e.hostConfig,repoRoot:e.repoRoot,resourcesPath:e.resourcesPath,defaultOriginator:e.defaultOriginator})}function afterFactory(){}",
+    "return new n.Cn({hostConfig:e.hostConfig,repoRoot:e.repoRoot,resourcesPath:e.resourcesPath,defaultOriginator:e.defaultOriginator,getConfigOverrides:()=>Ope(e)})}function afterFactory(){}",
   ].join("");
 }
 
@@ -545,8 +551,13 @@ test("patch selects the bridge only for the local host and is idempotent", () =>
   assert.equal(applySharedAppServerSocketPatch(patched), patched);
   assert.match(patched, /CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET/);
   assert.match(patched, /hostConfig\.kind===`local`/);
+  assert.match(
+    patched,
+    /CodexLinuxSharedAppServerSocketTransport\(process\.env\.CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET,\(\)=>Ope\(e\)\)/,
+  );
   assert.match(patched, /app-server`,\s*`proxy`,\s*`--sock`/);
-  assert.match(patched, /app-server`,\s*`--listen`,\s*`unix:\/\//);
+  assert.match(patched, /flatMap\(e=>\[`-c`,e\]\).*app-server`,\s*`--listen`,\s*`unix:\/\//);
+  assert.doesNotMatch(patched, /mcp_servers\.codex_app/);
   assert.match(patched, /await this\.ensureAuthority\(\)/);
   assert.match(patched, /e\.once\(`close`,t\);try\{e\.kill\(\)/);
   assert.match(patched, /openSync\(this\.lockPath,`wx`,384\)/);
@@ -571,7 +582,7 @@ test("patch leaves unsupported bundle shapes unchanged with a warning", () => {
   assert.match(warnings.join("\n"), /shared app-server socket/i);
 });
 
-test("patch rejects the previous SSH transport class shape", () => {
+test("patch rejects a current transport whose semantic SSH anchor is missing", () => {
   const source = syntheticBundle().replace(
     "class{options;kind=`websocket`;logger=i.i(`AppServerTransportSshWebsocket`);",
     "class{kind=`websocket`;",
@@ -585,6 +596,45 @@ test("patch rejects the previous SSH transport class shape", () => {
     console.warn = originalWarn;
   }
   assert.match(warnings.join("\n"), /SSH WebSocket transport/);
+});
+
+test("patch leaves a current transport with no config override callback byte-identical", () => {
+  const source = syntheticBundle().replace(
+    ",getConfigOverrides:()=>Ope(e)",
+    "",
+  );
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.join(" "));
+  try {
+    assert.equal(applySharedAppServerSocketPatch(source), source);
+  } finally {
+    console.warn = originalWarn;
+  }
+  assert.match(warnings.join("\n"), /config override callback.*found 0/i);
+});
+
+test("patch leaves an ambiguous config override callback byte-identical", () => {
+  const callbackTransport =
+    "return new n.Cn({hostConfig:e.hostConfig,repoRoot:e.repoRoot,resourcesPath:e.resourcesPath,defaultOriginator:e.defaultOriginator,getConfigOverrides:()=>Ope(e)})";
+  const source = syntheticBundle().replace(callbackTransport, `${callbackTransport};${callbackTransport}`);
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.join(" "));
+  try {
+    assert.equal(applySharedAppServerSocketPatch(source), source);
+  } finally {
+    console.warn = originalWarn;
+  }
+  assert.match(warnings.join("\n"), /config override callback.*found 2/i);
+});
+
+test("injected transport requires the captured config override callback", () => {
+  const { InjectedTransport } = loadInjectedTransport();
+  assert.throws(
+    () => new InjectedTransport("/unused/socket"),
+    /requires a config override callback/,
+  );
 });
 
 test("descriptor is optional and targets the main bundle", () => {
@@ -1059,6 +1109,157 @@ test("injected transport shares one readiness promise across concurrent connecti
     if (originalCli == null) delete process.env.CODEX_CLI_PATH;
     else process.env.CODEX_CLI_PATH = originalCli;
     await closeServer(server);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+for (const [name, overrides, expectedArgs] of [
+  [
+    "ordered config overrides",
+    ["mcp_servers.example={command=\"/bin/true\"}", "features.example=true"],
+    [
+      "-c",
+      "mcp_servers.example={command=\"/bin/true\"}",
+      "-c",
+      "features.example=true",
+      "app-server",
+      "--listen",
+    ],
+  ],
+  ["an empty config override list", [], ["app-server", "--listen"]],
+]) {
+  test(`injected transport forwards ${name} before the authority subcommand`, async () => {
+    const tempDir = makeSocketTempDir("shared-app-server-overrides-");
+    const socketPath = path.join(tempDir, "app-server.sock");
+    let observedArgs;
+    const { Transport } = loadInjectedTransport({
+      spawnImpl(_command, args) {
+        observedArgs = args;
+        throw new Error("stop after argument capture");
+      },
+    });
+    const transport = new Transport(socketPath, async () => overrides);
+    const originalCli = process.env.CODEX_CLI_PATH;
+    process.env.CODEX_CLI_PATH = "/fake/codex";
+    try {
+      await assert.rejects(transport.ensureAuthority(), /stop after argument capture/);
+      assert.deepEqual(
+        Array.from(observedArgs),
+        [...expectedArgs, `unix://${socketPath}`],
+      );
+      assert.equal(fs.existsSync(`${socketPath}.lock`), false);
+    } finally {
+      if (originalCli == null) delete process.env.CODEX_CLI_PATH;
+      else process.env.CODEX_CLI_PATH = originalCli;
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+}
+
+for (const [name, getConfigOverrides, expectedError] of [
+  ["a synchronous callback failure", () => { throw new Error("override failure"); }, /override failure/],
+  ["an asynchronous callback failure", async () => { throw new Error("override rejection"); }, /override rejection/],
+  ["a non-array callback result", async () => ({}), /invalid config overrides/],
+  ["a non-string callback member", async () => ["valid=true", 42], /invalid config overrides/],
+]) {
+  test(`injected transport rejects ${name} before ownership or spawn`, async () => {
+    const tempDir = makeSocketTempDir("shared-app-server-invalid-overrides-");
+    const socketPath = path.join(tempDir, "app-server.sock");
+    let spawnCalls = 0;
+    const { Transport } = loadInjectedTransport({
+      spawnImpl() {
+        spawnCalls += 1;
+        return fakeChild();
+      },
+    });
+    const transport = new Transport(socketPath, getConfigOverrides);
+    const originalCli = process.env.CODEX_CLI_PATH;
+    process.env.CODEX_CLI_PATH = "/fake/codex";
+    try {
+      await assert.rejects(transport.ensureAuthority(), expectedError);
+      assert.equal(spawnCalls, 0);
+      assert.equal(fs.existsSync(socketPath), false);
+      assert.equal(fs.existsSync(`${socketPath}.lock`), false);
+    } finally {
+      if (originalCli == null) delete process.env.CODEX_CLI_PATH;
+      else process.env.CODEX_CLI_PATH = originalCli;
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+}
+
+test("disposing while config overrides resolve prevents ownership and spawn", async () => {
+  const tempDir = makeSocketTempDir("shared-app-server-dispose-overrides-");
+  const socketPath = path.join(tempDir, "app-server.sock");
+  let resolveOverrides;
+  let spawnCalls = 0;
+  const overridesReady = new Promise((resolve) => {
+    resolveOverrides = resolve;
+  });
+  const { Transport } = loadInjectedTransport({
+    spawnImpl() {
+      spawnCalls += 1;
+      return fakeChild();
+    },
+  });
+  const transport = new Transport(socketPath, () => overridesReady);
+  const originalCli = process.env.CODEX_CLI_PATH;
+  process.env.CODEX_CLI_PATH = "/fake/codex";
+  try {
+    const startup = transport.ensureAuthority();
+    transport.dispose();
+    resolveOverrides([]);
+    await assert.rejects(startup, /disposed during startup/);
+    assert.equal(spawnCalls, 0);
+    assert.equal(fs.existsSync(socketPath), false);
+    assert.equal(fs.existsSync(`${socketPath}.lock`), false);
+  } finally {
+    if (originalCli == null) delete process.env.CODEX_CLI_PATH;
+    else process.env.CODEX_CLI_PATH = originalCli;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("a restarted authority resolves fresh config overrides", async () => {
+  const tempDir = makeSocketTempDir("shared-app-server-restart-overrides-");
+  const socketPath = path.join(tempDir, "app-server.sock");
+  const children = [];
+  const servers = [];
+  const observedArgs = [];
+  let overrideCalls = 0;
+  const { Transport } = loadInjectedTransport({
+    spawnImpl(_command, args) {
+      observedArgs.push(args);
+      const child = fakeChild();
+      children.push(child);
+      queueMicrotask(async () => {
+        servers.push(await listenUnix(socketPath));
+      });
+      return child;
+    },
+  });
+  const transport = new Transport(socketPath, async () => [`restart.count=${++overrideCalls}`]);
+  const originalCli = process.env.CODEX_CLI_PATH;
+  process.env.CODEX_CLI_PATH = "/fake/codex";
+  try {
+    await transport.ensureAuthority();
+    await closeServer(servers.shift());
+    children[0].exitCode = 0;
+    children[0].emit("exit", 0, null);
+    await transport.ensureAuthority();
+    assert.equal(overrideCalls, 2);
+    assert.deepEqual(observedArgs.map((args) => Array.from(args.slice(0, 2))), [
+      ["-c", "restart.count=1"],
+      ["-c", "restart.count=2"],
+    ]);
+  } finally {
+    if (originalCli == null) delete process.env.CODEX_CLI_PATH;
+    else process.env.CODEX_CLI_PATH = originalCli;
+    for (const server of servers) await closeServer(server);
+    for (const child of children) {
+      child.exitCode = 0;
+      child.emit("exit", 0, null);
+    }
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

The opt-in `shared-app-server-socket` feature replaced the official local app-server transport but did not preserve its `getConfigOverrides` callback. After upstream began synthesizing `mcp_servers.codex_app` through that callback, the shared authority could start without the complete transport configuration. Affected existing threads then failed to resume with an `invalid transport in mcp_servers.codex_app` error.

Capture the unique official local-transport callback and pass its opaque, ordered result to the shared authority as Codex CLI `-c` arguments before the `app-server` subcommand. Resolve the callback for every authority start and reject invalid callback results before socket ownership or process creation.

The feature remains disabled by default. This change does not add a core patch, reconstruct MCP configuration, change package identity, or modify generated output.

## Validation

- `node --test linux-features/shared-app-server-socket/test.js`: 52 passed
- `node --test scripts/patch-linux-window-ui.test.js scripts/lib/linux-features.test.js linux-features/shared-app-server-socket/test.js`: 87 passed
- `bash tests/scripts_smoke.sh`: 51 passed
- `git diff --check origin/main...HEAD`: passed
- Signed stable `26.820.71523` amd64 feature-only build: passed; the descriptor applied exactly once with no drift warning
- Signed package SHA-256 matched the repository pin: `472d03e88a29857f1015b2b9175d80523a131cf1bc3e9017eb1a8ff234de1bda`
- Earlier installed amd64 testing confirmed that existing threads opened and resumed with the fix. This manual UI check was not repeated after rebasing onto `26.820.71523`.
- Independent exact-commit code review: no actionable findings
- Independent repository and PR-requirements audit: no blockers
- All required hosted CI checks passed, including amd64 and arm64 signed baselines, package matrices, Nix builds, the Nix VM, Rust, and source and Node checks

Manual arm64 runtime testing was not performed.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest signed stable OpenAI Linux package and removes obsolete fallback code and tests.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
