### PR TITLE
Repair official Linux 26.901.31953 drift

### DIFF
--- a/linux-features/api-key-service-tier/patch.js
+++ b/linux-features/api-key-service-tier/patch.js
@@ -99,6 +99,17 @@ function matchesApiKeyServiceTierModelContract(source) {
   return PATCHED_MODEL_MARKER.test(source) || hasApiKeyModelListMappingShape(source);
 }
 
+function currentFallbackOptionsPattern(flags = "") {
+  return new RegExp(
+    `\\.\\.\\.\\((${JS_IDENT})\\?\\.serviceTiers\\?\\?\\[\\]\\)\\.map\\((${JS_IDENT})=>\\{` +
+      `let (${JS_IDENT})=${JS_IDENT}\\(\\2\\.id,\\2\\.name\\),` +
+      `(${JS_IDENT})=\\3===\\\`fast\\\`\\?${JS_IDENT}\\(\\1\\?\\.model\\):null;` +
+      `return\\{description:${JS_IDENT}\\(\\2,\\4\\),iconKind:\\3,label:${JS_IDENT}\\(\\2\\),` +
+      `speedMultiplier:\\4,tier:\\2,value:\\2\\.id\\}\\}\\)`,
+    flags,
+  );
+}
+
 function matchesFallbackFastTierContract(source) {
   if (hasCompleteFallbackFastTierPatch(source)) {
     return true;
@@ -108,12 +119,7 @@ function matchesFallbackFastTierContract(source) {
     `function ${JS_IDENT}\\(e\\)\\{return e\\?\\.serviceTiers\\?\\.find\\(e=>` +
       `${JS_IDENT}\\(e\\.id,e\\.name\\)===\\\`fast\\\`\\|\\|e\\.name\\.trim\\(\\)\\.toLowerCase\\(\\)===\\\`priority\\\`\\)\\?\\?null\\}`,
   );
-  const optionsShape = new RegExp(
-    `\\.\\.\\.\\(${JS_IDENT}\\?\\.serviceTiers\\?\\?\\[\\]\\)\\.map\\(${JS_IDENT}=>\\(\\{` +
-      `description:${JS_IDENT}\\(${JS_IDENT}\\),iconKind:${JS_IDENT}\\(${JS_IDENT}\\.id,${JS_IDENT}\\.name\\),` +
-      `label:${JS_IDENT}\\(${JS_IDENT}\\),tier:${JS_IDENT},value:${JS_IDENT}\\.id\\}\\)\\)`,
-  );
-  return fastResolverShape.test(source) && optionsShape.test(source);
+  return fastResolverShape.test(source) && currentFallbackOptionsPattern().test(source);
 }
 
 function hasCompleteFallbackFastTierPatch(source) {
@@ -155,15 +161,13 @@ function applyFallbackFastTierPatch(source) {
     `function $1(e){return e?.serviceTiers?.find(e=>$2(e.id,e.name)===\`fast\`||e.name.trim().toLowerCase()===\`priority\`)??${PATCH_MARKER}(e)}`,
   );
 
-  const optionsPatch = new RegExp(
-    `\\.\\.\\.\\((${JS_IDENT})\\?\\.serviceTiers\\?\\?\\[\\]\\)\\.map\\((${JS_IDENT})=>\\(\\{` +
-      `description:(${JS_IDENT})\\(\\2\\),iconKind:(${JS_IDENT})\\(\\2\\.id,\\2\\.name\\),` +
-      `label:(${JS_IDENT})\\(\\2\\),tier:\\2,value:\\2\\.id\\}\\)\\)`,
-    "g",
-  );
+  const optionsPatch = currentFallbackOptionsPattern("g");
   patched = patched.replace(
     optionsPatch,
-    `...(($1?.serviceTiers?.length?$1.serviceTiers:[${PATCH_MARKER}($1)]).filter(Boolean)).map($2=>({description:$3($2),iconKind:$4($2.id,$2.name),label:$5($2),tier:$2,value:$2.id}))`,
+    (match, modelVar) => match.replace(
+      `...(${modelVar}?.serviceTiers??[])`,
+      `...((${modelVar}?.serviceTiers?.length?${modelVar}.serviceTiers:[${PATCH_MARKER}(${modelVar})]).filter(Boolean))`,
+    ),
   );
 
   if (hasCompleteFallbackFastTierPatch(patched)) {

--- a/linux-features/api-key-service-tier/test.js
+++ b/linux-features/api-key-service-tier/test.js
@@ -145,7 +145,7 @@ test("partial current drift is reported when the other exact target still applie
         [
           "let defaultServiceTier=null;",
           "function pQ(e,t){return t==null?null:t===`fast`?mQ(e):e?.serviceTiers?.find(e=>e.id===t)??null}",
-          "function tEe(e){return[{description:yQ.standardDescription,iconKind:null,label:yQ.standardLabel,tier:null,value:null},...(e?.serviceTiers??[]).map(e=>({description:eEe(e),iconKind:fQ(e.id,e.name),label:$Te(e),tier:e,value:e.id}))]}",
+          "function tEe(e){return[gQ,...(e?.serviceTiers??[]).map(t=>{let n=fQ(t.id,t.name),r=n===`fast`?nQ(e?.model):null;return{description:eEe(t,r),iconKind:n,label:$Te(t),speedMultiplier:r,tier:t,value:t.id}})]}",
           "function mQ(e){return e?.serviceTiers?.find(e=>fQ(e.id,e.name)===`fast`||e.name.trim().toLowerCase()===`priority`)??null}",
         ].join(""),
       );
@@ -284,7 +284,7 @@ test("model list marker rejects the superseded pre-catalog signature byte-identi
 test("fallback fast tier is synthesized only for API-key model catalog entries", () => {
   const source = [
     "function pQ(e,t){return t==null?null:t===`fast`?mQ(e):e?.serviceTiers?.find(e=>e.id===t)??null}",
-    "function tEe(e){return[{description:yQ.standardDescription,iconKind:null,label:yQ.standardLabel,tier:null,value:null},...(e?.serviceTiers??[]).map(e=>({description:eEe(e),iconKind:fQ(e.id,e.name),label:$Te(e),tier:e,value:e.id}))]}",
+    "function tEe(e){return[gQ,...(e?.serviceTiers??[]).map(t=>{let n=fQ(t.id,t.name),r=n===`fast`?nQ(e?.model):null;return{description:eEe(t,r),iconKind:n,label:$Te(t),speedMultiplier:r,tier:t,value:t.id}})]}",
     "function nEe(e,t,n){return e?.find(e=>e.model===t&&hQ(e,n))??null}",
     "function mQ(e){return e?.serviceTiers?.find(e=>fQ(e.id,e.name)===`fast`||e.name.trim().toLowerCase()===`priority`)??null}",
   ].join("");
@@ -295,6 +295,7 @@ test("fallback fast tier is synthesized only for API-key model catalog entries",
   assert.match(patched, /e\?\.codexLinuxApiKeyServiceTierModel!==!0\?null/);
   assert.match(patched, /codexLinuxApiKeyFastTier\(e\)/);
   assert.match(patched, /\?e\.serviceTiers:\[codexLinuxApiKeyFastTier\(e\)\]\)\.filter\(Boolean\)\)\.map/);
+  assert.match(patched, /speedMultiplier:r,tier:t,value:t\.id/);
   assert.doesNotMatch(patched, /\(e\?\.serviceTiers\?\?\[\]\)\.map/);
   assert.doesNotMatch(patched, /\)\?\?null\}function nEe/);
 });
@@ -350,7 +351,7 @@ test("combined patch updates both service tier gate and fallback options", () =>
     "function sxe(e){let t=(0,cxe.c)(6),n=X(os),r=e?.hostId??n,i=Cf(r),a=i?.authMethod===`chatgpt`,o=i?.authMethod??null,s;t[0]!==r||t[1]!==o?(s={authMethod:o,hostId:r},t[0]=r,t[1]=o,t[2]=s):s=t[2];let{data:c,isPending:l}=ye(is,s),u=!!i?.isLoading||a&&l,d=a&&!u&&c!=null&&c?.requirements?.featureRequirements?.fast_mode!==!1,f;return t[3]!==u||t[4]!==d?(f={isServiceTierAllowed:d,isLoading:u},t[3]=u,t[4]=d,t[5]=f):f=t[5],f}",
     currentModelFixture(),
     "function pQ(e,t){return t==null?null:t===`fast`?mQ(e):e?.serviceTiers?.find(e=>e.id===t)??null}",
-    "function tEe(e){return[{description:yQ.standardDescription,iconKind:null,label:yQ.standardLabel,tier:null,value:null},...(e?.serviceTiers??[]).map(e=>({description:eEe(e),iconKind:fQ(e.id,e.name),label:$Te(e),tier:e,value:e.id}))]}",
+    "function tEe(e){return[gQ,...(e?.serviceTiers??[]).map(t=>{let n=fQ(t.id,t.name),r=n===`fast`?nQ(e?.model):null;return{description:eEe(t,r),iconKind:n,label:$Te(t),speedMultiplier:r,tier:t,value:t.id}})]}",
     "function mQ(e){return e?.serviceTiers?.find(e=>fQ(e.id,e.name)===`fast`||e.name.trim().toLowerCase()===`priority`)??null}",
   ].join("");
 

--- a/nix/upstream-linux-packages.json
+++ b/nix/upstream-linux-packages.json
@@ -1,13 +1,13 @@
 {
-  "version": "26.901.20858",
+  "version": "26.901.31953",
   "amd64": {
-    "repositoryPath": "pool/main/c/chatgpt/chatgpt_26.901.20858_amd64.deb",
-    "sha256": "42a6477f22f4136d62321eda7b4697a79da1eb66d61dcb85ab0420860a1a5223",
-    "sri": "sha256-QqZHfyL0E21iMh7ae0aXp52h62bWHcuFqwQghgoaUiM="
+    "repositoryPath": "pool/main/c/chatgpt/chatgpt_26.901.31953_amd64.deb",
+    "sha256": "2bb4522be877de6c17e5f4c071b06ec64882b1dd09a8f0bd204af023ab756d9c",
+    "sri": "sha256-K7RSK+h33mwX5fTAcbBuxkiCsd0JqPC9IErwI6t1bZw="
   },
   "arm64": {
-    "repositoryPath": "pool/main/c/chatgpt/chatgpt_26.901.20858_arm64.deb",
-    "sha256": "a9b6cabc7a4f38e62e78b37b5950050d3a189d4502dc7ca6e1285a7899d87469",
-    "sri": "sha256-qbbKvHpPOOYueLN7WVAFDToYnUUC3Hym4ShaeJnYdGk="
+    "repositoryPath": "pool/main/c/chatgpt/chatgpt_26.901.31953_arm64.deb",
+    "sha256": "0cdc246ee77896068f053754c295ca13825d0210068f746afd965c2f84c74974",
+    "sri": "sha256-DNwkbud4lgaPBTdUwpXKE4JdAhAGj3Rq/ZZcL4THSXQ="
   }
 }


### PR DESCRIPTION
<!-- official-linux-watchdog:4048a5a1493f954985f627e265c6385986d81636aa65e992047d4eaf3e5d640a -->
## Summary

Repair drift for signed Linux release `26.901.31953`.

## Evidence

- Campaign: `4048a5a1493f954985f627e265c6385986d81636aa65e992047d4eaf3e5d640a`
- Acceptance source head: `c73e7f6e635317c74d220d1aaa0e1fd5d2d77f0a`
- Package SHA-256: `2bb4522be877de6c17e5f4c071b06ec64882b1dd09a8f0bd204af023ab756d9c`
- ASAR SHA-256: `17ef298f24961f79a56b87c343e70c489c995afafc8dd97bdcb8214d5db08593`
- Internal review binding: `f95bf598340cec5be5a73b51b266564bb5f4714b98845bece69bac32f09e9520`
- Reviewed diff SHA-256: `f940c761d979a57b643746da455e02226f3753268163776128d2ed61a68e7531`

The GitHub approval requirement is not weakened. This unattended merge uses the
repository's existing admin bypass only after evidence-bound independent review.