### PR TITLE
fix(launcher): select the Wayland backend on Wayland sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Wayland sessions again start the app on a native Wayland surface. The
+  launcher appends `--ozone-platform=wayland` when `WAYLAND_DISPLAY` names a
+  live compositor socket, the session is not X11, Sommelier is absent, and no
+  command-line argument, flag file, feature argument, or launcher hook already
+  selects a backend. The runtime otherwise defaults to X11, so compositors that
+  do not scale XWayland clients drew the window at 1x on a HiDPI output.
 - Lifecycle hooks now use exported application paths without interpreting
   desktop arguments or deep-link URIs as launcher context. After-exit hooks
   receive the Electron status and cannot replace it when cleanup fails; the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Wayland sessions again start the app on a native Wayland surface. The
   launcher appends `--ozone-platform=wayland` when `WAYLAND_DISPLAY` names a
-  live compositor socket, the session is not X11, Sommelier is absent, and no
-  command-line argument, flag file, feature argument, or launcher hook already
-  selects a backend. The runtime otherwise defaults to X11, so compositors that
-  do not scale XWayland clients drew the window at 1x on a HiDPI output.
+  live compositor socket, the session is not X11, and no command-line argument,
+  flag file, feature argument, or launcher hook already selects a backend.
+  ChromeOS Crostini, GNOME Wayland with several monitors, and WSLg keep the X11
+  default, and `CODEX_OZONE_PLATFORM=x11|wayland` pins a backend ahead of the
+  detection; the Nix wrapper sets `x11` so `NIXOS_OZONE_WL` remains its opt-in.
+  The runtime otherwise defaults to X11, so compositors that do not scale
+  XWayland clients drew the window at 1x on a HiDPI output.
 - Lifecycle hooks now use exported application paths without interpreting
   desktop arguments or deep-link URIs as launcher context. After-exit hooks
   receive the Electron status and cannot replace it when cleanup fails; the

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ output layout, parallelism, and payload inspection.
 | Browser/Chrome extension cannot connect after migration | Exit ChatGPT and Chrome completely, then follow the narrow cache repair in [Troubleshooting](docs/troubleshooting.md#browser-or-chrome-plugin-is-visible-but-cannot-connect) |
 | Signature or package verification fails | Do not bypass it; check time, network, `gpgv`, architecture, and disk space |
 | App does not launch | Run `/opt/codex-desktop/start.sh --diagnose` |
-| App uses XWayland or needs persistent Electron flags | A confirmed Wayland session selects the native backend automatically; to override, put one flag per line in `~/.config/codex-desktop/electron-flags.conf`, for example `--ozone-platform=x11` |
+| App uses XWayland or needs persistent Electron flags | A confirmed Wayland session selects the native backend automatically; pin one with `CODEX_OZONE_PLATFORM=x11\|wayland`, or put one flag per line in `~/.config/codex-desktop/electron-flags.conf`, for example `--ozone-platform=x11` |
 | AppImage reports a sandbox error | Enable user namespaces or install a native package; `--no-sandbox` is not added automatically |
 | Enabled feature drifts after an upstream release | Disable that feature to confirm the clean baseline and attach its patch report to an issue |
 | Updater waits for application exit | Close official and Community processes, then inspect `codex-update-manager status --json` |

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ output layout, parallelism, and payload inspection.
 | Browser/Chrome extension cannot connect after migration | Exit ChatGPT and Chrome completely, then follow the narrow cache repair in [Troubleshooting](docs/troubleshooting.md#browser-or-chrome-plugin-is-visible-but-cannot-connect) |
 | Signature or package verification fails | Do not bypass it; check time, network, `gpgv`, architecture, and disk space |
 | App does not launch | Run `/opt/codex-desktop/start.sh --diagnose` |
-| App uses XWayland or needs persistent Electron flags | Put one flag per line in `~/.config/codex-desktop/electron-flags.conf`; for example, `--ozone-platform=wayland` |
+| App uses XWayland or needs persistent Electron flags | A confirmed Wayland session selects the native backend automatically; to override, put one flag per line in `~/.config/codex-desktop/electron-flags.conf`, for example `--ozone-platform=x11` |
 | AppImage reports a sandbox error | Enable user namespaces or install a native package; `--no-sandbox` is not added automatically |
 | Enabled feature drifts after an upstream release | Disable that feature to confirm the clean baseline and attach its patch report to an issue |
 | Updater waits for application exit | Close official and Community processes, then inspect `codex-update-manager status --json` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -327,7 +327,7 @@ make appimage
 | 迁移后 Browser/Chrome extension 无法连接 | 完全退出 ChatGPT 与 Chrome，再按[故障排除](docs/troubleshooting.md#browser-or-chrome-plugin-is-visible-but-cannot-connect)执行窄范围 cache repair |
 | 签名或软件包验证失败 | 不要绕过；检查系统时间、网络、`gpgv`、architecture 和磁盘空间 |
 | 应用无法启动 | 运行 `/opt/codex-desktop/start.sh --diagnose` |
-| 应用使用 XWayland，或需要持久化 Electron 参数 | 确认为 Wayland 会话时会自动选择原生后端；如需覆盖，请在 `~/.config/codex-desktop/electron-flags.conf` 中每行写一个参数，例如 `--ozone-platform=x11` |
+| 应用使用 XWayland，或需要持久化 Electron 参数 | 确认为 Wayland 会话时会自动选择原生后端；可用 `CODEX_OZONE_PLATFORM=x11\|wayland` 固定后端，或在 `~/.config/codex-desktop/electron-flags.conf` 中每行写一个参数，例如 `--ozone-platform=x11` |
 | AppImage 报 sandbox 错误 | 启用 user namespaces 或安装原生包；不会自动添加 `--no-sandbox` |
 | 上游更新后启用扩展发生 drift | 禁用该扩展确认 clean baseline，并在 issue 中附上 patch report |
 | updater 等待应用退出 | 关闭官方与 Community 进程，检查 `codex-update-manager status --json` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -327,7 +327,7 @@ make appimage
 | 迁移后 Browser/Chrome extension 无法连接 | 完全退出 ChatGPT 与 Chrome，再按[故障排除](docs/troubleshooting.md#browser-or-chrome-plugin-is-visible-but-cannot-connect)执行窄范围 cache repair |
 | 签名或软件包验证失败 | 不要绕过；检查系统时间、网络、`gpgv`、architecture 和磁盘空间 |
 | 应用无法启动 | 运行 `/opt/codex-desktop/start.sh --diagnose` |
-| 应用使用 XWayland，或需要持久化 Electron 参数 | 在 `~/.config/codex-desktop/electron-flags.conf` 中每行写一个参数，例如 `--ozone-platform=wayland` |
+| 应用使用 XWayland，或需要持久化 Electron 参数 | 确认为 Wayland 会话时会自动选择原生后端；如需覆盖，请在 `~/.config/codex-desktop/electron-flags.conf` 中每行写一个参数，例如 `--ozone-platform=x11` |
 | AppImage 报 sandbox 错误 | 启用 user namespaces 或安装原生包；不会自动添加 `--no-sandbox` |
 | 上游更新后启用扩展发生 drift | 禁用该扩展确认 clean baseline，并在 issue 中附上 patch report |
 | updater 等待应用退出 | 关闭官方与 Community 进程，检查 `codex-update-manager status --json` |

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -112,7 +112,9 @@ The NixOS module uses the same option namespace:
 
 The Nix package follows the standard `NIXOS_OZONE_WL` convention. When both
 `NIXOS_OZONE_WL` and `WAYLAND_DISPLAY` are set, its wrapper starts Electron with
-native Wayland rendering and text-input-v3 IME support.
+native Wayland rendering and text-input-v3 IME support. Otherwise the wrapper
+sets `CODEX_OZONE_PLATFORM=x11` so the generic launcher's Wayland-session
+detection does not select the backend behind that opt-in.
 
 On NixOS the launcher includes a package-local Bubblewrap adapter on `PATH` for
 the Codex Linux command sandbox. The adapter preserves the sandbox policy and

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,7 +52,8 @@ The official Electron runtime defaults to the X11 Ozone backend, so without a
 flag a Wayland session runs the app through XWayland, and a compositor whose
 XWayland does not scale clients draws the window at 1x on a HiDPI output. The
 launcher therefore appends `--ozone-platform=wayland` when `WAYLAND_DISPLAY`
-names a live compositor socket and the session is not X11. That switch has no
+names a compositor socket with a listener (checked through `ss` where iproute2
+is available) and the session is not X11. That switch has no
 fallback, which is why the socket is confirmed first, and sessions known to
 misbehave on the Wayland backend keep the X11 default: ChromeOS Crostini
 (Sommelier, read from the environment or the systemd user manager), GNOME

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -48,11 +48,21 @@ with `#` are ignored. App-specific flags are followed by enabled feature flags
 and explicit command-line arguments, so a later explicit argument can override
 an earlier setting.
 
-To force native Wayland rendering without editing a generated desktop entry:
+The official Electron runtime defaults to the X11 Ozone backend, so without a
+flag a Wayland session runs the app through XWayland, and a compositor whose
+XWayland does not scale clients draws the window at 1x on a HiDPI output. The
+launcher therefore appends `--ozone-platform=wayland` when `WAYLAND_DISPLAY`
+names a live compositor socket, the session is not X11, and Sommelier is not
+present. That switch has no fallback, which is why the socket is confirmed
+first. Any explicit selection wins: a command-line argument, either flag file, a
+feature argument, or a launcher hook. This runtime does not accept
+`--ozone-platform-hint` or `ELECTRON_OZONE_PLATFORM_HINT`.
+
+To pin a backend without editing a generated desktop entry:
 
 ```bash
 mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/codex-desktop"
-printf '%s\n' '--ozone-platform=wayland' > \
+printf '%s\n' '--ozone-platform=x11' > \
   "${XDG_CONFIG_HOME:-$HOME/.config}/codex-desktop/electron-flags.conf"
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,13 +52,19 @@ The official Electron runtime defaults to the X11 Ozone backend, so without a
 flag a Wayland session runs the app through XWayland, and a compositor whose
 XWayland does not scale clients draws the window at 1x on a HiDPI output. The
 launcher therefore appends `--ozone-platform=wayland` when `WAYLAND_DISPLAY`
-names a live compositor socket, the session is not X11, and Sommelier is not
-present. That switch has no fallback, which is why the socket is confirmed
-first. Any explicit selection wins: a command-line argument, either flag file, a
-feature argument, or a launcher hook. This runtime does not accept
-`--ozone-platform-hint` or `ELECTRON_OZONE_PLATFORM_HINT`.
+names a live compositor socket and the session is not X11. That switch has no
+fallback, which is why the socket is confirmed first, and sessions known to
+misbehave on the Wayland backend keep the X11 default: ChromeOS Crostini
+(Sommelier, read from the environment or the systemd user manager), GNOME
+Wayland with more than one connected monitor, and WSLg. Any explicit selection
+wins: a command-line argument, either flag file, a feature argument, or a
+launcher hook. This runtime does not accept `--ozone-platform-hint` or
+`ELECTRON_OZONE_PLATFORM_HINT`.
 
-To pin a backend without editing a generated desktop entry:
+`CODEX_OZONE_PLATFORM=x11` or `CODEX_OZONE_PLATFORM=wayland` pins a backend
+ahead of that detection while still yielding to an explicit flag; the Nix
+wrapper sets `x11` so its `NIXOS_OZONE_WL` opt-in stays authoritative. To pin a
+backend for every launch without editing a generated desktop entry:
 
 ```bash
 mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/codex-desktop"

--- a/flake.nix
+++ b/flake.nix
@@ -553,6 +553,7 @@
               makeWrapper "${nixRuntimeLauncher}" "$out/bin/codex-desktop" \
                 --prefix PATH : "${runtimePathFor effectiveFeatureIds}" \
                 --set-default ALSA_PLUGIN_DIR "${pkgs.pipewire}/lib/alsa-lib" \
+                --set-default CODEX_OZONE_PLATFORM x11 \
                 --run 'export XDG_DATA_DIRS="''${XDG_DATA_DIRS:-${xdgDefaultDataDirs}}"' \
                 --prefix XDG_DATA_DIRS : "${gsettingsSchemaDataDirs}" \
                 --set-default BAMF_DESKTOP_FILE_HINT "$out/share/applications/codex-desktop.desktop" \
@@ -611,6 +612,7 @@
           export XDG_DATA_DIRS="${gsettingsSchemaDataDirs}:''${XDG_DATA_DIRS:-${xdgDefaultDataDirs}}"
           export CODEX_CLI_PATH="''${CODEX_CLI_PATH:-$app_dir/resources/codex}"
           export BAMF_DESKTOP_FILE_HINT="''${BAMF_DESKTOP_FILE_HINT:-$app_dir/.codex-linux/codex-desktop.desktop}"
+          export CODEX_OZONE_PLATFORM="''${CODEX_OZONE_PLATFORM:-x11}"
           extra_flags=()
           if [[ -n "''${NIXOS_OZONE_WL-}" && -n "''${WAYLAND_DISPLAY-}" ]]; then
             extra_flags+=(
@@ -847,6 +849,7 @@
                 printf 'bwrap=%s\n' "$(command -v bwrap || true)"
                 printf 'ld=%s:%s\n' "''${LD_LIBRARY_PATH+x}" "''${LD_LIBRARY_PATH-}"
                 printf 'bamf=%s\n' "''${BAMF_DESKTOP_FILE_HINT-}"
+                printf 'ozone=%s\n' "''${CODEX_OZONE_PLATFORM-}"
                 printf 'args='
                 printf '<%s>' "$@"
                 printf '\n'
@@ -871,6 +874,7 @@
             "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'ld=:' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'bamf=${package}/share/applications/codex-desktop.desktop' "$capture"
+          ${pkgs.gnugrep}/bin/grep -Fx 'ozone=x11' "$capture"
           ${pkgs.gnugrep}/bin/grep -Fx 'args=<--diagnose>' "$capture"
           ${pkgs.coreutils}/bin/env -u WAYLAND_DISPLAY NIXOS_OZONE_WL=1 \
             BASH_ENV=${wrapperEnvironmentProbe} CODEX_NIX_ENV_CAPTURE="$capture" \

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -207,11 +207,14 @@ load_user_electron_args() {
     load_user_electron_args_file "$config_home/$CODEX_LINUX_APP_ID/electron-flags.conf"
 }
 
+# Only --ozone-platform counts as a selection. This runtime ignores
+# --ozone-platform-hint, so a leftover hint in a flags file must not keep a
+# session on XWayland.
 ozone_switch_present() {
     local arg
     for arg in "$@"; do
         case "$arg" in
-            --ozone-platform|--ozone-platform=*|--ozone-platform-hint|--ozone-platform-hint=*)
+            --ozone-platform|--ozone-platform=*)
                 return 0
                 ;;
         esac

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -207,6 +207,53 @@ load_user_electron_args() {
     load_user_electron_args_file "$config_home/$CODEX_LINUX_APP_ID/electron-flags.conf"
 }
 
+ozone_switch_present() {
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            --ozone-platform|--ozone-platform=*|--ozone-platform-hint|--ozone-platform-hint=*)
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+wayland_socket_present() {
+    local socket="${WAYLAND_DISPLAY:-}"
+    local runtime_dir="${XDG_RUNTIME_DIR:-}"
+
+    [ -n "$socket" ] || return 1
+    case "$socket" in
+        /*) ;;
+        *)
+            [ -n "$runtime_dir" ] || return 1
+            socket="$runtime_dir/$socket"
+            ;;
+    esac
+    [ -S "$socket" ] || return 1
+}
+
+# The official Electron runtime defaults to the X11 Ozone backend, so a Wayland
+# session runs the app through XWayland and a compositor whose XWayland does not
+# scale clients draws the window at 1x on a HiDPI output. `--ozone-platform` is
+# the only backend switch this runtime accepts: it carries no fallback, so the
+# session is confirmed through a live compositor socket before selecting it.
+append_wayland_ozone_platform() {
+    [ "${XDG_SESSION_TYPE:-}" != "x11" ] || return 0
+    wayland_socket_present || return 0
+    # On ChromeOS Crostini, Sommelier exports WAYLAND_DISPLAY, but an Electron
+    # Wayland window reaches ready-to-show without ever surfacing in the
+    # ChromeOS shell. Leave those sessions on the working X11 default; see
+    # https://github.com/ilysenko/codex-desktop-linux/issues/95.
+    if [ -n "${SOMMELIER_VERSION:-}" ] || [ -n "${SOMMELIER_VM_IDENTIFIER:-}" ]; then
+        return 0
+    fi
+    if ! ozone_switch_present "${ELECTRON_ARGS[@]}" "${ORIGINAL_ARGS[@]}"; then
+        ELECTRON_ARGS+=("--ozone-platform=wayland")
+    fi
+}
+
 run_launcher_hooks() {
     local hook
     local output
@@ -250,6 +297,7 @@ load_user_electron_args
 load_electron_args
 run_hook_directory "$HOOK_ROOT/prelaunch.d" prelaunch
 run_launcher_hooks "${ELECTRON_ARGS[@]}" "${ORIGINAL_ARGS[@]}"
+append_wayland_ozone_platform
 
 if [ -f "$HOOK_ROOT/codex-packaged-runtime.sh" ]; then
     # shellcheck disable=SC1091

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -234,24 +234,81 @@ wayland_socket_present() {
     [ -S "$socket" ] || return 1
 }
 
-# The official Electron runtime defaults to the X11 Ozone backend, so a Wayland
-# session runs the app through XWayland and a compositor whose XWayland does not
-# scale clients draws the window at 1x on a HiDPI output. `--ozone-platform` is
-# the only backend switch this runtime accepts: it carries no fallback, so the
-# session is confirmed through a live compositor socket before selecting it.
-append_wayland_ozone_platform() {
-    [ "${XDG_SESSION_TYPE:-}" != "x11" ] || return 0
-    wayland_socket_present || return 0
-    # On ChromeOS Crostini, Sommelier exports WAYLAND_DISPLAY, but an Electron
-    # Wayland window reaches ready-to-show without ever surfacing in the
-    # ChromeOS shell. Leave those sessions on the working X11 default; see
-    # https://github.com/ilysenko/codex-desktop-linux/issues/95.
+# ChromeOS Crostini: Sommelier exports WAYLAND_DISPLAY, but an Electron Wayland
+# window reaches ready-to-show without ever surfacing in the ChromeOS shell
+# (https://github.com/ilysenko/codex-desktop-linux/issues/95). App-menu
+# launches inherit WAYLAND_DISPLAY while the Sommelier markers exist only in
+# the systemd user manager, so that environment is consulted as well.
+sommelier_detected() {
+    local manager_environment
+
     if [ -n "${SOMMELIER_VERSION:-}" ] || [ -n "${SOMMELIER_VM_IDENTIFIER:-}" ]; then
         return 0
     fi
-    if ! ozone_switch_present "${ELECTRON_ARGS[@]}" "${ORIGINAL_ARGS[@]}"; then
-        ELECTRON_ARGS+=("--ozone-platform=wayland")
+    command -v systemctl >/dev/null 2>&1 || return 1
+    manager_environment="$(systemctl --user show-environment 2>/dev/null)" || return 1
+    grep -Eq '^SOMMELIER_(VERSION|VM_IDENTIFIER)=' <<< "$manager_environment"
+}
+
+# GNOME Wayland with several monitors rescaled and resized maximized Electron
+# windows whenever pointer focus crossed displays; XWayland stays stable there.
+gnome_wayland_multi_monitor_detected() {
+    local drm_root="${CODEX_DRM_CLASS_ROOT:-/sys/class/drm}"
+    local status_file
+    local status
+    local connected=0
+
+    case "${XDG_CURRENT_DESKTOP:-}:${XDG_SESSION_DESKTOP:-}:${DESKTOP_SESSION:-}" in
+        *GNOME*|*gnome*) ;;
+        *) return 1 ;;
+    esac
+    for status_file in "$drm_root"/*/status; do
+        [ -f "$status_file" ] || continue
+        IFS= read -r status < "$status_file" || continue
+        if [ "$status" = "connected" ]; then
+            connected=$((connected + 1))
+        fi
+    done
+    [ "$connected" -gt 1 ]
+}
+
+# WSLg publishes a Wayland socket, but Electron renders reliably there only on
+# the X11 path.
+wslg_detected() {
+    [ -e /mnt/wslg ]
+}
+
+# The official Electron runtime defaults to the X11 Ozone backend, so a Wayland
+# session runs the app through XWayland and a compositor whose XWayland does not
+# scale clients draws the window at 1x on a HiDPI output. `--ozone-platform` is
+# the only backend switch this runtime accepts and it carries no fallback, so a
+# Wayland session is confirmed through a live compositor socket first and the
+# sessions known to break on that backend keep the X11 default. Explicit
+# selections always win: command-line arguments, both flag files, feature
+# arguments, and launcher hooks. CODEX_OZONE_PLATFORM=x11|wayland pins a backend
+# when none of those did; packaging wrappers use it to keep their own policy.
+append_ozone_platform() {
+    local requested="${CODEX_OZONE_PLATFORM:-auto}"
+
+    if ozone_switch_present "${ELECTRON_ARGS[@]}" "${ORIGINAL_ARGS[@]}"; then
+        return 0
     fi
+    case "$requested" in
+        x11|wayland)
+            ELECTRON_ARGS+=("--ozone-platform=$requested")
+            return 0
+            ;;
+        auto) ;;
+        *)
+            printf 'Ignoring CODEX_OZONE_PLATFORM=%s; expected auto, x11, or wayland\n' "$requested" >&2
+            ;;
+    esac
+    [ "${XDG_SESSION_TYPE:-}" != "x11" ] || return 0
+    wayland_socket_present || return 0
+    if sommelier_detected || gnome_wayland_multi_monitor_detected || wslg_detected; then
+        return 0
+    fi
+    ELECTRON_ARGS+=("--ozone-platform=wayland")
 }
 
 run_launcher_hooks() {
@@ -297,7 +354,7 @@ load_user_electron_args
 load_electron_args
 run_hook_directory "$HOOK_ROOT/prelaunch.d" prelaunch
 run_launcher_hooks "${ELECTRON_ARGS[@]}" "${ORIGINAL_ARGS[@]}"
-append_wayland_ozone_platform
+append_ozone_platform
 
 if [ -f "$HOOK_ROOT/codex-packaged-runtime.sh" ]; then
     # shellcheck disable=SC1091

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -222,9 +222,13 @@ ozone_switch_present() {
     return 1
 }
 
+# A live compositor socket: the path is a unix socket and, where iproute2 can
+# tell, something is listening on it. A compositor that crashed leaves the
+# socket inode behind, and the Wayland backend has no fallback from that.
 wayland_socket_present() {
     local socket="${WAYLAND_DISPLAY:-}"
     local runtime_dir="${XDG_RUNTIME_DIR:-}"
+    local listeners
 
     [ -n "$socket" ] || return 1
     case "$socket" in
@@ -235,6 +239,12 @@ wayland_socket_present() {
             ;;
     esac
     [ -S "$socket" ] || return 1
+    command -v ss >/dev/null 2>&1 || return 0
+    listeners="$(ss -xlH 2>/dev/null)" || return 0
+    awk -v path="$socket" '
+        { for (field = 1; field <= NF; field++) if ($field == path) found = 1 }
+        END { exit !found }
+    ' <<< "$listeners"
 }
 
 # ChromeOS Crostini: Sommelier exports WAYLAND_DISPLAY, but an Electron Wayland

--- a/launcher/start.test.js
+++ b/launcher/start.test.js
@@ -3,6 +3,7 @@
 const assert = require("node:assert/strict");
 const childProcess = require("node:child_process");
 const fs = require("node:fs");
+const net = require("node:net");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
@@ -14,6 +15,12 @@ const dirnamePath = childProcess.execFileSync("bash", ["-c", "command -v dirname
 // Launcher tests must never contact the production usage counter. Individual
 // reporting tests opt back in with an isolated fake curl executable.
 process.env.CODEX_LINUX_DISABLE_USAGE_REPORTING = "1";
+
+// Ozone backend selection reads the session environment. Tests must not inherit
+// the developer's compositor; the Wayland cases below set these explicitly.
+delete process.env.WAYLAND_DISPLAY;
+delete process.env.XDG_RUNTIME_DIR;
+delete process.env.XDG_SESSION_TYPE;
 
 function writeExecutable(filePath, source) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -516,6 +523,127 @@ test("launcher uses the HOME config fallback and ignores non-file flag paths", (
     fs.readFileSync(path.join(root, "arguments"), "utf8"),
     "--class=codex-desktop\n--ozone-platform=wayland\n",
   );
+});
+
+function createWaylandSession(t, root) {
+  const runtimeDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-launcher-wayland-"));
+  const server = net.createServer();
+  server.listen(path.join(runtimeDir, "wayland-0"));
+  t.after(() => {
+    server.close();
+    fs.rmSync(runtimeDir, { recursive: true, force: true });
+  });
+  return {
+    ...process.env,
+    CODEX_HOME: path.join(root, "codex-home"),
+    TEST_ROOT: root,
+    WAYLAND_DISPLAY: "wayland-0",
+    XDG_CONFIG_HOME: path.join(root, "config"),
+    XDG_RUNTIME_DIR: runtimeDir,
+    XDG_SESSION_TYPE: "wayland",
+  };
+}
+
+test("launcher selects the Wayland backend for a live compositor socket", (t) => {
+  const root = createApp(t);
+  const result = childProcess.spawnSync(path.join(root, "start.sh"), ["codex://thread/123"], {
+    env: createWaylandSession(t, root),
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 7);
+  assert.deepEqual(fs.readFileSync(path.join(root, "arguments"), "utf8").trim().split("\n"), [
+    "--class=codex-desktop",
+    "--ozone-platform=wayland",
+    "codex://thread/123",
+  ]);
+});
+
+test("launcher keeps the X11 default when no Wayland session is confirmed", (t) => {
+  const root = createApp(t);
+  const session = createWaylandSession(t, root);
+  const expectDefault = (env) => {
+    const result = childProcess.spawnSync(path.join(root, "start.sh"), [], { env, encoding: "utf8" });
+    assert.equal(result.status, 7);
+    assert.equal(fs.readFileSync(path.join(root, "arguments"), "utf8"), "--class=codex-desktop\n");
+  };
+
+  // No compositor at all.
+  const bare = { ...session };
+  delete bare.WAYLAND_DISPLAY;
+  delete bare.XDG_SESSION_TYPE;
+  expectDefault(bare);
+
+  // A stale WAYLAND_DISPLAY left over from an earlier session.
+  expectDefault({ ...session, WAYLAND_DISPLAY: "wayland-9" });
+
+  // An absolute socket path that no longer exists.
+  expectDefault({ ...session, WAYLAND_DISPLAY: path.join(session.XDG_RUNTIME_DIR, "missing-0") });
+
+  // An X11 session that still exports a usable Wayland socket.
+  expectDefault({ ...session, XDG_SESSION_TYPE: "x11" });
+
+  // ChromeOS Crostini, where an Electron Wayland window never surfaces.
+  expectDefault({ ...session, SOMMELIER_VERSION: "0.20" });
+  expectDefault({ ...session, SOMMELIER_VM_IDENTIFIER: "termina" });
+});
+
+test("launcher accepts an absolute Wayland socket path", (t) => {
+  const root = createApp(t);
+  const session = createWaylandSession(t, root);
+  const result = childProcess.spawnSync(path.join(root, "start.sh"), [], {
+    env: { ...session, WAYLAND_DISPLAY: path.join(session.XDG_RUNTIME_DIR, "wayland-0") },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 7);
+  assert.deepEqual(fs.readFileSync(path.join(root, "arguments"), "utf8").trim().split("\n"), [
+    "--class=codex-desktop",
+    "--ozone-platform=wayland",
+  ]);
+});
+
+test("an explicit Ozone selection suppresses the Wayland backend", (t) => {
+  const root = createApp(t);
+  const session = createWaylandSession(t, root);
+  const configHome = session.XDG_CONFIG_HOME;
+  const hooks = path.join(root, ".codex-linux");
+  const expectExplicit = (args) => {
+    const result = childProcess.spawnSync(path.join(root, "start.sh"), args, {
+      env: session,
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 7);
+    assert.deepEqual(fs.readFileSync(path.join(root, "arguments"), "utf8").trim().split("\n"), [
+      "--class=codex-desktop",
+      "--ozone-platform=x11",
+    ]);
+  };
+
+  // A command-line argument.
+  expectExplicit(["--ozone-platform=x11"]);
+
+  // A user flag file.
+  fs.mkdirSync(path.join(configHome, "codex-desktop"), { recursive: true });
+  fs.writeFileSync(
+    path.join(configHome, "codex-desktop", "electron-flags.conf"),
+    "--ozone-platform=x11\n",
+  );
+  expectExplicit([]);
+  fs.rmSync(path.join(configHome, "codex-desktop", "electron-flags.conf"));
+
+  // A feature argument file.
+  fs.mkdirSync(path.join(hooks, "electron-args.d"), { recursive: true });
+  fs.writeFileSync(path.join(hooks, "electron-args.d", "fixture.args"), "--ozone-platform=x11\n");
+  expectExplicit([]);
+  fs.rmSync(path.join(hooks, "electron-args.d"), { recursive: true });
+
+  // A launcher hook.
+  writeExecutable(
+    path.join(hooks, "launcher.d", "select-backend.sh"),
+    "#!/bin/bash\nprintf 'electron-arg %s\\n' '--ozone-platform=x11'\n",
+  );
+  expectExplicit([]);
 });
 
 test("diagnose validates the official runtime without starting it", (t) => {

--- a/launcher/start.test.js
+++ b/launcher/start.test.js
@@ -18,9 +18,20 @@ process.env.CODEX_LINUX_DISABLE_USAGE_REPORTING = "1";
 
 // Ozone backend selection reads the session environment. Tests must not inherit
 // the developer's compositor; the Wayland cases below set these explicitly.
-delete process.env.WAYLAND_DISPLAY;
-delete process.env.XDG_RUNTIME_DIR;
-delete process.env.XDG_SESSION_TYPE;
+for (const name of [
+  "CODEX_DRM_CLASS_ROOT",
+  "CODEX_OZONE_PLATFORM",
+  "DESKTOP_SESSION",
+  "SOMMELIER_VERSION",
+  "SOMMELIER_VM_IDENTIFIER",
+  "WAYLAND_DISPLAY",
+  "XDG_CURRENT_DESKTOP",
+  "XDG_RUNTIME_DIR",
+  "XDG_SESSION_DESKTOP",
+  "XDG_SESSION_TYPE",
+]) {
+  delete process.env[name];
+}
 
 function writeExecutable(filePath, source) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -525,7 +536,10 @@ test("launcher uses the HOME config fallback and ignores non-file flag paths", (
   );
 });
 
-function createWaylandSession(t, root) {
+// A confirmed Wayland session: a live compositor socket in an isolated
+// XDG_RUNTIME_DIR, and a systemd user manager that exports no Sommelier
+// markers. Tests that need Crostini or GNOME layer their own markers on top.
+function createWaylandSession(t, root, { systemdEnvironment = "" } = {}) {
   const runtimeDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-launcher-wayland-"));
   const server = net.createServer();
   server.listen(path.join(runtimeDir, "wayland-0"));
@@ -533,9 +547,15 @@ function createWaylandSession(t, root) {
     server.close();
     fs.rmSync(runtimeDir, { recursive: true, force: true });
   });
+  const binDir = path.join(runtimeDir, "bin");
+  writeExecutable(
+    path.join(binDir, "systemctl"),
+    `#!/bin/bash\nprintf '%b' ${JSON.stringify(systemdEnvironment)}\n`,
+  );
   return {
     ...process.env,
     CODEX_HOME: path.join(root, "codex-home"),
+    PATH: `${binDir}:${process.env.PATH}`,
     TEST_ROOT: root,
     WAYLAND_DISPLAY: "wayland-0",
     XDG_CONFIG_HOME: path.join(root, "config"),
@@ -544,28 +564,57 @@ function createWaylandSession(t, root) {
   };
 }
 
-test("launcher selects the Wayland backend for a live compositor socket", (t) => {
-  const root = createApp(t);
-  const result = childProcess.spawnSync(path.join(root, "start.sh"), ["codex://thread/123"], {
-    env: createWaylandSession(t, root),
-    encoding: "utf8",
-  });
+function createDrmRoot(t, connectedCount) {
+  const drmRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-launcher-drm-"));
+  t.after(() => fs.rmSync(drmRoot, { recursive: true, force: true }));
+  for (let index = 0; index < connectedCount + 1; index += 1) {
+    const connector = path.join(drmRoot, `card0-DP-${index + 1}`);
+    fs.mkdirSync(connector);
+    fs.writeFileSync(path.join(connector, "status"), index < connectedCount ? "connected\n" : "disconnected\n");
+  }
+  return drmRoot;
+}
 
+function launchArguments(root, env, args = []) {
+  const result = childProcess.spawnSync(path.join(root, "start.sh"), args, { env, encoding: "utf8" });
   assert.equal(result.status, 7);
-  assert.deepEqual(fs.readFileSync(path.join(root, "arguments"), "utf8").trim().split("\n"), [
+  return { result, args: fs.readFileSync(path.join(root, "arguments"), "utf8").trim().split("\n") };
+}
+
+test("launcher selects the Wayland backend for a confirmed Wayland session", (t) => {
+  const root = createApp(t);
+  const session = createWaylandSession(t, root);
+
+  assert.deepEqual(launchArguments(root, session, ["codex://thread/123"]).args, [
     "--class=codex-desktop",
     "--ozone-platform=wayland",
     "codex://thread/123",
   ]);
+
+  // An absolute socket path.
+  assert.deepEqual(
+    launchArguments(root, { ...session, WAYLAND_DISPLAY: path.join(session.XDG_RUNTIME_DIR, "wayland-0") }).args,
+    ["--class=codex-desktop", "--ozone-platform=wayland"],
+  );
+
+  // GNOME with a single connected output is not the multi-monitor case.
+  assert.deepEqual(
+    launchArguments(root, {
+      ...session,
+      CODEX_DRM_CLASS_ROOT: createDrmRoot(t, 1),
+      XDG_CURRENT_DESKTOP: "GNOME",
+    }).args,
+    ["--class=codex-desktop", "--ozone-platform=wayland"],
+  );
 });
 
 test("launcher keeps the X11 default when no Wayland session is confirmed", (t) => {
   const root = createApp(t);
   const session = createWaylandSession(t, root);
   const expectDefault = (env) => {
-    const result = childProcess.spawnSync(path.join(root, "start.sh"), [], { env, encoding: "utf8" });
-    assert.equal(result.status, 7);
-    assert.equal(fs.readFileSync(path.join(root, "arguments"), "utf8"), "--class=codex-desktop\n");
+    const { result, args } = launchArguments(root, env);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(args, ["--class=codex-desktop"]);
   };
 
   // No compositor at all.
@@ -588,19 +637,60 @@ test("launcher keeps the X11 default when no Wayland session is confirmed", (t) 
   expectDefault({ ...session, SOMMELIER_VM_IDENTIFIER: "termina" });
 });
 
-test("launcher accepts an absolute Wayland socket path", (t) => {
+test("launcher finds Sommelier markers that only the systemd user manager exports", (t) => {
   const root = createApp(t);
-  const session = createWaylandSession(t, root);
-  const result = childProcess.spawnSync(path.join(root, "start.sh"), [], {
-    env: { ...session, WAYLAND_DISPLAY: path.join(session.XDG_RUNTIME_DIR, "wayland-0") },
-    encoding: "utf8",
+  const session = createWaylandSession(t, root, {
+    systemdEnvironment: "DISPLAY=:0\nSOMMELIER_VERSION=0.20\nWAYLAND_DISPLAY=wayland-0\n",
   });
 
-  assert.equal(result.status, 7);
-  assert.deepEqual(fs.readFileSync(path.join(root, "arguments"), "utf8").trim().split("\n"), [
-    "--class=codex-desktop",
-    "--ozone-platform=wayland",
-  ]);
+  assert.deepEqual(launchArguments(root, session).args, ["--class=codex-desktop"]);
+});
+
+test("launcher keeps GNOME Wayland multi-monitor sessions on X11", (t) => {
+  const root = createApp(t);
+  const session = createWaylandSession(t, root);
+  const drmRoot = createDrmRoot(t, 2);
+
+  for (const desktop of [
+    { XDG_CURRENT_DESKTOP: "ubuntu:GNOME" },
+    { XDG_SESSION_DESKTOP: "gnome" },
+    { DESKTOP_SESSION: "gnome-wayland" },
+  ]) {
+    assert.deepEqual(
+      launchArguments(root, { ...session, CODEX_DRM_CLASS_ROOT: drmRoot, ...desktop }).args,
+      ["--class=codex-desktop"],
+    );
+  }
+
+  // Another desktop with the same monitors keeps native Wayland.
+  assert.deepEqual(
+    launchArguments(root, { ...session, CODEX_DRM_CLASS_ROOT: drmRoot, XDG_CURRENT_DESKTOP: "KDE" }).args,
+    ["--class=codex-desktop", "--ozone-platform=wayland"],
+  );
+});
+
+test("CODEX_OZONE_PLATFORM pins a backend ahead of session detection", (t) => {
+  const root = createApp(t);
+  const session = createWaylandSession(t, root);
+
+  // Pinning X11 inside a confirmed Wayland session, as the Nix wrapper does.
+  let launch = launchArguments(root, { ...session, CODEX_OZONE_PLATFORM: "x11" });
+  assert.equal(launch.result.stderr, "");
+  assert.deepEqual(launch.args, ["--class=codex-desktop", "--ozone-platform=x11"]);
+
+  // Pinning Wayland where detection would have declined.
+  launch = launchArguments(root, { ...session, CODEX_OZONE_PLATFORM: "wayland", SOMMELIER_VERSION: "0.20" });
+  assert.equal(launch.result.stderr, "");
+  assert.deepEqual(launch.args, ["--class=codex-desktop", "--ozone-platform=wayland"]);
+
+  // An invalid value warns and falls back to detection.
+  launch = launchArguments(root, { ...session, CODEX_OZONE_PLATFORM: "gtk" });
+  assert.match(launch.result.stderr, /Ignoring CODEX_OZONE_PLATFORM=gtk; expected auto, x11, or wayland/);
+  assert.deepEqual(launch.args, ["--class=codex-desktop", "--ozone-platform=wayland"]);
+
+  // An explicit switch still wins over the pin.
+  launch = launchArguments(root, { ...session, CODEX_OZONE_PLATFORM: "wayland" }, ["--ozone-platform=x11"]);
+  assert.deepEqual(launch.args, ["--class=codex-desktop", "--ozone-platform=x11"]);
 });
 
 test("an explicit Ozone selection suppresses the Wayland backend", (t) => {
@@ -609,12 +699,7 @@ test("an explicit Ozone selection suppresses the Wayland backend", (t) => {
   const configHome = session.XDG_CONFIG_HOME;
   const hooks = path.join(root, ".codex-linux");
   const expectExplicit = (args) => {
-    const result = childProcess.spawnSync(path.join(root, "start.sh"), args, {
-      env: session,
-      encoding: "utf8",
-    });
-    assert.equal(result.status, 7);
-    assert.deepEqual(fs.readFileSync(path.join(root, "arguments"), "utf8").trim().split("\n"), [
+    assert.deepEqual(launchArguments(root, session, args).args, [
       "--class=codex-desktop",
       "--ozone-platform=x11",
     ]);

--- a/launcher/start.test.js
+++ b/launcher/start.test.js
@@ -729,6 +729,19 @@ test("an explicit Ozone selection suppresses the Wayland backend", (t) => {
     "#!/bin/bash\nprintf 'electron-arg %s\\n' '--ozone-platform=x11'\n",
   );
   expectExplicit([]);
+  fs.rmSync(path.join(hooks, "launcher.d"), { recursive: true });
+
+  // A leftover hint is not a selection: this runtime ignores it, so the
+  // session would otherwise stay on XWayland.
+  fs.writeFileSync(
+    path.join(configHome, "codex-desktop", "electron-flags.conf"),
+    "--ozone-platform-hint=auto\n",
+  );
+  assert.deepEqual(launchArguments(root, session).args, [
+    "--class=codex-desktop",
+    "--ozone-platform-hint=auto",
+    "--ozone-platform=wayland",
+  ]);
 });
 
 test("diagnose validates the official runtime without starting it", (t) => {

--- a/launcher/start.test.js
+++ b/launcher/start.test.js
@@ -539,10 +539,11 @@ test("launcher uses the HOME config fallback and ignores non-file flag paths", (
 // A confirmed Wayland session: a live compositor socket in an isolated
 // XDG_RUNTIME_DIR, and a systemd user manager that exports no Sommelier
 // markers. Tests that need Crostini or GNOME layer their own markers on top.
-function createWaylandSession(t, root, { systemdEnvironment = "" } = {}) {
+function createWaylandSession(t, root, { systemdEnvironment = "", listening = true } = {}) {
   const runtimeDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-launcher-wayland-"));
+  const socketPath = path.join(runtimeDir, "wayland-0");
   const server = net.createServer();
-  server.listen(path.join(runtimeDir, "wayland-0"));
+  server.listen(socketPath);
   t.after(() => {
     server.close();
     fs.rmSync(runtimeDir, { recursive: true, force: true });
@@ -551,6 +552,17 @@ function createWaylandSession(t, root, { systemdEnvironment = "" } = {}) {
   writeExecutable(
     path.join(binDir, "systemctl"),
     `#!/bin/bash\nprintf '%b' ${JSON.stringify(systemdEnvironment)}\n`,
+  );
+  // iproute2 listing of listening unix sockets; a crashed compositor leaves
+  // the inode without a listener, which "listening: false" reproduces.
+  const listenerLines = listening === true
+    ? `u_str LISTEN 0 4096 ${socketPath} 146902 * 0\nu_str LISTEN 0 4096 /run/user/1000/bus 146901 * 0\n`
+    : "u_str LISTEN 0 4096 /run/user/1000/bus 146901 * 0\n";
+  writeExecutable(
+    path.join(binDir, "ss"),
+    listening === "unavailable"
+      ? "#!/bin/bash\nexit 255\n"
+      : `#!/bin/bash\nprintf '%b' ${JSON.stringify(listenerLines)}\n`,
   );
   return {
     ...process.env,
@@ -635,6 +647,22 @@ test("launcher keeps the X11 default when no Wayland session is confirmed", (t) 
   // ChromeOS Crostini, where an Electron Wayland window never surfaces.
   expectDefault({ ...session, SOMMELIER_VERSION: "0.20" });
   expectDefault({ ...session, SOMMELIER_VM_IDENTIFIER: "termina" });
+});
+
+test("launcher treats a socket inode without a listener as no session", (t) => {
+  const root = createApp(t);
+  const stale = createWaylandSession(t, root, { listening: false });
+  const { result, args } = launchArguments(root, stale);
+
+  assert.equal(result.stderr, "");
+  assert.deepEqual(args, ["--class=codex-desktop"]);
+
+  // Without a usable iproute2 the inode check stands on its own.
+  const unlisted = createWaylandSession(t, root, { listening: "unavailable" });
+  assert.deepEqual(launchArguments(root, unlisted).args, [
+    "--class=codex-desktop",
+    "--ozone-platform=wayland",
+  ]);
 });
 
 test("launcher finds Sommelier markers that only the systemd user manager exports", (t) => {


### PR DESCRIPTION
## Summary

Since the official Linux package migration (33e2c03, 916a833) the launcher
passes only `--class=` to Electron. The runtime defaults to the X11 Ozone
backend, so Wayland sessions start the app under XWayland. On compositors whose
XWayland does not scale clients (niri via xwayland-satellite, among others) the
window renders at 1x on a 2x output and the whole UI is tiny. Before the
migration the launcher selected the backend itself.

`start.sh.template` now appends `--ozone-platform=wayland`, the only backend
switch the shipped runtime accepts. That switch has no fallback, so the session
is confirmed before it is used:

- `WAYLAND_DISPLAY` must name a compositor socket, either absolute or relative
  to `XDG_RUNTIME_DIR`, and where iproute2 is available `ss -xlH` must show a
  listener on it. A stale variable, or the inode a crashed compositor leaves
  behind, does not qualify.
- `XDG_SESSION_TYPE` must not be `x11`.
- Sessions the pre-migration launcher already kept on X11 stay there: ChromeOS
  Crostini (Sommelier markers from the environment or, for app-menu launches,
  the systemd user manager; #95), GNOME Wayland with more than one connected
  DRM output, and WSLg.
- Nothing may have selected a backend already: a command-line argument, either
  `electron-flags.conf`, an `electron-args.d` feature argument, or a launcher
  hook.

`CODEX_OZONE_PLATFORM=auto|x11|wayland` pins a backend ahead of that detection
and still yields to an explicit switch. The Nix wrappers set `x11`, so
`NIXOS_OZONE_WL` remains the Nix package's only Wayland opt-in and its
wrapper contract check now asserts that value.

The `CODEX_FORCE_DEVICE_SCALE_FACTOR` and GNOME multi-monitor handling that the
migration also removed are not restored; native Wayland resolves per-output
scale on its own.

User-visible behavior: a confirmed Wayland session gets a native Wayland surface
and correct per-output scaling with no config file. X11, Crostini, GNOME
multi-monitor, WSLg, Nix without `NIXOS_OZONE_WL`, and sessions with an explicit
flag are unchanged. This touches the launcher template (every package format that
ships it) and the two Nix wrappers; no feature or payload.

Workaround for affected users on current releases: add `--ozone-platform=wayland`
to `~/.config/codex-desktop/electron-flags.conf`.

## Validation

Runtime facts, all on the installed signed package `chatgpt` 26.901.41600 amd64
(`sha256:15cf422a…3efca77`, Electron `42.3.0`), niri under Wayland, 5K display at
scale 2 plus a panel at 1.25:

| Check | Result |
|---|---|
| `strings -a ChatGPT \| grep -cx ozone-platform-hint` | `0` |
| `strings -a ChatGPT \| grep -cx ELECTRON_OZONE_PLATFORM_HINT` | `0` |
| `strings -a ChatGPT \| grep -cx ozone-platform` | `1` |
| Launch with `--ozone-platform-hint=auto`, isolated `--user-data-dir` | GPU process resolves `--ozone-platform=x11` — the hint is a no-op |
| Launch with `--ozone-platform=wayland`, isolated `--user-data-dir` | GPU process resolves `--ozone-platform=wayland` |
| Patched launcher, empty `XDG_CONFIG_HOME`, no user flags, against the installed payload | Appends `--ozone-platform=wayland`; GPU process resolves Wayland; niri maps the window with `app_id=codex-desktop`, so the `--class` identity is preserved |
| Daily-driver instance on the same package with `--ozone-platform=wayland` | Renders at the output's 2x scale instead of 1x |

Suites:

```
bash -n install.sh scripts/lib/*.sh launcher/start.sh.template
node --test launcher/start.test.js                       # 22 pass
bash tests/scripts_smoke.sh                              # 62 pass
node --test scripts/lib/upstream-linux-package.test.js \
  scripts/patch-linux-window-ui.test.js \
  scripts/lib/linux-features.test.js                     # 39 pass
git diff --check
```

Launcher tests bind a real unix socket in an isolated `XDG_RUNTIME_DIR` and put
a fake `systemctl` and `ss` on `PATH` rather than asserting on mocked argv alone. They
cover: the Wayland selection, an absolute socket path, GNOME with one output;
eight negative cases (no compositor, stale `WAYLAND_DISPLAY`, missing absolute
socket, socket inode without a listener, X11 session, both Sommelier
environment markers, Sommelier exported only by the systemd user manager), plus
the inode-only fallback when `ss` is unusable; GNOME multi-monitor through each of the three
desktop variables against a two-output DRM fixture, plus a non-GNOME desktop
with the same fixture; `CODEX_OZONE_PLATFORM` for `x11`, `wayland`, an invalid
value (warns, falls back to detection), and losing to an explicit switch; and
suppression by each of the four explicit sources, with a leftover
`--ozone-platform-hint` confirmed not to count as one. As a negative control,
removing the `append_ozone_platform` call fails exactly the three positive
tests. The suite previously inherited the developer's compositor variables,
which made these outcomes machine-dependent, so the session, desktop, Sommelier,
and `CODEX_*` variables are cleared at the top of the file next to the existing
usage-reporting guard. WSLg detection (`/mnt/wslg`) is not unit-tested.

Not run: `shellcheck` and `nix` are not installed on this machine, so the Nix
wrapper edits and the extended contract check rely on the `nix-build` and
`nix-vm` jobs; `./scripts/ci-local.sh all` and `cargo` were skipped — no Rust or
packaging file is touched.

Manual matrix and risk: verified only on niri under Wayland, and on the amd64
payload. **Not tested on GNOME, KDE, Sway, Hyprland, COSMIC, WSLg, Crostini, or
Nix**, and not tested with any Linux feature enabled. The Crostini, GNOME, and
WSLg carve-outs are ported from the pre-migration launcher and #95, not
reproduced. Because
`--ozone-platform=wayland` has no fallback, the risk is a session that passes the
socket check but cannot actually run the Wayland backend; the socket, session
type, and Sommelier guards exist to bound that, and rollback is deleting one
line or setting `--ozone-platform=x11` in a flag file.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [ ] If this fixes upstream drift, it targets only the latest signed stable OpenAI Linux package and removes obsolete fallback code and tests. — not upstream drift.
- [x] I added or updated relevant tests and ran the validation listed above.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.

https://claude.ai/code/session_01VNzPTkRFp9PzKqoB46h4ku
