### PR TITLE
HEROX-1426: Fix lifecycle hook context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Lifecycle hooks now use exported application paths without interpreting
+  desktop arguments or deep-link URIs as launcher context. After-exit hooks
+  receive the Electron status and cannot replace it when cleanup fails; the
+  MCP and Node REPL reapers now run on normal and deep-link launches.
 - The opt-in `frameless-titlebar` feature again hides official Linux overlay
   buttons. It retargets the current `titleBarOverlay` window options, zoom
   update, and theme-sync contracts, remaps Linux webview chrome to `native`,

--- a/docs/linux-features-architecture.md
+++ b/docs/linux-features-architecture.md
@@ -161,9 +161,16 @@ a feature removes framework-owned files on the next rebuild.
 
 Launcher hooks receive the Electron arguments already loaded from user and
 feature configuration followed by the original launcher arguments. Other
-executable hooks receive the original arguments. All hooks receive the
-feature/app directory environment. Keep them bounded; the compact launcher
-does not supervise helper processes or provide a second application lifecycle.
+executable hooks receive the original arguments and use
+`CODEX_LINUX_APP_DIR`, `CODEX_LINUX_APP_STATE_DIR`, and
+`CODEX_LINUX_APP_CACHE_DIR` for lifecycle paths. Feature-owned runtime resources
+are available under `CODEX_LINUX_FEATURES_DIR`, and
+`CODEX_LINUX_LAUNCHER_LOG` names the canonical launcher log path. After-exit
+hooks receive the process status in `CODEX_LINUX_ELECTRON_EXIT_STATUS`. Keep
+hooks bounded; the compact launcher does not supervise helper processes or
+provide a second application lifecycle. The launcher exports lifecycle paths
+but does not create their directories; hooks must create a directory before
+writing into it.
 
 ## Native package extensions
 

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -13,6 +13,9 @@ export BAMF_DESKTOP_FILE_HINT="${BAMF_DESKTOP_FILE_HINT:-/usr/share/applications
 
 HOOK_ROOT="$CODEX_LINUX_APP_DIR/.codex-linux"
 CHATGPT_BINARY="$CODEX_LINUX_APP_DIR/ChatGPT"
+CODEX_LINUX_FEATURES_DIR="$HOOK_ROOT/features"
+CODEX_LINUX_LAUNCHER_LOG="$CODEX_LINUX_APP_CACHE_DIR/launcher.log"
+export CODEX_LINUX_FEATURES_DIR CODEX_LINUX_LAUNCHER_LOG
 
 usage() {
     cat <<EOF
@@ -232,6 +235,7 @@ run_launcher_hooks() {
 }
 
 ORIGINAL_ARGS=("$@")
+unset CODEX_LINUX_ELECTRON_EXIT_STATUS
 case "${1:-}" in
     -h|--help) usage; exit 0 ;;
     --diagnose) diagnose; exit $? ;;
@@ -265,6 +269,7 @@ fi
 set +e
 "$CHATGPT_BINARY" "${ELECTRON_ARGS[@]}" "${ORIGINAL_ARGS[@]}"
 status=$?
+CODEX_LINUX_ELECTRON_EXIT_STATUS="$status" run_hook_directory \
+    "$HOOK_ROOT/after-exit.d" after-exit
 set -e
-run_hook_directory "$HOOK_ROOT/after-exit.d" after-exit
 exit "$status"

--- a/launcher/start.test.js
+++ b/launcher/start.test.js
@@ -207,6 +207,101 @@ test("launcher composes declarative hooks and forwards arguments", (t) => {
   assert.equal(fs.readFileSync(path.join(root, "after-exit"), "utf8"), "after-exit");
 });
 
+test("launcher preserves desktop arguments and exposes the after-exit status", (t) => {
+  for (const originalArgs of [[], ["codex://thread/123", "--new-window"]]) {
+    const root = createApp(t);
+    const hooks = path.join(root, ".codex-linux");
+    const stateDir = path.join(root, "state", "codex-desktop");
+    const cacheDir = path.join(root, "cache", "codex-desktop");
+    const expectedDesktopArgs = ["--class=codex-desktop", ...originalArgs];
+    const expectedHookContext = [
+      `app=${root}`,
+      `state=${stateDir}`,
+      `cache=${cacheDir}`,
+      `features=${path.join(hooks, "features")}`,
+      `log=${path.join(cacheDir, "launcher.log")}`,
+    ];
+
+    for (const phase of ["prelaunch", "cold-start", "after-exit"]) {
+      writeExecutable(
+        path.join(hooks, `${phase}.d`, "capture.sh"),
+        `#!/bin/bash
+output="$TEST_ROOT/${phase}-context"
+{
+  printf 'phase=%s\\nexit=%s\\n' "$CODEX_LINUX_FEATURE_HOOK_PHASE" "\${CODEX_LINUX_ELECTRON_EXIT_STATUS:-}"
+  printf 'app=%s\\nstate=%s\\ncache=%s\\nfeatures=%s\\nlog=%s\\n' \
+    "$CODEX_LINUX_APP_DIR" "$CODEX_LINUX_APP_STATE_DIR" "$CODEX_LINUX_APP_CACHE_DIR" \
+    "$CODEX_LINUX_FEATURES_DIR" "$CODEX_LINUX_LAUNCHER_LOG"
+  printf '%s\\n' "$@"
+} > "$output.tmp"
+mv "$output.tmp" "$output"
+`,
+      );
+    }
+
+    const result = childProcess.spawnSync(path.join(root, "start.sh"), originalArgs, {
+      env: {
+        ...process.env,
+        CODEX_HOME: path.join(root, "codex-home"),
+        CODEX_LINUX_ELECTRON_EXIT_STATUS: "99",
+        TEST_ROOT: root,
+        XDG_CACHE_HOME: path.join(root, "cache"),
+        XDG_CONFIG_HOME: path.join(root, "config"),
+        XDG_STATE_HOME: path.join(root, "state"),
+      },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 7);
+    waitForFile(path.join(root, "cold-start-context"));
+    assert.deepEqual(
+      fs.readFileSync(path.join(root, "prelaunch-context"), "utf8").trim().split("\n"),
+      ["phase=prelaunch", "exit=", ...expectedHookContext, ...originalArgs],
+    );
+    assert.deepEqual(
+      fs.readFileSync(path.join(root, "cold-start-context"), "utf8").trim().split("\n"),
+      ["phase=cold-start", "exit=", ...expectedHookContext, ...originalArgs],
+    );
+    assert.deepEqual(
+      fs.readFileSync(path.join(root, "after-exit-context"), "utf8").trim().split("\n"),
+      ["phase=after-exit", "exit=7", ...expectedHookContext, ...originalArgs],
+    );
+    assert.deepEqual(
+      fs.readFileSync(path.join(root, "arguments"), "utf8").trim().split("\n"),
+      expectedDesktopArgs,
+    );
+  }
+});
+
+test("launcher preserves app status when an after-exit hook fails", (t) => {
+  const root = createApp(t);
+  const hooks = path.join(root, ".codex-linux", "after-exit.d");
+  writeExecutable(
+    path.join(hooks, "01-fail.sh"),
+    "#!/bin/bash\nprintf failed > \"$TEST_ROOT/failed-hook\"\nexit 42\n",
+  );
+  writeExecutable(
+    path.join(hooks, "02-continue.sh"),
+    "#!/bin/bash\nprintf continued > \"$TEST_ROOT/continued-hook\"\n",
+  );
+
+  const result = childProcess.spawnSync(path.join(root, "start.sh"), [], {
+    env: {
+      ...process.env,
+      CODEX_HOME: path.join(root, "codex-home"),
+      TEST_ROOT: root,
+      XDG_CACHE_HOME: path.join(root, "cache"),
+      XDG_CONFIG_HOME: path.join(root, "config"),
+      XDG_STATE_HOME: path.join(root, "state"),
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 7);
+  assert.equal(fs.readFileSync(path.join(root, "failed-hook"), "utf8"), "failed");
+  assert.equal(fs.readFileSync(path.join(root, "continued-hook"), "utf8"), "continued");
+});
+
 test("launcher exports the physical default CODEX_HOME when it is a symlink", (t) => {
   const root = createApp(t);
   const home = path.join(root, "home");

--- a/linux-features/README.md
+++ b/linux-features/README.md
@@ -125,7 +125,8 @@ Declarative resources and runtime hooks are tracked in
 the owning feature is disabled. Legacy `stage.sh` hooks own their own cleanup.
 
 Runtime hooks receive `CODEX_HOME`, `CODEX_LINUX_APP_DIR`,
-`CODEX_LINUX_APP_STATE_DIR`, `CODEX_LINUX_FEATURES_DIR`, and
+`CODEX_LINUX_APP_STATE_DIR`, `CODEX_LINUX_APP_CACHE_DIR`,
+`CODEX_LINUX_FEATURES_DIR`, and
 `CODEX_LINUX_LAUNCHER_LOG`. Executable hooks also receive
 `CODEX_LINUX_FEATURE_HOOK_PHASE`; after-exit hooks receive
 `CODEX_LINUX_ELECTRON_EXIT_STATUS`. If a feature needs to install a Codex skill

--- a/linux-features/mcp-helper-reaper/after-exit-hook.sh
+++ b/linux-features/mcp-helper-reaper/after-exit-hook.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-app_dir="${1:?usage: after-exit hook <app-dir> <state-dir> <log-dir> <status>}"
+app_dir="${CODEX_LINUX_APP_DIR:?after-exit hook requires CODEX_LINUX_APP_DIR}"
 reaper="$app_dir/.codex-linux/mcp-helper-reaper/codex-mcp-helper-reaper"
 
 [ "${CODEX_MCP_HELPER_REAPER_DISABLE:-}" = "1" ] && exit 0

--- a/linux-features/mcp-helper-reaper/cold-start-hook.sh
+++ b/linux-features/mcp-helper-reaper/cold-start-hook.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-app_dir="${1:?usage: cold-start hook <app-dir> <state-dir> <log-dir>}"
-state_dir="${2:?usage: cold-start hook <app-dir> <state-dir> <log-dir>}"
-log_dir="${3:-}"
+app_dir="${CODEX_LINUX_APP_DIR:?cold-start hook requires CODEX_LINUX_APP_DIR}"
 feature_dir="$app_dir/.codex-linux/mcp-helper-reaper"
 reaper="$feature_dir/codex-mcp-helper-reaper"
 hook_installer="$feature_dir/install-session-hook.sh"
@@ -11,7 +9,7 @@ hook_installer="$feature_dir/install-session-hook.sh"
 [ "${CODEX_MCP_HELPER_REAPER_DISABLE:-}" = "1" ] && exit 0
 
 if [ -x "$hook_installer" ]; then
-    "$hook_installer" "$app_dir" "$state_dir" "$log_dir" || true
+    "$hook_installer" || true
 fi
 
 [ -x "$reaper" ] || exit 0

--- a/linux-features/mcp-helper-reaper/install-session-hook.sh
+++ b/linux-features/mcp-helper-reaper/install-session-hook.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-app_dir="${1:?usage: install-session-hook <app-dir> <state-dir> <log-dir>}"
-state_dir="${2:-}"
-log_dir="${3:-}"
+app_dir="${CODEX_LINUX_APP_DIR:?install-session-hook requires CODEX_LINUX_APP_DIR}"
 reaper="$app_dir/.codex-linux/mcp-helper-reaper/codex-mcp-helper-reaper"
 
 [ "${CODEX_MCP_HELPER_REAPER_DISABLE_HOOK:-}" = "1" ] && exit 0

--- a/linux-features/mcp-helper-reaper/test.js
+++ b/linux-features/mcp-helper-reaper/test.js
@@ -14,6 +14,7 @@ const STAGE = path.join(FEATURE_DIR, "stage.sh");
 const CLEANUP = path.join(FEATURE_DIR, "cleanup.sh");
 const INSTALL_SESSION_HOOK = path.join(FEATURE_DIR, "install-session-hook.sh");
 const COLD_START_HOOK = path.join(FEATURE_DIR, "cold-start-hook.sh");
+const LAUNCHER_TEMPLATE = path.join(REPO_ROOT, "launcher", "start.sh.template");
 
 function makeTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -37,6 +38,18 @@ function run(command, args, options = {}) {
     `${command} ${args.join(" ")} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
   );
   return result;
+}
+
+async function waitForFileContent(file, predicate, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(file)) {
+      const content = fs.readFileSync(file, "utf8");
+      if (predicate(content)) return content;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  assert.fail(`timed out waiting for complete content in ${file}`);
 }
 
 test("stage hook installs the orphan reaper without wrapping node_repl", () => {
@@ -164,13 +177,9 @@ test("cleanup hook restores node_repl and removes staged hooks", () => {
 test("session hook merge preserves existing SessionStart hook and deduplicates reaper hook", () => {
   const tempDir = makeTempDir("codex-mcp-helper-reaper-hooks-");
   const appDir = path.join(tempDir, "app");
-  const stateDir = path.join(tempDir, "state");
-  const logDir = path.join(tempDir, "log");
   const codexHome = path.join(tempDir, "codex-home");
   const reaper = path.join(appDir, ".codex-linux", "mcp-helper-reaper", "codex-mcp-helper-reaper");
   fs.mkdirSync(codexHome, { recursive: true });
-  fs.mkdirSync(stateDir, { recursive: true });
-  fs.mkdirSync(logDir, { recursive: true });
   writeExecutable(reaper, "#!/usr/bin/env bash\nexit 0\n");
   fs.writeFileSync(
     path.join(codexHome, "hooks.json"),
@@ -196,9 +205,9 @@ test("session hook merge preserves existing SessionStart hook and deduplicates r
     ) + "\n",
   );
 
-  const env = { CODEX_HOME: codexHome };
-  run("bash", [INSTALL_SESSION_HOOK, appDir, stateDir, logDir], { env });
-  run("bash", [INSTALL_SESSION_HOOK, appDir, stateDir, logDir], { env });
+  const env = { CODEX_HOME: codexHome, CODEX_LINUX_APP_DIR: appDir };
+  run("bash", [INSTALL_SESSION_HOOK], { env });
+  run("bash", [INSTALL_SESSION_HOOK], { env });
 
   const merged = JSON.parse(fs.readFileSync(path.join(codexHome, "hooks.json"), "utf8"));
   const commands = merged.hooks.SessionStart.flatMap((entry) => entry.hooks ?? []).map((hook) => hook.command);
@@ -215,31 +224,111 @@ test("session hook merge preserves existing SessionStart hook and deduplicates r
 test("cold-start hook launches a short all-parent scan", async () => {
   const tempDir = makeTempDir("codex-mcp-helper-reaper-cold-");
   const appDir = path.join(tempDir, "app");
-  const stateDir = path.join(tempDir, "state");
-  const logDir = path.join(tempDir, "log");
   const callLog = path.join(tempDir, "calls.log");
   const featureDir = path.join(appDir, ".codex-linux", "mcp-helper-reaper");
   const reaper = path.join(featureDir, "codex-mcp-helper-reaper");
-  fs.mkdirSync(stateDir, { recursive: true });
-  fs.mkdirSync(logDir, { recursive: true });
   writeExecutable(
     reaper,
     "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$CODEX_MCP_HELPER_REAPER_TEST_LOG\"\n",
   );
 
-  run("bash", [COLD_START_HOOK, appDir, stateDir, logDir], {
+  run("bash", [COLD_START_HOOK], {
     env: {
+      CODEX_LINUX_APP_DIR: appDir,
       CODEX_MCP_HELPER_REAPER_TEST_LOG: callLog,
       CODEX_MCP_HELPER_REAPER_DELAY: "0",
       CODEX_MCP_HELPER_REAPER_PASSES: "1",
     },
   });
 
-  await new Promise((resolve) => setTimeout(resolve, 300));
-  const calls = fs.readFileSync(callLog, "utf8");
+  const calls = await waitForFileContent(
+    callLog,
+    (content) => content.includes("--all-codex-parents"),
+  );
   assert.match(calls, /--all-codex-parents/);
   assert.match(calls, /--include-orphans/);
   assert.match(calls, /--app-dir /);
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test("staged lifecycle hooks reach the reaper through the launcher", async () => {
+  const tempDir = makeTempDir("codex-mcp-helper-reaper-launcher-");
+  const appDir = path.join(tempDir, "app");
+  const workDir = path.join(tempDir, "work");
+  const source = path.join(tempDir, "source", "codex-mcp-helper-reaper");
+  const callLog = path.join(tempDir, "calls.log");
+  const appArgs = path.join(tempDir, "app-arguments.log");
+  const codexHome = path.join(tempDir, "codex-home");
+  const launcher = fs
+    .readFileSync(LAUNCHER_TEMPLATE, "utf8")
+    .replaceAll("__CODEX_LINUX_APP_ID__", "codex-desktop")
+    .replaceAll("__CODEX_LINUX_APP_DISPLAY_NAME__", "ChatGPT Community");
+
+  fs.mkdirSync(workDir, { recursive: true });
+  writeExecutable(
+    source,
+    "#!/usr/bin/env bash\nprintf '%s\\t%s\\n' \"$CODEX_LINUX_FEATURE_HOOK_PHASE\" \"$*\" >> \"$CODEX_MCP_HELPER_REAPER_TEST_LOG\"\n",
+  );
+  for (const relative of [
+    "resources/app.asar",
+    "resources/codex",
+    "resources/rg",
+    "resources/codex-code-mode-host",
+    "resources/node_repl",
+  ]) {
+    writeExecutable(path.join(appDir, relative), "#!/usr/bin/env bash\nexit 0\n");
+  }
+  writeExecutable(path.join(appDir, "start.sh"), launcher);
+  writeExecutable(
+    path.join(appDir, "ChatGPT"),
+    `#!/usr/bin/env bash
+printf '%s\\n' "$@" > "${appArgs}"
+exit 7
+`,
+  );
+
+  run("bash", [STAGE], {
+    env: {
+      ARCH: process.arch,
+      CODEX_MCP_HELPER_REAPER_SOURCE: source,
+      INSTALL_DIR: appDir,
+      SCRIPT_DIR: REPO_ROOT,
+      WORK_DIR: workDir,
+    },
+  });
+
+  const result = spawnSync(path.join(appDir, "start.sh"), ["codex://thread/123"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CODEX_HOME: codexHome,
+      CODEX_LINUX_DISABLE_USAGE_REPORTING: "1",
+      CODEX_MCP_HELPER_REAPER_DISABLE: "0",
+      CODEX_MCP_HELPER_REAPER_DISABLE_HOOK: "0",
+      CODEX_MCP_HELPER_REAPER_DELAY: "0",
+      CODEX_MCP_HELPER_REAPER_PASSES: "1",
+      CODEX_MCP_HELPER_REAPER_TEST_LOG: callLog,
+      XDG_CACHE_HOME: path.join(tempDir, "cache"),
+      XDG_CONFIG_HOME: path.join(tempDir, "config"),
+      XDG_STATE_HOME: path.join(tempDir, "state"),
+    },
+  });
+
+  assert.equal(result.status, 7, result.stderr);
+  const calls = await waitForFileContent(
+    callLog,
+    (content) =>
+      /^cold-start\t.*--all-codex-parents/m.test(content) &&
+      /^after-exit\t.*--all-codex-parents/m.test(content),
+  );
+  assert.match(calls, /^cold-start\t.*--all-codex-parents/m);
+  assert.match(calls, /^after-exit\t.*--all-codex-parents/m);
+  assert.deepEqual(fs.readFileSync(appArgs, "utf8").trim().split("\n"), [
+    "--class=codex-desktop",
+    "codex://thread/123",
+  ]);
+  assert.match(fs.readFileSync(path.join(codexHome, "hooks.json"), "utf8"), /codex-mcp-helper-reaper-session/);
 
   fs.rmSync(tempDir, { recursive: true, force: true });
 });

--- a/linux-features/node-repl-reaper/after-exit-hook.sh
+++ b/linux-features/node-repl-reaper/after-exit-hook.sh
@@ -5,7 +5,7 @@
 # from the install remains.
 set -euo pipefail
 
-app_dir="${1:?usage: after-exit hook <app-dir> <state-dir> <log-dir> <status>}"
+app_dir="${CODEX_LINUX_APP_DIR:?after-exit hook requires CODEX_LINUX_APP_DIR}"
 reaper="$app_dir/.codex-linux/node-repl-reaper.sh"
 
 [ -x "$reaper" ] || exit 0

--- a/linux-features/node-repl-reaper/cold-start-hook.sh
+++ b/linux-features/node-repl-reaper/cold-start-hook.sh
@@ -5,12 +5,13 @@
 # recorded pid is dead or no longer the reaper.
 set -euo pipefail
 
-app_dir="${1:?usage: cold-start hook <app-dir> <state-dir> <log-dir>}"
-state_dir="${2:?usage: cold-start hook <app-dir> <state-dir> <log-dir>}"
+app_dir="${CODEX_LINUX_APP_DIR:?cold-start hook requires CODEX_LINUX_APP_DIR}"
+state_dir="${CODEX_LINUX_APP_STATE_DIR:?cold-start hook requires CODEX_LINUX_APP_STATE_DIR}"
 pid_file="$state_dir/node-repl-reaper.pid"
 reaper="$app_dir/.codex-linux/node-repl-reaper.sh"
 
 [ -x "$reaper" ] || exit 0
+mkdir -p "$state_dir"
 
 if [ -f "$pid_file" ]; then
     existing="$(cat "$pid_file" 2>/dev/null || true)"

--- a/linux-features/node-repl-reaper/test.js
+++ b/linux-features/node-repl-reaper/test.js
@@ -9,6 +9,8 @@ const path = require("node:path");
 const test = require("node:test");
 
 const REAPER = path.join(__dirname, "reaper.sh");
+const COLD_START_HOOK = path.join(__dirname, "cold-start-hook.sh");
+const AFTER_EXIT_HOOK = path.join(__dirname, "after-exit-hook.sh");
 const LONG_RUNNING_NODE_ARGS = ["-e", "setInterval(() => {}, 1000)"];
 
 function commandPath(name) {
@@ -80,6 +82,60 @@ function waitForExit(pid, timeoutMs = 4000) {
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+async function waitForFileContent(file, predicate, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(file)) {
+      const content = fs.readFileSync(file, "utf8");
+      if (predicate(content)) return content;
+    }
+    await delay(20);
+  }
+  assert.fail(`timed out waiting for complete content in ${file}`);
+}
+
+test("lifecycle hooks use exported app context instead of desktop arguments", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-node-repl-hook-test-"));
+  const appDir = path.join(root, "app");
+  const stateDir = path.join(root, "state");
+  const callLog = path.join(root, "calls.log");
+  const stagedReaper = path.join(appDir, ".codex-linux", "node-repl-reaper.sh");
+  fs.mkdirSync(path.dirname(stagedReaper), { recursive: true });
+  fs.writeFileSync(
+    stagedReaper,
+    `#!${BASH}
+printf '%s %s\\n' "$1" "$2" >> "${callLog}"
+`,
+    { mode: 0o755 },
+  );
+  const env = {
+    ...process.env,
+    CODEX_LINUX_APP_DIR: appDir,
+    CODEX_LINUX_APP_STATE_DIR: stateDir,
+  };
+
+  const coldStart = spawnSync(BASH, [COLD_START_HOOK, "codex://thread/123"], {
+    encoding: "utf8",
+    env,
+  });
+  assert.equal(coldStart.status, 0, coldStart.stderr);
+  const afterExit = spawnSync(BASH, [AFTER_EXIT_HOOK, "codex://thread/123"], {
+    encoding: "utf8",
+    env,
+  });
+  assert.equal(afterExit.status, 0, afterExit.stderr);
+  assert.equal(fs.existsSync(path.join(stateDir, "node-repl-reaper.pid")), true);
+
+  const calls = await waitForFileContent(
+    callLog,
+    (content) => content.includes(`${appDir} watch`) && content.includes(`${appDir} once`),
+  );
+  assert.ok(calls.split("\n").includes(`${appDir} watch`));
+  assert.ok(calls.split("\n").includes(`${appDir} once`));
+
+  fs.rmSync(root, { recursive: true, force: true });
+});
 
 test("reaps a node_repl whose parent is not a live codex app-server", async () => {
   const { appDir, nodeReplBin } = makeFakeApp();


### PR DESCRIPTION
## Summary
- preserve original desktop and deep-link arguments for lifecycle hooks while exporting stable application paths and the Electron exit status
- update MCP helper and Node REPL reapers to consume lifecycle context from the environment and handle first-run state safely
- add launcher contract and staged feature integration coverage

## Tests
- `./scripts/ci-local.sh pr`
- `node --test launcher/start.test.js linux-features/mcp-helper-reaper/test.js linux-features/node-repl-reaper/test.js`
- `bash tests/scripts_smoke.sh`
- `bash -n launcher/start.sh.template linux-features/mcp-helper-reaper/*.sh linux-features/node-repl-reaper/*.sh`
- `git diff --check`

Fixes #1426