### PR TITLE
fix(bootstrap): skip pacman upgrade when dependencies exist

### DIFF
--- a/.github/workflows/install-deps.yml
+++ b/.github/workflows/install-deps.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - install.sh
       - scripts/install-deps.sh
+      - scripts/lib/install-deps-rust.sh
       - tests/install_deps_pacman_rust_matrix.sh
       - packaging/linux/control
       - .github/workflows/install-deps.yml
@@ -14,6 +15,7 @@ on:
     paths:
       - install.sh
       - scripts/install-deps.sh
+      - scripts/lib/install-deps-rust.sh
       - tests/install_deps_pacman_rust_matrix.sh
       - packaging/linux/control
       - .github/workflows/install-deps.yml

--- a/scripts/ci/github-actions-workflows.test.js
+++ b/scripts/ci/github-actions-workflows.test.js
@@ -116,6 +116,7 @@ test("official Linux validation runs fully on every pull request but not hourly"
 
 test("install-deps workflow covers apt and pacman Rust bootstrap", () => {
   const workflow = read(".github/workflows/install-deps.yml");
+  assert.match(workflow, /^      - scripts\/lib\/install-deps-rust\.sh$/m);
   assert.match(workflow, /^      - tests\/install_deps_pacman_rust_matrix\.sh$/m);
 
   const apt = job(workflow, "apt-node-bootstrap");

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -4,6 +4,8 @@ set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/linux-target-detect.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/install-deps-rust.sh"
 
 run_privileged() {
     if [ "$(id -u)" -eq 0 ]; then
@@ -86,18 +88,26 @@ install_zypper() {
 }
 
 install_pacman() {
-    local rust_packages=()
+    local -a packages=(
+        base-devel ca-certificates curl dpkg git gnupg nodejs npm python
+        tar unzip util-linux xz zstd
+    )
+    local rust_package
 
     # Match bootstrap-native's Rust resolution order. A user-local rustup
     # proxy can shadow a working distro Cargo once $HOME/.cargo/bin is
     # prepended for the native build.
-    if ! cargo_works_for_build && ! rustup_available_for_build; then
-        rust_packages=(rustup)
+    rust_package="$(PATH="$(build_path)" pacman_rust_bootstrap_package)"
+    if [ -n "$rust_package" ]; then
+        packages+=("$rust_package")
     fi
 
-    run_privileged pacman -Syu --noconfirm --needed base-devel ca-certificates \
-        curl dpkg git gnupg nodejs npm python "${rust_packages[@]}" \
-        tar unzip util-linux xz zstd
+    if pacman_dependencies_installed "${packages[@]}"; then
+        info 'pacman dependencies already installed; skipping system upgrade.'
+        return 0
+    fi
+
+    run_privileged pacman -Syu --noconfirm --needed "${packages[@]}"
 }
 
 install_rust() {

--- a/scripts/lib/install-deps-rust.sh
+++ b/scripts/lib/install-deps-rust.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+pacman_rust_bootstrap_package() {
+    # Arch's rust and rustup packages conflict. Preserve whichever provider is
+    # already installed (or available in the user's PATH) instead of forcing a
+    # switch during the required full-system upgrade.
+    if cargo --version >/dev/null 2>&1 || command -v rustup >/dev/null 2>&1; then
+        return 0
+    fi
+    printf '%s\n' rustup
+}
+
+pacman_dependencies_installed() {
+    pacman -T "$@" >/dev/null 2>&1
+}

--- a/tests/install_deps_pacman_rust_matrix.sh
+++ b/tests/install_deps_pacman_rust_matrix.sh
@@ -58,6 +58,33 @@ run_install_deps() {
     (cd "$REPO_DIR" && bash scripts/install-deps.sh)
 }
 
+assert_ready_host_skips_pacman_transaction() {
+    local wrapper_dir
+    local pacman_log
+
+    wrapper_dir="$(mktemp -d)"
+    pacman_log="$wrapper_dir/pacman.log"
+    cat >"$wrapper_dir/pacman" <<'EOF'
+#!/bin/bash
+printf '%q ' "$@" >>"$CODEX_TEST_PACMAN_LOG"
+printf '\n' >>"$CODEX_TEST_PACMAN_LOG"
+exec /usr/bin/pacman "$@"
+EOF
+    chmod +x "$wrapper_dir/pacman"
+
+    CODEX_TEST_PACMAN_LOG="$pacman_log" \
+        PATH="$wrapper_dir:$PATH" \
+        run_install_deps
+
+    grep -q '^-T ' "$pacman_log" ||
+        fail 'expected the ready-host dependency probe'
+    if grep -q '^-S' "$pacman_log"; then
+        fail 'ready host must not start a pacman install or upgrade transaction'
+    fi
+
+    rm -rf "$wrapper_dir"
+}
+
 verify_build_rust() {
     assert_succeeds with_build_path cargo --version
     assert_succeeds with_build_path rustc --version
@@ -71,6 +98,7 @@ case_working_distro_cargo() {
     assert_succeeds with_build_path cargo --version
     run_install_deps
     verify_build_rust
+    assert_ready_host_skips_pacman_transaction
     pacman_package_installed rust || fail 'expected pacman rust to remain installed'
     ! pacman_package_installed rustup || fail 'did not expect pacman rustup with distro rust'
 }


### PR DESCRIPTION
## Summary

Fixes #1432.

@ilysenko, please review and merge this focused fix.

- Probe the complete pacman dependency set before entering a privileged package transaction.
- Skip `pacman -Syu` only when every required dependency and a usable Rust provider are already present.
- Preserve the existing full-system upgrade and conditional `rustup` bootstrap whenever a dependency is missing.
- Extend the Arch Rust-state matrix with an instrumented ready-host regression and keep the install-deps workflow path filters in sync.

User-visible behavior: `bash scripts/install-deps.sh` and `make bootstrap-native` no longer fail on an otherwise build-ready Arch-family host because of an unrelated system-upgrade conflict. Apt, DNF, and Zypper paths are unchanged. The pacman logic is architecture-independent; the native reproduction and package build were on x86_64, while arm64 was not tested manually.

## Validation

- `bash scripts/install-deps.sh` — passed on CachyOS; reported that dependencies were already installed and did not start a pacman transaction.
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template tests/install_deps_pacman_rust_matrix.sh` — passed.
- `node --test scripts/ci/github-actions-workflows.test.js` — passed.
- `bash tests/scripts_smoke.sh` — passed.
- `CI_SKIP_PULL=1 ./scripts/ci-local.sh install-deps` — passed for Ubuntu 22.04, Ubuntu 24.04, Debian 12, and all four Arch Rust states.
- `CI_SKIP_PULL=1 ./scripts/ci-local.sh core` — passed.
- `make build-app` — built the signed stable `chatgpt` 26.901.41600 payload with no enabled ASAR features.
- `make pacman` — built `codex-desktop-2026.09.05.042520-1-x86_64.pkg.tar.zst` with the updater.
- `git diff --check upstream/main...HEAD` — passed.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest signed stable OpenAI Linux package and removes obsolete fallback code and tests. (Not an upstream-drift change.)
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
