### PR TITLE
Fix updater self-termination during deb upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -201,7 +201,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -421,7 +421,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -623,7 +623,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -634,7 +634,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -740,7 +740,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -903,7 +903,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1442,7 +1442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1471,21 +1471,11 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -1572,7 +1562,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1607,7 +1597,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1652,7 +1642,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1688,7 +1678,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1699,7 +1689,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1723,7 +1713,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1834,6 +1824,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,11 +1842,10 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tauri-winrt-notification"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
 dependencies = [
- "quick-xml 0.37.5",
  "thiserror",
  "windows",
  "windows-version",
@@ -1881,7 +1881,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1937,7 +1937,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2035,7 +2035,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2303,12 +2303,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.2",
+ "quick-xml",
  "quote",
 ]
 
@@ -2388,7 +2388,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2399,7 +2399,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2535,7 +2535,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2551,7 +2551,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2662,7 +2662,7 @@ checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "zbus-lockstep",
  "zbus_xml",
  "zvariant",
@@ -2677,17 +2677,17 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "zbus_names",
  "zvariant",
- "zvariant_utils",
+ "zvariant_utils 3.3.1",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "4.3.2"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
  "winnow 1.0.0",
@@ -2696,14 +2696,23 @@ dependencies = [
 
 [[package]]
 name = "zbus_xml"
-version = "5.1.1"
+version = "5.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8067892e940ed1727dea64690378601603b31d62dfde019a5335fbb7c0e0ed9"
+checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
 dependencies = [
- "quick-xml 0.39.2",
  "serde",
+ "winnow 1.0.0",
  "zbus_names",
  "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2723,7 +2732,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2749,29 +2758,30 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.10.1"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db0ecb8987cf5e92653c57c098f7f0e39a03112edb796f4fe089fb7eaa14ff"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "winnow 1.0.0",
+ "zcheapstr",
  "zvariant_derive",
- "zvariant_utils",
+ "zvariant_utils 4.2.0",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.10.1"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b949b639ab1b4bed763aa7481ba0e368af68d8b55532f8ed4bec86a59f2ca98"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
- "zvariant_utils",
+ "syn 3.0.5",
+ "zvariant_utils 4.2.0",
 ]
 
 [[package]]
@@ -2783,6 +2793,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.117",
+ "winnow 1.0.0",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.5",
  "winnow 1.0.0",
 ]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,8 +114,11 @@ user-authored plugins.
 The Rust updater polls signed metadata, downloads into a
 version/architecture/SHA cache, runs the minimal packaged update-builder, and
 builds a sibling candidate. Atomic promotion happens only after the app exits.
-The previous managed artifact is retained for rollback. Old incompatible state
-is reset without deleting installed or rollback packages.
+The previous managed artifact is retained for rollback. Legacy schema-v1
+candidate state is reset without deleting installed or rollback packages. A
+schema-2 interrupted package transaction whose owner identity cannot survive a
+reboot is instead retained as failed evidence behind a manual-recovery barrier;
+it is never auto-reconciled as a live install.
 
 ## Generated state
 

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -47,8 +47,16 @@ is cancelled before package mutation, the candidate instead remains ready; the
 updater suppresses repeat prompts until an explicit retry or another app-exit
 cycle.
 
-Legacy schema state is treated as an incompatible pending candidate and reset;
-the installed package and recorded rollback artifact are preserved.
+Legacy schema-v1 candidate state is treated as an incompatible pending candidate
+and reset; the installed package and recorded rollback artifact are preserved.
+An active package transaction from schema 2, or any persisted transaction whose
+owner lacks a reboot-safe identity, is marked failed without auto-reconciliation
+and sets a manual-recovery barrier. Automatic checks remain paused until the
+user confirms that no package manager is still running and explicitly retries
+the interrupted operation with `install-ready` or `rollback`; the candidate and
+rollback facts remain available. If owner classification stays unavailable
+through the recovery grace period, the same manual state is entered rather than
+assuming that the package manager exited.
 
 ## Commands
 

--- a/global-dictation-linux/Cargo.lock
+++ b/global-dictation-linux/Cargo.lock
@@ -258,11 +258,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/packaging/linux/codex-update-manager.prerm
+++ b/packaging/linux/codex-update-manager.prerm
@@ -3,6 +3,19 @@ set -eu
 
 SERVICE_NAME="codex-update-manager.service"
 
+# A managed package upgrade can be launched by codex-update-manager.service
+# itself. Stopping that service from this prerm would terminate the privileged
+# apt/dpkg transaction that is replacing the package, leaving root-owned
+# installer processes behind in the user-service cgroup. Keep the running
+# daemon alive for upgrades. After the package command returns, the updater
+# persists Installed state and only then exits on replacement so systemd can
+# restart the new binary.
+case "${1:-}" in
+    upgrade|failed-upgrade)
+        exit 0
+        ;;
+esac
+
 for runtime_dir in /run/user/*; do
     [ -d "$runtime_dir" ] || continue
 

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -134,13 +134,12 @@ CONTROL
     fi
     chmod 0644 "$PKG_ROOT/DEBIAN/control"
     if package_with_updater_enabled; then
-        sed \
-            -e "s|/opt/codex-desktop|/opt/$PACKAGE_NAME|g" \
-            -e "s|codex_desktop_repair_system_package_shadow_entries codex-desktop|codex_desktop_repair_system_package_shadow_entries $PACKAGE_NAME|g" \
-            "$POSTINST_TEMPLATE" > "$PKG_ROOT/DEBIAN/postinst"
-        cp "$PRERM_TEMPLATE" "$PKG_ROOT/DEBIAN/prerm"
-        cp "$POSTRM_TEMPLATE" "$PKG_ROOT/DEBIAN/postrm"
-        chmod 0755 "$PKG_ROOT/DEBIAN/postinst" "$PKG_ROOT/DEBIAN/prerm" "$PKG_ROOT/DEBIAN/postrm"
+        stage_deb_maintainer_scripts \
+            "$PKG_ROOT" \
+            "$PACKAGE_NAME" \
+            "$POSTINST_TEMPLATE" \
+            "$PRERM_TEMPLATE" \
+            "$POSTRM_TEMPLATE"
     else
         write_no_updater_deb_postinst "$PKG_ROOT/DEBIAN/postinst"
         write_no_updater_deb_prerm "$PKG_ROOT/DEBIAN/prerm"

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -540,6 +540,23 @@ exit 0
 SCRIPT
 }
 
+stage_deb_maintainer_scripts() {
+    local root="$1"
+    local package_name="$2"
+    local postinst_template="$3"
+    local prerm_template="$4"
+    local postrm_template="$5"
+
+    mkdir -p "$root/DEBIAN"
+    sed \
+        -e "s|/opt/codex-desktop|/opt/$package_name|g" \
+        -e "s|codex_desktop_repair_system_package_shadow_entries codex-desktop|codex_desktop_repair_system_package_shadow_entries $package_name|g" \
+        "$postinst_template" > "$root/DEBIAN/postinst"
+    cp "$prerm_template" "$root/DEBIAN/prerm"
+    cp "$postrm_template" "$root/DEBIAN/postrm"
+    chmod 0755 "$root/DEBIAN/postinst" "$root/DEBIAN/prerm" "$root/DEBIAN/postrm"
+}
+
 write_no_updater_deb_prerm() {
     local target="$1"
     local package_name

--- a/tests/deb-prerm.test.js
+++ b/tests/deb-prerm.test.js
@@ -1,0 +1,265 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const childProcess = require("node:child_process");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const net = require("node:net");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const repoRoot = path.resolve(__dirname, "..");
+const template = path.join(
+  repoRoot,
+  "packaging/linux/codex-update-manager.prerm",
+);
+
+function stagePrerm(root) {
+  const packageCommon = path.join(repoRoot, "scripts/lib/package-common.sh");
+  const postinst = path.join(
+    repoRoot,
+    "packaging/linux/codex-update-manager.postinst",
+  );
+  const postrm = path.join(
+    repoRoot,
+    "packaging/linux/codex-update-manager.postrm",
+  );
+  childProcess.execFileSync(
+    "bash",
+    [
+      "-c",
+      [
+        "set -euo pipefail",
+        '. "$PACKAGE_COMMON"',
+        'stage_deb_maintainer_scripts "$STAGE_ROOT" "$PACKAGE_NAME" "$POSTINST_TEMPLATE" "$PRERM_TEMPLATE" "$POSTRM_TEMPLATE"',
+      ].join("\n"),
+    ],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PACKAGE_COMMON: packageCommon,
+        STAGE_ROOT: root,
+        PACKAGE_NAME: "codex-desktop",
+        POSTINST_TEMPLATE: postinst,
+        PRERM_TEMPLATE: template,
+        POSTRM_TEMPLATE: postrm,
+      },
+    },
+  );
+  const staged = path.join(root, "DEBIAN/prerm");
+  assert.equal(
+    fs.readFileSync(staged, "utf8"),
+    fs.readFileSync(template, "utf8"),
+  );
+  return staged;
+}
+
+function writeFakeCommands(root, logPath) {
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(bin, { recursive: true });
+  fs.writeFileSync(
+    path.join(bin, "getent"),
+    "#!/bin/sh\n[ \"${1:-}\" = passwd ] || exit 1\nprintf 'fixture:x:%s:100:Fixture:/tmp:/bin/sh\\n' \"${2:-1000}\"\n",
+    { mode: 0o755 },
+  );
+  fs.writeFileSync(
+    path.join(bin, "runuser"),
+    "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$RUNUSER_LOG\"\n",
+    { mode: 0o755 },
+  );
+  return {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH || ""}`,
+    RUNUSER_LOG: logPath,
+  };
+}
+
+function runPrerm(staged, action, env) {
+  return childProcess.spawnSync(staged, [action], {
+    encoding: "utf8",
+    env,
+  });
+}
+
+async function usableRuntimeBus(t) {
+  const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+  const ownBus = path.join("/run/user", String(uid), "bus");
+  if (uid !== 0 && fs.existsSync(ownBus) && fs.statSync(ownBus).isSocket()) {
+    return ownBus;
+  }
+
+  let runtimeDir = null;
+  let fixtureIdentity = null;
+  let cleanupWithSudo = false;
+
+  if (uid !== 0) {
+    const sudo = childProcess.spawnSync("sudo", ["-n", "true"], {
+      stdio: "ignore",
+    });
+    if (sudo.status !== 0) {
+      t.skip(
+        "no active user bus or passwordless sudo available for maintainer-script cleanup test",
+      );
+      return null;
+    }
+    cleanupWithSudo = true;
+  }
+
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const fixtureUid = crypto.randomInt(60000, 1_000_000_000);
+    const candidate = path.join("/run/user", String(fixtureUid));
+    if (cleanupWithSudo) {
+      const created = childProcess.spawnSync(
+        "sudo",
+        ["-n", "mkdir", "--mode=0700", candidate],
+        { stdio: "ignore" },
+      );
+      if (created.status !== 0) continue;
+      try {
+        childProcess.execFileSync("sudo", [
+          "-n",
+          "chown",
+          `${uid}:${typeof process.getgid === "function" ? process.getgid() : uid}`,
+          candidate,
+        ]);
+      } catch (error) {
+        childProcess.spawnSync("sudo", ["-n", "rmdir", "--", candidate], {
+          stdio: "ignore",
+        });
+        throw error;
+      }
+    } else {
+      try {
+        fs.mkdirSync(candidate, { mode: 0o700 });
+      } catch (error) {
+        if (error && error.code === "EEXIST") continue;
+        throw error;
+      }
+    }
+    runtimeDir = candidate;
+    const stat = fs.statSync(runtimeDir);
+    fixtureIdentity = { dev: stat.dev, ino: stat.ino };
+    break;
+  }
+  assert.ok(runtimeDir, "could not reserve a unique /run/user fixture directory");
+
+  const ownershipMarker = path.join(runtimeDir, ".codex-prerm-test-owner");
+  const ownershipToken = crypto.randomBytes(24).toString("hex");
+  fs.writeFileSync(ownershipMarker, ownershipToken, { mode: 0o600 });
+  const bus = path.join(runtimeDir, "bus");
+  const server = net.createServer();
+  t.after(async () => {
+    if (server.listening) {
+      await new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+
+    const stat = fs.statSync(runtimeDir, { throwIfNoEntry: false });
+    const marker =
+      stat && fs.existsSync(ownershipMarker)
+        ? fs.readFileSync(ownershipMarker, "utf8")
+        : null;
+    assert.equal(
+      Boolean(
+        stat &&
+          stat.dev === fixtureIdentity.dev &&
+          stat.ino === fixtureIdentity.ino &&
+          marker === ownershipToken,
+      ),
+      true,
+      "refusing to clean a /run/user directory not owned by this fixture",
+    );
+    if (cleanupWithSudo) {
+      childProcess.execFileSync("sudo", ["-n", "rm", "-rf", runtimeDir]);
+    } else {
+      fs.rmSync(runtimeDir, { recursive: true, force: true });
+    }
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(bus, resolve);
+  });
+  return bus;
+}
+
+test("staged Debian prerm upgrade has no user-service side effects", async (t) => {
+  const bus = await usableRuntimeBus(t);
+  if (!bus) return;
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-prerm-upgrade-"));
+  try {
+    const staged = stagePrerm(root);
+    const logPath = path.join(root, "runuser.log");
+    const result = runPrerm(staged, "upgrade", writeFakeCommands(root, logPath));
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.existsSync(logPath), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("staged Debian prerm failed-upgrade has no user-service side effects", async (t) => {
+  const bus = await usableRuntimeBus(t);
+  if (!bus) return;
+
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), "codex-prerm-failed-upgrade-"),
+  );
+  try {
+    const staged = stagePrerm(root);
+    const logPath = path.join(root, "runuser.log");
+    const result = runPrerm(
+      staged,
+      "failed-upgrade",
+      writeFakeCommands(root, logPath),
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      fs.existsSync(logPath),
+      false,
+      "upgrade error recovery must not stop the updater service that owns the package transaction",
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+for (const action of ["remove", "deconfigure"]) {
+  test(
+    `staged Debian prerm ${action} retains stop, disable, and reload cleanup`,
+    async (t) => {
+      const bus = await usableRuntimeBus(t);
+      if (!bus) return;
+
+      const root = fs.mkdtempSync(
+        path.join(os.tmpdir(), `codex-prerm-${action}-`),
+      );
+      try {
+        const staged = stagePrerm(root);
+        const logPath = path.join(root, "runuser.log");
+        const result = runPrerm(
+          staged,
+          action,
+          writeFakeCommands(root, logPath),
+        );
+        assert.equal(result.status, 0, result.stderr);
+        const calls = fs.readFileSync(logPath, "utf8");
+        assert.match(
+          calls,
+          /systemctl --user stop codex-update-manager\.service/,
+        );
+        assert.match(
+          calls,
+          /systemctl --user disable codex-update-manager\.service/,
+        );
+        assert.match(calls, /systemctl --user daemon-reload/);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+}

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -116,7 +116,7 @@ for (const architecture of ["amd64", "arm64"]) {
 }
 NODE
 
-node --test launcher/start.test.js scripts/lib/upstream-linux-package.test.js \
+node --test launcher/start.test.js tests/deb-prerm.test.js scripts/lib/upstream-linux-package.test.js \
   scripts/automation/upstream-linux-package-watchdog/test.js \
   scripts/patch-linux-window-ui.test.js scripts/lib/linux-features.test.js
 

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -4,18 +4,19 @@ use crate::{
     builder, cache_cleanup,
     cli::{Cli, Commands},
     config::{RuntimeConfig, RuntimePaths},
-    install, install_rollback, liveness, logging, notify, restart, rollback,
-    state::{PersistedState, UpdateStatus},
+    install, install_rollback, install_transaction, liveness, logging, notify, restart, rollback,
+    state::{InstallOperation, PersistedState, UpdateStatus},
     upstream,
 };
 use anyhow::{Context, Result};
 use chrono::Utc;
-use std::{fs::{self, OpenOptions}, path::Path, time::Duration};
+use std::{
+    fs::{self, OpenOptions},
+    path::Path,
+    time::Duration,
+};
 use tokio::time;
-use tracing::{error, info};
-
-// Nonzero so `Restart=on-failure` relaunches the daemon on the new binary.
-const BINARY_REPLACED_RESTART_EXIT_CODE: i32 = 12;
+use tracing::{error, info, warn};
 
 pub async fn run(cli: Cli) -> Result<()> {
     if let Some(result) = run_privileged_command(&cli.command) {
@@ -25,16 +26,81 @@ pub async fn run(cli: Cli) -> Result<()> {
     paths.ensure_dirs()?;
     logging::init(&paths.log_file)?;
     let config = RuntimeConfig::load_or_default(&paths)?;
-    let mut state = PersistedState::load_or_default(&paths.state_file, config.auto_install_on_app_exit)?;
-    state.installed_version = install::installed_package_version();
 
     match cli.command {
-        Commands::Daemon => daemon(&config, &mut state, &paths).await,
-        Commands::CheckNow => check(&config, &mut state, &paths).await,
-        Commands::Status { json } => status(&state, json),
-        Commands::Diagnose { json } => diagnose(&config, &state, &paths, json),
-        Commands::InstallReady => run_install_ready(&config, &mut state, &paths).await,
-        Commands::Rollback => run_rollback(&config, &mut state, &paths).await,
+        Commands::Daemon => {
+            let mut state = PersistedState::load_or_default(
+                &paths.state_file,
+                config.auto_install_on_app_exit,
+            )?;
+            daemon(&config, &mut state, &paths).await
+        }
+        Commands::CheckNow => {
+            let Some(_lock) = MutationLock::try_acquire(&paths.state_dir.join("check.lock"))?
+            else {
+                info!("another updater mutation is active");
+                return Ok(());
+            };
+            let mut state = PersistedState::load_or_default(
+                &paths.state_file,
+                config.auto_install_on_app_exit,
+            )?;
+            if !prepare_mutation_state(&config, &mut state, &paths)? {
+                println!(
+                    "A package transaction is still active; refusing to start another update."
+                );
+                return Ok(());
+            }
+            check(&config, &mut state, &paths, false).await
+        }
+        Commands::Status { json } => {
+            let state = PersistedState::load_or_default(
+                &paths.state_file,
+                config.auto_install_on_app_exit,
+            )?;
+            status(&state, json)
+        }
+        Commands::Diagnose { json } => {
+            let state = PersistedState::load_or_default(
+                &paths.state_file,
+                config.auto_install_on_app_exit,
+            )?;
+            diagnose(&config, &state, &paths, json)
+        }
+        Commands::InstallReady => {
+            let Some(_lock) = MutationLock::try_acquire(&paths.state_dir.join("check.lock"))?
+            else {
+                info!("another updater mutation is active");
+                return Ok(());
+            };
+            let mut state = PersistedState::load_or_default(
+                &paths.state_file,
+                config.auto_install_on_app_exit,
+            )?;
+            if !prepare_mutation_state(&config, &mut state, &paths)? {
+                println!(
+                    "A package transaction is still active; refusing to start another install."
+                );
+                return Ok(());
+            }
+            install_ready(&config, &mut state, &paths, true, false).await
+        }
+        Commands::Rollback => {
+            let Some(_lock) = MutationLock::try_acquire(&paths.state_dir.join("check.lock"))?
+            else {
+                info!("another updater mutation is active");
+                return Ok(());
+            };
+            let mut state = PersistedState::load_or_default(
+                &paths.state_file,
+                config.auto_install_on_app_exit,
+            )?;
+            if !prepare_mutation_state(&config, &mut state, &paths)? {
+                println!("A package transaction is still active; refusing to start rollback.");
+                return Ok(());
+            }
+            rollback::run(&config, &mut state, &paths).await
+        }
         Commands::InstallDeb { .. }
         | Commands::InstallRpm { .. }
         | Commands::InstallPacman { .. }
@@ -56,28 +122,44 @@ fn run_privileged_command(command: &Commands) -> Option<Result<()>> {
     }
 }
 
-async fn daemon(config: &RuntimeConfig, state: &mut PersistedState, paths: &RuntimePaths) -> Result<()> {
+async fn daemon(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
     time::sleep(config.initial_check_delay_duration()).await;
-    if let Err(error) = check(config, state, paths).await {
-        error!(?error, "initial update check failed");
+    if let Some(_lock) = MutationLock::try_acquire(&paths.state_dir.join("check.lock"))? {
+        if daemon_replacement_gate(config, state, paths)? {
+            if let Err(error) = check(config, state, paths, true).await {
+                error!(?error, "initial update check failed");
+            }
+        }
+    } else {
+        info!("another updater mutation is active");
     }
     let mut checks = time::interval(config.check_interval_duration());
     let mut reconcile = time::interval(Duration::from_secs(15));
     checks.tick().await;
     reconcile.tick().await;
     loop {
-        if let Some(installed_binary) = restart::replacement_binary() {
-            info!(
-                installed_binary = %installed_binary.display(),
-                "updater binary was replaced on disk; exiting so systemd restarts the daemon"
-            );
-            std::process::exit(BINARY_REPLACED_RESTART_EXIT_CODE);
-        }
-
         tokio::select! {
-            _ = checks.tick() => if let Err(error) = check(config, state, paths).await { error!(?error, "periodic update check failed"); },
-            _ = reconcile.tick() => if let Err(error) = reconcile_pending_install(config, state, paths).await {
-                error!(?error, "deferred install failed");
+            _ = checks.tick() => {
+                if let Some(_lock) = MutationLock::try_acquire(&paths.state_dir.join("check.lock"))? {
+                    if daemon_replacement_gate(config, state, paths)? {
+                        if let Err(error) = check(config, state, paths, true).await {
+                            error!(?error, "periodic update check failed");
+                        }
+                    }
+                }
+            },
+            _ = reconcile.tick() => {
+                if let Some(_lock) = MutationLock::try_acquire(&paths.state_dir.join("check.lock"))? {
+                    if daemon_replacement_gate(config, state, paths)? {
+                        if let Err(error) = reconcile_pending_install(config, state, paths).await {
+                            error!(?error, "deferred install failed");
+                        }
+                    }
+                }
             },
             signal = tokio::signal::ctrl_c() => { signal?; break; }
         }
@@ -90,19 +172,13 @@ async fn reconcile_pending_install(
     state: &mut PersistedState,
     paths: &RuntimePaths,
 ) -> Result<()> {
-    let _lock = match CheckLock::try_acquire(&paths.state_dir.join("check.lock"))? {
-        Some(lock) => lock,
-        None => return Ok(()),
-    };
-    reload_state(config, state, paths)?;
     match state.status {
         UpdateStatus::WaitingForAppExit if !liveness::is_app_running(config)? => {
-            install_ready_locked(config, state, paths, false).await?;
+            install_ready(config, state, paths, false, true).await?;
         }
         UpdateStatus::ReadyToInstall
             if state.install_auth_retry_is_blocked()
-                && (config.auto_install_on_app_exit
-                    || state.install_after_app_exit_requested)
+                && (config.auto_install_on_app_exit || state.install_after_app_exit_requested)
                 && liveness::is_app_running(config)? =>
         {
             state.clear_install_auth_retry_block();
@@ -116,54 +192,209 @@ async fn reconcile_pending_install(
     Ok(())
 }
 
-async fn run_install_ready(
+fn daemon_replacement_gate(
     config: &RuntimeConfig,
     state: &mut PersistedState,
     paths: &RuntimePaths,
-) -> Result<()> {
-    let _lock = loop {
-        match CheckLock::try_acquire(&paths.state_dir.join("check.lock"))? {
-            Some(lock) => break lock,
-            None => time::sleep(Duration::from_millis(50)).await,
-        }
-    };
-    reload_state(config, state, paths)?;
-    install_ready_locked(config, state, paths, true).await
+) -> Result<bool> {
+    if !prepare_mutation_state(config, state, paths)? {
+        warn!("package transaction is still active; deferring updater work");
+        return Ok(false);
+    }
+
+    if let Some(installed_binary) = restart::replacement_binary() {
+        restart_daemon(&installed_binary);
+    }
+    Ok(true)
 }
 
-async fn run_rollback(
+fn prepare_mutation_state(
     config: &RuntimeConfig,
     state: &mut PersistedState,
     paths: &RuntimePaths,
-) -> Result<()> {
-    let _lock = loop {
-        match CheckLock::try_acquire(&paths.state_dir.join("check.lock"))? {
-            Some(lock) => break lock,
-            None => time::sleep(Duration::from_millis(50)).await,
+) -> Result<bool> {
+    *state = PersistedState::load_or_default(&paths.state_file, config.auto_install_on_app_exit)?;
+
+    if state.status != UpdateStatus::Installing {
+        state.installed_version = install::installed_package_version();
+        state.save_updater(&paths.state_file)?;
+        return Ok(true);
+    }
+
+    match state.install_transaction.clone() {
+        Some(transaction)
+            if install_transaction::is_active(&transaction)
+                || !install_transaction::grace_expired(&transaction) =>
+        {
+            Ok(false)
         }
-    };
-    reload_state(config, state, paths)?;
-    rollback::run(config, state, paths).await
+        Some(_) => {
+            recover_abandoned_install(state, paths)?;
+            Ok(true)
+        }
+        None => {
+            state.mark_failed("Installing state has no recoverable package transaction owner");
+            state.save_updater(&paths.state_file)?;
+            Ok(true)
+        }
+    }
 }
 
-fn reload_state(
-    config: &RuntimeConfig,
-    state: &mut PersistedState,
-    paths: &RuntimePaths,
-) -> Result<()> {
-    *state = PersistedState::load_or_default(
-        &paths.state_file,
-        config.auto_install_on_app_exit,
-    )?;
+fn recover_abandoned_install(state: &mut PersistedState, paths: &RuntimePaths) -> Result<()> {
+    let transaction = state
+        .install_transaction
+        .clone()
+        .context("Installing state has no transaction metadata")?;
+
+    let observed_installed_version = install::installed_package_version();
+    let verified_installed_version =
+        install::installed_package_version_for_recovery(&transaction.package_path);
+    let package_version = install::package_version(&transaction.package_path).ok();
+    let package_sha256 = install_transaction::package_sha256(&transaction.package_path).ok();
+    let package_identity_matches = transaction
+        .package_sha256
+        .as_deref()
+        .zip(package_sha256.as_deref())
+        .is_some_and(|(expected, actual)| expected == actual);
+    let replacement_observed = restart::replacement_binary().is_some();
+    let version_transition_observed = state.installed_version != "unknown"
+        && verified_installed_version
+            .as_deref()
+            .is_some_and(|installed| installed != state.installed_version);
+
+    let verified_package_matches = verified_installed_version
+        .as_deref()
+        .zip(package_version.as_deref())
+        .is_some_and(|(installed, candidate)| installed == candidate);
+
+    if verified_package_matches
+        && package_identity_matches
+        && (version_transition_observed || replacement_observed)
+    {
+        apply_reconciled_install(
+            state,
+            transaction,
+            verified_installed_version.expect("verified install version disappeared"),
+        );
+    } else {
+        state.mark_failed(format!(
+            "abandoned package transaction could not be reconciled: installed={observed_installed_version}, candidate={}, configured={}, artifact_identity={}, install_effect={}",
+            package_version.as_deref().unwrap_or("unknown"),
+            if verified_installed_version.is_some() {
+                "verified"
+            } else {
+                "unproven"
+            },
+            if package_identity_matches { "matched" } else { "unproven" },
+            if version_transition_observed || replacement_observed {
+                "observed"
+            } else {
+                "unproven"
+            }
+        ));
+    }
+
+    state.save_updater(&paths.state_file)?;
     Ok(())
 }
 
-async fn check(config: &RuntimeConfig, state: &mut PersistedState, paths: &RuntimePaths) -> Result<()> {
-    let _lock = match CheckLock::try_acquire(&paths.state_dir.join("check.lock"))? {
-        Some(lock) => lock,
-        None => { info!("another update check is active"); return Ok(()); }
+fn apply_reconciled_install(
+    state: &mut PersistedState,
+    transaction: crate::state::InstallTransaction,
+    installed_version: String,
+) {
+    match transaction.operation {
+        InstallOperation::Update => {
+            state.installed_version = installed_version;
+            state.installed_upstream_version = state.candidate_version.clone();
+            state.installed_upstream_sha256 = state.upstream_package_sha256.clone();
+            state
+                .last_known_good_version
+                .get_or_insert_with(|| state.installed_version.clone());
+            state.candidate_version = None;
+            state.candidate_architecture = None;
+            state.candidate_repository_path = None;
+            state.waiting_for_app_exit_auto_install = false;
+        }
+        InstallOperation::Rollback => {
+            let blocked_version = state
+                .candidate_version
+                .clone()
+                .or_else(|| Some(state.installed_version.clone()));
+            let blocked_sha = state.upstream_package_sha256.clone();
+
+            state.installed_version = installed_version;
+            state.installed_upstream_version = state.last_known_good_upstream_version.clone();
+            state.installed_upstream_sha256 = state.last_known_good_upstream_sha256.clone();
+            state.candidate_version = None;
+            state.rollback_blocked_candidate_version = blocked_version;
+            state.rollback_blocked_package_sha256 = blocked_sha;
+            state.artifact_paths.package_path = Some(transaction.package_path.clone());
+            state.artifact_paths.rollback_package_path = Some(transaction.package_path);
+            state.last_known_good_version = Some(state.installed_version.clone());
+        }
+    }
+
+    state.status = UpdateStatus::Installed;
+    state.install_transaction = None;
+    state.error_message = None;
+}
+
+fn restart_after_persisted_install(config: &RuntimeConfig, paths: &RuntimePaths) -> Result<()> {
+    let replacement = restart::replacement_binary();
+    let Some(installed_binary) = replacement else {
+        return Ok(());
     };
-    reload_state(config, state, paths)?;
+    test_wait_before_restart_readback()?;
+    let persisted =
+        PersistedState::load_or_default(&paths.state_file, config.auto_install_on_app_exit)?;
+    if persisted.status != UpdateStatus::Installed {
+        warn!(
+            status = ?persisted.status,
+            installed_binary = %installed_binary.display(),
+            "replacement updater exists but Installed state was not read back successfully; refusing to restart"
+        );
+        return Ok(());
+    }
+    restart_daemon(&installed_binary)
+}
+
+#[cfg(test)]
+fn test_wait_before_restart_readback() -> Result<()> {
+    let Some(marker) = std::env::var_os("CODEX_TEST_BEFORE_RESTART_READBACK") else {
+        return Ok(());
+    };
+    let marker = std::path::PathBuf::from(marker);
+    fs::write(&marker, b"ready")?;
+    let release = std::path::PathBuf::from(
+        std::env::var_os("CODEX_TEST_RELEASE_RESTART_READBACK")
+            .context("restart readback fixture release path is required")?,
+    );
+    while !release.exists() {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    Ok(())
+}
+
+#[cfg(not(test))]
+fn test_wait_before_restart_readback() -> Result<()> {
+    Ok(())
+}
+
+fn restart_daemon(installed_binary: &Path) -> ! {
+    info!(
+        installed_binary = %installed_binary.display(),
+        "updater binary was replaced after Installed state was persisted; exiting so systemd restarts on the new binary"
+    );
+    restart::exit_for_replacement();
+}
+
+async fn check(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    restart_on_replacement: bool,
+) -> Result<()> {
     recover_interrupted_check(state);
     let previous_state = state.clone();
     let previous_status = state.status.clone();
@@ -175,22 +406,38 @@ async fn check(config: &RuntimeConfig, state: &mut PersistedState, paths: &Runti
     state.save_updater(&paths.state_file)?;
 
     let package_cache = paths.cache_dir.join("packages");
-    let metadata = match upstream::resolve_metadata(&config.builder_bundle_root, &config.repository_url, &package_cache).await {
+    let metadata = match upstream::resolve_metadata(
+        &config.builder_bundle_root,
+        &config.repository_url,
+        &package_cache,
+    )
+    .await
+    {
         Ok(value) => value,
-        Err(error) => return fail_check(state, paths, previous_state, error),
+        Err(error) => return fail_check(state, paths, previous_state.clone(), error),
     };
     state.last_successful_check_at = Some(Utc::now());
     let _ = cache_cleanup::prune(&paths.cache_dir, state);
 
     let same_failed_candidate = previous_status == UpdateStatus::Failed
         && previous_sha256.as_deref() == Some(metadata.sha256.as_str());
-    let already_installed = state.installed_upstream_version.as_deref() == Some(metadata.version.as_str())
+    let already_installed = state.installed_upstream_version.as_deref()
+        == Some(metadata.version.as_str())
         && state.installed_upstream_sha256.as_deref() == Some(metadata.sha256.as_str())
         && state.candidate_version.is_none();
     if already_installed || same_failed_candidate {
-        state.status = if same_failed_candidate { UpdateStatus::Failed } else { UpdateStatus::Idle };
-        if same_failed_candidate { state.error_message = previous_error; }
-        if already_installed { state.clear_install_auth_retry_block(); }
+        state.status = if same_failed_candidate {
+            UpdateStatus::Failed
+        } else {
+            UpdateStatus::Idle
+        };
+        if same_failed_candidate {
+            state.error_message = previous_error;
+        }
+        if already_installed {
+            state.clear_install_auth_retry_block();
+            state.install_after_app_exit_requested = false;
+        }
         state.save_updater(&paths.state_file)?;
         return Ok(());
     }
@@ -199,7 +446,7 @@ async fn check(config: &RuntimeConfig, state: &mut PersistedState, paths: &Runti
         state.status = previous_status;
         state.error_message = previous_error;
         state.waiting_for_app_exit_auto_install = previous_waiting_auto_install;
-        return install_ready_locked(config, state, paths, false).await;
+        return install_ready(config, state, paths, false, restart_on_replacement).await;
     }
 
     rollback::record_current_package_as_known_good(state);
@@ -217,19 +464,29 @@ async fn check(config: &RuntimeConfig, state: &mut PersistedState, paths: &Runti
         &config.repository_url,
         &package_cache,
         &metadata,
-    ).await {
+    )
+    .await
+    {
         Ok(path) => path,
         Err(error) => return fail(state, paths, error),
     };
     state.artifact_paths.upstream_package_path = Some(upstream_package.clone());
-    if let Err(error) = builder::build_update(config, state, paths, &metadata.version, &upstream_package).await {
+    if let Err(error) =
+        builder::build_update(config, state, paths, &metadata.version, &upstream_package).await
+    {
         return fail(state, paths, error);
     }
 
     if config.notifications {
-        let _ = notify::send("codex-desktop update ready", &format!("Version {} has been rebuilt from OpenAI's signed Linux package.", metadata.version));
+        let _ = notify::send(
+            "codex-desktop update ready",
+            &format!(
+                "Version {} has been rebuilt from OpenAI's signed Linux package.",
+                metadata.version
+            ),
+        );
     }
-    install_ready_locked(config, state, paths, false).await
+    install_ready(config, state, paths, false, restart_on_replacement).await
 }
 
 fn mark_check_started(state: &mut PersistedState) {
@@ -255,27 +512,56 @@ fn same_pending_candidate(state: &PersistedState, version: &str, sha256: &str) -
         )
 }
 
-async fn install_ready_locked(
+async fn install_ready(
     config: &RuntimeConfig,
     state: &mut PersistedState,
     paths: &RuntimePaths,
     explicit_retry: bool,
+    restart_on_replacement: bool,
 ) -> Result<()> {
-    if !matches!(state.status, UpdateStatus::ReadyToInstall | UpdateStatus::WaitingForAppExit | UpdateStatus::Failed) {
+    install_ready_with_launcher(
+        config,
+        state,
+        paths,
+        explicit_retry,
+        restart_on_replacement,
+        Path::new("/bin/sh"),
+    )
+    .await
+}
+
+async fn install_ready_with_launcher(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    explicit_retry: bool,
+    restart_on_replacement: bool,
+    launcher_program: &Path,
+) -> Result<()> {
+    if !matches!(
+        state.status,
+        UpdateStatus::ReadyToInstall | UpdateStatus::WaitingForAppExit | UpdateStatus::Failed
+    ) {
         println!("No rebuilt package is ready to install.");
         return Ok(());
     }
     if state.status == UpdateStatus::Failed && !explicit_retry {
         return Ok(());
     }
-    let package = state.artifact_paths.package_path.clone().context("ready state has no package")?;
-    anyhow::ensure!(package.is_file(), "rebuilt package is missing: {}", package.display());
+    let package = state
+        .artifact_paths
+        .package_path
+        .clone()
+        .context("ready state has no package")?;
+    anyhow::ensure!(
+        package.is_file(),
+        "rebuilt package is missing: {}",
+        package.display()
+    );
     let auth_retry_blocked = state.install_auth_retry_is_blocked();
     let install_after_app_exit_requested = state.install_after_app_exit_requested;
     if liveness::is_app_running(config)? {
-        if !explicit_retry
-            && !install_after_app_exit_requested
-            && !config.auto_install_on_app_exit
+        if !explicit_retry && !install_after_app_exit_requested && !config.auto_install_on_app_exit
         {
             state.status = UpdateStatus::ReadyToInstall;
             state.waiting_for_app_exit_auto_install = false;
@@ -284,8 +570,7 @@ async fn install_ready_locked(
         }
         state.clear_install_auth_retry_block();
         state.status = UpdateStatus::WaitingForAppExit;
-        state.install_after_app_exit_requested =
-            explicit_retry || install_after_app_exit_requested;
+        state.install_after_app_exit_requested = explicit_retry || install_after_app_exit_requested;
         state.waiting_for_app_exit_auto_install =
             !state.install_after_app_exit_requested && config.auto_install_on_app_exit;
         state.save_updater(&paths.state_file)?;
@@ -298,10 +583,7 @@ async fn install_ready_locked(
         state.save_updater(&paths.state_file)?;
         return Ok(());
     }
-    if !explicit_retry
-        && !install_after_app_exit_requested
-        && !config.auto_install_on_app_exit
-    {
+    if !explicit_retry && !install_after_app_exit_requested && !config.auto_install_on_app_exit {
         state.status = UpdateStatus::ReadyToInstall;
         state.save_updater(&paths.state_file)?;
         return Ok(());
@@ -310,23 +592,42 @@ async fn install_ready_locked(
     let explicit_install = explicit_retry || install_after_app_exit_requested;
     state.clear_install_auth_retry_block();
     state.install_after_app_exit_requested = false;
-    state.status = UpdateStatus::Installing;
-    state.error_message = None;
-    state.save_updater(&paths.state_file)?;
     let current_exe = std::env::current_exe()?;
-    let output = install::pkexec_command(&current_exe, &package)
-        .output()
-        .context("Failed to launch privileged package install")?;
-    if !output.status.success() {
-        let mut message = format!("privileged install exited with status {}", output.status);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stderr = stderr.trim();
-        if !stderr.is_empty() {
-            message.push_str(": ");
-            message.push_str(stderr);
+    install_transaction::begin(state, &paths.state_file, &package, InstallOperation::Update)?;
+    let mut command = install::pkexec_command(&current_exe, &package);
+    let output = match install_transaction::run_owned_command_with_launcher(
+        &mut command,
+        state,
+        &paths.state_file,
+        launcher_program,
+    ) {
+        Ok(output) => output,
+        Err(failure) if !failure.mutation_may_have_started => {
+            return fail(
+                state,
+                paths,
+                failure
+                    .error
+                    .context("Failed to launch privileged package install"),
+            );
         }
-        let error = anyhow::anyhow!(message);
+        Err(failure) => {
+            return Err(failure
+                .error
+                .context("Privileged package install outcome is unknown"));
+        }
+    };
+    if !output.status.success() {
         if pkexec_authentication_was_not_obtained(&output.status) {
+            let mut message = format!("privileged install exited with status {}", output.status);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr = stderr.trim();
+            if !stderr.is_empty() {
+                message.push_str(": ");
+                message.push_str(stderr);
+            }
+            let error = anyhow::anyhow!(message);
+            state.install_transaction = None;
             state.status = UpdateStatus::ReadyToInstall;
             state.waiting_for_app_exit_auto_install = false;
             state.error_message = Some(format!("{error:#}"));
@@ -335,7 +636,14 @@ async fn install_ready_locked(
             state.save_updater(&paths.state_file)?;
             return Err(error);
         }
-        return fail(state, paths, error);
+        // The launch gate has already been released, so a nonzero exit cannot
+        // prove that the package manager made no changes. Keep the durable
+        // Installing transaction intact and let ownership-aware reconciliation
+        // determine whether the package completed, partially applied, or failed.
+        anyhow::bail!(
+            "privileged install exited unsuccessfully after package mutation may have started: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
     }
 
     let installed_upstream_version = state.candidate_version.clone();
@@ -344,7 +652,10 @@ async fn install_ready_locked(
     state.installed_upstream_version = installed_upstream_version;
     state.installed_upstream_sha256 = installed_upstream_sha256;
     state.status = UpdateStatus::Installed;
-    state.last_known_good_version.get_or_insert_with(|| state.installed_version.clone());
+    state.install_transaction = None;
+    state
+        .last_known_good_version
+        .get_or_insert_with(|| state.installed_version.clone());
     state.candidate_version = None;
     state.candidate_architecture = None;
     state.candidate_repository_path = None;
@@ -355,7 +666,13 @@ async fn install_ready_locked(
     state.save_updater(&paths.state_file)?;
     let _ = cache_cleanup::prune(&paths.cache_dir, state);
     if config.notifications {
-        let _ = notify::send("codex-desktop updated", &format!("Installed {}.", state.installed_version));
+        let _ = notify::send(
+            "codex-desktop updated",
+            &format!("Installed {}.", state.installed_version),
+        );
+    }
+    if restart_on_replacement {
+        restart_after_persisted_install(config, paths)?;
     }
     Ok(())
 }
@@ -389,19 +706,39 @@ fn fail<T>(state: &mut PersistedState, paths: &RuntimePaths, error: anyhow::Erro
 }
 
 fn status(state: &PersistedState, json: bool) -> Result<()> {
-    if json { println!("{}", serde_json::to_string_pretty(state)?); }
-    else {
+    if json {
+        println!("{}", serde_json::to_string_pretty(state)?);
+    } else {
         println!("status: {:?}", state.status);
         println!("installed_version: {}", state.installed_version);
-        println!("installed_upstream_version: {}", state.installed_upstream_version.as_deref().unwrap_or("unknown"));
-        println!("candidate_version: {}", state.candidate_version.as_deref().unwrap_or("none"));
-        println!("candidate_sha256: {}", state.upstream_package_sha256.as_deref().unwrap_or("none"));
-        if let Some(error) = &state.error_message { println!("error: {error}"); }
+        println!(
+            "installed_upstream_version: {}",
+            state
+                .installed_upstream_version
+                .as_deref()
+                .unwrap_or("unknown")
+        );
+        println!(
+            "candidate_version: {}",
+            state.candidate_version.as_deref().unwrap_or("none")
+        );
+        println!(
+            "candidate_sha256: {}",
+            state.upstream_package_sha256.as_deref().unwrap_or("none")
+        );
+        if let Some(error) = &state.error_message {
+            println!("error: {error}");
+        }
     }
     Ok(())
 }
 
-fn diagnose(config: &RuntimeConfig, state: &PersistedState, paths: &RuntimePaths, json: bool) -> Result<()> {
+fn diagnose(
+    config: &RuntimeConfig,
+    state: &PersistedState,
+    paths: &RuntimePaths,
+    json: bool,
+) -> Result<()> {
     let value = serde_json::json!({
         "repository": config.repository_url,
         "appExecutable": config.app_executable_path,
@@ -411,13 +748,21 @@ fn diagnose(config: &RuntimeConfig, state: &PersistedState, paths: &RuntimePaths
         "appRunning": liveness::is_app_running(config)?,
         "status": state.status,
     });
-    if json { println!("{}", serde_json::to_string_pretty(&value)?); }
-    else { println!("repository: {}\napp: {}\nstatus: {:?}", config.repository_url, config.app_executable_path.display(), state.status); }
+    if json {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else {
+        println!(
+            "repository: {}\napp: {}\nstatus: {:?}",
+            config.repository_url,
+            config.app_executable_path.display(),
+            state.status
+        );
+    }
     Ok(())
 }
 
-struct CheckLock(fs::File);
-impl CheckLock {
+struct MutationLock(fs::File);
+impl MutationLock {
     fn try_acquire(path: &Path) -> Result<Option<Self>> {
         let file = OpenOptions::new()
             .create(true)
@@ -432,14 +777,41 @@ impl CheckLock {
         }
     }
 }
-impl Drop for CheckLock { fn drop(&mut self) { let _ = self.0.unlock(); } }
+impl Drop for MutationLock {
+    fn drop(&mut self) {
+        let _ = self.0.unlock();
+    }
+}
 
 #[cfg(test)]
-mod tests {
+mod replacement_tests {
     use super::*;
-    use std::{os::unix::fs::PermissionsExt, path::PathBuf};
+    use crate::state::{InstallTransaction, ProcessIdentity};
+    use anyhow::Result;
+    use chrono::Utc;
+    use std::{
+        env,
+        ffi::OsStr,
+        fs::{self, File, OpenOptions},
+        io,
+        os::unix::{
+            ffi::OsStrExt,
+            fs::{OpenOptionsExt, PermissionsExt},
+        },
+        path::{Path, PathBuf},
+        process::{Command, Stdio},
+        thread,
+        time::Duration,
+    };
 
-    fn test_paths(root: &Path) -> RuntimePaths {
+    fn stale_identity() -> ProcessIdentity {
+        ProcessIdentity {
+            pid: std::process::id(),
+            start_time_ticks: 0,
+        }
+    }
+
+    fn fixture_paths(root: &Path) -> RuntimePaths {
         RuntimePaths {
             config_file: root.join("config/config.toml"),
             state_file: root.join("state/state.json"),
@@ -472,17 +844,14 @@ mod tests {
     #[test]
     fn pkexec_authentication_failures_are_retryable() -> Result<()> {
         for code in [126, 127] {
-            let status = std::process::Command::new("/bin/sh")
+            let status = Command::new("/bin/sh")
                 .arg("-c")
                 .arg(format!("exit {code}"))
                 .status()?;
             assert!(pkexec_authentication_was_not_obtained(&status));
         }
 
-        let status = std::process::Command::new("/bin/sh")
-            .arg("-c")
-            .arg("exit 1")
-            .status()?;
+        let status = Command::new("/bin/sh").arg("-c").arg("exit 1").status()?;
         assert!(!pkexec_authentication_was_not_obtained(&status));
         Ok(())
     }
@@ -497,33 +866,46 @@ mod tests {
         ]);
         let runtime = tokio::runtime::Runtime::new()?;
         let temp = tempfile::tempdir()?;
-        let paths = test_paths(temp.path());
+        let paths = fixture_paths(temp.path());
         paths.ensure_dirs()?;
         let package = temp.path().join("codex-desktop.deb");
         fs::write(&package, b"package")?;
         let fake_pkexec = write_fake_pkexec(temp.path())?;
         let invocation_count = temp.path().join("pkexec-count");
-        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", fake_pkexec);
-        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_PKEXEC_COUNT", &invocation_count);
-        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_PKEXEC_EXIT", "126");
+        env::set_var("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", fake_pkexec);
+        env::set_var("CODEX_UPDATE_MANAGER_TEST_PKEXEC_COUNT", &invocation_count);
+        env::set_var("CODEX_UPDATE_MANAGER_TEST_PKEXEC_EXIT", "126");
 
         let mut config = RuntimeConfig::default_with_paths(&paths);
         config.auto_install_on_app_exit = false;
         config.notifications = false;
         config.app_executable_path = temp.path().join("not-running");
         let mut state = ready_state(package);
-        let mut daemon_state = PersistedState::new(false);
 
         let error = runtime
-            .block_on(install_ready_locked(&config, &mut state, &paths, true))
+            .block_on(install_ready_with_launcher(
+                &config,
+                &mut state,
+                &paths,
+                true,
+                false,
+                Path::new("/bin/sh"),
+            ))
             .expect_err("authentication cancellation should be reported");
         assert!(error.to_string().contains("status exit status: 126"));
         assert_eq!(state.status, UpdateStatus::ReadyToInstall);
+        assert!(state.install_transaction.is_none());
         assert!(state.install_auth_retry_is_blocked());
         assert!(state.install_after_app_exit_requested);
         assert_eq!(fs::read_to_string(&invocation_count)?, "x");
 
-        runtime.block_on(reconcile_pending_install(&config, &mut daemon_state, &paths))?;
+        let mut daemon_state = PersistedState::new(false);
+        assert!(prepare_mutation_state(&config, &mut daemon_state, &paths)?);
+        runtime.block_on(reconcile_pending_install(
+            &config,
+            &mut daemon_state,
+            &paths,
+        ))?;
         state = daemon_state;
         assert_eq!(state.status, UpdateStatus::ReadyToInstall);
         assert!(state.install_auth_retry_is_blocked());
@@ -531,21 +913,36 @@ mod tests {
         assert_eq!(fs::read_to_string(&invocation_count)?, "x");
 
         runtime
-            .block_on(install_ready_locked(&config, &mut state, &paths, true))
+            .block_on(install_ready_with_launcher(
+                &config,
+                &mut state,
+                &paths,
+                true,
+                false,
+                Path::new("/bin/sh"),
+            ))
             .expect_err("an explicit retry should bypass the authentication block");
         assert_eq!(state.status, UpdateStatus::ReadyToInstall);
+        assert!(state.install_transaction.is_none());
         assert!(state.install_auth_retry_is_blocked());
         assert!(state.install_after_app_exit_requested);
         assert_eq!(fs::read_to_string(&invocation_count)?, "xx");
 
-        config.app_executable_path = std::env::current_exe()?;
+        config.app_executable_path = env::current_exe()?;
         runtime.block_on(reconcile_pending_install(&config, &mut state, &paths))?;
         assert_eq!(state.status, UpdateStatus::WaitingForAppExit);
         assert!(!state.install_auth_retry_is_blocked());
         assert!(state.install_after_app_exit_requested);
         assert_eq!(fs::read_to_string(&invocation_count)?, "xx");
 
-        runtime.block_on(install_ready_locked(&config, &mut state, &paths, false))?;
+        runtime.block_on(install_ready_with_launcher(
+            &config,
+            &mut state,
+            &paths,
+            false,
+            false,
+            Path::new("/bin/sh"),
+        ))?;
         assert_eq!(state.status, UpdateStatus::WaitingForAppExit);
         assert!(!state.waiting_for_app_exit_auto_install);
         assert_eq!(fs::read_to_string(&invocation_count)?, "xx");
@@ -555,6 +952,7 @@ mod tests {
             .block_on(reconcile_pending_install(&config, &mut state, &paths))
             .expect_err("the next app exit should permit one retry");
         assert_eq!(state.status, UpdateStatus::ReadyToInstall);
+        assert!(state.install_transaction.is_none());
         assert!(state.install_auth_retry_is_blocked());
         assert!(state.install_after_app_exit_requested);
         assert_eq!(fs::read_to_string(&invocation_count)?, "xxx");
@@ -562,7 +960,7 @@ mod tests {
     }
 
     #[test]
-    fn non_authentication_install_failure_is_terminal() -> Result<()> {
+    fn non_authentication_install_failure_preserves_recovery_transaction() -> Result<()> {
         let _env_guard = crate::test_util::env_lock();
         let _restore_env = crate::test_util::EnvRestoreGuard::capture(&[
             "CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH",
@@ -571,19 +969,19 @@ mod tests {
         ]);
         let runtime = tokio::runtime::Runtime::new()?;
         let temp = tempfile::tempdir()?;
-        let paths = test_paths(temp.path());
+        let paths = fixture_paths(temp.path());
         paths.ensure_dirs()?;
         let package = temp.path().join("codex-desktop.deb");
         fs::write(&package, b"package")?;
-        std::env::set_var(
+        env::set_var(
             "CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH",
             write_fake_pkexec(temp.path())?,
         );
-        std::env::set_var(
+        env::set_var(
             "CODEX_UPDATE_MANAGER_TEST_PKEXEC_COUNT",
             temp.path().join("pkexec-count"),
         );
-        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_PKEXEC_EXIT", "1");
+        env::set_var("CODEX_UPDATE_MANAGER_TEST_PKEXEC_EXIT", "1");
 
         let mut config = RuntimeConfig::default_with_paths(&paths);
         config.notifications = false;
@@ -591,9 +989,17 @@ mod tests {
         let mut state = ready_state(package);
 
         runtime
-            .block_on(install_ready_locked(&config, &mut state, &paths, true))
-            .expect_err("ordinary install failures should remain terminal");
-        assert_eq!(state.status, UpdateStatus::Failed);
+            .block_on(install_ready_with_launcher(
+                &config,
+                &mut state,
+                &paths,
+                true,
+                false,
+                Path::new("/bin/sh"),
+            ))
+            .expect_err("ordinary post-gate install failure should remain recoverable");
+        assert_eq!(state.status, UpdateStatus::Installing);
+        assert!(state.install_transaction.is_some());
         assert!(!state.install_auth_retry_is_blocked());
         assert!(!state.install_after_app_exit_requested);
         Ok(())
@@ -602,7 +1008,7 @@ mod tests {
     #[test]
     fn failed_check_preserves_pending_auth_retry_state() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let paths = test_paths(temp.path());
+        let paths = fixture_paths(temp.path());
         paths.ensure_dirs()?;
         let package = temp.path().join("codex-desktop.deb");
         fs::write(&package, b"package")?;
@@ -654,5 +1060,557 @@ mod tests {
         assert_eq!(state.status, UpdateStatus::ReadyToInstall);
         assert!(state.install_auth_retry_is_blocked());
         assert!(state.last_check_at.is_some());
+    }
+
+    #[test]
+    fn live_install_transaction_blocks_mutation_without_replacement_detection() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let paths = fixture_paths(dir.path());
+        paths.ensure_dirs()?;
+        let config = RuntimeConfig::default_with_paths(&paths);
+        let current = crate::install_transaction::test_current_process_identity()?;
+
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::Installing;
+        state.install_transaction = Some(InstallTransaction {
+            package_path: dir.path().join("candidate.deb"),
+            package_sha256: Some("fixture".into()),
+            package_command: Some(current),
+            started_at: Utc::now(),
+            operation: InstallOperation::Update,
+        });
+        state.save_updater(&paths.state_file)?;
+
+        assert!(!prepare_mutation_state(&config, &mut state, &paths)?);
+        assert_eq!(state.status, UpdateStatus::Installing);
+        assert!(state.install_transaction.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn ownerless_installing_state_converges_to_failed_without_replacement_detection() -> Result<()>
+    {
+        let dir = tempfile::tempdir()?;
+        let paths = fixture_paths(dir.path());
+        paths.ensure_dirs()?;
+        let config = RuntimeConfig::default_with_paths(&paths);
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::Installing;
+        state.install_transaction = None;
+        state.save_updater(&paths.state_file)?;
+
+        assert!(prepare_mutation_state(&config, &mut state, &paths)?);
+        assert_eq!(state.status, UpdateStatus::Failed);
+        assert!(state.install_transaction.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn failed_prelaunch_install_does_not_leave_daemon_blocked_in_installing() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let paths = fixture_paths(dir.path());
+        paths.ensure_dirs()?;
+        let mut config = RuntimeConfig::default_with_paths(&paths);
+        config.app_executable_path = dir.path().join("app-not-running");
+
+        let package = dir.path().join("candidate.deb");
+        fs::write(&package, b"fixture package")?;
+
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::ReadyToInstall;
+        state.candidate_version = Some("fixture".into());
+        state.artifact_paths.package_path = Some(package);
+        state.save_updater(&paths.state_file)?;
+
+        let missing_launcher = dir.path().join("missing-gated-launcher");
+        let result = install_ready_with_launcher(
+            &config,
+            &mut state,
+            &paths,
+            true,
+            false,
+            &missing_launcher,
+        )
+        .await;
+
+        assert!(result.is_err(), "forced gated-launcher spawn must fail");
+
+        let persisted =
+            PersistedState::load_or_default(&paths.state_file, config.auto_install_on_app_exit)?;
+        assert_eq!(persisted.status, UpdateStatus::Failed);
+        assert!(
+            persisted.install_transaction.is_none(),
+            "pre-launch failure must clear durable install ownership"
+        );
+
+        let mut daemon_state = persisted;
+        assert!(
+            prepare_mutation_state(&config, &mut daemon_state, &paths)?,
+            "a still-running daemon must not remain blocked after a pre-launch failure"
+        );
+        assert_ne!(daemon_state.status, UpdateStatus::Installing);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn nonzero_exit_after_gate_release_preserves_install_recovery_evidence() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let paths = fixture_paths(dir.path());
+        paths.ensure_dirs()?;
+        let mut config = RuntimeConfig::default_with_paths(&paths);
+        config.app_executable_path = dir.path().join("app-not-running");
+
+        let package = dir.path().join("candidate.deb");
+        fs::write(&package, b"fixture package")?;
+
+        let launcher = dir.path().join("released-then-fails");
+        fs::write(
+            &launcher,
+            "#!/bin/sh\nIFS= read -r state || exit 125\n[ \"$state\" = go ] || exit 125\nexit 42\n",
+        )?;
+        fs::set_permissions(&launcher, fs::Permissions::from_mode(0o755))?;
+
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::ReadyToInstall;
+        state.candidate_version = Some("fixture".into());
+        state.artifact_paths.package_path = Some(package);
+        state.save_updater(&paths.state_file)?;
+
+        let result =
+            install_ready_with_launcher(&config, &mut state, &paths, true, false, &launcher).await;
+
+        assert!(
+            result.is_err(),
+            "forced post-release command failure must surface"
+        );
+        let persisted =
+            PersistedState::load_or_default(&paths.state_file, config.auto_install_on_app_exit)?;
+        assert_eq!(
+            persisted.status,
+            UpdateStatus::Installing,
+            "once the gate is released, a nonzero package-command exit cannot prove that mutation did not occur"
+        );
+        assert!(
+            persisted.install_transaction.is_some(),
+            "post-release failure must preserve durable recovery evidence"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn abandoned_install_state_is_reconciled_without_replacement_detection() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let paths = fixture_paths(dir.path());
+        paths.ensure_dirs()?;
+        let config = RuntimeConfig::default_with_paths(&paths);
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::Installing;
+        state.install_transaction = Some(InstallTransaction {
+            package_path: dir.path().join("missing.deb"),
+            package_sha256: Some("fixture".into()),
+            package_command: Some(stale_identity()),
+            started_at: Utc::now()
+                - chrono::Duration::seconds(
+                    install_transaction::ABANDONED_INSTALL_GRACE.as_secs() as i64 + 1,
+                ),
+            operation: InstallOperation::Update,
+        });
+        state.save_updater(&paths.state_file)?;
+
+        assert!(prepare_mutation_state(&config, &mut state, &paths)?);
+        assert_eq!(state.status, UpdateStatus::Failed);
+        assert!(state.install_transaction.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn reconciled_update_matches_successful_install_state_bookkeeping() {
+        let package = PathBuf::from("/tmp/candidate.deb");
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::Installing;
+        state.installed_version = "old-local".into();
+        state.candidate_version = Some("new-upstream".into());
+        state.candidate_architecture = Some("amd64".into());
+        state.candidate_repository_path = Some("pool/codex.deb".into());
+        state.upstream_package_sha256 = Some("new-sha".into());
+        state.waiting_for_app_exit_auto_install = true;
+        let transaction = InstallTransaction {
+            package_path: package,
+            package_sha256: Some("fixture".into()),
+            package_command: Some(stale_identity()),
+            started_at: Utc::now(),
+            operation: InstallOperation::Update,
+        };
+        state.install_transaction = Some(transaction.clone());
+
+        apply_reconciled_install(&mut state, transaction, "new-local".into());
+
+        assert_eq!(state.status, UpdateStatus::Installed);
+        assert_eq!(state.install_transaction, None);
+        assert_eq!(state.installed_version, "new-local");
+        assert_eq!(
+            state.installed_upstream_version.as_deref(),
+            Some("new-upstream")
+        );
+        assert_eq!(state.installed_upstream_sha256.as_deref(), Some("new-sha"));
+        assert_eq!(state.last_known_good_version.as_deref(), Some("new-local"));
+        assert_eq!(state.candidate_version, None);
+        assert_eq!(state.candidate_architecture, None);
+        assert_eq!(state.candidate_repository_path, None);
+        assert!(!state.waiting_for_app_exit_auto_install);
+        assert_eq!(state.error_message, None);
+    }
+
+    #[test]
+    fn reconciled_rollback_matches_successful_rollback_bookkeeping() {
+        let package = PathBuf::from("/tmp/known-good.deb");
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::Installing;
+        state.installed_version = "bad-local".into();
+        state.installed_upstream_version = Some("bad-upstream".into());
+        state.installed_upstream_sha256 = Some("bad-installed-sha".into());
+        state.candidate_version = Some("bad-candidate".into());
+        state.upstream_package_sha256 = Some("bad-candidate-sha".into());
+        state.last_known_good_upstream_version = Some("good-upstream".into());
+        state.last_known_good_upstream_sha256 = Some("good-sha".into());
+        let transaction = InstallTransaction {
+            package_path: package.clone(),
+            package_sha256: Some("fixture".into()),
+            package_command: Some(stale_identity()),
+            started_at: Utc::now(),
+            operation: InstallOperation::Rollback,
+        };
+        state.install_transaction = Some(transaction.clone());
+
+        apply_reconciled_install(&mut state, transaction, "good-local".into());
+
+        assert_eq!(state.status, UpdateStatus::Installed);
+        assert_eq!(state.install_transaction, None);
+        assert_eq!(state.installed_version, "good-local");
+        assert_eq!(
+            state.installed_upstream_version.as_deref(),
+            Some("good-upstream")
+        );
+        assert_eq!(state.installed_upstream_sha256.as_deref(), Some("good-sha"));
+        assert_eq!(
+            state.rollback_blocked_candidate_version.as_deref(),
+            Some("bad-candidate")
+        );
+        assert_eq!(
+            state.rollback_blocked_package_sha256.as_deref(),
+            Some("bad-candidate-sha")
+        );
+        assert_eq!(state.artifact_paths.package_path.as_ref(), Some(&package));
+        assert_eq!(
+            state.artifact_paths.rollback_package_path.as_ref(),
+            Some(&package)
+        );
+        assert_eq!(state.last_known_good_version.as_deref(), Some("good-local"));
+        assert_eq!(state.candidate_version, None);
+        assert_eq!(state.error_message, None);
+    }
+
+    #[test]
+    fn installing_state_preserves_pre_transaction_installed_version_for_recovery() {
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::Installing;
+        state.installed_version = "pre-rollback-local".into();
+
+        if state.status != UpdateStatus::Installing {
+            state.installed_version = "post-rollback-local".into();
+        }
+
+        assert_eq!(state.installed_version, "pre-rollback-local");
+    }
+
+    fn stage_executable(source: &Path, destination: &Path) -> Result<()> {
+        let staging = destination.with_extension(format!(
+            "stage-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+
+        let mut input = File::open(source)
+            .with_context(|| format!("fixture: open source executable {}", source.display()))?;
+        let mut output = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o755)
+            .open(&staging)
+            .with_context(|| format!("fixture: create staged executable {}", staging.display()))?;
+        io::copy(&mut input, &mut output)
+            .with_context(|| format!("fixture: copy executable to {}", staging.display()))?;
+        output
+            .sync_all()
+            .with_context(|| format!("fixture: sync staged executable {}", staging.display()))?;
+        drop(output);
+        drop(input);
+
+        fs::rename(&staging, destination).with_context(|| {
+            format!(
+                "fixture: publish staged executable {} -> {}",
+                staging.display(),
+                destination.display()
+            )
+        })?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn install_ready_replacement_process_fixture() -> Result<()> {
+        let Some(mode) = env::var_os("CODEX_INSTALL_READY_FIXTURE_MODE") else {
+            return Ok(());
+        };
+        let root = PathBuf::from(
+            env::var_os("CODEX_INSTALL_READY_FIXTURE_ROOT").expect("fixture root path is required"),
+        );
+
+        match mode.to_string_lossy().as_ref() {
+            "install" => {
+                let paths = RuntimePaths {
+                    config_file: root.join("config/config.toml"),
+                    state_file: root.join("state/state.json"),
+                    log_file: root.join("state/service.log"),
+                    cache_dir: root.join("cache"),
+                    state_dir: root.join("state"),
+                    config_dir: root.join("config"),
+                };
+                paths.ensure_dirs()?;
+
+                let package = root.join("candidate.deb");
+                let mut config = RuntimeConfig::default_with_paths(&paths);
+                config.auto_install_on_app_exit = true;
+                config.notifications = false;
+                config.app_executable_path = root.join("missing-chatgpt");
+
+                let mut state = PersistedState::new(true);
+                state.status = UpdateStatus::ReadyToInstall;
+                state.candidate_version = Some("fixture-upstream".into());
+                state.upstream_package_sha256 = Some("fixture-sha256".into());
+                state.artifact_paths.package_path = Some(package);
+                state.save_updater(&paths.state_file)?;
+
+                install_ready(&config, &mut state, &paths, true, true).await?;
+            }
+            "report" => {
+                fs::write(
+                    root.join("new-exe"),
+                    env::current_exe()?.as_os_str().as_bytes(),
+                )?;
+            }
+            other => panic!("unknown install-ready fixture mode: {other}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn successful_self_replacement_restarts_on_new_binary_and_next_build_uses_it() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let source = env::current_exe()?;
+        let installed = temp.path().join("codex-update-manager");
+        let replacement = temp.path().join("codex-update-manager.new");
+        let package = temp.path().join("candidate.deb");
+        let fake_pkexec = temp.path().join("fake-pkexec");
+        let install_started = temp.path().join("install-started");
+        let install_release = temp.path().join("install-release");
+        let state_file = temp.path().join("state/state.json");
+
+        stage_executable(&source, &installed)?;
+        fs::write(&package, b"fixture package")?;
+        fs::write(
+            &fake_pkexec,
+            "#!/bin/sh\nset -eu\n: > \"$CODEX_TEST_INSTALL_STARTED\"\nwhile [ ! -e \"$CODEX_TEST_INSTALL_RELEASE\" ]; do sleep 0.01; done\nexit 0\n",
+        )?;
+        fs::set_permissions(&fake_pkexec, fs::Permissions::from_mode(0o755))?;
+
+        let mut old = Command::new(&installed)
+            .args([
+                "app::replacement_tests::install_ready_replacement_process_fixture",
+                "--exact",
+                "--nocapture",
+            ])
+            .env("CODEX_INSTALL_READY_FIXTURE_MODE", "install")
+            .env("CODEX_INSTALL_READY_FIXTURE_ROOT", temp.path())
+            .env("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", &fake_pkexec)
+            .env("CODEX_TEST_INSTALL_STARTED", &install_started)
+            .env("CODEX_TEST_INSTALL_RELEASE", &install_release)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .context("fixture: spawn installed updater")?;
+
+        for _ in 0..500 {
+            if install_started.exists() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            install_started.exists(),
+            "production install_ready fixture did not launch its package command"
+        );
+
+        let installing = PersistedState::load_or_default(&state_file, true)?;
+        assert_eq!(installing.status, UpdateStatus::Installing);
+        assert!(
+            installing
+                .install_transaction
+                .as_ref()
+                .and_then(|transaction| transaction.package_command.as_ref())
+                .is_some(),
+            "install_ready must durably publish the package-command owner"
+        );
+
+        stage_executable(&source, &replacement)?;
+        fs::rename(&replacement, &installed)
+            .context("fixture: rename replacement over installed")?;
+        fs::write(&install_release, b"go")?;
+
+        assert_eq!(
+            old.wait()?.code(),
+            Some(restart::REPLACEMENT_RESTART_EXIT_CODE),
+            "install_ready must persist Installed, read it back, then exit for replacement"
+        );
+
+        let installed_state = PersistedState::load_or_default(&state_file, true)?;
+        assert_eq!(installed_state.status, UpdateStatus::Installed);
+        assert_eq!(installed_state.install_transaction, None);
+        assert_eq!(
+            installed_state.installed_upstream_version.as_deref(),
+            Some("fixture-upstream")
+        );
+        assert_eq!(
+            installed_state.installed_upstream_sha256.as_deref(),
+            Some("fixture-sha256")
+        );
+
+        let restarted = Command::new(&installed)
+            .args([
+                "app::replacement_tests::install_ready_replacement_process_fixture",
+                "--exact",
+                "--nocapture",
+            ])
+            .env("CODEX_INSTALL_READY_FIXTURE_MODE", "report")
+            .env("CODEX_INSTALL_READY_FIXTURE_ROOT", temp.path())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .context("fixture: spawn replacement updater")?;
+        assert!(restarted.success(), "replacement updater failed to start");
+
+        let restarted_exe =
+            PathBuf::from(OsStr::from_bytes(&fs::read(temp.path().join("new-exe"))?));
+        assert_eq!(restarted_exe, installed);
+        assert_eq!(
+            install::resolve_updater_binary_for_build(&restarted_exe),
+            installed,
+            "the next rebuild must source the live replacement updater"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn self_replacement_requires_installed_state_readback_before_exit() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let source = env::current_exe()?;
+        let installed = temp.path().join("codex-update-manager");
+        let replacement = temp.path().join("codex-update-manager.new");
+        let package = temp.path().join("candidate.deb");
+        let fake_pkexec = temp.path().join("fake-pkexec");
+        let install_started = temp.path().join("install-started");
+        let install_release = temp.path().join("install-release");
+        let before_readback = temp.path().join("before-readback");
+        let release_readback = temp.path().join("release-readback");
+        let state_file = temp.path().join("state/state.json");
+
+        stage_executable(&source, &installed)?;
+        fs::write(&package, b"fixture package")?;
+        fs::write(
+            &fake_pkexec,
+            "#!/bin/sh\nset -eu\n: > \"$CODEX_TEST_INSTALL_STARTED\"\nwhile [ ! -e \"$CODEX_TEST_INSTALL_RELEASE\" ]; do sleep 0.01; done\nexit 0\n",
+        )?;
+        fs::set_permissions(&fake_pkexec, fs::Permissions::from_mode(0o755))?;
+
+        let mut old = Command::new(&installed)
+            .args([
+                "app::replacement_tests::install_ready_replacement_process_fixture",
+                "--exact",
+                "--nocapture",
+            ])
+            .env("CODEX_INSTALL_READY_FIXTURE_MODE", "install")
+            .env("CODEX_INSTALL_READY_FIXTURE_ROOT", temp.path())
+            .env("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", &fake_pkexec)
+            .env("CODEX_TEST_INSTALL_STARTED", &install_started)
+            .env("CODEX_TEST_INSTALL_RELEASE", &install_release)
+            .env("CODEX_TEST_BEFORE_RESTART_READBACK", &before_readback)
+            .env("CODEX_TEST_RELEASE_RESTART_READBACK", &release_readback)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .context("fixture: spawn installed updater")?;
+
+        for _ in 0..500 {
+            if install_started.exists() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            install_started.exists(),
+            "production install_ready fixture did not launch its package command"
+        );
+
+        stage_executable(&source, &replacement)?;
+        fs::rename(&replacement, &installed)
+            .context("fixture: rename replacement over installed")?;
+        fs::write(&install_release, b"go")?;
+
+        for _ in 0..500 {
+            if before_readback.exists() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            before_readback.exists(),
+            "install_ready did not reach the persisted-state readback boundary"
+        );
+
+        let mut persisted = PersistedState::load_or_default(&state_file, true)?;
+        assert_eq!(
+            persisted.status,
+            UpdateStatus::Installed,
+            "Installed must be durably saved before the readback boundary"
+        );
+        persisted.status = UpdateStatus::Failed;
+        persisted.error_message = Some("readback tamper fixture".into());
+        persisted.save_updater(&state_file)?;
+        fs::write(&release_readback, b"go")?;
+
+        assert_eq!(
+            old.wait()?.code(),
+            Some(0),
+            "replacement exit must be refused when Installed cannot be read back"
+        );
+
+        let after = PersistedState::load_or_default(&state_file, true)?;
+        assert_eq!(after.status, UpdateStatus::Failed);
+        assert_eq!(
+            after.error_message.as_deref(),
+            Some("readback tamper fixture")
+        );
+        Ok(())
+    }
+    #[test]
+    fn ambiguous_preinstall_version_is_not_sufficient_recovery_evidence() {
+        fn transition_observed(previous: &str, verified: Option<&str>) -> bool {
+            previous != "unknown" && verified.is_some_and(|installed| installed != previous)
+        }
+
+        assert!(!transition_observed("2026.09.06", Some("2026.09.06")));
+        assert!(!transition_observed("unknown", Some("2026.09.07")));
+        assert!(transition_observed("2026.09.06", Some("2026.09.07")));
     }
 }

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -18,6 +18,8 @@ use std::{
 use tokio::time;
 use tracing::{error, info, warn};
 
+const UNKNOWN_INSTALL_RECOVERY_MESSAGE: &str = "Package transaction owner could not be classified safely after the recovery grace period; automatic recovery stopped. Confirm no package manager is running, then explicitly retry the interrupted update or rollback";
+
 pub async fn run(cli: Cli) -> Result<()> {
     if let Some(result) = run_privileged_command(&cli.command) {
         return result;
@@ -77,7 +79,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 &paths.state_file,
                 config.auto_install_on_app_exit,
             )?;
-            if !prepare_mutation_state(&config, &mut state, &paths)? {
+            if !prepare_explicit_mutation_state(&config, &mut state, &paths)? {
                 println!(
                     "A package transaction is still active; refusing to start another install."
                 );
@@ -95,7 +97,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 &paths.state_file,
                 config.auto_install_on_app_exit,
             )?;
-            if !prepare_mutation_state(&config, &mut state, &paths)? {
+            if !prepare_explicit_mutation_state(&config, &mut state, &paths)? {
                 println!("A package transaction is still active; refusing to start rollback.");
                 return Ok(());
             }
@@ -213,7 +215,29 @@ fn prepare_mutation_state(
     state: &mut PersistedState,
     paths: &RuntimePaths,
 ) -> Result<bool> {
+    prepare_mutation_state_with_policy(config, state, paths, false)
+}
+
+fn prepare_explicit_mutation_state(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<bool> {
+    prepare_mutation_state_with_policy(config, state, paths, true)
+}
+
+fn prepare_mutation_state_with_policy(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    allow_manual_recovery: bool,
+) -> Result<bool> {
     *state = PersistedState::load_or_default(&paths.state_file, config.auto_install_on_app_exit)?;
+
+    if state.manual_recovery_required && !allow_manual_recovery {
+        warn!("manual recovery confirmation is required before automatic updater work");
+        return Ok(false);
+    }
 
     if state.status != UpdateStatus::Installing {
         state.installed_version = install::installed_package_version();
@@ -222,15 +246,41 @@ fn prepare_mutation_state(
     }
 
     match state.install_transaction.clone() {
-        Some(transaction)
-            if install_transaction::is_active(&transaction)
-                || !install_transaction::grace_expired(&transaction) =>
-        {
-            Ok(false)
-        }
-        Some(_) => {
-            recover_abandoned_install(state, paths)?;
-            Ok(true)
+        Some(transaction) => {
+            let owner_state = install_transaction::owner_state(&transaction);
+            match owner_state {
+                install_transaction::OwnerState::Running => Ok(false),
+                install_transaction::OwnerState::Unknown => {
+                    if !install_transaction::grace_expired(&transaction) {
+                        warn!(
+                            "package transaction owner cannot be classified safely; deferring recovery"
+                        );
+                        return Ok(false);
+                    }
+                    state.mark_manual_recovery_required(UNKNOWN_INSTALL_RECOVERY_MESSAGE);
+                    state.save_updater(&paths.state_file)?;
+                    if allow_manual_recovery {
+                        // This explicit install-ready/rollback invocation is
+                        // the user's confirmation that no package manager is
+                        // still running. The transaction has been cleared, so
+                        // the requested operation can proceed immediately.
+                        Ok(true)
+                    } else {
+                        Ok(false)
+                    }
+                }
+                install_transaction::OwnerState::NotStarted
+                | install_transaction::OwnerState::Exited
+                    if !install_transaction::grace_expired(&transaction) =>
+                {
+                    Ok(false)
+                }
+                install_transaction::OwnerState::NotStarted
+                | install_transaction::OwnerState::Exited => {
+                    recover_abandoned_install(state, paths)?;
+                    Ok(true)
+                }
+            }
         }
         None => {
             state.mark_failed("Installing state has no recoverable package transaction owner");
@@ -336,6 +386,7 @@ fn apply_reconciled_install(
     }
 
     state.status = UpdateStatus::Installed;
+    state.manual_recovery_required = false;
     state.install_transaction = None;
     state.error_message = None;
 }
@@ -558,6 +609,11 @@ async fn install_ready_with_launcher(
         "rebuilt package is missing: {}",
         package.display()
     );
+    if explicit_retry {
+        // An explicit install-ready command is the user's confirmation that
+        // any previously ambiguous package transaction has been checked.
+        state.manual_recovery_required = false;
+    }
     let auth_retry_blocked = state.install_auth_retry_is_blocked();
     let install_after_app_exit_requested = state.install_after_app_exit_requested;
     if liveness::is_app_running(config)? {
@@ -710,6 +766,10 @@ fn status(state: &PersistedState, json: bool) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(state)?);
     } else {
         println!("status: {:?}", state.status);
+        println!(
+            "manual_recovery_required: {}",
+            state.manual_recovery_required
+        );
         println!("installed_version: {}", state.installed_version);
         println!(
             "installed_upstream_version: {}",
@@ -745,6 +805,7 @@ fn diagnose(
         "builderBundle": config.builder_bundle_root,
         "stateFile": paths.state_file,
         "stateSchema": state.schema_version,
+        "manualRecoveryRequired": state.manual_recovery_required,
         "appRunning": liveness::is_app_running(config)?,
         "status": state.status,
     });
@@ -808,6 +869,7 @@ mod replacement_tests {
         ProcessIdentity {
             pid: std::process::id(),
             start_time_ticks: 0,
+            boot_id: Some("stale-boot".into()),
         }
     }
 
@@ -837,6 +899,93 @@ mod replacement_tests {
             &path,
             "#!/bin/sh\nprintf x >> \"$CODEX_UPDATE_MANAGER_TEST_PKEXEC_COUNT\"\nexit \"$CODEX_UPDATE_MANAGER_TEST_PKEXEC_EXIT\"\n",
         )?;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700))?;
+        Ok(path)
+    }
+
+    fn abandoned_state(package: PathBuf, installed_version: &str) -> Result<PersistedState> {
+        let package_sha256 = install_transaction::package_sha256(&package)?;
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::Installing;
+        state.installed_version = installed_version.into();
+        state.candidate_version = Some("candidate-upstream".into());
+        state.upstream_package_sha256 = Some("candidate-upstream-sha".into());
+        state.install_transaction = Some(InstallTransaction {
+            package_path: package,
+            package_sha256: Some(package_sha256),
+            package_command: Some(stale_identity()),
+            started_at: Utc::now()
+                - chrono::Duration::seconds(
+                    install_transaction::ABANDONED_INSTALL_GRACE.as_secs() as i64 + 1,
+                ),
+            operation: InstallOperation::Update,
+        });
+        Ok(state)
+    }
+
+    fn write_fake_rpm_recovery_command(
+        root: &Path,
+        verification_succeeds: bool,
+    ) -> Result<PathBuf> {
+        let path = root.join("rpm-recovery-fixture");
+        let verification = if verification_succeeds {
+            "exit 0"
+        } else {
+            "exit 1"
+        };
+        let script = r#"#!/bin/sh
+set -eu
+if [ "$1" = "-V" ]; then
+  [ "$2" = "--noscripts" ]
+  __VERIFY__
+fi
+if [ "$1" = "-q" ] || [ "$1" = "-qp" ]; then
+  if [ "$3" = "%{NAME}" ]; then
+    printf 'codex-desktop\n'
+  elif [ "$3" = "%{VERSION}-%{RELEASE}" ]; then
+    printf '2026.09.06-1.fc42\n'
+  else
+    printf 'codex-desktop\t2026.09.06-1.fc42\tx86_64\n'
+  fi
+  exit 0
+fi
+exit 90
+"#
+        .replace("__VERIFY__", verification);
+        fs::write(&path, script)?;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700))?;
+        Ok(path)
+    }
+
+    fn write_fake_pacman_recovery_command(
+        root: &Path,
+        verification_succeeds: bool,
+    ) -> Result<PathBuf> {
+        let path = root.join("pacman-recovery-fixture");
+        let verification = if verification_succeeds {
+            "exit 0"
+        } else {
+            "exit 1"
+        };
+        let script = r#"#!/bin/sh
+set -eu
+if [ "$1" = "-Q" ] && [ "$2" = "codex-desktop" ]; then
+  printf 'codex-desktop 2026.09.06-1\n'
+  exit 0
+fi
+if [ "$1" = "-Qip" ] || [ "$1" = "-Qi" ]; then
+  printf 'Name            : codex-desktop\n'
+  printf 'Version         : 2026.09.06-1\n'
+  printf 'Architecture    : x86_64\n'
+  exit 0
+fi
+if [ "$1" = "-Qkk" ]; then
+  __VERIFY__
+fi
+exit 90
+"#
+        .replace("__VERIFY__", verification);
+        fs::write(&path, script)?;
         fs::set_permissions(&path, fs::Permissions::from_mode(0o700))?;
         Ok(path)
     }
@@ -1088,6 +1237,91 @@ mod replacement_tests {
     }
 
     #[test]
+    fn legacy_install_owner_migrates_to_manual_recovery() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let paths = fixture_paths(dir.path());
+        paths.ensure_dirs()?;
+        let config = RuntimeConfig::default_with_paths(&paths);
+        let current = install_transaction::test_current_process_identity()?;
+
+        let mut state = PersistedState::new(true);
+        state.schema_version = 2;
+        state.status = UpdateStatus::Installing;
+        state.install_transaction = Some(InstallTransaction {
+            package_path: dir.path().join("candidate.deb"),
+            package_sha256: Some("fixture".into()),
+            package_command: Some(ProcessIdentity {
+                pid: current.pid,
+                start_time_ticks: current.start_time_ticks,
+                // This models a persisted owner from before boot identity was
+                // available, which cannot be classified safely now.
+                boot_id: None,
+            }),
+            started_at: Utc::now()
+                - chrono::Duration::seconds(
+                    install_transaction::ABANDONED_INSTALL_GRACE.as_secs() as i64 + 1,
+                ),
+            operation: InstallOperation::Update,
+        });
+        state.save_updater(&paths.state_file)?;
+
+        assert!(!prepare_mutation_state(&config, &mut state, &paths)?);
+        assert_eq!(state.schema_version, 3);
+        assert_eq!(state.status, UpdateStatus::Failed);
+        assert!(state.manual_recovery_required);
+        assert!(state.install_transaction.is_none());
+        assert!(state
+            .error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("reboot-safe process identity")));
+
+        assert!(prepare_explicit_mutation_state(
+            &config, &mut state, &paths
+        )?);
+        assert!(state.manual_recovery_required);
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_install_owner_becomes_manual_after_recovery_grace() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let paths = fixture_paths(dir.path());
+        paths.ensure_dirs()?;
+        let config = RuntimeConfig::default_with_paths(&paths);
+        let current = install_transaction::test_current_process_identity()?;
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::Installing;
+        state.install_transaction = Some(InstallTransaction {
+            package_path: dir.path().join("candidate.deb"),
+            package_sha256: Some("fixture".into()),
+            package_command: Some(ProcessIdentity {
+                // This value cannot be represented by pid_t on Linux. The
+                // resulting classification is deliberately Unknown, rather
+                // than treating an unreadable owner as definitely exited.
+                pid: u32::MAX,
+                start_time_ticks: current.start_time_ticks,
+                boot_id: current.boot_id,
+            }),
+            started_at: Utc::now()
+                - chrono::Duration::seconds(
+                    install_transaction::ABANDONED_INSTALL_GRACE.as_secs() as i64 + 1,
+                ),
+            operation: InstallOperation::Update,
+        });
+        state.save_updater(&paths.state_file)?;
+
+        assert!(!prepare_mutation_state(&config, &mut state, &paths)?);
+        assert_eq!(state.status, UpdateStatus::Failed);
+        assert!(state.manual_recovery_required);
+        assert!(state.install_transaction.is_none());
+        assert!(state
+            .error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("could not be classified safely")));
+        Ok(())
+    }
+
+    #[test]
     fn ownerless_installing_state_converges_to_failed_without_replacement_detection() -> Result<()>
     {
         let dir = tempfile::tempdir()?;
@@ -1097,6 +1331,92 @@ mod replacement_tests {
         let mut state = PersistedState::new(true);
         state.status = UpdateStatus::Installing;
         state.install_transaction = None;
+        state.save_updater(&paths.state_file)?;
+
+        assert!(prepare_mutation_state(&config, &mut state, &paths)?);
+        assert_eq!(state.status, UpdateStatus::Failed);
+        assert!(state.install_transaction.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn abandoned_rpm_install_reconciles_after_verified_payload() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let paths = fixture_paths(dir.path());
+        paths.ensure_dirs()?;
+        let package = dir.path().join("codex-desktop.rpm");
+        fs::write(&package, b"rpm fixture")?;
+        let fake_rpm = write_fake_rpm_recovery_command(dir.path(), true)?;
+        let _package_manager_paths = install::test_program_path_overrides(Some(&fake_rpm), None);
+
+        let config = RuntimeConfig::default_with_paths(&paths);
+        let mut state = abandoned_state(package, "2026.09.05-1.fc42")?;
+        state.save_updater(&paths.state_file)?;
+
+        assert!(prepare_mutation_state(&config, &mut state, &paths)?);
+        assert_eq!(state.status, UpdateStatus::Installed);
+        assert_eq!(state.installed_version, "2026.09.06-1.fc42");
+        assert!(state.install_transaction.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn abandoned_rpm_install_rejects_unverified_payload() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let paths = fixture_paths(dir.path());
+        paths.ensure_dirs()?;
+        let package = dir.path().join("codex-desktop.rpm");
+        fs::write(&package, b"rpm fixture")?;
+        let fake_rpm = write_fake_rpm_recovery_command(dir.path(), false)?;
+        let _package_manager_paths = install::test_program_path_overrides(Some(&fake_rpm), None);
+
+        let config = RuntimeConfig::default_with_paths(&paths);
+        let mut state = abandoned_state(package, "2026.09.05-1.fc42")?;
+        state.save_updater(&paths.state_file)?;
+
+        assert!(prepare_mutation_state(&config, &mut state, &paths)?);
+        assert_eq!(state.status, UpdateStatus::Failed);
+        assert!(state.install_transaction.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn abandoned_pacman_install_reconciles_after_verified_payload() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let paths = fixture_paths(dir.path());
+        paths.ensure_dirs()?;
+        let package = dir
+            .path()
+            .join("codex-desktop-2026.09.06-1-x86_64.pkg.tar.zst");
+        fs::write(&package, b"pacman fixture")?;
+        let fake_pacman = write_fake_pacman_recovery_command(dir.path(), true)?;
+        let _package_manager_paths = install::test_program_path_overrides(None, Some(&fake_pacman));
+
+        let config = RuntimeConfig::default_with_paths(&paths);
+        let mut state = abandoned_state(package, "2026.09.05-1")?;
+        state.save_updater(&paths.state_file)?;
+
+        assert!(prepare_mutation_state(&config, &mut state, &paths)?);
+        assert_eq!(state.status, UpdateStatus::Installed);
+        assert_eq!(state.installed_version, "2026.09.06-1");
+        assert!(state.install_transaction.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn abandoned_pacman_install_rejects_unverified_payload() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let paths = fixture_paths(dir.path());
+        paths.ensure_dirs()?;
+        let package = dir
+            .path()
+            .join("codex-desktop-2026.09.06-1-x86_64.pkg.tar.zst");
+        fs::write(&package, b"pacman fixture")?;
+        let fake_pacman = write_fake_pacman_recovery_command(dir.path(), false)?;
+        let _package_manager_paths = install::test_program_path_overrides(None, Some(&fake_pacman));
+
+        let config = RuntimeConfig::default_with_paths(&paths);
+        let mut state = abandoned_state(package, "2026.09.05-1")?;
         state.save_updater(&paths.state_file)?;
 
         assert!(prepare_mutation_state(&config, &mut state, &paths)?);

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -7,8 +7,15 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use chrono::Utc;
-use std::{fs, path::{Path, PathBuf}};
-use tokio::{fs as async_fs, io::{AsyncBufReadExt, BufReader}, process::Command};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+use tokio::{
+    fs as async_fs,
+    io::{AsyncBufReadExt, BufReader},
+    process::Command,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BuildArtifacts {
@@ -30,11 +37,7 @@ const REQUIRED_BUNDLE_ENTRIES: &[&str] = &[
     "linux-features",
 ];
 
-const OPTIONAL_BUNDLE_ENTRIES: &[&str] = &[
-    "target",
-    "global-dictation-linux",
-    "plugins",
-];
+const OPTIONAL_BUNDLE_ENTRIES: &[&str] = &["target", "global-dictation-linux", "plugins"];
 
 pub async fn build_update(
     config: &RuntimeConfig,
@@ -43,7 +46,10 @@ pub async fn build_update(
     candidate_version: &str,
     upstream_package: &Path,
 ) -> Result<BuildArtifacts> {
-    let workspace = config.workspace_root.join("workspaces").join(safe_component(candidate_version));
+    let workspace = config
+        .workspace_root
+        .join("workspaces")
+        .join(safe_component(candidate_version));
     if workspace.exists() {
         fs::remove_dir_all(&workspace)?;
     }
@@ -65,7 +71,10 @@ pub async fn build_update(
         .arg(upstream_package)
         .env("CODEX_INSTALL_TRANSACTION_ACTIVE", "1")
         .env("CODEX_INSTALL_DIR", &app)
-        .env("CODEX_PATCH_REPORT_JSON", workspace.join("reports/patch-report.json"))
+        .env(
+            "CODEX_PATCH_REPORT_JSON",
+            workspace.join("reports/patch-report.json"),
+        )
         .current_dir(&bundle);
     if let Some(config_path) = effective_feature_config_path(config) {
         install.env("CODEX_LINUX_FEATURES_CONFIG", config_path);
@@ -87,7 +96,10 @@ pub async fn build_update(
         .env("APP_DIR_OVERRIDE", &app)
         .env("DIST_DIR_OVERRIDE", &dist)
         .env("UPDATER_BINARY_SOURCE", updater_binary)
-        .env("UPDATER_SERVICE_SOURCE", bundle.join("packaging/linux/codex-update-manager.service"))
+        .env(
+            "UPDATER_SERVICE_SOURCE",
+            bundle.join("packaging/linux/codex-update-manager.service"),
+        )
         .current_dir(&bundle);
     if let Some(config_path) = effective_feature_config_path(config) {
         package.env("CODEX_LINUX_FEATURES_CONFIG", config_path);
@@ -103,7 +115,10 @@ pub async fn build_update(
         rollback_package_path: state.artifact_paths.rollback_package_path.clone(),
     };
     state.save_updater(&paths.state_file)?;
-    Ok(BuildArtifacts { workspace_dir: workspace, package_path })
+    Ok(BuildArtifacts {
+        workspace_dir: workspace,
+        package_path,
+    })
 }
 
 fn package_version() -> String {
@@ -111,7 +126,16 @@ fn package_version() -> String {
 }
 
 fn safe_component(value: &str) -> String {
-    value.chars().map(|c| if c.is_ascii_alphanumeric() || ".+-_".contains(c) { c } else { '_' }).collect()
+    value
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || ".+-_".contains(c) {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 fn copy_builder_bundle(source: &Path, destination: &Path) -> Result<()> {
@@ -132,7 +156,11 @@ fn copy_builder_bundle(source: &Path, destination: &Path) -> Result<()> {
 
 fn copy_path(source: &Path, destination: &Path) -> Result<()> {
     let metadata = fs::symlink_metadata(source)?;
-    anyhow::ensure!(!metadata.file_type().is_symlink(), "update-builder entry cannot be a symlink: {}", source.display());
+    anyhow::ensure!(
+        !metadata.file_type().is_symlink(),
+        "update-builder entry cannot be a symlink: {}",
+        source.display()
+    );
     if metadata.is_dir() {
         fs::create_dir_all(destination)?;
         for entry in fs::read_dir(source)? {
@@ -140,7 +168,9 @@ fn copy_path(source: &Path, destination: &Path) -> Result<()> {
             copy_path(&entry.path(), &destination.join(entry.file_name()))?;
         }
     } else {
-        if let Some(parent) = destination.parent() { fs::create_dir_all(parent)?; }
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent)?;
+        }
         fs::copy(source, destination)?;
         fs::set_permissions(destination, metadata.permissions())?;
     }
@@ -148,9 +178,15 @@ fn copy_path(source: &Path, destination: &Path) -> Result<()> {
 }
 
 async fn run_logged(command: &mut Command, log_path: &Path) -> Result<()> {
-    if let Some(parent) = log_path.parent() { async_fs::create_dir_all(parent).await?; }
-    command.stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::piped());
-    let mut child = command.spawn().context("Failed to start update build command")?;
+    if let Some(parent) = log_path.parent() {
+        async_fs::create_dir_all(parent).await?;
+    }
+    command
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = command
+        .spawn()
+        .context("Failed to start update build command")?;
     let stdout = child.stdout.take().context("missing stdout")?;
     let stderr = child.stderr.take().context("missing stderr")?;
     let (out, err) = tokio::join!(read_stream(stdout), read_stream(stderr));
@@ -158,7 +194,11 @@ async fn run_logged(command: &mut Command, log_path: &Path) -> Result<()> {
     text.push_str(&err?);
     async_fs::write(log_path, &text).await?;
     let status = child.wait().await?;
-    anyhow::ensure!(status.success(), "update build command failed; see {}", log_path.display());
+    anyhow::ensure!(
+        status.success(),
+        "update build command failed; see {}",
+        log_path.display()
+    );
     Ok(())
 }
 
@@ -187,7 +227,11 @@ fn find_package(dist: &Path) -> Result<PathBuf> {
             matches.push(path);
         }
     }
-    anyhow::ensure!(matches.len() == 1, "expected one rebuilt package, found {}", matches.len());
+    anyhow::ensure!(
+        matches.len() == 1,
+        "expected one rebuilt package, found {}",
+        matches.len()
+    );
     Ok(matches.remove(0))
 }
 
@@ -311,13 +355,22 @@ mod tests {
     #[test]
     fn find_package_still_rejects_two_real_packages() {
         let dist = scratch_dir("two-real");
-        fs::write(dist.join("codex-desktop-2026.09.03.120000-1-x86_64.pkg.tar.zst"), b"a")
-            .expect("first package");
-        fs::write(dist.join("codex-desktop-2026.09.03.130000-1-x86_64.pkg.tar.zst"), b"b")
-            .expect("second package");
+        fs::write(
+            dist.join("codex-desktop-2026.09.03.120000-1-x86_64.pkg.tar.zst"),
+            b"a",
+        )
+        .expect("first package");
+        fs::write(
+            dist.join("codex-desktop-2026.09.03.130000-1-x86_64.pkg.tar.zst"),
+            b"b",
+        )
+        .expect("second package");
 
         let error = find_package(&dist).expect_err("ambiguous dist must fail");
-        assert!(error.to_string().contains("found 2"), "unexpected error: {error}");
+        assert!(
+            error.to_string().contains("found 2"),
+            "unexpected error: {error}"
+        );
 
         fs::remove_dir_all(&dist).expect("cleanup");
     }
@@ -352,7 +405,11 @@ mod tests {
         fs::write(&helper, "binary").expect("helper");
         let enabled_destination = root.join("enabled");
         copy_builder_bundle(&source, &enabled_destination).expect("feature bundle copy");
-        assert_eq!(fs::read_to_string(enabled_destination.join("target/release/helper")).expect("copied helper"), "binary");
+        assert_eq!(
+            fs::read_to_string(enabled_destination.join("target/release/helper"))
+                .expect("copied helper"),
+            "binary"
+        );
         fs::remove_dir_all(root).expect("cleanup");
     }
 }

--- a/updater/src/cache_cleanup.rs
+++ b/updater/src/cache_cleanup.rs
@@ -10,15 +10,23 @@ pub fn prune(cache_root: &Path, state: &PersistedState) -> Result<usize> {
         state.artifact_paths.upstream_package_path.as_ref(),
         state.artifact_paths.package_path.as_ref(),
         state.artifact_paths.rollback_package_path.as_ref(),
-    ].into_iter().flatten() {
-        if let Ok(path) = path.canonicalize() { retained.insert(path); }
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if let Ok(path) = path.canonicalize() {
+            retained.insert(path);
+        }
     }
     let mut removed = 0;
     let package_dir = cache_root.join("packages");
-    if !package_dir.is_dir() { return Ok(0); }
+    if !package_dir.is_dir() {
+        return Ok(0);
+    }
     for entry in fs::read_dir(package_dir)? {
         let path = entry?.path();
-        if path.is_file() && path.extension().and_then(|v| v.to_str()) == Some("deb")
+        if path.is_file()
+            && path.extension().and_then(|v| v.to_str()) == Some("deb")
             && !retained.contains(&path.canonicalize()?)
         {
             fs::remove_file(path)?;

--- a/updater/src/cli.rs
+++ b/updater/src/cli.rs
@@ -2,7 +2,10 @@ use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
-#[command(name = "codex-update-manager", about = "Signed Linux-package updater for codex-desktop")]
+#[command(
+    name = "codex-update-manager",
+    about = "Signed Linux-package updater for codex-desktop"
+)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,
@@ -12,20 +15,44 @@ pub struct Cli {
 pub enum Commands {
     Daemon,
     CheckNow,
-    Status { #[arg(long)] json: bool },
-    Diagnose { #[arg(long)] json: bool },
+    Status {
+        #[arg(long)]
+        json: bool,
+    },
+    Diagnose {
+        #[arg(long)]
+        json: bool,
+    },
     InstallReady,
     Rollback,
     #[command(hide = true)]
-    InstallDeb { #[arg(long)] path: PathBuf },
+    InstallDeb {
+        #[arg(long)]
+        path: PathBuf,
+    },
     #[command(hide = true)]
-    InstallRpm { #[arg(long)] path: PathBuf },
+    InstallRpm {
+        #[arg(long)]
+        path: PathBuf,
+    },
     #[command(hide = true)]
-    InstallPacman { #[arg(long)] path: PathBuf },
+    InstallPacman {
+        #[arg(long)]
+        path: PathBuf,
+    },
     #[command(hide = true)]
-    InstallRollbackDeb { #[arg(long)] path: PathBuf },
+    InstallRollbackDeb {
+        #[arg(long)]
+        path: PathBuf,
+    },
     #[command(hide = true)]
-    InstallRollbackRpm { #[arg(long)] path: PathBuf },
+    InstallRollbackRpm {
+        #[arg(long)]
+        path: PathBuf,
+    },
     #[command(hide = true)]
-    InstallRollbackPacman { #[arg(long)] path: PathBuf },
+    InstallRollbackPacman {
+        #[arg(long)]
+        path: PathBuf,
+    },
 }

--- a/updater/src/config.rs
+++ b/updater/src/config.rs
@@ -113,10 +113,14 @@ impl RuntimeConfig {
 
     fn validate(&self) -> Result<()> {
         anyhow::ensure!(
-            self.repository_url.starts_with("https://") || self.repository_url.starts_with("http://127.0.0.1"),
+            self.repository_url.starts_with("https://")
+                || self.repository_url.starts_with("http://127.0.0.1"),
             "repository_url must use HTTPS"
         );
-        anyhow::ensure!(self.check_interval_hours > 0, "check_interval_hours must be positive");
+        anyhow::ensure!(
+            self.check_interval_hours > 0,
+            "check_interval_hours must be positive"
+        );
         Ok(())
     }
 
@@ -146,7 +150,10 @@ mod tests {
         let paths = RuntimePaths::detect()?;
         let config = RuntimeConfig::default_with_paths(&paths);
         assert!(config.repository_url.ends_with("/linux/deb"));
-        assert_eq!(config.app_executable_path, PathBuf::from("/opt/codex-desktop/ChatGPT"));
+        assert_eq!(
+            config.app_executable_path,
+            PathBuf::from("/opt/codex-desktop/ChatGPT")
+        );
         Ok(())
     }
 }

--- a/updater/src/install.rs
+++ b/updater/src/install.rs
@@ -1,6 +1,8 @@
 //! Installation helpers for privileged and non-privileged package application.
 
 use anyhow::{Context, Result};
+#[cfg(test)]
+use std::cell::RefCell;
 use std::ffi::OsStr;
 use std::{
     fs,
@@ -43,6 +45,15 @@ pub enum PackageKind {
     Rpm,
     Pacman,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PackageIdentity {
+    name: String,
+    version: String,
+    architecture: String,
+}
+
+const RPM_IDENTITY_QUERY: &str = "%{NAME}\t%{VERSION}-%{RELEASE}\t%{ARCH}";
 
 impl PackageKind {
     pub fn detect() -> Self {
@@ -189,10 +200,8 @@ fn installed_deb_version() -> String {
 pub(crate) fn installed_package_version_for_recovery(path: &Path) -> Option<String> {
     match PackageKind::from_path(path) {
         PackageKind::Deb => installed_deb_version_if_configured(),
-        // rpm/pacman expose the installed version, but that alone is not proof
-        // that an abandoned package transaction completed successfully. Fail
-        // closed until an equally strong completion predicate exists there.
-        PackageKind::Rpm | PackageKind::Pacman => None,
+        PackageKind::Rpm => installed_rpm_version_for_recovery(path),
+        PackageKind::Pacman => installed_pacman_version_for_recovery(path),
     }
 }
 
@@ -214,6 +223,138 @@ fn parse_configured_deb_version(stdout: &[u8]) -> Option<String> {
         return None;
     }
     Some(version.to_string())
+}
+
+fn installed_rpm_version_for_recovery(path: &Path) -> Option<String> {
+    let candidate = rpm_package_identity(path).ok()?;
+    let installed = rpm_installed_package_identity().ok()?;
+    if candidate != installed || installed.name != PACKAGE_NAME {
+        return None;
+    }
+
+    // rpm's verification pass checks the installed package database against
+    // the payload on disk. The package identity match alone would not rule
+    // out a database entry from an interrupted or unrelated transaction.
+    let verification = Command::new(program_path(RPM_CANDIDATES, "rpm"))
+        .args(["-V", "--noscripts", "--", PACKAGE_NAME])
+        .output()
+        .ok()?;
+    if !verification.status.success() || !verification.stdout.is_empty() {
+        return None;
+    }
+
+    Some(installed.version)
+}
+
+fn rpm_package_identity(path: &Path) -> Result<PackageIdentity> {
+    let output = rpm_query_command(path, RPM_IDENTITY_QUERY)
+        .output()
+        .context("Failed to inspect RPM package identity")?;
+    anyhow::ensure!(
+        output.status.success(),
+        "rpm could not read the package identity from {}",
+        path.display()
+    );
+    parse_rpm_package_identity(&output.stdout)
+}
+
+fn rpm_installed_package_identity() -> Result<PackageIdentity> {
+    let output = Command::new(program_path(RPM_CANDIDATES, "rpm"))
+        .args([
+            "-q",
+            "--queryformat",
+            RPM_IDENTITY_QUERY,
+            "--",
+            PACKAGE_NAME,
+        ])
+        .output()
+        .context("Failed to inspect installed RPM package identity")?;
+    anyhow::ensure!(
+        output.status.success(),
+        "rpm could not read the installed package identity"
+    );
+    parse_rpm_package_identity(&output.stdout)
+}
+
+fn parse_rpm_package_identity(stdout: &[u8]) -> Result<PackageIdentity> {
+    let text = String::from_utf8(stdout.to_vec()).context("rpm returned a non-UTF8 identity")?;
+    let fields = text.trim().split('\t').collect::<Vec<_>>();
+    anyhow::ensure!(
+        fields.len() == 3 && fields.iter().all(|field| !field.is_empty()),
+        "rpm returned an invalid package identity"
+    );
+    Ok(PackageIdentity {
+        name: fields[0].to_string(),
+        version: fields[1].to_string(),
+        architecture: fields[2].to_string(),
+    })
+}
+
+fn installed_pacman_version_for_recovery(path: &Path) -> Option<String> {
+    let candidate = pacman_package_identity(path).ok()?;
+    let installed = pacman_installed_package_identity().ok()?;
+    if candidate != installed || installed.name != PACKAGE_NAME {
+        return None;
+    }
+
+    // pacman -Qkk verifies that the files recorded for the installed package
+    // are present and intact. This is stronger than trusting pacman -Q's
+    // version string after an owner process disappeared.
+    let verification = pacman_query_command(["-Qkk", "--", PACKAGE_NAME])
+        .output()
+        .ok()?;
+    if !verification.status.success() {
+        return None;
+    }
+
+    Some(installed.version)
+}
+
+fn pacman_package_identity(path: &Path) -> Result<PackageIdentity> {
+    let output = pacman_query_info_command(path)
+        .output()
+        .context("Failed to inspect pacman package identity")?;
+    anyhow::ensure!(
+        output.status.success(),
+        "pacman could not read the package identity from {}",
+        path.display()
+    );
+    parse_pacman_package_identity(&output.stdout)
+}
+
+fn pacman_installed_package_identity() -> Result<PackageIdentity> {
+    let output = pacman_query_command(["-Qi", "--", PACKAGE_NAME])
+        .output()
+        .context("Failed to inspect installed pacman package identity")?;
+    anyhow::ensure!(
+        output.status.success(),
+        "pacman could not read the installed package identity"
+    );
+    parse_pacman_package_identity(&output.stdout)
+}
+
+fn parse_pacman_package_identity(stdout: &[u8]) -> Result<PackageIdentity> {
+    let text = String::from_utf8(stdout.to_vec()).context("pacman returned a non-UTF8 identity")?;
+    let mut name = None;
+    let mut version = None;
+    let mut architecture = None;
+    for line in text.lines() {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+        match key.trim() {
+            "Name" => name = Some(value.to_string()),
+            "Version" => version = Some(value.to_string()),
+            "Architecture" => architecture = Some(value.to_string()),
+            _ => {}
+        }
+    }
+    Ok(PackageIdentity {
+        name: name.context("pacman output is missing the package name")?,
+        version: version.context("pacman output is missing the package version")?,
+        architecture: architecture.context("pacman output is missing the package architecture")?,
+    })
 }
 
 fn installed_rpm_version() -> String {
@@ -744,8 +885,20 @@ fn rpm_query_command(path: &Path, queryformat: &str) -> Command {
 }
 
 fn pacman_query_name_command(path: &Path) -> Command {
+    let mut command = pacman_query_command(["-Qqp", "--"]);
+    command.arg(path);
+    command
+}
+
+fn pacman_query_info_command(path: &Path) -> Command {
+    let mut command = pacman_query_command(["-Qip", "--"]);
+    command.arg(path);
+    command
+}
+
+fn pacman_query_command<const N: usize>(args: [&str; N]) -> Command {
     let mut command = Command::new(program_path(PACMAN_CANDIDATES, "pacman"));
-    command.args(["-Qqp", "--"]).arg(path);
+    command.env("LC_ALL", "C").args(args);
     command
 }
 
@@ -875,11 +1028,69 @@ fn program_exists(candidates: &[&str], fallback: &str) -> bool {
 }
 
 fn program_path(candidates: &[&str], fallback: &str) -> PathBuf {
+    #[cfg(test)]
+    if let Some(path) = test_program_path_override(fallback) {
+        return path;
+    }
+
     candidates
         .iter()
         .map(PathBuf::from)
         .find(|path| path.is_file())
         .unwrap_or_else(|| PathBuf::from(fallback))
+}
+
+#[cfg(test)]
+fn test_program_path_override(fallback: &str) -> Option<PathBuf> {
+    TEST_PROGRAM_PATH_OVERRIDES.with(|overrides| {
+        let overrides = overrides.borrow();
+        match fallback {
+            "rpm" => overrides.rpm.clone(),
+            "pacman" => overrides.pacman.clone(),
+            _ => None,
+        }
+    })
+}
+
+#[cfg(test)]
+#[derive(Clone, Default)]
+struct TestProgramPathOverrides {
+    rpm: Option<PathBuf>,
+    pacman: Option<PathBuf>,
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_PROGRAM_PATH_OVERRIDES: RefCell<TestProgramPathOverrides> =
+        RefCell::new(TestProgramPathOverrides::default());
+}
+
+#[cfg(test)]
+pub(crate) struct TestProgramPathGuard {
+    previous: TestProgramPathOverrides,
+}
+
+#[cfg(test)]
+impl Drop for TestProgramPathGuard {
+    fn drop(&mut self) {
+        let previous = self.previous.clone();
+        TEST_PROGRAM_PATH_OVERRIDES.with(|overrides| {
+            *overrides.borrow_mut() = previous;
+        });
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_program_path_overrides(
+    rpm: Option<&Path>,
+    pacman: Option<&Path>,
+) -> TestProgramPathGuard {
+    let next = TestProgramPathOverrides {
+        rpm: rpm.map(Path::to_path_buf),
+        pacman: pacman.map(Path::to_path_buf),
+    };
+    let previous = TEST_PROGRAM_PATH_OVERRIDES.with(|overrides| overrides.replace(next));
+    TestProgramPathGuard { previous }
 }
 
 fn command_exists(name: &str) -> bool {
@@ -1429,5 +1640,35 @@ mod tests {
             parse_configured_deb_version(b"install ok half-configured\t2026.09.06\n"),
             None
         );
+    }
+
+    #[test]
+    fn recovery_parses_exact_rpm_package_identity() -> Result<()> {
+        assert_eq!(
+            parse_rpm_package_identity(b"codex-desktop\t2026.09.06-1.fc42\tx86_64\n")?,
+            PackageIdentity {
+                name: "codex-desktop".into(),
+                version: "2026.09.06-1.fc42".into(),
+                architecture: "x86_64".into(),
+            }
+        );
+        assert!(parse_rpm_package_identity(b"codex-desktop\t2026.09.06-1.fc42\n").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn recovery_parses_exact_pacman_package_identity() -> Result<()> {
+        assert_eq!(
+            parse_pacman_package_identity(
+                b"Name            : codex-desktop\nVersion         : 2026.09.06-1\nArchitecture    : x86_64\n"
+            )?,
+            PackageIdentity {
+                name: "codex-desktop".into(),
+                version: "2026.09.06-1".into(),
+                architecture: "x86_64".into(),
+            }
+        );
+        assert!(parse_pacman_package_identity(b"Name : codex-desktop\n").is_err());
+        Ok(())
     }
 }

--- a/updater/src/install.rs
+++ b/updater/src/install.rs
@@ -186,6 +186,36 @@ fn installed_deb_version() -> String {
     )
 }
 
+pub(crate) fn installed_package_version_for_recovery(path: &Path) -> Option<String> {
+    match PackageKind::from_path(path) {
+        PackageKind::Deb => installed_deb_version_if_configured(),
+        // rpm/pacman expose the installed version, but that alone is not proof
+        // that an abandoned package transaction completed successfully. Fail
+        // closed until an equally strong completion predicate exists there.
+        PackageKind::Rpm | PackageKind::Pacman => None,
+    }
+}
+
+fn installed_deb_version_if_configured() -> Option<String> {
+    let output = Command::new(program_path(DPKG_QUERY_CANDIDATES, "dpkg-query"))
+        .args(["-W", "-f=${Status}\t${Version}", PACKAGE_NAME])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_configured_deb_version(&output.stdout)
+}
+
+fn parse_configured_deb_version(stdout: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(stdout);
+    let (status, version) = text.trim().rsplit_once('\t')?;
+    if status != "install ok installed" || version.is_empty() {
+        return None;
+    }
+    Some(version.to_string())
+}
+
 fn installed_rpm_version() -> String {
     installed_version_from_command(
         &program_path(RPM_CANDIDATES, "rpm"),
@@ -611,7 +641,10 @@ fn resolve_updater_binary_for_build_at(current_exe: &Path, installed: &Path) -> 
 }
 
 pub(crate) fn strip_deleted_path_suffix(path: &Path) -> Option<PathBuf> {
-    let stripped = path.as_os_str().as_bytes().strip_suffix(DELETED_PATH_SUFFIX)?;
+    let stripped = path
+        .as_os_str()
+        .as_bytes()
+        .strip_suffix(DELETED_PATH_SUFFIX)?;
     Some(PathBuf::from(OsStr::from_bytes(stripped)))
 }
 
@@ -621,6 +654,14 @@ fn deb_package_name(path: &Path) -> Result<String> {
         .context("Failed to inspect Debian package metadata")?;
 
     package_metadata_field(output, "dpkg-deb", "package name", path)
+}
+
+pub(crate) fn package_version(path: &Path) -> Result<String> {
+    match PackageKind::from_path(path) {
+        PackageKind::Deb => deb_package_version(path),
+        PackageKind::Rpm => rpm_package_version(path),
+        PackageKind::Pacman => pacman_package_version(path),
+    }
 }
 
 fn deb_package_version(path: &Path) -> Result<String> {
@@ -1373,5 +1414,20 @@ mod tests {
         .expect_err("foreign pacman packages must be rejected");
 
         assert!(error.to_string().contains("codex-desktop-"));
+    }
+    #[test]
+    fn recovery_accepts_only_fully_configured_debian_package_state() {
+        assert_eq!(
+            parse_configured_deb_version(b"install ok installed\t2026.09.06\n").as_deref(),
+            Some("2026.09.06")
+        );
+        assert_eq!(
+            parse_configured_deb_version(b"install ok unpacked\t2026.09.06\n"),
+            None
+        );
+        assert_eq!(
+            parse_configured_deb_version(b"install ok half-configured\t2026.09.06\n"),
+            None
+        );
     }
 }

--- a/updater/src/install_transaction.rs
+++ b/updater/src/install_transaction.rs
@@ -9,13 +9,14 @@ use sha2::{Digest, Sha256};
 use std::{
     ffi::OsString,
     fs,
-    io::Write,
+    io::{self, Write},
     path::Path,
     process::{Command, Output, Stdio},
     time::Duration,
 };
 
 pub(crate) const ABANDONED_INSTALL_GRACE: Duration = Duration::from_secs(300);
+const BOOT_ID_PATH: &str = "/proc/sys/kernel/random/boot_id";
 
 const GATED_EXEC_SCRIPT: &str = r#"
 IFS= read -r state || exit 125
@@ -27,6 +28,19 @@ exec "$@"
 pub(crate) struct OwnedCommandFailure {
     pub error: anyhow::Error,
     pub mutation_may_have_started: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OwnerState {
+    /// No privileged package command has been released yet.
+    NotStarted,
+    /// The exact recorded package-command process is still running.
+    Running,
+    /// The recorded process is definitely gone or belongs to another boot or
+    /// process incarnation.
+    Exited,
+    /// The owner cannot be classified safely. Recovery must remain blocked.
+    Unknown,
 }
 
 impl OwnedCommandFailure {
@@ -54,6 +68,7 @@ pub(crate) fn begin(
     let package_sha256 = package_sha256(package_path)
         .with_context(|| format!("Failed to hash install package {}", package_path.display()))?;
     state.status = UpdateStatus::Installing;
+    state.manual_recovery_required = false;
     state.error_message = None;
     state.install_transaction = Some(InstallTransaction {
         package_path: package_path.to_path_buf(),
@@ -178,11 +193,12 @@ fn gated_command(command: &Command, launcher_program: &Path) -> Command {
     launcher
 }
 
-pub(crate) fn is_active(transaction: &InstallTransaction) -> bool {
+pub(crate) fn owner_state(transaction: &InstallTransaction) -> OwnerState {
     transaction
         .package_command
         .as_ref()
-        .is_some_and(identity_is_alive)
+        .map(owner_state_for_identity)
+        .unwrap_or(OwnerState::NotStarted)
 }
 
 pub(crate) fn grace_expired(transaction: &InstallTransaction) -> bool {
@@ -201,24 +217,71 @@ pub(crate) fn package_sha256(path: &Path) -> Result<String> {
 }
 
 fn process_identity(pid: u32) -> Result<ProcessIdentity> {
+    let boot_id = current_boot_id()?;
+    let start_time_ticks = read_process_start_time_ticks(pid)
+        .with_context(|| format!("Failed to read /proc/{pid}/stat"))?;
+    Ok(ProcessIdentity {
+        pid,
+        start_time_ticks,
+        boot_id: Some(boot_id),
+    })
+}
+
+fn current_boot_id() -> Result<String> {
+    let boot_id = fs::read_to_string(BOOT_ID_PATH)
+        .with_context(|| format!("Failed to read {BOOT_ID_PATH}"))?;
+    let boot_id = boot_id.trim();
+    anyhow::ensure!(!boot_id.is_empty(), "Kernel boot identity is empty");
+    Ok(boot_id.to_string())
+}
+
+fn read_process_start_time_ticks(pid: u32) -> io::Result<u64> {
     let stat_path = Path::new("/proc").join(pid.to_string()).join("stat");
-    let stat = fs::read_to_string(&stat_path)
-        .with_context(|| format!("Failed to read {}", stat_path.display()))?;
+    let stat = fs::read_to_string(&stat_path)?;
     let close_paren = stat
         .rfind(')')
-        .context("Malformed /proc stat: missing process-name terminator")?;
+        .ok_or_else(|| invalid_proc_stat("missing process-name terminator"))?;
     let fields = stat[close_paren + 1..]
         .split_whitespace()
         .collect::<Vec<_>>();
     let start_time_ticks = fields
         .get(19)
-        .context("Malformed /proc stat: missing process start time")?
+        .ok_or_else(|| invalid_proc_stat("missing process start time"))?
         .parse::<u64>()
-        .context("Malformed /proc stat process start time")?;
-    Ok(ProcessIdentity {
-        pid,
-        start_time_ticks,
-    })
+        .map_err(|_| invalid_proc_stat("invalid process start time"))?;
+    Ok(start_time_ticks)
+}
+
+fn invalid_proc_stat(message: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("Malformed /proc stat: {message}"),
+    )
+}
+
+fn process_exists(pid: u32) -> io::Result<bool> {
+    let pid = libc::pid_t::try_from(pid).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "persisted process identity does not fit in pid_t",
+        )
+    })?;
+    // kill(pid, 0) does not signal the process. It distinguishes an absent
+    // process (ESRCH) from a live process whose /proc entry is hidden or
+    // unreadable (EPERM), which is important when the owner has become root
+    // through pkexec on a hidepid-mounted procfs.
+    if unsafe { libc::kill(pid, 0) } == 0 {
+        return Ok(true);
+    }
+    let error = io::Error::last_os_error();
+    match error.raw_os_error() {
+        Some(code) if code == libc::ESRCH => Ok(false),
+        Some(code) if code == libc::EPERM => Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "process exists but its identity cannot be inspected",
+        )),
+        _ => Err(error),
+    }
 }
 
 #[cfg(test)]
@@ -226,10 +289,30 @@ pub(crate) fn test_current_process_identity() -> Result<ProcessIdentity> {
     process_identity(std::process::id())
 }
 
-fn identity_is_alive(identity: &ProcessIdentity) -> bool {
-    process_identity(identity.pid)
-        .map(|current| current.start_time_ticks == identity.start_time_ticks)
-        .unwrap_or(false)
+fn owner_state_for_identity(identity: &ProcessIdentity) -> OwnerState {
+    let Some(expected_boot_id) = identity.boot_id.as_deref() else {
+        return OwnerState::Unknown;
+    };
+    let current_boot_id = match current_boot_id() {
+        Ok(boot_id) => boot_id,
+        Err(_) => return OwnerState::Unknown,
+    };
+    if current_boot_id != expected_boot_id {
+        return OwnerState::Exited;
+    }
+
+    match read_process_start_time_ticks(identity.pid) {
+        Ok(start_time_ticks) if start_time_ticks == identity.start_time_ticks => {
+            OwnerState::Running
+        }
+        Ok(_) => OwnerState::Exited,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => match process_exists(identity.pid)
+        {
+            Ok(false) => OwnerState::Exited,
+            Ok(true) | Err(_) => OwnerState::Unknown,
+        },
+        Err(_) => OwnerState::Unknown,
+    }
 }
 
 #[cfg(test)]
@@ -240,13 +323,38 @@ mod tests {
     #[test]
     fn process_identity_is_pid_reuse_safe() -> Result<()> {
         let current = process_identity(std::process::id())?;
-        assert!(identity_is_alive(&current));
+        assert_eq!(owner_state_for_identity(&current), OwnerState::Running);
 
         let stale = ProcessIdentity {
             pid: current.pid,
             start_time_ticks: current.start_time_ticks.wrapping_add(1),
+            boot_id: current.boot_id.clone(),
         };
-        assert!(!identity_is_alive(&stale));
+        assert_eq!(owner_state_for_identity(&stale), OwnerState::Exited);
+        Ok(())
+    }
+
+    #[test]
+    fn boot_mismatch_confirms_owner_is_exited() -> Result<()> {
+        let current = process_identity(std::process::id())?;
+        let stale = ProcessIdentity {
+            pid: current.pid,
+            start_time_ticks: current.start_time_ticks,
+            boot_id: Some("different-boot".into()),
+        };
+        assert_eq!(owner_state_for_identity(&stale), OwnerState::Exited);
+        Ok(())
+    }
+
+    #[test]
+    fn missing_boot_identity_is_unknown_and_blocks_recovery() -> Result<()> {
+        let current = process_identity(std::process::id())?;
+        let legacy = ProcessIdentity {
+            pid: current.pid,
+            start_time_ticks: current.start_time_ticks,
+            boot_id: None,
+        };
+        assert_eq!(owner_state_for_identity(&legacy), OwnerState::Unknown);
         Ok(())
     }
 
@@ -256,6 +364,7 @@ mod tests {
         let stale = ProcessIdentity {
             pid: current.pid,
             start_time_ticks: current.start_time_ticks.wrapping_add(1),
+            boot_id: current.boot_id.clone(),
         };
         let tx = InstallTransaction {
             package_path: PathBuf::from("/tmp/codex.deb"),
@@ -265,7 +374,7 @@ mod tests {
                 - chrono::Duration::seconds(ABANDONED_INSTALL_GRACE.as_secs() as i64 + 1),
             operation: InstallOperation::Update,
         };
-        assert!(!is_active(&tx));
+        assert_eq!(owner_state(&tx), OwnerState::Exited);
         assert!(grace_expired(&tx));
         Ok(())
     }
@@ -319,6 +428,43 @@ mod tests {
         let status = child.wait()?;
         assert!(status.success());
         assert!(marker.is_file());
+        Ok(())
+    }
+
+    #[test]
+    fn package_command_observes_persisted_owner_before_release() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state_file = dir.path().join("state/state.json");
+        let package = dir.path().join("candidate.deb");
+        let marker = dir.path().join("mutation-started");
+        fs::write(&package, b"fixture")?;
+
+        let mut state = PersistedState::new(true);
+        begin(&mut state, &state_file, &package, InstallOperation::Update)?;
+
+        let mut command = Command::new("/bin/sh");
+        command
+            .args([
+                "-c",
+                "grep -q '\"package_command\": {' \"$CODEX_TEST_STATE_FILE\" && grep -q '\"boot_id\":' \"$CODEX_TEST_STATE_FILE\" && : > \"$CODEX_TEST_MUTATION_MARKER\"",
+            ])
+            .env("CODEX_TEST_STATE_FILE", &state_file)
+            .env("CODEX_TEST_MUTATION_MARKER", &marker);
+
+        let output = run_owned_command_with_launcher(
+            &mut command,
+            &mut state,
+            &state_file,
+            Path::new("/bin/sh"),
+        )
+        .map_err(|failure| failure.error)?;
+        assert!(output.status.success());
+        assert!(marker.is_file());
+        let persisted = PersistedState::load_or_default(&state_file, true)?;
+        assert!(persisted
+            .install_transaction
+            .and_then(|transaction| transaction.package_command)
+            .is_some());
         Ok(())
     }
 

--- a/updater/src/install_transaction.rs
+++ b/updater/src/install_transaction.rs
@@ -1,0 +1,393 @@
+//! Durable ownership for package-replacing updater transactions.
+
+use crate::state::{
+    InstallOperation, InstallTransaction, PersistedState, ProcessIdentity, UpdateStatus,
+};
+use anyhow::{Context, Result};
+use chrono::Utc;
+use sha2::{Digest, Sha256};
+use std::{
+    ffi::OsString,
+    fs,
+    io::Write,
+    path::Path,
+    process::{Command, Output, Stdio},
+    time::Duration,
+};
+
+pub(crate) const ABANDONED_INSTALL_GRACE: Duration = Duration::from_secs(300);
+
+const GATED_EXEC_SCRIPT: &str = r#"
+IFS= read -r state || exit 125
+[ "$state" = "go" ] || exit 125
+exec "$@"
+"#;
+
+#[derive(Debug)]
+pub(crate) struct OwnedCommandFailure {
+    pub error: anyhow::Error,
+    pub mutation_may_have_started: bool,
+}
+
+impl OwnedCommandFailure {
+    fn before_mutation(error: anyhow::Error) -> Self {
+        Self {
+            error,
+            mutation_may_have_started: false,
+        }
+    }
+
+    fn outcome_unknown(error: anyhow::Error) -> Self {
+        Self {
+            error,
+            mutation_may_have_started: true,
+        }
+    }
+}
+
+pub(crate) fn begin(
+    state: &mut PersistedState,
+    state_file: &Path,
+    package_path: &Path,
+    operation: InstallOperation,
+) -> Result<()> {
+    let package_sha256 = package_sha256(package_path)
+        .with_context(|| format!("Failed to hash install package {}", package_path.display()))?;
+    state.status = UpdateStatus::Installing;
+    state.error_message = None;
+    state.install_transaction = Some(InstallTransaction {
+        package_path: package_path.to_path_buf(),
+        package_sha256: Some(package_sha256),
+        // No package mutation is active yet. The exact gated child identity is
+        // published durably below before that child is allowed to exec pkexec.
+        // Recording the updater itself here would make a failed launch look
+        // live forever while the daemon remains running.
+        package_command: None,
+        started_at: Utc::now(),
+        operation,
+    });
+    state.save_updater(state_file)
+}
+
+pub(crate) fn run_owned_command_with_launcher(
+    command: &mut Command,
+    state: &mut PersistedState,
+    state_file: &Path,
+    launcher_program: &Path,
+) -> std::result::Result<Output, OwnedCommandFailure> {
+    // Spawn only a non-mutating launcher first. Its PID is the PID that will
+    // become pkexec via exec(2), so we can durably publish that exact process
+    // identity before permitting package mutation.
+    //
+    // The launch token travels over stdin. If this updater dies before the
+    // durable owner save and token write, the pipe closes and the launcher
+    // exits without ever exec'ing pkexec. This removes the spawn-before-owner
+    // crash window without a polling timeout or persistent gate file.
+    let mut launcher = gated_command(command, launcher_program);
+    launcher
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = launcher
+        .spawn()
+        .context("Failed to launch gated privileged package command")
+        .map_err(OwnedCommandFailure::before_mutation)?;
+
+    let identity = match process_identity(child.id()) {
+        Ok(identity) => identity,
+        Err(error) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(OwnedCommandFailure::before_mutation(
+                error.context("Failed to identify privileged package-command owner"),
+            ));
+        }
+    };
+    let Some(transaction) = state.install_transaction.as_mut() else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(OwnedCommandFailure::before_mutation(anyhow::anyhow!(
+            "Package command started without a durable install transaction"
+        )));
+    };
+    transaction.package_command = Some(identity);
+    if let Err(error) = state
+        .save_updater(state_file)
+        .context("Failed to persist package-command ownership")
+    {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(OwnedCommandFailure::before_mutation(error));
+    }
+
+    let release_result = child
+        .stdin
+        .take()
+        .context("Privileged package-command launcher has no stdin gate")
+        .and_then(|mut stdin| {
+            stdin
+                .write_all(b"go\n")
+                .context("Failed to release privileged package-command launch gate")
+        });
+    if let Err(error) = release_result {
+        // Once writing the release token has been attempted, a partial write
+        // can no longer prove that the launcher did not consume "go" and exec
+        // the privileged command. Preserve the durable child ownership and let
+        // normal liveness/grace reconciliation decide the outcome.
+        drop(child.stdin.take());
+        let _ = child.wait();
+        return Err(OwnedCommandFailure::outcome_unknown(error));
+    }
+
+    child
+        .wait_with_output()
+        .context("Failed while waiting for privileged package command")
+        .map_err(OwnedCommandFailure::outcome_unknown)
+}
+
+fn gated_command(command: &Command, launcher_program: &Path) -> Command {
+    let program = command.get_program().to_os_string();
+    let args = command
+        .get_args()
+        .map(OsString::from)
+        .collect::<Vec<OsString>>();
+
+    let mut launcher = Command::new(launcher_program);
+    launcher
+        .arg("-c")
+        .arg(GATED_EXEC_SCRIPT)
+        .arg("codex-update-launcher")
+        .arg(program)
+        .args(args);
+
+    for (key, value) in command.get_envs() {
+        match value {
+            Some(value) => {
+                launcher.env(key, value);
+            }
+            None => {
+                launcher.env_remove(key);
+            }
+        }
+    }
+    if let Some(dir) = command.get_current_dir() {
+        launcher.current_dir(dir);
+    }
+
+    launcher
+}
+
+pub(crate) fn is_active(transaction: &InstallTransaction) -> bool {
+    transaction
+        .package_command
+        .as_ref()
+        .is_some_and(identity_is_alive)
+}
+
+pub(crate) fn grace_expired(transaction: &InstallTransaction) -> bool {
+    match (Utc::now() - transaction.started_at).to_std() {
+        Ok(elapsed) => elapsed >= ABANDONED_INSTALL_GRACE,
+        Err(_) => true,
+    }
+}
+
+pub(crate) fn package_sha256(path: &Path) -> Result<String> {
+    let bytes = fs::read(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    Ok(Sha256::digest(&bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect())
+}
+
+fn process_identity(pid: u32) -> Result<ProcessIdentity> {
+    let stat_path = Path::new("/proc").join(pid.to_string()).join("stat");
+    let stat = fs::read_to_string(&stat_path)
+        .with_context(|| format!("Failed to read {}", stat_path.display()))?;
+    let close_paren = stat
+        .rfind(')')
+        .context("Malformed /proc stat: missing process-name terminator")?;
+    let fields = stat[close_paren + 1..]
+        .split_whitespace()
+        .collect::<Vec<_>>();
+    let start_time_ticks = fields
+        .get(19)
+        .context("Malformed /proc stat: missing process start time")?
+        .parse::<u64>()
+        .context("Malformed /proc stat process start time")?;
+    Ok(ProcessIdentity {
+        pid,
+        start_time_ticks,
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn test_current_process_identity() -> Result<ProcessIdentity> {
+    process_identity(std::process::id())
+}
+
+fn identity_is_alive(identity: &ProcessIdentity) -> bool {
+    process_identity(identity.pid)
+        .map(|current| current.start_time_ticks == identity.start_time_ticks)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn process_identity_is_pid_reuse_safe() -> Result<()> {
+        let current = process_identity(std::process::id())?;
+        assert!(identity_is_alive(&current));
+
+        let stale = ProcessIdentity {
+            pid: current.pid,
+            start_time_ticks: current.start_time_ticks.wrapping_add(1),
+        };
+        assert!(!identity_is_alive(&stale));
+        Ok(())
+    }
+
+    #[test]
+    fn stale_owner_does_not_keep_install_blocked() -> Result<()> {
+        let current = process_identity(std::process::id())?;
+        let stale = ProcessIdentity {
+            pid: current.pid,
+            start_time_ticks: current.start_time_ticks.wrapping_add(1),
+        };
+        let tx = InstallTransaction {
+            package_path: PathBuf::from("/tmp/codex.deb"),
+            package_sha256: Some("fixture".into()),
+            package_command: Some(stale),
+            started_at: Utc::now()
+                - chrono::Duration::seconds(ABANDONED_INSTALL_GRACE.as_secs() as i64 + 1),
+            operation: InstallOperation::Update,
+        };
+        assert!(!is_active(&tx));
+        assert!(grace_expired(&tx));
+        Ok(())
+    }
+
+    #[test]
+    fn future_started_at_does_not_extend_abandoned_install_grace() {
+        let tx = InstallTransaction {
+            package_path: PathBuf::from("/tmp/codex.deb"),
+            package_sha256: Some("fixture".into()),
+            package_command: None,
+            started_at: Utc::now() + chrono::Duration::hours(1),
+            operation: InstallOperation::Update,
+        };
+
+        assert!(
+            grace_expired(&tx),
+            "a future wall-clock timestamp must not defer abandoned-install recovery"
+        );
+    }
+
+    #[test]
+    fn gated_launcher_requires_explicit_release_before_exec() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let marker = dir.path().join("started");
+
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg("printf started > \"$1\"")
+            .arg("fixture")
+            .arg(&marker);
+
+        let mut launcher = gated_command(&command, Path::new("/bin/sh"));
+        launcher
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut child = launcher.spawn()?;
+
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            !marker.exists(),
+            "privileged command executed before launch gate release"
+        );
+
+        child
+            .stdin
+            .take()
+            .context("fixture launcher has no stdin gate")?
+            .write_all(b"go\n")?;
+        let status = child.wait()?;
+        assert!(status.success());
+        assert!(marker.is_file());
+        Ok(())
+    }
+
+    #[test]
+    fn gated_launcher_eof_exits_without_exec() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let marker = dir.path().join("started");
+
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg("printf started > \"$1\"")
+            .arg("fixture")
+            .arg(&marker);
+
+        let mut launcher = gated_command(&command, Path::new("/bin/sh"));
+        launcher
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut child = launcher.spawn()?;
+        drop(child.stdin.take());
+
+        let status = child.wait()?;
+        assert_eq!(status.code(), Some(125));
+        assert!(
+            !marker.exists(),
+            "EOF before durable owner publication must not execute package command"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn failed_gated_spawn_is_classified_before_mutation_and_does_not_publish_daemon_owner(
+    ) -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state_file = dir.path().join("state.json");
+        let package = dir.path().join("candidate.deb");
+        fs::write(&package, b"fixture")?;
+
+        let mut state = PersistedState::new(true);
+        begin(&mut state, &state_file, &package, InstallOperation::Update)?;
+        assert_eq!(state.status, UpdateStatus::Installing);
+        assert_eq!(
+            state
+                .install_transaction
+                .as_ref()
+                .and_then(|transaction| transaction.package_command.as_ref()),
+            None,
+            "pre-launch Installing state must not claim that the daemon is the package owner"
+        );
+
+        let mut command = Command::new("/bin/true");
+        let failure = run_owned_command_with_launcher(
+            &mut command,
+            &mut state,
+            &state_file,
+            &dir.path().join("missing-launcher"),
+        )
+        .expect_err("missing gated launcher must fail");
+
+        assert!(!failure.mutation_may_have_started);
+        assert_eq!(
+            state
+                .install_transaction
+                .as_ref()
+                .and_then(|transaction| transaction.package_command.as_ref()),
+            None
+        );
+        Ok(())
+    }
+}

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -7,6 +7,7 @@ mod cli;
 mod config;
 mod install;
 mod install_rollback;
+mod install_transaction;
 mod liveness;
 mod logging;
 mod notify;

--- a/updater/src/restart.rs
+++ b/updater/src/restart.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 const PROC_SELF_EXE: &str = "/proc/self/exe";
+pub const REPLACEMENT_RESTART_EXIT_CODE: i32 = 12;
 
 /// Returns the replacement path when the running image and its path on disk
 /// no longer refer to the same inode.
@@ -15,6 +16,10 @@ pub fn replacement_binary() -> Option<PathBuf> {
     let link_target = fs::read_link(PROC_SELF_EXE).ok()?;
     let installed_path = install::strip_deleted_path_suffix(&link_target).unwrap_or(link_target);
     replacement_at(Path::new(PROC_SELF_EXE), &installed_path)
+}
+
+pub fn exit_for_replacement() -> ! {
+    std::process::exit(REPLACEMENT_RESTART_EXIT_CODE);
 }
 
 fn replacement_at(running_image: &Path, installed_path: &Path) -> Option<PathBuf> {

--- a/updater/src/rollback.rs
+++ b/updater/src/rollback.rs
@@ -1,13 +1,23 @@
 //! Manual rollback to the immediately previous retained native package.
 
-use crate::{config::{RuntimeConfig, RuntimePaths}, install, install_rollback, liveness, state::{PersistedState, UpdateStatus}};
-use anyhow::{Context, Result};
+use crate::{
+    config::{RuntimeConfig, RuntimePaths},
+    install, install_rollback, install_transaction, liveness,
+    state::{InstallOperation, PersistedState, UpdateStatus},
+};
+use anyhow::Result;
+use std::path::Path;
 
 pub fn record_current_package_as_known_good(state: &mut PersistedState) {
     if state.installed_version == "unknown" || state.candidate_version.is_some() {
         return;
     }
-    if let Some(path) = state.artifact_paths.package_path.clone().filter(|path| path.is_file()) {
+    if let Some(path) = state
+        .artifact_paths
+        .package_path
+        .clone()
+        .filter(|path| path.is_file())
+    {
         state.last_known_good_version = Some(state.installed_version.clone());
         state.last_known_good_upstream_version = state.installed_upstream_version.clone();
         state.last_known_good_upstream_sha256 = state.installed_upstream_sha256.clone();
@@ -15,29 +25,73 @@ pub fn record_current_package_as_known_good(state: &mut PersistedState) {
     }
 }
 
-pub async fn run(config: &RuntimeConfig, state: &mut PersistedState, paths: &RuntimePaths) -> Result<()> {
+pub async fn run(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    run_with_launcher(config, state, paths, Path::new("/bin/sh")).await
+}
+
+async fn run_with_launcher(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    launcher_program: &Path,
+) -> Result<()> {
     if liveness::is_app_running(config)? {
         println!("ChatGPT Community is running. Close it before rollback.");
         return Ok(());
     }
     let package = match state.artifact_paths.rollback_package_path.clone() {
         Some(path) if path.is_file() => path,
-        _ => { println!("No rollback package is available."); return Ok(()); }
+        _ => {
+            println!("No rollback package is available.");
+            return Ok(());
+        }
     };
-    let blocked_version = state.candidate_version.clone().or_else(|| Some(state.installed_version.clone()));
+    let blocked_version = state
+        .candidate_version
+        .clone()
+        .or_else(|| Some(state.installed_version.clone()));
     let blocked_sha = state.upstream_package_sha256.clone();
-    state.status = UpdateStatus::Installing;
-    state.save_updater(&paths.state_file)?;
-    let output = install_rollback::pkexec_command(&std::env::current_exe()?, &package)
-        .output()
-        .context("Failed to launch privileged rollback")?;
+    install_transaction::begin(
+        state,
+        &paths.state_file,
+        &package,
+        InstallOperation::Rollback,
+    )?;
+    let mut command = install_rollback::pkexec_command(&std::env::current_exe()?, &package);
+    let output = match install_transaction::run_owned_command_with_launcher(
+        &mut command,
+        state,
+        &paths.state_file,
+        launcher_program,
+    ) {
+        Ok(output) => output,
+        Err(failure) if !failure.mutation_may_have_started => {
+            let message = format!("Failed to launch privileged rollback: {:#}", failure.error);
+            state.mark_failed(&message);
+            state.save_updater(&paths.state_file)?;
+            anyhow::bail!(message);
+        }
+        Err(failure) => {
+            return Err(failure
+                .error
+                .context("Privileged rollback outcome is unknown"));
+        }
+    };
     if !output.status.success() {
-        let message = format!("rollback failed: {}", String::from_utf8_lossy(&output.stderr).trim());
-        state.mark_failed(&message);
-        state.save_updater(&paths.state_file)?;
-        anyhow::bail!(message);
+        // Once the gated command has been released, a nonzero package-manager
+        // exit is not evidence that rollback made no changes. Preserve the
+        // durable transaction so the same recovery path can reconcile it.
+        anyhow::bail!(
+            "privileged rollback exited unsuccessfully after package mutation may have started: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
     }
     state.status = UpdateStatus::Installed;
+    state.install_transaction = None;
     state.installed_version = install::installed_package_version();
     state.installed_upstream_version = state.last_known_good_upstream_version.clone();
     state.installed_upstream_sha256 = state.last_known_good_upstream_sha256.clone();
@@ -56,6 +110,7 @@ pub async fn run(config: &RuntimeConfig, state: &mut PersistedState, paths: &Run
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{fs, os::unix::fs::PermissionsExt};
 
     #[test]
     fn current_package_becomes_the_single_rollback_artifact() -> Result<()> {
@@ -67,6 +122,52 @@ mod tests {
         state.artifact_paths.package_path = Some(package.clone());
         record_current_package_as_known_good(&mut state);
         assert_eq!(state.artifact_paths.rollback_package_path, Some(package));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn nonzero_exit_after_gate_release_preserves_rollback_recovery_evidence() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let paths = RuntimePaths {
+            config_file: dir.path().join("config/config.toml"),
+            state_file: dir.path().join("state/state.json"),
+            log_file: dir.path().join("state/service.log"),
+            cache_dir: dir.path().join("cache"),
+            state_dir: dir.path().join("state"),
+            config_dir: dir.path().join("config"),
+        };
+        paths.ensure_dirs()?;
+        let mut config = RuntimeConfig::default_with_paths(&paths);
+        config.app_executable_path = dir.path().join("app-not-running");
+
+        let package = dir.path().join("known-good.deb");
+        fs::write(&package, b"fixture package")?;
+        let launcher = dir.path().join("released-then-fails");
+        fs::write(
+            &launcher,
+            "#!/bin/sh\nIFS= read -r state || exit 125\n[ \"$state\" = go ] || exit 125\nexit 42\n",
+        )?;
+        fs::set_permissions(&launcher, fs::Permissions::from_mode(0o755))?;
+
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::Installed;
+        state.installed_version = "bad-local".into();
+        state.artifact_paths.rollback_package_path = Some(package);
+        state.save_updater(&paths.state_file)?;
+
+        let result = run_with_launcher(&config, &mut state, &paths, &launcher).await;
+        assert!(
+            result.is_err(),
+            "forced post-release rollback failure must surface"
+        );
+
+        let persisted =
+            PersistedState::load_or_default(&paths.state_file, config.auto_install_on_app_exit)?;
+        assert_eq!(persisted.status, UpdateStatus::Installing);
+        assert!(
+            persisted.install_transaction.is_some(),
+            "post-release rollback failure must preserve durable recovery evidence"
+        );
         Ok(())
     }
 }

--- a/updater/src/rollback.rs
+++ b/updater/src/rollback.rs
@@ -55,6 +55,9 @@ async fn run_with_launcher(
         .clone()
         .or_else(|| Some(state.installed_version.clone()));
     let blocked_sha = state.upstream_package_sha256.clone();
+    // The explicit rollback command confirms that the user has checked for an
+    // orphaned package manager after any ambiguous interrupted transaction.
+    state.manual_recovery_required = false;
     install_transaction::begin(
         state,
         &paths.state_file,
@@ -82,6 +85,22 @@ async fn run_with_launcher(
         }
     };
     if !output.status.success() {
+        if matches!(output.status.code(), Some(126 | 127)) {
+            // pkexec uses 126/127 when authorization was dismissed or could
+            // not be obtained. No package mutation was released, so clear the
+            // transaction and leave the candidate retryable instead of making
+            // recovery wait for the abandoned-transaction grace period.
+            let mut message = format!("privileged rollback exited with status {}", output.status);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr = stderr.trim();
+            if !stderr.is_empty() {
+                message.push_str(": ");
+                message.push_str(stderr);
+            }
+            state.mark_failed(&message);
+            state.save_updater(&paths.state_file)?;
+            anyhow::bail!(message);
+        }
         // Once the gated command has been released, a nonzero package-manager
         // exit is not evidence that rollback made no changes. Preserve the
         // durable transaction so the same recovery path can reconcile it.
@@ -168,6 +187,62 @@ mod tests {
             persisted.install_transaction.is_some(),
             "post-release rollback failure must preserve durable recovery evidence"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn authentication_cancelled_rollback_is_retryable() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let paths = RuntimePaths {
+            config_file: dir.path().join("config/config.toml"),
+            state_file: dir.path().join("state/state.json"),
+            log_file: dir.path().join("state/service.log"),
+            cache_dir: dir.path().join("cache"),
+            state_dir: dir.path().join("state"),
+            config_dir: dir.path().join("config"),
+        };
+        paths.ensure_dirs()?;
+        let mut config = RuntimeConfig::default_with_paths(&paths);
+        config.app_executable_path = dir.path().join("app-not-running");
+
+        let package = dir.path().join("known-good.deb");
+        fs::write(&package, b"fixture package")?;
+
+        for code in [126, 127] {
+            let launcher = dir.path().join(format!("cancelled-rollback-{code}"));
+            fs::write(
+                &launcher,
+                format!(
+                    "#!/bin/sh\nIFS= read -r state || exit 125\n[ \"$state\" = go ] || exit 125\nexit {code}\n"
+                ),
+            )?;
+            fs::set_permissions(&launcher, fs::Permissions::from_mode(0o755))?;
+
+            let mut state = PersistedState::new(true);
+            state.status = UpdateStatus::Installed;
+            state.installed_version = "bad-local".into();
+            state.artifact_paths.rollback_package_path = Some(package.clone());
+            state.save_updater(&paths.state_file)?;
+
+            let error = run_with_launcher(&config, &mut state, &paths, &launcher)
+                .await
+                .expect_err("authentication cancellation should be reported");
+            assert!(error
+                .to_string()
+                .contains(&format!("status exit status: {code}")));
+
+            let persisted = PersistedState::load_or_default(
+                &paths.state_file,
+                config.auto_install_on_app_exit,
+            )?;
+            assert_eq!(persisted.status, UpdateStatus::Failed);
+            assert!(persisted.install_transaction.is_none());
+            assert!(!persisted.manual_recovery_required);
+            assert!(persisted
+                .error_message
+                .as_deref()
+                .is_some_and(|message| message.contains("privileged rollback exited")));
+        }
         Ok(())
     }
 }

--- a/updater/src/state.rs
+++ b/updater/src/state.rs
@@ -3,7 +3,34 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::{fs, os::unix::fs::PermissionsExt, path::{Path, PathBuf}};
+use std::{
+    fs,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProcessIdentity {
+    pub pid: u32,
+    pub start_time_ticks: u64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InstallOperation {
+    Update,
+    Rollback,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstallTransaction {
+    pub package_path: PathBuf,
+    #[serde(default)]
+    pub package_sha256: Option<String>,
+    pub package_command: Option<ProcessIdentity>,
+    pub started_at: DateTime<Utc>,
+    pub operation: InstallOperation,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -45,6 +72,7 @@ pub struct PersistedState {
     pub candidate_repository_path: Option<String>,
     pub upstream_package_sha256: Option<String>,
     pub status: UpdateStatus,
+    pub install_transaction: Option<InstallTransaction>,
     pub last_check_at: Option<DateTime<Utc>>,
     pub last_successful_check_at: Option<DateTime<Utc>>,
     pub artifact_paths: ArtifactPaths,
@@ -78,6 +106,7 @@ impl PersistedState {
             candidate_repository_path: None,
             upstream_package_sha256: None,
             status: UpdateStatus::Idle,
+            install_transaction: None,
             last_check_at: None,
             last_successful_check_at: None,
             artifact_paths: ArtifactPaths::default(),
@@ -106,7 +135,12 @@ impl PersistedState {
         // A schema-v1 candidate cannot be resumed safely. Preserve only the
         // installed/rollback facts and drop the pending candidate atomically on
         // the next save.
-        if raw.get("schema_version").and_then(|v| v.as_u64()).unwrap_or(1) < 2 {
+        if raw
+            .get("schema_version")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(1)
+            < 2
+        {
             let mut migrated = Self::new(auto_install);
             migrated.installed_version = raw
                 .get("installed_version")
@@ -142,6 +176,7 @@ impl PersistedState {
 
     pub fn mark_failed(&mut self, message: impl Into<String>) {
         self.status = UpdateStatus::Failed;
+        self.install_transaction = None;
         self.error_message = Some(message.into());
         self.waiting_for_app_exit_auto_install = false;
         self.install_auth_blocked_package_sha256 = None;
@@ -160,7 +195,6 @@ impl PersistedState {
     pub fn clear_install_auth_retry_block(&mut self) {
         self.install_auth_blocked_package_sha256 = None;
     }
-
 }
 
 #[cfg(test)]
@@ -171,18 +205,24 @@ mod tests {
     fn legacy_v1_candidate_is_reset_but_rollback_is_preserved() -> Result<()> {
         let dir = tempfile::tempdir()?;
         let state_path = dir.path().join("state.json");
-        fs::write(&state_path, r#"{
+        fs::write(
+            &state_path,
+            r#"{
           "installed_version":"1.2.3",
           "candidate_version":"legacy",
           "status":"ready_to_install",
           "artifact_paths":{"legacy_source_path":"/tmp/legacy-upstream","rollback_package_path":"/tmp/good.deb"},
           "last_known_good_version":"1.2.2"
-        }"#)?;
+        }"#,
+        )?;
         let state = PersistedState::load_or_default(&state_path, true)?;
         assert_eq!(state.schema_version, 2);
         assert_eq!(state.candidate_version, None);
         assert_eq!(state.installed_version, "1.2.3");
-        assert_eq!(state.artifact_paths.rollback_package_path, Some(PathBuf::from("/tmp/good.deb")));
+        assert_eq!(
+            state.artifact_paths.rollback_package_path,
+            Some(PathBuf::from("/tmp/good.deb"))
+        );
         Ok(())
     }
 

--- a/updater/src/state.rs
+++ b/updater/src/state.rs
@@ -5,14 +5,21 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::{
     fs,
+    io::Write,
     os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
 };
+
+const LEGACY_INSTALL_RECOVERY_MESSAGE: &str = "Interrupted package operation lacks a reboot-safe process identity; it was not auto-reconciled. Confirm no package manager is running, then explicitly retry the interrupted update or rollback";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProcessIdentity {
     pub pid: u32,
     pub start_time_ticks: u64,
+    /// The kernel boot identity prevents a PID/start-time pair from being
+    /// mistaken for the same process after a reboot.
+    #[serde(default)]
+    pub boot_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -72,6 +79,10 @@ pub struct PersistedState {
     pub candidate_repository_path: Option<String>,
     pub upstream_package_sha256: Option<String>,
     pub status: UpdateStatus,
+    /// An interrupted transaction was not safe to reconcile automatically.
+    /// Only an explicit install-ready or rollback command may clear this
+    /// barrier after the user confirms that no package manager is running.
+    pub manual_recovery_required: bool,
     pub install_transaction: Option<InstallTransaction>,
     pub last_check_at: Option<DateTime<Utc>>,
     pub last_successful_check_at: Option<DateTime<Utc>>,
@@ -97,7 +108,7 @@ impl Default for PersistedState {
 impl PersistedState {
     pub fn new(auto_install_on_app_exit: bool) -> Self {
         Self {
-            schema_version: 2,
+            schema_version: 3,
             installed_version: "unknown".into(),
             installed_upstream_version: None,
             installed_upstream_sha256: None,
@@ -106,6 +117,7 @@ impl PersistedState {
             candidate_repository_path: None,
             upstream_package_sha256: None,
             status: UpdateStatus::Idle,
+            manual_recovery_required: false,
             install_transaction: None,
             last_check_at: None,
             last_successful_check_at: None,
@@ -159,8 +171,30 @@ impl PersistedState {
         }
 
         let mut state: Self = serde_json::from_value(raw)?;
-        state.schema_version = 2;
+        let needs_manual_install_recovery = state.status == UpdateStatus::Installing
+            && state
+                .install_transaction
+                .as_ref()
+                .is_some_and(|transaction| {
+                    transaction
+                        .package_command
+                        .as_ref()
+                        .is_some_and(|owner| owner.boot_id.is_none())
+                });
+        state.schema_version = 3;
         state.auto_install_on_app_exit = auto_install;
+        if needs_manual_install_recovery {
+            // Schema 2 persisted only PID/start-time. That pair cannot prove
+            // ownership after a reboot, so never auto-reconcile it. Preserve
+            // the candidate and rollback facts while requiring an explicit
+            // user-confirmed retry instead of leaving the updater blocked in
+            // Installing forever.
+            state.mark_manual_recovery_required(LEGACY_INSTALL_RECOVERY_MESSAGE);
+            // Persist the migration while the old transaction shape is still
+            // in hand. Automatic callers must not repeatedly rediscover a
+            // schema-2 owner that can never be classified safely.
+            state.save_updater(path)?;
+        }
         Ok(state)
     }
 
@@ -168,19 +202,39 @@ impl PersistedState {
         let parent = path.parent().context("state path has no parent")?;
         fs::create_dir_all(parent)?;
         let temp = parent.join(format!(".state-{}.tmp", std::process::id()));
-        fs::write(&temp, format!("{}\n", serde_json::to_string_pretty(self)?))?;
+        let contents = format!("{}\n", serde_json::to_string_pretty(self)?);
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&temp)?;
+        file.write_all(contents.as_bytes())?;
         fs::set_permissions(&temp, fs::Permissions::from_mode(0o600))?;
+        // The transaction owner must be durable before the caller releases a
+        // gated package command. A rename alone only updates the namespace;
+        // it does not order the file contents against a power loss.
+        file.sync_all()?;
+        drop(file);
         fs::rename(&temp, path)?;
+        // The directory entry for the atomic rename is also part of the
+        // recovery journal and must be durable before mutation is released.
+        fs::File::open(parent)?.sync_all()?;
         Ok(())
     }
 
     pub fn mark_failed(&mut self, message: impl Into<String>) {
         self.status = UpdateStatus::Failed;
+        self.manual_recovery_required = false;
         self.install_transaction = None;
         self.error_message = Some(message.into());
         self.waiting_for_app_exit_auto_install = false;
         self.install_auth_blocked_package_sha256 = None;
         self.install_after_app_exit_requested = false;
+    }
+
+    pub fn mark_manual_recovery_required(&mut self, message: impl Into<String>) {
+        self.mark_failed(message);
+        self.manual_recovery_required = true;
     }
 
     pub fn install_auth_retry_is_blocked(&self) -> bool {
@@ -216,7 +270,7 @@ mod tests {
         }"#,
         )?;
         let state = PersistedState::load_or_default(&state_path, true)?;
-        assert_eq!(state.schema_version, 2);
+        assert_eq!(state.schema_version, 3);
         assert_eq!(state.candidate_version, None);
         assert_eq!(state.installed_version, "1.2.3");
         assert_eq!(
@@ -254,6 +308,73 @@ mod tests {
         state.save_updater(&state_path)?;
         let loaded = PersistedState::load_or_default(&state_path, true)?;
         assert!(loaded.install_auth_retry_is_blocked());
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_active_install_is_migrated_to_manual_recovery() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state_path = dir.path().join("state.json");
+        fs::write(
+            &state_path,
+            r#"{
+          "schema_version":2,
+          "installed_version":"2026.09.05-1",
+          "candidate_version":"2026.09.06",
+          "upstream_package_sha256":"candidate-sha",
+          "status":"installing",
+          "artifact_paths":{
+            "package_path":"/tmp/candidate.deb",
+            "rollback_package_path":"/tmp/known-good.deb"
+          },
+          "install_transaction":{
+            "package_path":"/tmp/candidate.deb",
+            "package_sha256":"package-sha",
+            "package_command":{"pid":4242,"start_time_ticks":1234},
+            "started_at":"2026-01-01T00:00:00Z",
+            "operation":"update"
+          }
+        }"#,
+        )?;
+
+        let state = PersistedState::load_or_default(&state_path, true)?;
+        assert_eq!(state.schema_version, 3);
+        assert_eq!(state.status, UpdateStatus::Failed);
+        assert!(state.manual_recovery_required);
+        assert!(state.install_transaction.is_none());
+        assert_eq!(state.candidate_version.as_deref(), Some("2026.09.06"));
+        assert_eq!(
+            state.artifact_paths.rollback_package_path,
+            Some(PathBuf::from("/tmp/known-good.deb"))
+        );
+        assert!(state
+            .error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("reboot-safe process identity")));
+
+        let on_disk: serde_json::Value = serde_json::from_str(&fs::read_to_string(&state_path)?)?;
+        assert_eq!(
+            on_disk
+                .get("schema_version")
+                .and_then(|value| value.as_u64()),
+            Some(3)
+        );
+        assert_eq!(
+            on_disk
+                .get("manual_recovery_required")
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+
+        state.save_updater(&state_path)?;
+        let persisted = PersistedState::load_or_default(&state_path, true)?;
+        assert_eq!(persisted.status, UpdateStatus::Failed);
+        assert!(persisted.manual_recovery_required);
+        assert!(persisted.install_transaction.is_none());
+        assert_eq!(
+            persisted.artifact_paths.rollback_package_path,
+            Some(PathBuf::from("/tmp/known-good.deb"))
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

During updater-initiated Debian upgrades, `prerm` stopped `codex-update-manager.service` while it owned the apt/dpkg transaction. That left stale `(deleted)` binaries and caused retry loops.

## Solution

- `prerm upgrade` now leaves the updater service running; `remove` and `deconfigure` cleanup is unchanged.
- Install/rollback journaling is durable and ownership-aware, including boot-ID identity, bounded abandoned recovery, schema-2 manual migration, and `Installed` save/readback before replacement restart.
- Debian, RPM, and pacman recovery require verified package evidence; RPM verification uses `rpm -V --noscripts`.
- Public recovery documentation is updated. Advisory lockfile refreshes are isolated in a separate commit.

## Scope

Updater/package lifecycle for signed official Linux package `26.908.40834` on amd64 and arm64: Debian, RPM, pacman, candidate promotion, and rollback. No core ASAR or enabled-feature behavior changed.

## Validation

- CI green: source/Node, Rust, signed baseline amd64/arm64, Dock-icon feature, package matrix amd64/arm64, Nix x86_64/aarch64, Nix VM, watchdog, and release gates.
- `cargo test -p codex-update-manager --locked -- --test-threads=1`: 106 passed; workspace tests and updater Clippy passed.
- `cargo audit --no-fetch --deny warnings`: root and optional lockfiles clean.
- Shell/Node checks passed: `scripts_smoke.sh` 75 passed; broad Node suite 916 passed, 1 intentional skip.
- Fedora amd64 RPM and Arch amd64 pacman build/install/verify/remove passed; Fedora arm64 smoke passed.

## Limitations

- Arch arm64 native package validation was unavailable because the pinned Arch image has no arm64 manifest.
- One host-Wayland fixture is environment-sensitive; neutral-X11 and CI pass.