### PR TITLE
fix(updater): ignore latest-package symlink when locating the rebuilt artifact

### DIFF
--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -170,7 +170,13 @@ async fn read_stream<R: tokio::io::AsyncRead + Unpin>(stream: R) -> Result<Strin
 fn find_package(dist: &Path) -> Result<PathBuf> {
     let mut matches = Vec::new();
     for entry in fs::read_dir(dist).with_context(|| format!("Failed to read {}", dist.display()))? {
-        let path = entry?.path();
+        let entry = entry?;
+        // Skip alias symlinks such as codex-desktop-latest.pkg.tar.zst, which
+        // build-pacman.sh creates alongside the real artifact.
+        if entry.file_type().map(|t| t.is_symlink()).unwrap_or(false) {
+            continue;
+        }
+        let path = entry.path();
         let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
         if name.ends_with(".deb") || name.ends_with(".rpm") || name.contains(".pkg.tar.") {
             matches.push(path);
@@ -187,6 +193,53 @@ mod tests {
     #[test]
     fn workspace_component_never_contains_separators() {
         assert_eq!(safe_component("26.1/../../x"), "26.1_.._.._x");
+    }
+
+    fn scratch_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "codex-find-package-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos(),
+        ));
+        fs::create_dir_all(&dir).expect("scratch dir");
+        dir
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn find_package_ignores_latest_alias_symlink() {
+        // build-pacman.sh writes codex-desktop-latest.pkg.tar.zst as a symlink
+        // next to the real artifact; it must not count as a second package.
+        let dist = scratch_dir("latest-alias");
+        let real = dist.join("codex-desktop-2026.09.03.120000-1-x86_64.pkg.tar.zst");
+        fs::write(&real, b"package").expect("real package");
+        std::os::unix::fs::symlink(
+            real.file_name().expect("file name"),
+            dist.join("codex-desktop-latest.pkg.tar.zst"),
+        )
+        .expect("latest symlink");
+
+        let found = find_package(&dist).expect("exactly one real package");
+        assert_eq!(found, real);
+
+        fs::remove_dir_all(&dist).expect("cleanup");
+    }
+
+    #[test]
+    fn find_package_still_rejects_two_real_packages() {
+        let dist = scratch_dir("two-real");
+        fs::write(dist.join("codex-desktop-2026.09.03.120000-1-x86_64.pkg.tar.zst"), b"a")
+            .expect("first package");
+        fs::write(dist.join("codex-desktop-2026.09.03.130000-1-x86_64.pkg.tar.zst"), b"b")
+            .expect("second package");
+
+        let error = find_package(&dist).expect_err("ambiguous dist must fail");
+        assert!(error.to_string().contains("found 2"), "unexpected error: {error}");
+
+        fs::remove_dir_all(&dist).expect("cleanup");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

On pacman systems the update manager never finishes an auto-update. Every rebuild fails at the package-selection step with:

```
expected one rebuilt package, found 2
```

`scripts/build-pacman.sh` writes `codex-desktop-latest.pkg.tar.zst` as a **symlink** next to the real versioned artifact (added in "fix(pacman): expose latest package"). `updater/src/builder.rs::find_package` was later introduced ("refactor: rebuild updates from signed Linux packages") and enumerates every entry in `dist/` whose name contains `.pkg.tar.`, so it counts the real package **and** the `-latest` symlink, then trips `ensure!(matches.len() == 1)`.

`build-deb.sh` / `build-rpm.sh` emit no such alias, so deb/rpm are unaffected — this is pacman-only, i.e. the platform this project targets.

Observed in the wild on a normally-running install (`service.log`):

```
2026-08-29T06:22:30Z ERROR periodic update check failed error=expected one rebuilt package, found 2
2026-08-30T06:22:55Z ERROR periodic update check failed error=expected one rebuilt package, found 2
```

## Solution

Skip symlinked directory entries in `find_package`, so only real artifacts are counted. `copy_path` in the same module already treats symlinks as non-artifacts (`"update-builder entry cannot be a symlink"`), so this matches existing behaviour. The `-latest` alias keeps working for its intended external consumers.

The "two real packages" guard is retained (still errors).

## User-visible behavior

Pacman auto-updates complete instead of failing at every check. No change for deb/rpm.

## Affected formats/features

- Package formats: pacman (fix); deb/rpm/AppImage unchanged.
- Features: none.

## Validation

```
cargo test -p codex-update-manager          # 51 passed (incl. 2 new regression tests)
cargo clippy -p codex-update-manager --all-targets -- -D warnings   # clean
```

New regression tests in `builder::tests`:
- `find_package_ignores_latest_alias_symlink` — real package + `-latest` symlink → returns the real package. Verified it **fails without** the production change (`expected one rebuilt package, found 2`).
- `find_package_still_rejects_two_real_packages` — two real packages still error.

End-to-end: rebuilt the pacman package with the patched updater, installed it, and `codex-update-manager check-now` then completed to `status: Idle` on the current stable (26.901.20858); previously it aborted at `find_package`.

## Risk

Low. No change to signature/hash/sandbox/promotion checks. Only effect is that symlinks in the build output dir are no longer considered candidate artifacts.