### PR TITLE
fix: require Node.js 24 for native updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Native updater packages now require Node.js 24 or newer, and the update
+  manager rejects obsolete runtimes before invoking the signed-package
+  verifier at `/usr/bin/node`, so user version-manager shims cannot select an
+  older runtime. Debian bootstrap installs the latest available Node.js 24 LTS
+  from the signed NodeSource repository when the distro candidate is too old.
+- Debian upgrades no longer stop the update-manager service from inside its own
+  privileged package transaction, allowing it to record successful promotion
+  instead of rebuilding the same upstream package on the next start.
 - The opt-in `frameless-titlebar` feature again hides official Linux overlay
   buttons. It retargets the current `titleBarOverlay` window options, zoom
   update, and theme-sync contracts, remaps Linux webview chrome to `native`,

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Old `.dmg`, `DMG=`, and `CODEX_DMG_*` inputs are intentionally unsupported.
   `dpkg-deb`, tar, make, and a C/C++ toolchain. Rust is used for the updater and
   enabled native feature helpers. `make bootstrap-native` installs or guides
   you through these requirements.
+- Native packages that include the update manager require Node.js 24 or newer.
+  On Debian-derived systems, `make bootstrap-native` installs the latest
+  available Node.js 24 LTS release from NodeSource when the distro candidate is
+  too old.
 - The official `chatgpt` and custom `codex-desktop` packages may coexist, but
   both intentionally use the upstream `Codex` user profile. Do not run them at
   the same time; the upstream single-instance lock may route the second launch

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -101,6 +101,9 @@ UPSTREAM_DEB=/path/to/chatgpt_<version>_<arch>.deb make build-app
 - 构建需要 Node.js 20+、npm、Python 3、curl、`gpgv`、`dpkg-deb`、tar、
   make 和 C/C++ 工具链。更新器及启用的原生扩展 helper 还需要 Rust。
   `make bootstrap-native` 会安装或提示这些依赖。
+- 包含更新管理器的原生软件包需要 Node.js 24+。在 Debian 衍生发行版上，
+  如果系统仓库版本过旧，`make bootstrap-native` 会从 NodeSource 安装最新的
+  Node.js 24 LTS 版本。
 - 官方 `chatgpt` 与自定义 `codex-desktop` 可以同时安装，但两者会共享上游
   `Codex` 用户 profile。请勿同时运行；上游 single-instance lock 可能把第二次
   启动交给已经运行的进程。

--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -16,6 +16,11 @@ AppImage or native package out. Debian-derived systems use the pinned
 NodeSource keyring when a newer Node.js is required; the script never pipes a
 remote installer directly to a shell.
 
+Native packages built with the update manager declare Node.js 24 or newer as a
+runtime dependency. On Debian-derived systems, the dependency bootstrap uses
+the signed NodeSource repository to install the latest available 24.x LTS
+release when the distro package is too old.
+
 If you install dependencies manually, use `scripts/install-deps.sh` as the
 authoritative package list. At minimum, the source verifier needs Bash, curl,
 GnuPG, `dpkg-deb`, Node.js 20+, Python 3, SHA-256 tools, tar, and `xz`; native
@@ -190,6 +195,7 @@ feature selection/descriptors/resources, the ASAR toolchain, package templates,
 required build helpers, and already staged release executables for enabled
 native features. It excludes the full repository, Cargo workspaces, and
 disabled features, and never contains an app-runtime Node installation.
+The update manager executes the host's packaged Node.js 24+ runtime.
 
 ## Cross-format validation
 

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -25,7 +25,10 @@ working app.
 The packaged update-builder extracts the official payload, applies only the
 locally enabled features, generates the selected package format, and places the
 result beside the active install. It contains its own minimal Node/ASAR build
-tools but does not install them in the application runtime.
+tools but does not install Node.js in the application runtime. Native packages
+require the host's packaged Node.js 24 or newer, and the updater validates that
+version at `/usr/bin/node` before running the signed-package verifier. User
+version-manager shims do not override the packaged updater runtime.
 
 Enabled feature drift rejects the candidate. Disabled features are neither
 loaded nor probed. Native helper binaries belong to the project release package

--- a/packaging/linux/PKGBUILD.template
+++ b/packaging/linux/PKGBUILD.template
@@ -11,7 +11,7 @@ depends=(
     'curl'
     'dpkg'
     'gnupg'
-    'nodejs'
+    'nodejs>=24'
     'xdg-utils'
     # Electron runtime libraries
     'alsa-lib'

--- a/packaging/linux/codex-desktop.spec
+++ b/packaging/linux/codex-desktop.spec
@@ -12,7 +12,7 @@ ExclusiveArch:  __ARCH__
 %endif
 
 %if __PACKAGE_WITH_UPDATER__
-Requires:       polkit, curl, dpkg, nodejs, xdg-utils
+Requires:       polkit, curl, dpkg, nodejs >= 24, xdg-utils
 %if 0%{?suse_version}
 Requires:       gpg2
 %else

--- a/packaging/linux/codex-update-manager.prerm
+++ b/packaging/linux/codex-update-manager.prerm
@@ -19,13 +19,12 @@ for runtime_dir in /run/user/*; do
     user_name="$(getent passwd "$uid" | cut -d: -f1 || true)"
     [ -n "$user_name" ] || continue
 
-    runuser -u "$user_name" -- env \
-        XDG_RUNTIME_DIR="$runtime_dir" \
-        DBUS_SESSION_BUS_ADDRESS="unix:path=$bus" \
-        systemctl --user stop "$SERVICE_NAME" >/dev/null 2>&1 || true
-
     case "${1:-}" in
         remove|purge|deconfigure)
+            runuser -u "$user_name" -- env \
+                XDG_RUNTIME_DIR="$runtime_dir" \
+                DBUS_SESSION_BUS_ADDRESS="unix:path=$bus" \
+                systemctl --user stop "$SERVICE_NAME" >/dev/null 2>&1 || true
             runuser -u "$user_name" -- env \
                 XDG_RUNTIME_DIR="$runtime_dir" \
                 DBUS_SESSION_BUS_ADDRESS="unix:path=$bus" \

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -113,7 +113,7 @@ main() {
         replace_literal_file_token \
             "$PKG_ROOT/DEBIAN/control" \
             "__UPDATER_DEPENDENCIES__" \
-            "curl, dpkg, gnupg, nodejs, pkexec | policykit-1, polkitd | policykit-1, "
+            "curl, dpkg, gnupg, nodejs (>= 24), pkexec | policykit-1, polkitd | policykit-1, "
     else
         replace_literal_file_token "$PKG_ROOT/DEBIAN/control" "__UPDATER_DEPENDENCIES__" ""
     fi

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -160,7 +160,7 @@ main() {
 			-e "/'curl'/d" \
 			-e "/'dpkg'/d" \
 			-e "/'gnupg'/d" \
-			-e "/'nodejs'/d" \
+			-e "/'nodejs>=24'/d" \
 			"$build_root/PKGBUILD"
 	fi
 	local feature_dependency_lines=""

--- a/scripts/lib/package-common.test.js
+++ b/scripts/lib/package-common.test.js
@@ -84,10 +84,20 @@ test("non-Debian package formats map the official runtime libraries", () => {
 
 test("RPM updater selects the distro-specific GnuPG package", () => {
   const rpm = fs.readFileSync(path.join(repoRoot, "packaging/linux/codex-desktop.spec"), "utf8");
+  const pacman = fs.readFileSync(path.join(repoRoot, "packaging/linux/PKGBUILD.template"), "utf8");
   assert.match(
     rpm,
-    /%if __PACKAGE_WITH_UPDATER__\nRequires:\s+polkit, curl, dpkg, nodejs, xdg-utils\n%if 0%\{\?suse_version\}\nRequires:\s+gpg2\n%else\nRequires:\s+gnupg2\n%endif\n%else\nRequires:\s+xdg-utils\n%endif/,
+    /%if __PACKAGE_WITH_UPDATER__\nRequires:\s+polkit, curl, dpkg, nodejs >= 24, xdg-utils\n%if 0%\{\?suse_version\}\nRequires:\s+gpg2\n%else\nRequires:\s+gnupg2\n%endif\n%else\nRequires:\s+xdg-utils\n%endif/,
   );
+  assert.match(pacman, /'nodejs>=24'/);
+});
+
+test("Debian upgrades do not stop the update manager that owns the transaction", () => {
+  const prerm = fs.readFileSync(path.join(repoRoot, "packaging/linux/codex-update-manager.prerm"), "utf8");
+  const removalBranch = prerm.match(/remove\|purge\|deconfigure\)([\s\S]*?)esac/);
+  assert.ok(removalBranch);
+  assert.match(removalBranch[1], /systemctl --user stop/);
+  assert.doesNotMatch(prerm.slice(0, removalBranch.index), /systemctl --user stop/);
 });
 
 test("update-builder copies staged native feature artifacts without Cargo workspaces", (t) => {

--- a/updater/src/upstream.rs
+++ b/updater/src/upstream.rs
@@ -9,6 +9,8 @@ use std::{
 };
 use tokio::process::Command;
 
+const SYSTEM_NODE: &str = "/usr/bin/node";
+
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageMetadata {
@@ -107,7 +109,8 @@ async fn run_verifier(
     }
     fs::create_dir_all(&run_dir)?;
     let metadata_path = run_dir.join("package.json");
-    let mut command = Command::new("node");
+    ensure_supported_node().await?;
+    let mut command = Command::new(SYSTEM_NODE);
     command
         .arg(builder_root.join("scripts/lib/upstream-linux-package.js"))
         .args([
@@ -152,6 +155,23 @@ async fn run_verifier(
     Ok(metadata)
 }
 
+async fn ensure_supported_node() -> Result<()> {
+    let output = Command::new(SYSTEM_NODE)
+        .arg("--version")
+        .output()
+        .await
+        .context("Node.js 24 or newer is required by the update manager")?;
+    anyhow::ensure!(output.status.success(), "Node.js version check failed");
+    let version = String::from_utf8_lossy(&output.stdout);
+    let major = parse_node_major(&version).context("Node.js returned an invalid version")?;
+    anyhow::ensure!(major >= 24, "Node.js 24 or newer is required by the update manager; found {}", version.trim());
+    Ok(())
+}
+
+fn parse_node_major(version: &str) -> Option<u32> {
+    version.trim().strip_prefix('v')?.split('.').next()?.parse().ok()
+}
+
 fn verify_cached_file(path: &Path, expected: &PackageMetadata) -> Result<bool> {
     if fs::metadata(path)?.len() != expected.size {
         return Ok(false);
@@ -167,6 +187,15 @@ fn verify_cached_file(path: &Path, expected: &PackageMetadata) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn node_version_gate_requires_current_lts_or_newer() {
+        assert_eq!(SYSTEM_NODE, "/usr/bin/node");
+        assert_eq!(parse_node_major("v24.20.0\n"), Some(24));
+        assert_eq!(parse_node_major("v26.8.1"), Some(26));
+        assert_eq!(parse_node_major("v22.19.0"), Some(22));
+        assert_eq!(parse_node_major("12.22.9"), None);
+    }
 
     #[test]
     fn cache_identity_contains_version_architecture_and_sha() {


### PR DESCRIPTION
## Summary

- require Node.js 24 or newer in deb, RPM, and pacman updater packages
- execute the packaged system runtime at /usr/bin/node so user version-manager shims cannot select an older Node.js
- keep the Debian update-manager service alive during self-upgrades so successful promotion state is recorded
- document the Node.js runtime requirement in English, Chinese, packaging, updater, and changelog documentation

## Validation

- cargo test -p codex-update-manager: 50 passed
- cargo clippy -p codex-update-manager --all-targets -- -D warnings
- node --test scripts/lib/package-common.test.js: 12 passed
- bash syntax and git diff checks
- built and installed codex-desktop 2026.08.31.172424 on Pop!_OS
- verified nodejs 24.20.0, active updater service, signed upstream metadata check, idle status, and no updater error