### PR TITLE
Fix sidebar project name styling

### DIFF
--- a/linux-features/ui-tweaks/patches/sidebar-project-name.js
+++ b/linux-features/ui-tweaks/patches/sidebar-project-name.js
@@ -2,14 +2,17 @@
 
 const DEFAULT_PROJECT_NAME_STYLE = "font-weight: 700 !important;";
 const PROJECTS_SIDEBAR_ASSET_PATTERN = /^app-initial-[^.]+\.js$/;
-const PROJECT_NAME_SELECTOR = ".group\\/folder-row .text-fade-truncate.pe-1";
+const PROJECT_ROW_ATTRIBUTE = "data-app-action-sidebar-project-row";
+const PROJECT_NAME_SELECTOR = `[${PROJECT_ROW_ATTRIBUTE}] [data-marquee-text]`;
 const STYLE_ID = "codex-linux-ui-tweaks-sidebar-project-name-style";
 const RUNTIME_MARKER = "codexLinuxUiTweaksSidebarProjectNameStyleRuntime";
 const UNSAFE_PROJECT_NAME_STYLE_PATTERN = /[{}@<>]|\r|\n|\/\*|\*\/|\burl\s*\(/i;
 
 const SIDEBAR_PROJECT_NAME_MARKERS = [
-  "group/folder-row",
-  "className:`text-fade-truncate pe-1`",
+  `sidebarProjectRow:\`${PROJECT_ROW_ATTRIBUTE}\``,
+  "sidebarProjectRow({collapsed:",
+  "className:`select-none`,animateOnGroupHover:!0",
+  '"data-marquee-text":!0',
 ];
 
 function warn(message) {
@@ -125,6 +128,7 @@ const descriptors = [
 
 module.exports = {
   DEFAULT_PROJECT_NAME_STYLE,
+  PROJECT_ROW_ATTRIBUTE,
   PROJECTS_SIDEBAR_ASSET_PATTERN,
   PROJECT_NAME_SELECTOR,
   RUNTIME_MARKER,

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -28,6 +28,7 @@ const {
 } = require("./patches/model-picker-model-list.js");
 const {
   DEFAULT_PROJECT_NAME_STYLE,
+  PROJECT_ROW_ATTRIBUTE,
   PROJECTS_SIDEBAR_ASSET_PATTERN,
   PROJECT_NAME_SELECTOR,
   RUNTIME_MARKER,
@@ -55,8 +56,11 @@ const {
 
 function projectBundleFixture() {
   return [
-    "function row(){let j=Pn(`group/folder-row group relative flex h-[var(--height-token-row)] text-sm text-token-foreground`);",
-    "let V=(0,Iy.jsx)(`span`,{className:`text-fade-truncate pe-1`,children:p});return [j,V]}",
+    `var actions={sidebarProjectRow:\`${PROJECT_ROW_ATTRIBUTE}\`};`,
+    "function marquee(e){return(0,Iy.jsx)(`span`,{...e,\"data-marquee-text\":!0})}",
+    "function projectRow(){let p=actions.sidebarProjectRow({collapsed:r,label:c,projectId:l});",
+    "let E=(0,Iy.jsx)(Marquee,{className:`select-none`,animateOnGroupHover:!0,children:c});",
+    "return(0,Iy.jsx)(FolderRow,{...p,label:E})}",
   ].join("");
 }
 
@@ -796,6 +800,14 @@ test("patch injects sidebar project-name stylesheet runtime once", () => {
   assert.equal((patched.match(new RegExp(STYLE_ID, "g")) ?? []).length, 1);
 });
 
+test("sidebar project name selector follows the semantic project-row marquee contract", () => {
+  assert.equal(
+    PROJECT_NAME_SELECTOR,
+    `[${PROJECT_ROW_ATTRIBUTE}] [data-marquee-text]`,
+  );
+  assert.doesNotMatch(PROJECT_NAME_SELECTOR, /folder-row|text-fade-truncate/);
+});
+
 test("feature manifest defaults reach descriptor context through the feature loader", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ui-tweaks-manifest-defaults-"));
   try {
@@ -926,10 +938,24 @@ test("patch skips unrelated assets", () => {
 test("drift warning returns source unchanged", () => {
   const source = [
     "function Hd(){return {id:`sidebarElectron.projectsNavLink`,defaultMessage:`Projects`}}",
-    "function row(){let j=Pn(`group/folder-row group relative flex`);return j}",
+    "function row(){return actions.sidebarProjectRow({collapsed:r,label:c,projectId:l})}",
   ].join("");
 
   const { value, warnings } = withCapturedWarns(() => applySidebarProjectNameStylePatch(source));
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /^WARN: Could not find current sidebar project name markers/);
+});
+
+test("obsolete project-name markers do not produce a false applied result", () => {
+  const source = [
+    "function row(){let j=Pn(`group/folder-row group relative flex`);",
+    "let V=(0,Iy.jsx)(`span`,{className:`text-fade-truncate pe-1`,children:p});return [j,V]}",
+    'function marquee(){return {"data-marquee-text":!0}}',
+  ].join("");
+
+  const { value, warnings } = withCapturedWarns(() => patches[0].apply(source, {}));
 
   assert.equal(value, source);
   assert.equal(warnings.length, 1);


### PR DESCRIPTION
Summary
- retarget the sidebar project-name tweak to the semantic project-row marquee DOM contract
- reject obsolete bundle markers that previously produced a false applied result
- add regression coverage for the current selector and drift behavior

Tests/checks run
- node --test linux-features/ui-tweaks/test.js
- feature-alone build against signed Linux 26.825.51511 with required patch-report assertion
- node scripts/ci/verify-official-linux-features.js against signed Linux 26.825.51511 (30 ASAR features)
- git diff --check

Notes/risks
- the selector is scoped to data-app-action-sidebar-project-row and data-marquee-text, avoiding unrelated folder rows.