### PR TITLE
fix(updater): harden rebuilt package artifact discovery

### DIFF
--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -171,14 +171,17 @@ fn find_package(dist: &Path) -> Result<PathBuf> {
     let mut matches = Vec::new();
     for entry in fs::read_dir(dist).with_context(|| format!("Failed to read {}", dist.display()))? {
         let entry = entry?;
-        // Skip alias symlinks such as codex-desktop-latest.pkg.tar.zst, which
-        // build-pacman.sh creates alongside the real artifact.
-        if entry.file_type().map(|t| t.is_symlink()).unwrap_or(false) {
+        // Package builders may also emit a `latest` symlink. Count only the
+        // actual package files, without following aliases or accepting directories.
+        if !entry.file_type()?.is_file() {
             continue;
         }
         let path = entry.path();
         let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-        if name.ends_with(".deb") || name.ends_with(".rpm") || name.contains(".pkg.tar.") {
+        if name.ends_with(".deb")
+            || name.ends_with(".rpm")
+            || crate::install::is_pacman_package_file_name(name)
+        {
             matches.push(path);
         }
     }
@@ -189,6 +192,81 @@ fn find_package(dist: &Path) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::symlink;
+    use tempfile::tempdir;
+
+    #[test]
+    fn find_package_accepts_each_supported_native_format() -> Result<()> {
+        for suffix in [
+            ".deb",
+            ".rpm",
+            ".pkg.tar.zst",
+            ".pkg.tar.xz",
+            ".pkg.tar.gz",
+            ".pkg.tar.bz2",
+            ".pkg.tar.lz",
+            ".pkg.tar.lz4",
+            ".pkg.tar.lz5",
+        ] {
+            let dist = tempdir()?;
+            let package = dist.path().join(format!("codex-desktop-1{suffix}"));
+            fs::write(&package, b"package fixture")?;
+            assert_eq!(find_package(dist.path())?, package);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn find_package_ignores_package_named_directories() -> Result<()> {
+        let dist = tempdir()?;
+        let package = dist.path().join("codex-desktop-1.deb");
+        fs::write(&package, b"package fixture")?;
+        for name in ["staging.deb", "staging.rpm", "staging.pkg.tar.zst"] {
+            fs::create_dir(dist.path().join(name))?;
+        }
+        assert_eq!(find_package(dist.path())?, package);
+        Ok(())
+    }
+
+    #[test]
+    fn find_package_ignores_sidecars_and_unrelated_files() -> Result<()> {
+        let dist = tempdir()?;
+        let package = dist.path().join("codex-desktop-1.pkg.tar.zst");
+        fs::write(&package, b"package fixture")?;
+        for name in [
+            "codex-desktop-1.pkg.tar.zst.sig",
+            "codex-desktop-1.pkg.tar.zst.sha256",
+            "codex-desktop-1.pkg.tar.zst.part",
+            "report.pkg.tar.json",
+            "codex-desktop-1.deb.sig",
+            "codex-desktop-1.rpm.sig",
+            "build.log",
+        ] {
+            fs::write(dist.path().join(name), b"not a package")?;
+        }
+        assert_eq!(find_package(dist.path())?, package);
+        Ok(())
+    }
+
+    #[test]
+    fn find_package_rejects_missing_or_symlink_only_packages() -> Result<()> {
+        let root = tempdir()?;
+        let dist = root.path().join("dist");
+        fs::create_dir(&dist)?;
+        assert_eq!(
+            find_package(&dist).unwrap_err().to_string(),
+            "expected one rebuilt package, found 0"
+        );
+
+        let outside = root.path().join("outside.pkg.tar.zst");
+        fs::write(&outside, b"outside fixture")?;
+        symlink(&outside, dist.join("codex-desktop-latest.pkg.tar.zst"))?;
+        assert_eq!(
+            find_package(&dist).unwrap_err().to_string(),
+            "expected one rebuilt package, found 0"
+        );
+        Ok(())
+    }
 
     #[test]
     fn workspace_component_never_contains_separators() {

--- a/updater/src/install.rs
+++ b/updater/src/install.rs
@@ -787,7 +787,7 @@ fn strip_pacman_package_suffix(file_name: &str) -> Option<&str> {
     })
 }
 
-fn is_pacman_package_file_name(file_name: &str) -> bool {
+pub(crate) fn is_pacman_package_file_name(file_name: &str) -> bool {
     strip_pacman_package_suffix(file_name).is_some()
 }
 


### PR DESCRIPTION
## Summary

Build on merged #1422 by hardening rebuilt-package discovery at the filesystem and filename boundaries.

#1422 correctly skips pacman's `latest` symlink and retains the two-real-package ambiguity guard. This follow-up:

- accepts only regular directory entries and propagates `DirEntry::file_type` errors;
- reuses the installer's supported pacman suffix matcher, excluding `.sig`, checksum, partial-download, and other `.pkg.tar.*` lookalikes;
- retains #1422's alias and ambiguity tests while adding four complementary tests for all supported formats, package-named directories, sidecars/unrelated files, and missing or symlink-only output.

The branch is rebased onto current `main` at `613e718246180d075afcabd8d859d499883c0991`. It contains one focused commit and no fork-sync or historical fork-only changes.

## Validation

Rerun after rebasing and resolving the #1422 overlap:

- `cargo test --locked --jobs 4 -p codex-update-manager`: **55 passed**.
- `cargo clippy --locked --jobs 4 -p codex-update-manager --all-targets -- -D warnings`: **passed**.
- `node --test scripts/lib/package-common.test.js`: **11 passed**.
- `bash tests/scripts_smoke.sh`: **57 passed**.
- `git diff --check upstream/main...HEAD`: **passed**.

The complete updated base-to-head diff (`613e718..c04e867`) was reviewed with a code-review model after validation. The review checked artifact classification, symlink/directory behavior, file-type error handling, supported pacman suffix consistency, exactly-one-artifact failure behavior, test overlap, and scope. It reported no blockers, so no fix-and-rerun cycle was required.

The collector is shared by deb/RPM/pacman and is architecture-independent. AppImage/Nix do not use this mutable package updater. A live updater promotion was not performed for the rebased follow-up. No changes affect signed-source verification, package installation, running-app guards, promotion, rollback, dependencies, or generated application payloads.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source rather than generated output, and removed duplicate #1422 coverage.
- [x] Relevant regression tests were added and the validation above passes.
- [x] I reviewed the complete rebased diff with a code-review model and found no remaining blockers.
- [x] Required checks on rebased head `c04e867` pass.
- [ ] Maximum-reasoning review specifically verified (not claimed).

This is package discovery, not ASAR/upstream-runtime drift; no compatibility fallback was added.
