### PR TITLE
Fix symlinked CODEX_HOME launcher identity

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -102,6 +102,15 @@ load_environment_hooks() {
     done < <(find "$HOOK_ROOT/env.d" -maxdepth 1 -type f -print0 | sort -z)
 }
 
+canonicalize_codex_home() {
+    local requested_codex_home="${CODEX_HOME:-$HOME/.codex}"
+    local physical_codex_home
+
+    [ -d "$requested_codex_home" ] || return 0
+    physical_codex_home="$(cd -P -- "$requested_codex_home" && pwd -P)"
+    export CODEX_HOME="$physical_codex_home"
+}
+
 refresh_legacy_bundled_plugin_cache() {
     local plugin_id="$1"
     local bundled_plugin="$CODEX_LINUX_APP_DIR/resources/plugins/openai-bundled/plugins/$plugin_id"
@@ -228,6 +237,7 @@ esac
 
 ELECTRON_ARGS=("--class=$CODEX_LINUX_APP_ID")
 load_environment_hooks
+canonicalize_codex_home
 refresh_legacy_bundled_plugin_caches
 load_user_electron_args
 load_electron_args

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -107,7 +107,10 @@ canonicalize_codex_home() {
     local physical_codex_home
 
     [ -d "$requested_codex_home" ] || return 0
-    physical_codex_home="$(cd -P -- "$requested_codex_home" && pwd -P)"
+    if [ "$requested_codex_home" = "-" ]; then
+        requested_codex_home="./-"
+    fi
+    physical_codex_home="$(CDPATH='' cd -P -- "$requested_codex_home" && pwd -P)"
     export CODEX_HOME="$physical_codex_home"
 }
 

--- a/launcher/start.test.js
+++ b/launcher/start.test.js
@@ -253,6 +253,69 @@ test("launcher exports a physical explicit CODEX_HOME when it is a symlink", (t)
   assert.equal(fs.readFileSync(path.join(root, "codex-home"), "utf8").trim(), physicalCodexHome);
 });
 
+test("launcher ignores CDPATH when canonicalizing a relative CODEX_HOME", (t) => {
+  const root = createApp(t);
+  const codexHome = path.join(root, "profile");
+  const cdpathRoot = path.join(root, "cdpath");
+  fs.mkdirSync(codexHome, { recursive: true });
+  fs.mkdirSync(path.join(cdpathRoot, "profile"), { recursive: true });
+
+  const result = childProcess.spawnSync(path.join(root, "start.sh"), [], {
+    cwd: root,
+    env: {
+      ...process.env,
+      CDPATH: cdpathRoot,
+      CODEX_HOME: "profile",
+      TEST_ROOT: root,
+      XDG_CONFIG_HOME: path.join(root, "config"),
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 7);
+  assert.equal(fs.readFileSync(path.join(root, "codex-home"), "utf8").trim(), codexHome);
+});
+
+test("launcher treats a dash CODEX_HOME as a relative directory", (t) => {
+  const root = createApp(t);
+  const codexHome = path.join(root, "-");
+  const oldWorkingDirectory = path.join(root, "old-working-directory");
+  fs.mkdirSync(codexHome, { recursive: true });
+  fs.mkdirSync(oldWorkingDirectory, { recursive: true });
+
+  const result = childProcess.spawnSync(path.join(root, "start.sh"), [], {
+    cwd: root,
+    env: {
+      ...process.env,
+      CODEX_HOME: "-",
+      OLDPWD: oldWorkingDirectory,
+      TEST_ROOT: root,
+      XDG_CONFIG_HOME: path.join(root, "config"),
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 7);
+  assert.equal(fs.readFileSync(path.join(root, "codex-home"), "utf8").trim(), codexHome);
+});
+
+test("launcher preserves the physical root CODEX_HOME spelling", (t) => {
+  const root = createApp(t);
+
+  const result = childProcess.spawnSync(path.join(root, "start.sh"), [], {
+    env: {
+      ...process.env,
+      CODEX_HOME: "/",
+      TEST_ROOT: root,
+      XDG_CONFIG_HOME: path.join(root, "config"),
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 7);
+  assert.equal(fs.readFileSync(path.join(root, "codex-home"), "utf8").trim(), "/");
+});
+
 test("launcher canonicalizes CODEX_HOME loaded from an environment hook", (t) => {
   const root = createApp(t);
   const physicalCodexHome = path.join(root, "physical-codex-home");

--- a/launcher/start.test.js
+++ b/launcher/start.test.js
@@ -8,6 +8,8 @@ const path = require("node:path");
 const test = require("node:test");
 
 const templatePath = path.join(__dirname, "start.sh.template");
+const bashPath = childProcess.execFileSync("bash", ["-c", "command -v bash"], { encoding: "utf8" }).trim();
+const dirnamePath = childProcess.execFileSync("bash", ["-c", "command -v dirname"], { encoding: "utf8" }).trim();
 
 // Launcher tests must never contact the production usage counter. Individual
 // reporting tests opt back in with an isolated fake curl executable.
@@ -15,12 +17,12 @@ process.env.CODEX_LINUX_DISABLE_USAGE_REPORTING = "1";
 
 function writeExecutable(filePath, source) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, source, { mode: 0o755 });
+  fs.writeFileSync(filePath, source.replace(/^#!\/bin\/bash\n/, `#!${bashPath}\n`), { mode: 0o755 });
 }
 
 function createApp(t) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-launcher-test-"));
-  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 }));
   const launcher = fs.readFileSync(templatePath, "utf8")
     .replaceAll("__CODEX_LINUX_APP_ID__", "codex-desktop")
     .replaceAll("__CODEX_LINUX_APP_DISPLAY_NAME__", "ChatGPT Community");
@@ -32,6 +34,7 @@ function createApp(t) {
   }
   writeExecutable(path.join(root, "ChatGPT"), `#!/bin/bash
 printf '%s\n' "$CHROME_DESKTOP" "$BAMF_DESKTOP_FILE_HINT" "$HOOK_ENV" "$LAUNCHER_ENV" > "$TEST_ROOT/environment"
+printf '%s\n' "\${CODEX_HOME:-}" > "$TEST_ROOT/codex-home"
 printf '%s\n' "$@" > "$TEST_ROOT/arguments"
 exit 7
 `);
@@ -113,11 +116,15 @@ printf 'unexpected\\n' >> "$TEST_ROOT/curl-calls"
   assert.equal(disabled.stderr, "");
   assert.equal(fs.existsSync(path.join(disabledRoot, "curl-calls")), false);
   assert.equal(fs.existsSync(path.join(disabledRoot, "state")), false);
+  assert.equal(
+    fs.readFileSync(path.join(disabledRoot, "codex-home"), "utf8").trim(),
+    path.join(disabledRoot, "codex-home"),
+  );
 
   const missingRoot = createApp(t);
   const missingBin = path.join(missingRoot, "bin");
   fs.mkdirSync(missingBin, { recursive: true });
-  fs.symlinkSync("/usr/bin/dirname", path.join(missingBin, "dirname"));
+  fs.symlinkSync(dirnamePath, path.join(missingBin, "dirname"));
   const missing = childProcess.spawnSync(path.join(missingRoot, "start.sh"), [], {
     env: {
       ...process.env,
@@ -198,6 +205,77 @@ test("launcher composes declarative hooks and forwards arguments", (t) => {
   ]);
   assert.equal(fs.readFileSync(path.join(root, "prelaunch"), "utf8"), "prelaunch");
   assert.equal(fs.readFileSync(path.join(root, "after-exit"), "utf8"), "after-exit");
+});
+
+test("launcher exports the physical default CODEX_HOME when it is a symlink", (t) => {
+  const root = createApp(t);
+  const home = path.join(root, "home");
+  const physicalCodexHome = path.join(root, "physical-codex-home");
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(physicalCodexHome, { recursive: true });
+  fs.symlinkSync(physicalCodexHome, path.join(home, ".codex"), "dir");
+
+  const env = {
+    ...process.env,
+    HOME: home,
+    TEST_ROOT: root,
+    XDG_CONFIG_HOME: path.join(root, "config"),
+  };
+  delete env.CODEX_HOME;
+
+  const result = childProcess.spawnSync(path.join(root, "start.sh"), [], {
+    env,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 7);
+  assert.equal(fs.readFileSync(path.join(root, "codex-home"), "utf8").trim(), physicalCodexHome);
+});
+
+test("launcher exports a physical explicit CODEX_HOME when it is a symlink", (t) => {
+  const root = createApp(t);
+  const physicalCodexHome = path.join(root, "physical-codex-home");
+  const linkedCodexHome = path.join(root, "linked-codex-home");
+  fs.mkdirSync(physicalCodexHome, { recursive: true });
+  fs.symlinkSync(physicalCodexHome, linkedCodexHome, "dir");
+
+  const result = childProcess.spawnSync(path.join(root, "start.sh"), [], {
+    env: {
+      ...process.env,
+      CODEX_HOME: linkedCodexHome,
+      TEST_ROOT: root,
+      XDG_CONFIG_HOME: path.join(root, "config"),
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 7);
+  assert.equal(fs.readFileSync(path.join(root, "codex-home"), "utf8").trim(), physicalCodexHome);
+});
+
+test("launcher canonicalizes CODEX_HOME loaded from an environment hook", (t) => {
+  const root = createApp(t);
+  const physicalCodexHome = path.join(root, "physical-codex-home");
+  const linkedCodexHome = path.join(root, "linked-codex-home");
+  fs.mkdirSync(physicalCodexHome, { recursive: true });
+  fs.symlinkSync(physicalCodexHome, linkedCodexHome, "dir");
+  fs.mkdirSync(path.join(root, ".codex-linux", "env.d"), { recursive: true });
+  fs.writeFileSync(path.join(root, ".codex-linux", "env.d", "codex-home.env"), `CODEX_HOME=${linkedCodexHome}\n`);
+
+  const env = {
+    ...process.env,
+    TEST_ROOT: root,
+    XDG_CONFIG_HOME: path.join(root, "config"),
+  };
+  delete env.CODEX_HOME;
+
+  const result = childProcess.spawnSync(path.join(root, "start.sh"), [], {
+    env,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 7);
+  assert.equal(fs.readFileSync(path.join(root, "codex-home"), "utf8").trim(), physicalCodexHome);
 });
 
 test("launcher loads global and app-specific Electron flags", (t) => {


### PR DESCRIPTION
## Summary

- Canonicalize an existing `CODEX_HOME` (or the default `$HOME/.codex`) after environment hooks and before the official ChatGPT/Codex consumers start.
- Ignore inherited `CDPATH` while resolving relative paths, and handle the `-` and `/` boundary cases explicitly.
- Keep missing paths unchanged and preserve Codex's reserved-marketplace validation.
- Make launcher tests portable to NixOS and cover default, explicit, environment-hook, missing-path, `CDPATH`, `-`, and `/` cases.

On NixOS, `~/.codex` may be a symlink into a dotfiles checkout. The desktop app staged `openai-bundled` under the logical path while the bundled CLI saw the physical path. Codex then correctly rejected the reserved marketplace because the lexical paths did not match. Giving both processes the same physical `CODEX_HOME` fixes the Brave/Chrome side-panel connection without weakening marketplace trust checks.

User-visible behavior: the official ChatGPT browser extension can connect to ChatGPT Community when `~/.codex` or an explicit `CODEX_HOME` is a symlink.

Scope: the shared launcher, so this applies to deb, RPM, pacman, AppImage, and Nix packages on amd64 and arm64. There are no ASAR or dependency changes. I found no exact existing issue or pull request; #1266/#1267 concern retired plugin-cache paths rather than logical-versus-physical `CODEX_HOME` identity.

## Validation

- Red: the original symlink regression test failed with an empty `CODEX_HOME` instead of the physical path.
- Red: the maintainer-requested relative-path test selected the `CDPATH` alternate and contaminated command-substitution output.
- Red: complete-diff review found that exact `CODEX_HOME=-` resolved `OLDPWD`; its regression test reproduced that behavior.
- Red: the next complete-diff review found that the first `-` fix changed `CODEX_HOME=/` to `//`; its regression test reproduced that behavior.
- `node --test launcher/start.test.js` — 13/13 passed.
- `bash -n launcher/start.sh.template` — passed.
- `node --check launcher/start.test.js` — passed.
- `git diff upstream/main...HEAD --check` — passed.
- Complete updated `upstream/main...HEAD` code-review loop: 1 blocker, then 1 blocker, then 0 blockers after both fixes.
- GitHub Actions — all 13 checks passed on `8b52592`.

Not manually tested: a live installed deb/RPM/pacman package. Security risk is limited: only existing directories are canonicalized; missing paths and reserved-marketplace checks remain unchanged.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] This is not an upstream-drift fix; it targets launcher path identity and adds no fallback code.
- [x] I added or updated relevant tests and ran the validation listed above.
- [x] I reviewed the complete updated base-to-head diff until the review reported no remaining blockers.
