### PR TITLE
HEROX-1434: Add Flatpak Chrome native messaging bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ requirements, known limitations, configuration, and tests.
 | `computer-use-linux` | Linux desktop-control UI and native MCP backend | [Docs](linux-features/computer-use-linux/README.md) |
 | `copilot-reasoning-effort` | Persistent reasoning-effort defaults for Copilot-auth sessions | [Docs](linux-features/copilot-reasoning-effort/README.md) |
 | `directory-only-working-tree-watch` | Bounded Watchbound working-tree watching | [Docs](linux-features/directory-only-working-tree-watch/README.md) |
+| `flatpak-chrome-native-messaging` | Bridge the official Chrome extension into Flatpak Google Chrome | [Docs](linux-features/flatpak-chrome-native-messaging/README.md) |
 | `frameless-titlebar` | Hide official Linux overlay buttons for compositor-managed decorations | [Docs](linux-features/frameless-titlebar/README.md) |
 | `global-dictation` | X11 and XDG portal global dictation hotkeys | [Docs](linux-features/global-dictation/README.md) |
 | `linux-performance-workarounds` | Measured renderer workarounds for affected systems | [Docs](linux-features/linux-performance-workarounds/README.md) |
@@ -349,7 +350,7 @@ output layout, parallelism, and payload inspection.
 | Problem | First check |
 |---|---|
 | Official and Community launches interfere | Fully exit every `ChatGPT` process; both apps share the upstream profile |
-| AppImage opens from Flatpak Chrome, but the extension says `Native transport disconnected` | This combination is currently unsupported; see [Flatpak Chrome diagnostics](docs/troubleshooting.md#appimage-opens-from-flatpak-chrome-but-the-extension-cannot-connect) |
+| AppImage opens from Flatpak Chrome, but the extension says `Native transport disconnected` | Enable `flatpak-chrome-native-messaging`; see [Flatpak Chrome setup](docs/troubleshooting.md#appimage-opens-from-flatpak-chrome-but-the-extension-cannot-connect) |
 | Browser/Chrome extension cannot connect after migration | Exit ChatGPT and Chrome completely, then follow the narrow cache repair in [Troubleshooting](docs/troubleshooting.md#browser-or-chrome-plugin-is-visible-but-cannot-connect) |
 | Signature or package verification fails | Do not bypass it; check time, network, `gpgv`, architecture, and disk space |
 | App does not launch | Run `/opt/codex-desktop/start.sh --diagnose` |

--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ output layout, parallelism, and payload inspection.
 | Problem | First check |
 |---|---|
 | Official and Community launches interfere | Fully exit every `ChatGPT` process; both apps share the upstream profile |
+| AppImage opens from Flatpak Chrome, but the extension says `Native transport disconnected` | This combination is currently unsupported; see [Flatpak Chrome diagnostics](docs/troubleshooting.md#appimage-opens-from-flatpak-chrome-but-the-extension-cannot-connect) |
 | Browser/Chrome extension cannot connect after migration | Exit ChatGPT and Chrome completely, then follow the narrow cache repair in [Troubleshooting](docs/troubleshooting.md#browser-or-chrome-plugin-is-visible-but-cannot-connect) |
 | Signature or package verification fails | Do not bypass it; check time, network, `gpgv`, architecture, and disk space |
 | App does not launch | Run `/opt/codex-desktop/start.sh --diagnose` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -324,6 +324,7 @@ make appimage
 | 问题 | 首先检查 |
 |---|---|
 | 官方与 Community 启动互相影响 | 完全退出所有 `ChatGPT` 进程；两者共享上游 profile |
+| Flatpak Chrome 能打开 AppImage，但扩展显示 `Native transport disconnected` | 目前不支持此组合；参阅 [Flatpak Chrome 诊断](docs/troubleshooting.md#appimage-opens-from-flatpak-chrome-but-the-extension-cannot-connect) |
 | 迁移后 Browser/Chrome extension 无法连接 | 完全退出 ChatGPT 与 Chrome，再按[故障排除](docs/troubleshooting.md#browser-or-chrome-plugin-is-visible-but-cannot-connect)执行窄范围 cache repair |
 | 签名或软件包验证失败 | 不要绕过；检查系统时间、网络、`gpgv`、architecture 和磁盘空间 |
 | 应用无法启动 | 运行 `/opt/codex-desktop/start.sh --diagnose` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -209,6 +209,7 @@ Nix 用户应从 profile、Home Manager 配置或 NixOS module 中删除该包�
 | `computer-use-linux` | Linux desktop-control UI 与原生 MCP backend | [文档](linux-features/computer-use-linux/README.md) |
 | `copilot-reasoning-effort` | Copilot auth 的 reasoning-effort 默认值 | [文档](linux-features/copilot-reasoning-effort/README.md) |
 | `directory-only-working-tree-watch` | 有界 Watchbound 工作树监听 | [文档](linux-features/directory-only-working-tree-watch/README.md) |
+| `flatpak-chrome-native-messaging` | 将官方 Chrome 扩展连接到 Flatpak Google Chrome | [文档](linux-features/flatpak-chrome-native-messaging/README.md) |
 | `frameless-titlebar` | 隐藏官方 Linux overlay 按钮，改由 compositor 管理窗口装饰 | [文档](linux-features/frameless-titlebar/README.md) |
 | `global-dictation` | X11 / XDG portal 全局听写快捷键 | [文档](linux-features/global-dictation/README.md) |
 | `linux-performance-workarounds` | 针对受影响系统的 renderer workaround | [文档](linux-features/linux-performance-workarounds/README.md) |
@@ -324,7 +325,7 @@ make appimage
 | 问题 | 首先检查 |
 |---|---|
 | 官方与 Community 启动互相影响 | 完全退出所有 `ChatGPT` 进程；两者共享上游 profile |
-| Flatpak Chrome 能打开 AppImage，但扩展显示 `Native transport disconnected` | 目前不支持此组合；参阅 [Flatpak Chrome 诊断](docs/troubleshooting.md#appimage-opens-from-flatpak-chrome-but-the-extension-cannot-connect) |
+| Flatpak Chrome 能打开 AppImage，但扩展显示 `Native transport disconnected` | 启用 `flatpak-chrome-native-messaging`；参阅 [Flatpak Chrome 设置](docs/troubleshooting.md#appimage-opens-from-flatpak-chrome-but-the-extension-cannot-connect) |
 | 迁移后 Browser/Chrome extension 无法连接 | 完全退出 ChatGPT 与 Chrome，再按[故障排除](docs/troubleshooting.md#browser-or-chrome-plugin-is-visible-but-cannot-connect)执行窄范围 cache repair |
 | 签名或软件包验证失败 | 不要绕过；检查系统时间、网络、`gpgv`、architecture 和磁盘空间 |
 | 应用无法启动 | 运行 `/opt/codex-desktop/start.sh --diagnose` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -96,6 +96,51 @@ parallel sessions.
 In the desktop menu, the custom build is **ChatGPT Community** with a blue `C`;
 the unqualified **ChatGPT** entry is OpenAI's package.
 
+## AppImage opens from Flatpak Chrome but the extension cannot connect
+
+**AppImage + Flatpak Google Chrome (`com.google.Chrome`) is not currently a
+supported Chrome extension combination in this project.** The AppImage desktop
+integration registers `codex-browser-sidebar` links, but does not install a
+Flatpak native-messaging bridge. The Chrome extension host and its connection
+status UI come from the official Linux payload.
+
+In [issue #1434](https://github.com/ilysenko/codex-desktop-linux/issues/1434),
+**Open the app** launches Community, while the extension reports **Native
+transport disconnected** and Settings > Computer use > Google Chrome shows
+**Not installed**. Opening a URI only verifies the desktop link handler; it
+does not verify the extension's native-messaging handshake.
+
+Flatpak isolates the browser's configuration and host access. Its ability to
+open a URI through a portal does not establish access to a native host; see the
+[Flatpak sandbox documentation](https://docs.flatpak.org/en/latest/sandbox-permissions.html).
+The report identifies the Flatpak Chrome manifest directory as
+`~/.var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts/`.
+Copying a manifest there alone is not a verified fix: the referenced host must
+also be executable from the browser environment and reach the desktop transport.
+
+To identify this case, open `chrome://version` in the browser that has the
+extension and inspect **Executable Path** and **Profile Path**. Check the
+Flatpak installation with:
+
+```bash
+flatpak info com.google.Chrome
+```
+
+An installed Flatpak does not prove that the current browser is using it; check
+the browser paths as well, especially when native Chrome is also installed.
+
+For a comparison without the Flatpak boundary, use a host-installed Google
+Chrome and retry the extension installation there. This is a diagnostic step,
+not a verified fix for every AppImage environment. Changing only the desktop
+package format does not add a Flatpak browser bridge. If the problem persists
+with host-installed Chrome, include both application and browser versions,
+package formats, enabled Community features, and the extension error in the
+issue. Redact personal directory names from paths before sharing them.
+
+The legacy plugin-cache repair below addresses a different migration problem;
+it does not add Flatpak support. This limitation currently has no dedicated
+in-app detection, so the upstream **Not installed** status can still appear.
+
 ## Browser or Chrome plugin is visible but cannot connect
 
 The first Community launch after migrating from the legacy pre-official build

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -98,11 +98,18 @@ the unqualified **ChatGPT** entry is OpenAI's package.
 
 ## AppImage opens from Flatpak Chrome but the extension cannot connect
 
-**AppImage + Flatpak Google Chrome (`com.google.Chrome`) is not currently a
-supported Chrome extension combination in this project.** The AppImage desktop
-integration registers `codex-browser-sidebar` links, but does not install a
-Flatpak native-messaging bridge. The Chrome extension host and its connection
-status UI come from the official Linux payload.
+The optional `flatpak-chrome-native-messaging` feature supports the
+**AppImage + Flatpak Google Chrome (`com.google.Chrome`)** combination. Enable
+it before building the AppImage:
+
+```json
+{
+  "enabled": ["flatpak-chrome-native-messaging"]
+}
+```
+
+Fully exit ChatGPT Community and Chrome after installing the rebuilt AppImage.
+Start ChatGPT Community first, then reopen Chrome.
 
 In [issue #1434](https://github.com/ilysenko/codex-desktop-linux/issues/1434),
 **Open the app** launches Community, while the extension reports **Native
@@ -113,10 +120,12 @@ does not verify the extension's native-messaging handshake.
 Flatpak isolates the browser's configuration and host access. Its ability to
 open a URI through a portal does not establish access to a native host; see the
 [Flatpak sandbox documentation](https://docs.flatpak.org/en/latest/sandbox-permissions.html).
-The report identifies the Flatpak Chrome manifest directory as
+The feature installs a private native-host manifest and Bash wrapper under
 `~/.var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts/`.
-Copying a manifest there alone is not a verified fix: the referenced host must
-also be executable from the browser environment and reach the desktop transport.
+The wrapper forwards the binary native-messaging stream to an authenticated
+`127.0.0.1` relay. The relay runs the exact official host selected by the
+upstream runtime registry outside the sandbox. It does not add a Flatpak
+override or copy the official host into the sandbox.
 
 To identify this case, open `chrome://version` in the browser that has the
 extension and inspect **Executable Path** and **Profile Path**. Check the
@@ -129,17 +138,15 @@ flatpak info com.google.Chrome
 An installed Flatpak does not prove that the current browser is using it; check
 the browser paths as well, especially when native Chrome is also installed.
 
-For a comparison without the Flatpak boundary, use a host-installed Google
-Chrome and retry the extension installation there. This is a diagnostic step,
-not a verified fix for every AppImage environment. Changing only the desktop
-package format does not add a Flatpak browser bridge. If the problem persists
-with host-installed Chrome, include both application and browser versions,
-package formats, enabled Community features, and the extension error in the
-issue. Redact personal directory names from paths before sharing them.
+The launcher also points the upstream Chrome diagnostics at the Flatpak profile
+and manifest. If Settings still shows **Not installed**, verify that the
+extension is installed in the same Flatpak profile shown by `chrome://version`,
+then restart both applications in that order. If the problem persists, include
+both application and browser versions, the enabled feature list, and the
+extension error in the issue. Redact personal directory names from paths before
+sharing them.
 
-The legacy plugin-cache repair below addresses a different migration problem;
-it does not add Flatpak support. This limitation currently has no dedicated
-in-app detection, so the upstream **Not installed** status can still appear.
+The legacy plugin-cache repair below addresses a different migration problem.
 
 ## Browser or Chrome plugin is visible but cannot connect
 

--- a/linux-features/flatpak-chrome-native-messaging/README.md
+++ b/linux-features/flatpak-chrome-native-messaging/README.md
@@ -1,0 +1,42 @@
+# Flatpak Chrome native messaging
+
+This disabled-by-default feature connects the official bundled Chrome
+extension to ChatGPT Community when Google Chrome runs as the
+`com.google.Chrome` Flatpak.
+
+Flatpak Chrome can open `codex-browser-sidebar` links through the desktop
+portal, but its sandbox cannot execute the official native host from the
+ChatGPT Community plugin cache. When enabled, this feature installs a private
+native-host manifest and a small Bash wrapper in the Flatpak Chrome profile.
+The wrapper forwards the binary native-messaging stream over an authenticated
+loopback connection. The relay runs the exact official native host outside the
+sandbox, where its signed runtime registry and plugin files are available.
+
+The feature does not add a Flatpak override. It relies on the network namespace
+already shared by the published Google Chrome Flatpak and binds only to
+`127.0.0.1`. A random token is stored in user-only files. The relay validates
+the Chrome extension origin and the registered official host path before it
+starts a host process.
+
+Enable the feature before building:
+
+```json
+{
+  "enabled": ["flatpak-chrome-native-messaging"]
+}
+```
+
+Then rebuild the AppImage, fully exit ChatGPT Community and Chrome, start
+ChatGPT Community, and reopen Chrome. The launcher points the upstream Chrome
+diagnostics at the Flatpak profile, so Settings can inspect the same extension
+and native-host manifest used by the sandbox.
+
+Runtime files are stored under:
+
+- `~/.var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts/`
+- `${XDG_STATE_HOME:-~/.local/state}/codex-desktop/flatpak-chrome-native-messaging/`
+
+If an unrelated native-host manifest already owns
+`com.openai.codexextension`, startup fails closed and leaves that manifest
+untouched. A recognized official manifest is restored when the owning desktop
+process exits.

--- a/linux-features/flatpak-chrome-native-messaging/bridge.mjs
+++ b/linux-features/flatpak-chrome-native-messaging/bridge.mjs
@@ -1,0 +1,626 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const HOST_NAME = "com.openai.codexextension";
+const MAX_PRELUDE_BYTES = 4096;
+const AUTH_TIMEOUT_MS = 2000;
+const MAX_CLIENTS = 8;
+const START_TIMEOUT_MS = 5000;
+const OWNER_POLL_MS = 500;
+const BRIDGE_WRAPPER_NAME = `${HOST_NAME}-codex-desktop-bridge`;
+
+function parseArgs(argv) {
+  const command = argv[0];
+  const options = {};
+  for (let index = 1; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value == null) throw new Error(`invalid argument: ${key ?? ""}`);
+    options[key.slice(2)] = value;
+  }
+  for (const key of ["app-dir", "codex-home", "state-dir", "flatpak-root", "owner-pid"]) {
+    if (!options[key]) throw new Error(`missing --${key}`);
+  }
+  const ownerPid = Number.parseInt(options["owner-pid"], 10);
+  if (!Number.isSafeInteger(ownerPid) || ownerPid <= 1) throw new Error("invalid --owner-pid");
+  return {
+    command,
+    appDir: path.resolve(options["app-dir"]),
+    codexHome: path.resolve(options["codex-home"]),
+    stateDir: path.resolve(options["state-dir"]),
+    flatpakRoot: path.resolve(options["flatpak-root"]),
+    ownerPid,
+  };
+}
+
+function processIdentity(pid) {
+  try {
+    const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
+    const close = stat.lastIndexOf(")");
+    if (close < 0) return null;
+    const fields = stat.slice(close + 2).trim().split(/\s+/);
+    const startTime = fields[19];
+    return startTime ? `${pid}:${startTime}` : null;
+  } catch {
+    return null;
+  }
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function privateDirectory(directory) {
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  fs.chmodSync(directory, 0o700);
+}
+
+function writePrivateAtomic(target, contents, mode = 0o600) {
+  privateDirectory(path.dirname(target));
+  const temporary = `${target}.tmp-${process.pid}-${crypto.randomBytes(6).toString("hex")}`;
+  fs.writeFileSync(temporary, contents, { mode, flag: "wx" });
+  fs.chmodSync(temporary, mode);
+  fs.renameSync(temporary, target);
+}
+
+function readJson(target) {
+  return JSON.parse(fs.readFileSync(target, "utf8"));
+}
+
+function pathsFor(options) {
+  const nativeDirectory = path.join(
+    options.flatpakRoot,
+    "config",
+    "google-chrome",
+    "NativeMessagingHosts",
+  );
+  return {
+    stateFile: path.join(options.stateDir, "bridge-state.json"),
+    backupFile: path.join(options.stateDir, "original-manifest.json"),
+    lockDirectory: path.join(options.stateDir, "startup.lock"),
+    logFile: path.join(options.stateDir, "bridge.log"),
+    nativeDirectory,
+    manifestPath: path.join(nativeDirectory, `${HOST_NAME}.json`),
+    wrapperPath: path.join(nativeDirectory, BRIDGE_WRAPPER_NAME),
+  };
+}
+
+function loadExtensionRegistry(appDir) {
+  const target = path.join(
+    appDir,
+    "resources",
+    "plugins",
+    "openai-bundled",
+    "plugins",
+    "chrome",
+    "scripts",
+    "extension-ids.json",
+  );
+  const registry = readJson(target);
+  if (registry.extensionHostName !== HOST_NAME || !Array.isArray(registry.extensionIds)) {
+    throw new Error(`unsupported Chrome extension registry: ${target}`);
+  }
+  const origins = registry.extensionIds.map((id) => `chrome-extension://${id}/`);
+  if (origins.length === 0 || origins.some((origin) => !/^chrome-extension:\/\/[a-p]{32}\/$/.test(origin))) {
+    throw new Error(`invalid Chrome extension ids: ${target}`);
+  }
+  return { origins };
+}
+
+function bridgeManifest(wrapperPath, origins) {
+  return {
+    name: HOST_NAME,
+    description: "ChatGPT Community Flatpak Chrome bridge",
+    path: wrapperPath,
+    type: "stdio",
+    allowed_origins: origins,
+  };
+}
+
+function isPathInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+}
+
+function isRecognizedUpstreamManifest(manifest, options, origins) {
+  if (
+    manifest?.name !== HOST_NAME ||
+    manifest?.type !== "stdio" ||
+    !Array.isArray(manifest.allowed_origins) ||
+    manifest.allowed_origins.length !== origins.length ||
+    !origins.every((origin) => manifest.allowed_origins.includes(origin)) ||
+    typeof manifest.path !== "string" ||
+    path.basename(manifest.path) !== "extension-host"
+  ) return false;
+  const candidate = path.resolve(manifest.path);
+  return [
+    path.join(options.codexHome, "plugins", "cache", "openai-bundled", "chrome"),
+    path.join(options.appDir, "resources", "plugins", "openai-bundled", "plugins", "chrome"),
+  ].some((root) => isPathInside(root, candidate));
+}
+
+function assertManifestCanBeReplaced(options, origins) {
+  const paths = pathsFor(options);
+  if (!fs.existsSync(paths.manifestPath)) return;
+  let current;
+  try {
+    current = readJson(paths.manifestPath);
+  } catch {
+    throw new Error(`refusing to replace invalid manifest: ${paths.manifestPath}`);
+  }
+  if (current?.path === paths.wrapperPath) {
+    if (!fs.existsSync(paths.backupFile)) {
+      throw new Error(`bridge manifest has no recovery record: ${paths.manifestPath}`);
+    }
+    return;
+  }
+  if (!isRecognizedUpstreamManifest(current, options, origins)) {
+    throw new Error(`refusing to replace an unrecognized native host manifest: ${paths.manifestPath}`);
+  }
+}
+
+function wrapperSource(port, token) {
+  return `#!/usr/bin/bash
+# Managed by ChatGPT Community feature flatpak-chrome-native-messaging.
+set -u
+reader_pid=
+writer_pid=
+cleanup() {
+    trap - EXIT HUP INT TERM
+    [ -n "$reader_pid" ] && kill "$reader_pid" 2>/dev/null || true
+    [ -n "$writer_pid" ] && kill "$writer_pid" 2>/dev/null || true
+    exec 3>&- 3<&-
+    [ -n "$reader_pid" ] && wait "$reader_pid" 2>/dev/null || true
+    [ -n "$writer_pid" ] && wait "$writer_pid" 2>/dev/null || true
+}
+trap cleanup EXIT HUP INT TERM
+exec 3<>/dev/tcp/127.0.0.1/${port} || exit 1
+printf '%s\\n%s\\n' '${token}' "\${1:-}" >&3 || exit 1
+cat <&3 >&1 & reader_pid=$!
+cat <&0 >&3 & writer_pid=$!
+wait -n "$reader_pid" "$writer_pid"
+status=$?
+cleanup
+exit "$status"
+`;
+}
+
+function prepareManifest(options, state) {
+  const paths = pathsFor(options);
+  privateDirectory(options.stateDir);
+  privateDirectory(paths.nativeDirectory);
+
+  let currentText = null;
+  if (fs.existsSync(paths.manifestPath)) {
+    currentText = fs.readFileSync(paths.manifestPath, "utf8");
+  }
+
+  assertManifestCanBeReplaced(options, state.origins);
+  if (!fs.existsSync(paths.backupFile)) {
+    writePrivateAtomic(paths.backupFile, `${JSON.stringify({ existed: currentText != null, contents: currentText })}\n`);
+  }
+
+  writePrivateAtomic(paths.wrapperPath, wrapperSource(state.port, state.token), 0o700);
+  writePrivateAtomic(paths.manifestPath, `${JSON.stringify(bridgeManifest(paths.wrapperPath, state.origins), null, 2)}\n`);
+}
+
+function restoreManifest(options) {
+  const paths = pathsFor(options);
+  let current;
+  try { current = readJson(paths.manifestPath); } catch { current = null; }
+  if (current?.path !== paths.wrapperPath) {
+    fs.rmSync(paths.wrapperPath, { force: true });
+    fs.rmSync(paths.backupFile, { force: true });
+    return;
+  }
+
+  let backup;
+  try { backup = readJson(paths.backupFile); } catch { backup = null; }
+  if (backup?.existed === true && typeof backup.contents === "string") {
+    writePrivateAtomic(paths.manifestPath, backup.contents);
+  } else if (backup?.existed === false) {
+    fs.rmSync(paths.manifestPath, { force: true });
+  } else {
+    return;
+  }
+  fs.rmSync(paths.wrapperPath, { force: true });
+  fs.rmSync(paths.backupFile, { force: true });
+}
+
+function sameRealPath(left, right) {
+  try {
+    return fs.realpathSync(left) === fs.realpathSync(right);
+  } catch {
+    return false;
+  }
+}
+
+function readRuntimeHost(options, origin) {
+  const stateHome = process.env.XDG_STATE_HOME || path.join(os.homedir(), ".local", "state");
+  const registryPath = process.env.CODEX_CHROME_NATIVE_HOST_REGISTRY || path.join(
+    stateHome,
+    "openai-codex",
+    "chrome-native-hosts-v2.json",
+  );
+  const registry = readJson(registryPath);
+  const extensionId = /^chrome-extension:\/\/([a-p]{32})\/$/.exec(origin)?.[1];
+  const entries = registry?.schemaVersion === 2 && Array.isArray(registry.entries)
+    ? registry.entries
+    : [];
+  const matchingEntries = entries.filter((entry) => (
+    entry?.schemaVersion === 2 &&
+    entry.nativeHostNames?.includes(HOST_NAME) &&
+    entry.extensionIds?.includes(extensionId) &&
+    sameRealPath(entry.paths?.codexHome, options.codexHome) &&
+    sameRealPath(entry.paths?.resourcesPath, path.join(options.appDir, "resources"))
+  ));
+  matchingEntries.sort((left, right) => (
+    String(right.presence?.lastSeenAt || "").localeCompare(String(left.presence?.lastSeenAt || ""))
+  ));
+  const candidate = matchingEntries[0]?.paths?.extensionHostPath;
+  if (typeof candidate !== "string" || !path.isAbsolute(candidate)) {
+    throw new Error(`official Chrome native host is not registered for this app: ${registryPath}`);
+  }
+  const resolved = fs.realpathSync(candidate);
+  const trustedRoots = [
+    path.join(options.codexHome, "plugins", "cache", "openai-bundled", "chrome"),
+    path.join(options.appDir, "resources", "plugins", "openai-bundled", "plugins", "chrome"),
+  ].filter((root) => fs.existsSync(root)).map((root) => fs.realpathSync(root));
+  if (!trustedRoots.some((root) => isPathInside(root, resolved))) {
+    throw new Error(`registered Chrome native host is outside trusted roots: ${resolved}`);
+  }
+  const stat = fs.statSync(resolved);
+  if (!stat.isFile() || (stat.mode & 0o111) === 0 || (stat.mode & 0o022) !== 0) {
+    throw new Error(`registered Chrome native host has unsafe permissions: ${resolved}`);
+  }
+  if (stat.uid !== process.getuid() && stat.uid !== 0) {
+    throw new Error(`registered Chrome native host has an unexpected owner: ${resolved}`);
+  }
+  return resolved;
+}
+
+function parsePrelude(socket, onAuthenticated) {
+  let buffered = Buffer.alloc(0);
+  const timer = setTimeout(() => socket.destroy(), AUTH_TIMEOUT_MS);
+  timer.unref();
+  const onData = (chunk) => {
+    buffered = Buffer.concat([buffered, chunk]);
+    const first = buffered.indexOf(0x0a);
+    const second = first < 0 ? -1 : buffered.indexOf(0x0a, first + 1);
+    if (second < 0) {
+      if (buffered.length > MAX_PRELUDE_BYTES) socket.destroy();
+      return;
+    }
+    if (second + 1 > MAX_PRELUDE_BYTES) return socket.destroy();
+    socket.off("data", onData);
+    clearTimeout(timer);
+    onAuthenticated(
+      buffered.subarray(0, first).toString("utf8"),
+      buffered.subarray(first + 1, second).toString("utf8"),
+      buffered.subarray(second + 1),
+    );
+  };
+  socket.on("data", onData);
+}
+
+function connectHost(socket, initialPayload, origin, options, hostChildren) {
+  let child;
+  try {
+    child = spawn(readRuntimeHost(options, origin), [origin], {
+      env: process.env,
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+  } catch {
+    socket.destroy();
+    return;
+  }
+  hostChildren.add(child);
+  let terminationTimer;
+  let killTimer;
+  const terminateChild = (graceMilliseconds = 0) => {
+    if (child.exitCode != null || child.signalCode != null || terminationTimer) return;
+    terminationTimer = setTimeout(() => {
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => child.kill("SIGKILL"), 500);
+      killTimer.unref();
+    }, graceMilliseconds);
+    terminationTimer.unref();
+  };
+  const abort = () => {
+    socket.destroy();
+    terminateChild();
+  };
+  child.on("error", abort);
+  child.on("close", () => {
+    if (terminationTimer) clearTimeout(terminationTimer);
+    if (killTimer) clearTimeout(killTimer);
+    hostChildren.delete(child);
+  });
+  child.stdout.on("error", abort);
+  child.stdin.on("error", (error) => {
+    if (error.code !== "EPIPE") abort();
+  });
+  socket.on("error", abort);
+  socket.on("close", () => terminateChild(250));
+  socket.on("end", () => child.stdin.end());
+  if (initialPayload.length > 0) child.stdin.write(initialPayload);
+  socket.pipe(child.stdin, { end: true });
+  child.stdout.pipe(socket, { end: true });
+}
+
+function probe(state, request = "@ping") {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port: state.port });
+    const timer = setTimeout(() => { socket.destroy(); resolve(false); }, 500);
+    timer.unref();
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.on("connect", () => socket.write(`${state.token}\n${request}\n`));
+    socket.on("data", (chunk) => { response += chunk; });
+    socket.on("end", () => { clearTimeout(timer); resolve(response === "ok\n"); });
+    socket.on("error", () => { clearTimeout(timer); resolve(false); });
+  });
+}
+
+async function acquireLock(lockDirectory) {
+  const deadline = Date.now() + START_TIMEOUT_MS;
+  const ownerIdentity = processIdentity(process.pid);
+  const temporary = `${lockDirectory}.${process.pid}.${crypto.randomBytes(6).toString("hex")}`;
+  while (true) {
+    try {
+      fs.mkdirSync(temporary, { mode: 0o700 });
+      fs.writeFileSync(
+        path.join(temporary, "owner.json"),
+        `${JSON.stringify({ pid: process.pid, identity: ownerIdentity })}\n`,
+        { mode: 0o600 },
+      );
+      fs.renameSync(temporary, lockDirectory);
+      return () => {
+        try {
+          const owner = readJson(path.join(lockDirectory, "owner.json"));
+          if (owner.pid === process.pid && owner.identity === ownerIdentity) {
+            fs.rmSync(lockDirectory, { recursive: true, force: true });
+          }
+        } catch {}
+      };
+    } catch (error) {
+      fs.rmSync(temporary, { recursive: true, force: true });
+      if (error.code !== "EEXIST" && error.code !== "ENOTEMPTY") throw error;
+      try {
+        const owner = readJson(path.join(lockDirectory, "owner.json"));
+        if (processIdentity(owner.pid) !== owner.identity) {
+          fs.rmSync(lockDirectory, { recursive: true, force: true });
+          continue;
+        }
+      } catch {
+        fs.rmSync(lockDirectory, { recursive: true, force: true });
+        continue;
+      }
+      if (Date.now() >= deadline) throw new Error("timed out waiting for bridge startup lock");
+      await delay(50);
+    }
+  }
+}
+
+function loadState(options) {
+  try {
+    const state = readJson(pathsFor(options).stateFile);
+    if (
+      state?.version !== 1 ||
+      !Number.isSafeInteger(state.serverPid) ||
+      typeof state.serverIdentity !== "string" ||
+      !Number.isSafeInteger(state.ownerPid) ||
+      !Number.isSafeInteger(state.port) ||
+      !/^[a-f0-9]{64}$/.test(state.token || "") ||
+      typeof state.ownerIdentity !== "string" ||
+      !path.isAbsolute(state.appDir || "") ||
+      !path.isAbsolute(state.codexHome || "") ||
+      !path.isAbsolute(state.flatpakRoot || "")
+    ) return null;
+    return state;
+  } catch {
+    return null;
+  }
+}
+
+async function ensure(options) {
+  privateDirectory(options.stateDir);
+  const release = await acquireLock(pathsFor(options).lockDirectory);
+  try {
+    const stateFileExists = fs.existsSync(pathsFor(options).stateFile);
+    const existing = loadState(options);
+    if (stateFileExists && !existing) {
+      throw new Error("refusing to replace an invalid Flatpak Chrome bridge state file");
+    }
+    let startOptions = options;
+    if (existing) {
+      const existingOptions = {
+        ...options,
+        appDir: existing.appDir,
+        codexHome: existing.codexHome,
+        flatpakRoot: existing.flatpakRoot,
+        ownerPid: existing.ownerPid,
+      };
+      const ownerIsAlive = processIdentity(existing.ownerPid) === existing.ownerIdentity;
+      const serverIsAlive = processIdentity(existing.serverPid) === existing.serverIdentity;
+      const existingResponds = await probe(existing);
+      if (ownerIsAlive && existingResponds) return;
+      if (ownerIsAlive && serverIsAlive) {
+        throw new Error("live Flatpak Chrome bridge did not answer its health check");
+      }
+      if (ownerIsAlive) startOptions = existingOptions;
+      if (serverIsAlive) {
+        if (existingResponds) {
+          await probe(existing, `@shutdown:${existing.ownerIdentity}`);
+        } else {
+          process.kill(existing.serverPid, "SIGTERM");
+        }
+        const shutdownDeadline = Date.now() + 2000;
+        while (
+          processIdentity(existing.serverPid) === existing.serverIdentity &&
+          Date.now() < shutdownDeadline
+        ) {
+          await delay(25);
+        }
+        if (processIdentity(existing.serverPid) === existing.serverIdentity) {
+          throw new Error("stale Flatpak Chrome bridge did not shut down");
+        }
+      }
+      restoreManifest(existingOptions);
+      fs.rmSync(pathsFor(options).stateFile, { force: true });
+    }
+    const extension = loadExtensionRegistry(startOptions.appDir);
+    assertManifestCanBeReplaced(startOptions, extension.origins);
+    const ownerIdentity = processIdentity(startOptions.ownerPid);
+    if (!ownerIdentity) throw new Error(`owner process ${startOptions.ownerPid} is not running`);
+    const logFd = fs.openSync(pathsFor(options).logFile, "a", 0o600);
+    const argumentsForServe = [
+      fileURLToPath(import.meta.url), "serve",
+      "--app-dir", startOptions.appDir,
+      "--codex-home", startOptions.codexHome,
+      "--state-dir", startOptions.stateDir,
+      "--flatpak-root", startOptions.flatpakRoot,
+      "--owner-pid", String(startOptions.ownerPid),
+    ];
+    const child = spawn(process.execPath, argumentsForServe, {
+      detached: true,
+      env: process.env,
+      stdio: ["ignore", logFd, logFd],
+    });
+    child.unref();
+    fs.closeSync(logFd);
+
+    const deadline = Date.now() + START_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const state = loadState(options);
+      if (state?.ownerIdentity === ownerIdentity && await probe(state)) return;
+      await delay(50);
+    }
+    throw new Error("Flatpak Chrome bridge did not become ready");
+  } finally {
+    release();
+  }
+}
+
+async function serve(options) {
+  const ownerIdentity = processIdentity(options.ownerPid);
+  if (!ownerIdentity) throw new Error(`owner process ${options.ownerPid} is not running`);
+  const extension = loadExtensionRegistry(options.appDir);
+  const token = crypto.randomBytes(32).toString("hex");
+  let clients = 0;
+  let stopping = false;
+  const sockets = new Set();
+  const hostChildren = new Set();
+  const state = {
+    version: 1,
+    serverPid: process.pid,
+    serverIdentity: processIdentity(process.pid),
+    ownerPid: options.ownerPid,
+    ownerIdentity,
+    appDir: options.appDir,
+    codexHome: options.codexHome,
+    flatpakRoot: options.flatpakRoot,
+    port: 0,
+    token,
+    origins: extension.origins,
+  };
+  let ownerTimer;
+
+  const server = net.createServer((socket) => {
+    if (clients >= MAX_CLIENTS) return socket.destroy();
+    clients += 1;
+    sockets.add(socket);
+    socket.on("error", () => socket.destroy());
+    socket.once("close", () => { clients -= 1; sockets.delete(socket); });
+    parsePrelude(socket, (providedToken, origin, initialPayload) => {
+      const providedTokenBuffer = Buffer.from(providedToken);
+      const tokenBuffer = Buffer.from(token);
+      if (
+        providedTokenBuffer.length !== tokenBuffer.length ||
+        !crypto.timingSafeEqual(providedTokenBuffer, tokenBuffer)
+      ) return socket.destroy();
+      if (origin === "@ping") { socket.end("ok\n"); return; }
+      if (origin === `@shutdown:${ownerIdentity}`) { socket.end("ok\n"); stop(); return; }
+      if (!extension.origins.includes(origin)) return socket.destroy();
+      connectHost(socket, initialPayload, origin, options, hostChildren);
+    });
+  });
+
+  const stop = () => {
+    if (stopping) return;
+    stopping = true;
+    if (ownerTimer) clearInterval(ownerTimer);
+    for (const socket of sockets) socket.destroy();
+    server.close();
+    for (const child of hostChildren) child.kill("SIGTERM");
+    const killTimer = setTimeout(() => {
+      for (const child of hostChildren) child.kill("SIGKILL");
+    }, 500);
+    killTimer.unref();
+    const finishDeadline = Date.now() + 1000;
+    const finishTimer = setInterval(() => {
+      if (hostChildren.size > 0 && Date.now() < finishDeadline) return;
+      clearInterval(finishTimer);
+      restoreManifest(options);
+      fs.rmSync(pathsFor(options).stateFile, { force: true });
+      process.exit(0);
+    }, 25);
+  };
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen({ host: "127.0.0.1", port: 0, exclusive: true }, resolve);
+  });
+  try {
+    state.port = server.address().port;
+    prepareManifest(options, state);
+    writePrivateAtomic(pathsFor(options).stateFile, `${JSON.stringify(state)}\n`);
+  } catch (error) {
+    server.close();
+    throw error;
+  }
+  ownerTimer = setInterval(() => {
+    if (processIdentity(options.ownerPid) !== ownerIdentity) stop();
+  }, OWNER_POLL_MS);
+  ownerTimer.unref();
+  process.on("SIGINT", stop);
+  process.on("SIGTERM", stop);
+  process.on("SIGHUP", stop);
+}
+
+async function cleanup(options) {
+  const state = loadState(options);
+  const ownerIdentity = processIdentity(options.ownerPid);
+  if (!state || !ownerIdentity || state.ownerIdentity !== ownerIdentity) return;
+  await probe(state, `@shutdown:${ownerIdentity}`);
+}
+
+export {
+  bridgeManifest,
+  loadExtensionRegistry,
+  parsePrelude,
+  pathsFor,
+  processIdentity,
+  wrapperSource,
+};
+
+if (path.resolve(process.argv[1] || "") === fileURLToPath(import.meta.url)) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.command === "ensure") await ensure(options);
+    else if (options.command === "serve") await serve(options);
+    else if (options.command === "cleanup") await cleanup(options);
+    else throw new Error(`unsupported command: ${options.command}`);
+  } catch (error) {
+    console.error(`flatpak-chrome-native-messaging: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/linux-features/flatpak-chrome-native-messaging/feature.json
+++ b/linux-features/flatpak-chrome-native-messaging/feature.json
@@ -1,0 +1,33 @@
+{
+  "id": "flatpak-chrome-native-messaging",
+  "title": "Flatpak Chrome Native Messaging",
+  "description": "Bridges the official Chrome extension host into the Flatpak Google Chrome sandbox without adding sandbox overrides.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  },
+  "resources": [
+    {
+      "source": "bridge.mjs",
+      "target": ".codex-linux/features/flatpak-chrome-native-messaging/bridge.mjs",
+      "mode": "0644"
+    }
+  ],
+  "runtimeHooks": {
+    "prelaunch": {
+      "source": "runtime.sh",
+      "name": "start.sh",
+      "mode": "0755"
+    },
+    "launcher": {
+      "source": "runtime.sh",
+      "name": "environment.sh",
+      "mode": "0755"
+    },
+    "afterExit": {
+      "source": "runtime.sh",
+      "name": "stop.sh",
+      "mode": "0755"
+    }
+  }
+}

--- a/linux-features/flatpak-chrome-native-messaging/patch.js
+++ b/linux-features/flatpak-chrome-native-messaging/patch.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const IDENTIFIER = "([A-Za-z_$][\\w$]*)";
+const LINUX_PROFILE_ROOTS = new RegExp(
+  `if\\(${IDENTIFIER}===\\\`linux\\\`\\)\\{` +
+  `let ${IDENTIFIER}=${IDENTIFIER}\\.F\\(\\{` +
+  `chromeConfigHome:${IDENTIFIER}===\\\`chrome\\\`\\?${IDENTIFIER}:void 0,` +
+  `homeDir:${IDENTIFIER},xdgConfigHome:${IDENTIFIER}\\}\\);` +
+  `return ${IDENTIFIER}\\.linux\\.installations\\.map\\(${IDENTIFIER}=>` +
+  `\\(0,${IDENTIFIER}\\.join\\)\\(${IDENTIFIER},${IDENTIFIER}\\.userDataDirName\\)\\)\\}`,
+  "g",
+);
+
+function applyFlatpakChromeProfileRoot(source) {
+  const matches = [...source.matchAll(LINUX_PROFILE_ROOTS)];
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one Linux Chromium profile resolver, found ${matches.length}`,
+    );
+  }
+  LINUX_PROFILE_ROOTS.lastIndex = 0;
+  return source.replace(
+    LINUX_PROFILE_ROOTS,
+    (
+      original,
+      platform,
+      configRoot,
+      diagnosticsNamespace,
+      browserFamily,
+      chromeConfigHome,
+      homeDir,
+      xdgConfigHome,
+      browserDefinition,
+      installation,
+      pathNamespace,
+      mappedRoot,
+      mappedInstallation,
+    ) => {
+      if (configRoot !== mappedRoot || installation !== mappedInstallation) {
+        throw new Error("Linux Chromium profile resolver symbols do not match");
+      }
+      const originalRoots = `${browserDefinition}.linux.installations.map(` +
+        `${installation}=>(0,${pathNamespace}.join)(` +
+        `${configRoot},${installation}.userDataDirName))`;
+      return `if(${platform}===\`linux\`){let ${configRoot}=` +
+        `${diagnosticsNamespace}.F({chromeConfigHome:${browserFamily}===\`chrome\`?` +
+        `${chromeConfigHome}:void 0,homeDir:${homeDir},xdgConfigHome:${xdgConfigHome}}),` +
+        `codexLinuxChromeProfileRoots=${originalRoots},` +
+        `codexLinuxFlatpakChromeProfile=process.env.CODEX_CHROME_USER_DATA_DIR;` +
+        `return ${browserFamily}===\`chrome\`&&codexLinuxFlatpakChromeProfile?` +
+        `[...codexLinuxChromeProfileRoots,codexLinuxFlatpakChromeProfile]:` +
+        `codexLinuxChromeProfileRoots}`;
+    },
+  );
+}
+
+module.exports = {
+  descriptors: [
+    {
+      id: "flatpak-chrome-profile-status",
+      phase: "main-bundle",
+      order: 20600,
+      ciPolicy: "opt-in",
+      apply: applyFlatpakChromeProfileRoot,
+    },
+  ],
+  applyFlatpakChromeProfileRoot,
+};

--- a/linux-features/flatpak-chrome-native-messaging/runtime.sh
+++ b/linux-features/flatpak-chrome-native-messaging/runtime.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -u
+
+warn() {
+    printf 'WARN: flatpak-chrome-native-messaging: %s\n' "$*" >&2
+}
+
+flatpak_root="${CODEX_FLATPAK_CHROME_ROOT:-${HOME:-}/.var/app/com.google.Chrome}"
+chrome_config="$flatpak_root/config/google-chrome"
+manifest_path="$chrome_config/NativeMessagingHosts/com.openai.codexextension.json"
+
+flatpak_chrome_is_available() {
+    if [ -n "${CODEX_FLATPAK_CHROME_ROOT:-}" ]; then
+        [ -d "$flatpak_root" ]
+        return
+    fi
+    command -v flatpak >/dev/null 2>&1 && flatpak info com.google.Chrome >/dev/null 2>&1
+}
+
+flatpak_chrome_is_available || exit 0
+
+case "${CODEX_LINUX_FEATURE_HOOK_PHASE:-}" in
+    launcher)
+        printf 'env CODEX_CHROME_USER_DATA_DIR=%s\n' "$chrome_config"
+        printf 'env CODEX_CHROME_NATIVE_HOST_MANIFEST_PATH=%s\n' "$manifest_path"
+        ;;
+    prelaunch|after-exit)
+        app_dir="${CODEX_LINUX_APP_DIR:-}"
+        state_root="${CODEX_LINUX_APP_STATE_DIR:-}"
+        bridge="${CODEX_LINUX_FEATURES_DIR:-}/flatpak-chrome-native-messaging/bridge.mjs"
+        node_bin="$app_dir/resources/cua_node/bin/node"
+        owner_pid="$PPID"
+
+        if [ -z "$app_dir" ] || [ -z "$state_root" ] || [ ! -f "$bridge" ] || [ ! -x "$node_bin" ]; then
+            warn "the packaged Node runtime or bridge resource is unavailable"
+            exit 0
+        fi
+
+        command=ensure
+        [ "${CODEX_LINUX_FEATURE_HOOK_PHASE:-}" = after-exit ] && command=cleanup
+        if ! "$node_bin" "$bridge" "$command" \
+            --app-dir "$app_dir" \
+            --codex-home "${CODEX_HOME:-${HOME:-}/.codex}" \
+            --state-dir "$state_root/flatpak-chrome-native-messaging" \
+            --flatpak-root "$flatpak_root" \
+            --owner-pid "$owner_pid"; then
+            warn "could not $command the Flatpak Chrome bridge; the desktop app will continue"
+        fi
+        ;;
+esac

--- a/linux-features/flatpak-chrome-native-messaging/test.js
+++ b/linux-features/flatpak-chrome-native-messaging/test.js
@@ -1,0 +1,444 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const { spawn, spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const net = require("node:net");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const {
+  enabledLinuxFeatureIds,
+  enabledLinuxFeatureInstallPlan,
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const { applyFlatpakChromeProfileRoot } = require("./patch.js");
+
+const FEATURE_DIR = __dirname;
+const BRIDGE = path.join(FEATURE_DIR, "bridge.mjs");
+const HOST_NAME = "com.openai.codexextension";
+const EXTENSION_ID = "hehggadaopoacecdllhhajmbjkdcmajg";
+const ORIGIN = `chrome-extension://${EXTENSION_ID}/`;
+
+function commandPath(name) {
+  for (const directory of (process.env.PATH || "").split(path.delimiter)) {
+    if (!directory || !path.isAbsolute(directory)) continue;
+    const candidate = path.join(directory, name);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      if (fs.statSync(candidate).isFile()) return candidate;
+    } catch {}
+  }
+  throw new Error(`could not resolve executable from PATH: ${name}`);
+}
+
+const BASH = commandPath("bash");
+
+function withFeatureConfig(enabled, fn) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-flatpak-chrome-config-"));
+  const configPath = path.join(tempDir, "features.json");
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  fs.writeFileSync(configPath, `${JSON.stringify({ enabled }, null, 2)}\n`);
+  process.env.CODEX_LINUX_FEATURES_CONFIG = configPath;
+  try {
+    return fn(path.resolve(FEATURE_DIR, ".."));
+  } finally {
+    if (originalConfig == null) delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+    else process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function createFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-flatpak-chrome-"));
+  const appDir = path.join(root, "app");
+  const codexHome = path.join(root, "codex-home");
+  const stateDir = path.join(root, "state", "bridge");
+  const flatpakRoot = path.join(root, "flatpak");
+  const registryPath = path.join(root, "chrome-native-hosts-v2.json");
+  const extensionRegistry = path.join(
+    appDir,
+    "resources/plugins/openai-bundled/plugins/chrome/scripts/extension-ids.json",
+  );
+  const hostPath = path.join(
+    codexHome,
+    "plugins/cache/openai-bundled/chrome/1/extension-host/linux/x64/extension-host",
+  );
+  const hostMarker = path.join(root, "host-started");
+  fs.mkdirSync(path.dirname(extensionRegistry), { recursive: true });
+  fs.mkdirSync(path.dirname(hostPath), { recursive: true });
+  fs.mkdirSync(flatpakRoot, { recursive: true });
+  fs.writeFileSync(extensionRegistry, `${JSON.stringify({
+    extensionHostName: HOST_NAME,
+    extensionIds: [EXTENSION_ID],
+  })}\n`);
+  fs.writeFileSync(hostPath, `#!/usr/bin/bash\nprintf started >> '${hostMarker}'\ncat\n`, { mode: 0o700 });
+  fs.writeFileSync(registryPath, `${JSON.stringify({
+    schemaVersion: 2,
+    entries: [{
+      schemaVersion: 2,
+      nativeHostNames: [HOST_NAME],
+      extensionIds: [EXTENSION_ID],
+      paths: {
+        codexHome,
+        resourcesPath: path.join(appDir, "resources"),
+        extensionHostPath: hostPath,
+      },
+      presence: { lastSeenAt: new Date().toISOString() },
+    }],
+  })}\n`);
+  const options = [
+    "--app-dir", appDir,
+    "--codex-home", codexHome,
+    "--state-dir", stateDir,
+    "--flatpak-root", flatpakRoot,
+    "--owner-pid", String(process.pid),
+  ];
+  const env = { ...process.env, CODEX_CHROME_NATIVE_HOST_REGISTRY: registryPath };
+  return {
+    root,
+    appDir,
+    codexHome,
+    stateDir,
+    flatpakRoot,
+    registryPath,
+    hostPath,
+    hostMarker,
+    options,
+    env,
+    stateFile: path.join(stateDir, "bridge-state.json"),
+    manifestPath: path.join(
+      flatpakRoot,
+      "config/google-chrome/NativeMessagingHosts",
+      `${HOST_NAME}.json`,
+    ),
+  };
+}
+
+function bridgeCommand(fixture, command) {
+  return spawnSync(process.execPath, [BRIDGE, command, ...fixture.options], {
+    env: fixture.env,
+    encoding: "utf8",
+    timeout: 10000,
+  });
+}
+
+async function waitFor(predicate, timeout = 3000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  assert.fail("timed out waiting for condition");
+}
+
+async function cleanupFixture(fixture) {
+  bridgeCommand(fixture, "cleanup");
+  await waitFor(() => !fs.existsSync(fixture.stateFile)).catch(() => {});
+  fs.rmSync(fixture.root, { recursive: true, force: true });
+}
+
+test("flatpak-chrome-native-messaging stays disabled until selected", () => {
+  withFeatureConfig([], (featuresRoot) => {
+    assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot }), []);
+  });
+});
+
+test("feature stages the relay and lifecycle hooks only when enabled", () => {
+  withFeatureConfig(["flatpak-chrome-native-messaging"], (featuresRoot) => {
+    assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot }), ["flatpak-chrome-native-messaging"]);
+    const descriptors = loadLinuxFeaturePatchDescriptors({ featuresRoot });
+    assert.equal(descriptors.length, 1);
+    assert.equal(
+      descriptors[0].id,
+      "feature:flatpak-chrome-native-messaging:flatpak-chrome-profile-status",
+    );
+    assert.equal(descriptors[0].ciPolicy, "opt-in");
+    const plan = enabledLinuxFeatureInstallPlan({ featuresRoot });
+    assert.deepEqual(
+      plan.resources.map(({ target, mode }) => [target, mode]),
+      [[".codex-linux/features/flatpak-chrome-native-messaging/bridge.mjs", 0o644]],
+    );
+    assert.deepEqual(
+      plan.runtimeHooks.map(({ key, mode }) => [key, mode]),
+      [["prelaunch", 0o755], ["launcher", 0o755], ["afterExit", 0o755]],
+    );
+  });
+});
+
+test("Settings detector adds only the explicit Flatpak Chrome profile", () => {
+  const source = "function Va({browserFamily:e,chromeConfigHome:t,homeDir:r," +
+    "localAppDataDir:i,roamingAppDataDir:a,platform:o,xdgConfigHome:s}){" +
+    "let c=n.as[e];if(o===`darwin`)return[(0,p.join)(r,...c.macos.userDataDirectorySegments)];" +
+    "if(o===`win32`)return[i,a];if(o===`linux`){let i=n.F({chromeConfigHome:" +
+    "e===`chrome`?t:void 0,homeDir:r,xdgConfigHome:s});return c.linux.installations.map(" +
+    "e=>(0,p.join)(i,e.userDataDirName))}return[]}";
+  const patched = applyFlatpakChromeProfileRoot(source);
+  const sandbox = {
+    n: {
+      as: {
+        chrome: {
+          linux: { installations: [{ userDataDirName: "google-chrome" }] },
+          macos: { userDataDirectorySegments: ["Library", "Chrome"] },
+        },
+        edge: {
+          linux: { installations: [{ userDataDirName: "microsoft-edge" }] },
+          macos: { userDataDirectorySegments: ["Library", "Edge"] },
+        },
+      },
+      F: ({ homeDir }) => `${homeDir}/.config`,
+    },
+    p: { join: path.join },
+    process: { env: { CODEX_CHROME_USER_DATA_DIR: "/flatpak/google-chrome" } },
+  };
+  const resolveProfiles = vm.runInNewContext(`${patched}; Va`, sandbox);
+  assert.deepEqual(
+    [...resolveProfiles({ browserFamily: "chrome", homeDir: "/home/test", platform: "linux" })],
+    ["/home/test/.config/google-chrome", "/flatpak/google-chrome"],
+  );
+  assert.deepEqual(
+    [...resolveProfiles({ browserFamily: "edge", homeDir: "/home/test", platform: "linux" })],
+    ["/home/test/.config/microsoft-edge"],
+  );
+  assert.deepEqual(
+    [...resolveProfiles({ browserFamily: "chrome", homeDir: "/home/test", platform: "darwin" })],
+    ["/home/test/Library/Chrome"],
+  );
+  assert.throws(() => applyFlatpakChromeProfileRoot("function unrelated(){}"), /found 0/);
+  assert.throws(() => applyFlatpakChromeProfileRoot(`${source}${source}`), /found 2/);
+});
+
+test("launcher points upstream diagnostics at the Flatpak Chrome profile", () => {
+  const fixture = createFixture();
+  try {
+    const result = spawnSync(BASH, [path.join(FEATURE_DIR, "runtime.sh")], {
+      env: {
+        ...process.env,
+        CODEX_LINUX_FEATURE_HOOK_PHASE: "launcher",
+        CODEX_FLATPAK_CHROME_ROOT: fixture.flatpakRoot,
+      },
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, new RegExp(`CODEX_CHROME_USER_DATA_DIR=${fixture.flatpakRoot}`));
+    assert.match(result.stdout, /CODEX_CHROME_NATIVE_HOST_MANIFEST_PATH=/);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("relay preserves binary native-messaging bytes and rejects invalid authentication", async () => {
+  const fixture = createFixture();
+  try {
+    const started = bridgeCommand(fixture, "ensure");
+    assert.equal(started.status, 0, started.stderr);
+    const state = JSON.parse(fs.readFileSync(fixture.stateFile, "utf8"));
+    const manifest = JSON.parse(fs.readFileSync(fixture.manifestPath, "utf8"));
+    assert.equal(manifest.name, HOST_NAME);
+    assert.equal(manifest.path, path.join(path.dirname(fixture.manifestPath), `${HOST_NAME}-codex-desktop-bridge`));
+    assert.deepEqual(manifest.allowed_origins, [ORIGIN]);
+    assert.equal(fs.statSync(manifest.path).mode & 0o777, 0o700);
+    assert.equal(fs.statSync(fixture.stateFile).mode & 0o777, 0o600);
+
+    await new Promise((resolve, reject) => {
+      const socket = net.createConnection({ host: "127.0.0.1", port: state.port });
+      socket.on("connect", () => socket.resetAndDestroy());
+      socket.on("close", resolve);
+      socket.on("error", (error) => {
+        if (error.code === "ECONNRESET") resolve();
+        else reject(error);
+      });
+    });
+    const afterReset = bridgeCommand(fixture, "ensure");
+    assert.equal(afterReset.status, 0, afterReset.stderr);
+    assert.equal(JSON.parse(fs.readFileSync(fixture.stateFile, "utf8")).serverPid, state.serverPid);
+
+    await new Promise((resolve, reject) => {
+      const socket = net.createConnection({ host: "127.0.0.1", port: state.port });
+      socket.on("connect", () => socket.end(`wrong-token\n${ORIGIN}\n`));
+      socket.on("close", resolve);
+      socket.on("error", reject);
+    });
+    assert.equal(fs.existsSync(fixture.hostMarker), false);
+
+    const payload = Buffer.alloc(4096);
+    for (let index = 0; index < payload.length; index += 1) payload[index] = index % 256;
+    const echoed = await new Promise((resolve, reject) => {
+      const chunks = [];
+      let length = 0;
+      const socket = net.createConnection({ host: "127.0.0.1", port: state.port });
+      socket.on("connect", () => {
+        socket.write(Buffer.concat([Buffer.from(`${state.token}\n${ORIGIN}\n`), payload]));
+      });
+      socket.on("data", (chunk) => {
+        chunks.push(chunk);
+        length += chunk.length;
+        if (length >= payload.length) socket.end();
+      });
+      socket.on("close", () => resolve(Buffer.concat(chunks)));
+      socket.on("error", reject);
+    });
+    assert.deepEqual(echoed, payload);
+    assert.equal(fs.readFileSync(fixture.hostMarker, "utf8"), "started");
+  } finally {
+    await cleanupFixture(fixture);
+  }
+});
+
+test("Flatpak wrapper forwards bytes and a repeated launch reuses the live relay", async () => {
+  const fixture = createFixture();
+  try {
+    const first = bridgeCommand(fixture, "ensure");
+    assert.equal(first.status, 0, first.stderr);
+    const initialState = JSON.parse(fs.readFileSync(fixture.stateFile, "utf8"));
+    const second = bridgeCommand(fixture, "ensure");
+    assert.equal(second.status, 0, second.stderr);
+    assert.deepEqual(JSON.parse(fs.readFileSync(fixture.stateFile, "utf8")), initialState);
+
+    const saturatedSockets = await Promise.all(Array.from({ length: 8 }, () => (
+      new Promise((resolve, reject) => {
+        const socket = net.createConnection({ host: "127.0.0.1", port: initialState.port });
+        socket.on("connect", () => { socket.write("partial-auth"); resolve(socket); });
+        socket.on("error", reject);
+      })
+    )));
+    const whileSaturated = bridgeCommand(fixture, "ensure");
+    assert.notEqual(whileSaturated.status, 0);
+    assert.deepEqual(JSON.parse(fs.readFileSync(fixture.stateFile, "utf8")), initialState);
+    for (const socket of saturatedSockets) socket.destroy();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const afterSaturation = bridgeCommand(fixture, "ensure");
+    assert.equal(afterSaturation.status, 0, afterSaturation.stderr);
+
+    const manifest = JSON.parse(fs.readFileSync(fixture.manifestPath, "utf8"));
+    const child = spawn(BASH, [manifest.path, ORIGIN], { stdio: ["pipe", "pipe", "pipe"] });
+    const payload = Buffer.from([8, 0, 0, 0, 0, 1, 2, 3, 255, 4, 5, 6]);
+    const received = await new Promise((resolve, reject) => {
+      const chunks = [];
+      let length = 0;
+      child.stdout.on("data", (chunk) => {
+        chunks.push(chunk);
+        length += chunk.length;
+        if (length >= payload.length) {
+          child.stdin.end();
+          resolve(Buffer.concat(chunks));
+        }
+      });
+      child.on("error", reject);
+      child.stdin.write(payload);
+    });
+    assert.deepEqual(received, payload);
+    await new Promise((resolve) => child.once("exit", resolve));
+  } finally {
+    await cleanupFixture(fixture);
+  }
+});
+
+test("relay drains a final host response before closing the browser pipe", async () => {
+  const fixture = createFixture();
+  const outputSize = 4 * 1024 * 1024;
+  fs.writeFileSync(
+    fixture.hostPath,
+    `#!/usr/bin/bash\nhead -c ${outputSize} /dev/zero\n`,
+    { mode: 0o700 },
+  );
+  try {
+    const started = bridgeCommand(fixture, "ensure");
+    assert.equal(started.status, 0, started.stderr);
+    const state = JSON.parse(fs.readFileSync(fixture.stateFile, "utf8"));
+    const received = await new Promise((resolve, reject) => {
+      let byteCount = 0;
+      let allZero = true;
+      const socket = net.createConnection({ host: "127.0.0.1", port: state.port });
+      socket.on("connect", () => socket.write(`${state.token}\n${ORIGIN}\n`));
+      socket.on("data", (chunk) => {
+        byteCount += chunk.length;
+        if (chunk.some((byte) => byte !== 0)) allZero = false;
+        socket.pause();
+        setTimeout(() => socket.resume(), 1);
+      });
+      socket.on("end", () => resolve({ byteCount, allZero }));
+      socket.on("error", reject);
+    });
+    assert.deepEqual(received, { byteCount: outputSize, allZero: true });
+  } finally {
+    await cleanupFixture(fixture);
+  }
+});
+
+test("cleanup restores a recognized official manifest byte for byte", async () => {
+  const fixture = createFixture();
+  const nativeDirectory = path.dirname(fixture.manifestPath);
+  const original = `${JSON.stringify({
+    name: HOST_NAME,
+    description: "Official host",
+    path: fixture.hostPath,
+    type: "stdio",
+    allowed_origins: [ORIGIN],
+  }, null, 2)}\n`;
+  fs.mkdirSync(nativeDirectory, { recursive: true });
+  fs.writeFileSync(fixture.manifestPath, original);
+  try {
+    const started = bridgeCommand(fixture, "ensure");
+    assert.equal(started.status, 0, started.stderr);
+    assert.notEqual(fs.readFileSync(fixture.manifestPath, "utf8"), original);
+    const stopped = bridgeCommand(fixture, "cleanup");
+    assert.equal(stopped.status, 0, stopped.stderr);
+    await waitFor(() => fs.existsSync(fixture.manifestPath) && fs.readFileSync(fixture.manifestPath, "utf8") === original);
+  } finally {
+    await cleanupFixture(fixture);
+  }
+});
+
+test("relay leaves an unrelated native-host manifest untouched", () => {
+  const fixture = createFixture();
+  const nativeDirectory = path.dirname(fixture.manifestPath);
+  const foreign = `${JSON.stringify({
+    name: HOST_NAME,
+    description: "Local override",
+    path: "/opt/local/custom-host",
+    type: "stdio",
+    allowed_origins: [ORIGIN],
+  })}\n`;
+  fs.mkdirSync(nativeDirectory, { recursive: true });
+  fs.writeFileSync(fixture.manifestPath, foreign);
+  try {
+    const result = bridgeCommand(fixture, "ensure");
+    assert.notEqual(result.status, 0);
+    assert.equal(fs.readFileSync(fixture.manifestPath, "utf8"), foreign);
+  } finally {
+    const state = fs.existsSync(fixture.stateFile) ? JSON.parse(fs.readFileSync(fixture.stateFile, "utf8")) : null;
+    if (state?.serverPid) {
+      try { process.kill(state.serverPid, "SIGTERM"); } catch {}
+    }
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("a manifest replaced while running becomes the next recovery baseline", async () => {
+  const fixture = createFixture();
+  const official = `${JSON.stringify({
+    name: HOST_NAME,
+    description: "Updated official host",
+    path: fixture.hostPath,
+    type: "stdio",
+    allowed_origins: [ORIGIN],
+  }, null, 2)}\n`;
+  try {
+    assert.equal(bridgeCommand(fixture, "ensure").status, 0);
+    fs.writeFileSync(fixture.manifestPath, official);
+    assert.equal(bridgeCommand(fixture, "cleanup").status, 0);
+    await waitFor(() => !fs.existsSync(fixture.stateFile));
+    assert.equal(fs.readFileSync(fixture.manifestPath, "utf8"), official);
+
+    assert.equal(bridgeCommand(fixture, "ensure").status, 0);
+    assert.notEqual(fs.readFileSync(fixture.manifestPath, "utf8"), official);
+    assert.equal(bridgeCommand(fixture, "cleanup").status, 0);
+    await waitFor(() => fs.readFileSync(fixture.manifestPath, "utf8") === official);
+  } finally {
+    await cleanupFixture(fixture);
+  }
+});


### PR DESCRIPTION
## Summary

- add the disabled-by-default `flatpak-chrome-native-messaging` feature
- install a private Flatpak Chrome manifest and authenticated loopback relay that launches the exact official native host selected by the upstream runtime registry
- include the Flatpak Chrome profile in the existing Settings detector without redirecting the upstream manifest installer
- document enablement and recovery behavior in the English and Chinese usage guides

## Tests

- `node --test linux-features/flatpak-chrome-native-messaging/test.js scripts/lib/linux-features.test.js`
- `bash tests/scripts_smoke.sh`
- `node --test scripts/patch-linux-window-ui.test.js scripts/patches/descriptor.test.js scripts/patches/runner.test.js`
- feature-only `./install.sh` build against signed upstream `chatgpt_26.901.41600_amd64.deb`
- packaged `resources/cua_node/bin/node --check` on the staged relay
- `git diff --check`

## Notes

The relay binds only to `127.0.0.1`, uses a private random token, validates the extension origin and registered host path, and does not add a Flatpak override. Flatpak Google Chrome is not installed on the test host, so the Chrome UI handshake was not reproduced end to end there; the binary bridge was exercised through a Flatpak sandbox and with lifecycle/protocol integration tests.

Fixes #1434
