### PR TITLE
HEROX-1437: Fix updater self-replacement builds

### DIFF
--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -652,9 +652,22 @@ updater_build_output_binary() {
 ensure_updater_binary() {
     local cargo_cmd=""
     local built_binary=""
+    local deleted_suffix=" (deleted)"
+    local recovered_binary=""
 
     if ! package_with_updater_enabled; then
         return
+    fi
+
+    if [ ! -x "$UPDATER_BINARY_SOURCE" ]; then
+        case "$UPDATER_BINARY_SOURCE" in
+            *"$deleted_suffix")
+                recovered_binary="${UPDATER_BINARY_SOURCE%"$deleted_suffix"}"
+                if [ -x "$recovered_binary" ]; then
+                    UPDATER_BINARY_SOURCE="$recovered_binary"
+                fi
+                ;;
+        esac
     fi
 
     if [ -x "$UPDATER_BINARY_SOURCE" ] && ! updater_binary_is_stale "$UPDATER_BINARY_SOURCE"; then

--- a/scripts/lib/package-common.test.js
+++ b/scripts/lib/package-common.test.js
@@ -9,15 +9,32 @@ const test = require("node:test");
 
 const repoRoot = path.resolve(__dirname, "../..");
 
-function runPackageCommon(script, appDir) {
+function runPackageCommon(script, appDir, sourceRoot = repoRoot) {
   return childProcess.execFileSync("bash", ["-c", [
     "set -euo pipefail",
-    `REPO_DIR=${JSON.stringify(repoRoot)}`,
+    `REPO_DIR=${JSON.stringify(sourceRoot)}`,
     `APP_DIR=${JSON.stringify(appDir)}`,
     `. ${JSON.stringify(path.join(repoRoot, "scripts/lib/package-common.sh"))}`,
     script,
   ].join("\n")], { encoding: "utf8" });
 }
+
+test("updater binary source recovers the Linux deleted-path marker", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-updater-deleted-path-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const sourceRoot = path.join(root, "minimal-update-builder");
+  const updater = path.join(root, "codex-update-manager");
+  fs.mkdirSync(sourceRoot, { recursive: true });
+  fs.writeFileSync(updater, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+  const output = runPackageCommon([
+    `UPDATER_BINARY_SOURCE=${JSON.stringify(`${updater} (deleted)`)}`,
+    "ensure_updater_binary",
+    'printf "%s\\n" "$UPDATER_BINARY_SOURCE"',
+  ].join("\n"), root, sourceRoot);
+
+  assert.equal(output, `${updater}\n`);
+});
 
 test("package metadata is read from the staged official Linux control file", (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-package-common-"));

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -4,7 +4,7 @@ use crate::{
     builder, cache_cleanup,
     cli::{Cli, Commands},
     config::{RuntimeConfig, RuntimePaths},
-    install, install_rollback, liveness, logging, notify, rollback,
+    install, install_rollback, liveness, logging, notify, restart, rollback,
     state::{PersistedState, UpdateStatus},
     upstream,
 };
@@ -13,6 +13,9 @@ use chrono::Utc;
 use std::{fs::{self, OpenOptions}, path::Path, time::Duration};
 use tokio::time;
 use tracing::{error, info};
+
+// Nonzero so `Restart=on-failure` relaunches the daemon on the new binary.
+const BINARY_REPLACED_RESTART_EXIT_CODE: i32 = 12;
 
 pub async fn run(cli: Cli) -> Result<()> {
     if let Some(result) = run_privileged_command(&cli.command) {
@@ -64,6 +67,14 @@ async fn daemon(config: &RuntimeConfig, state: &mut PersistedState, paths: &Runt
     checks.tick().await;
     reconcile.tick().await;
     loop {
+        if let Some(installed_binary) = restart::replacement_binary() {
+            info!(
+                installed_binary = %installed_binary.display(),
+                "updater binary was replaced on disk; exiting so systemd restarts the daemon"
+            );
+            std::process::exit(BINARY_REPLACED_RESTART_EXIT_CODE);
+        }
+
         tokio::select! {
             _ = checks.tick() => if let Err(error) = check(config, state, paths).await { error!(?error, "periodic update check failed"); },
             _ = reconcile.tick() => if state.status == UpdateStatus::WaitingForAppExit && !liveness::is_app_running(config)? {

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     config::{effective_feature_config_path, RuntimeConfig, RuntimePaths},
-    install::PackageKind,
+    install::{self, PackageKind},
     state::{ArtifactPaths, PersistedState, UpdateStatus},
 };
 use anyhow::{Context, Result};
@@ -79,12 +79,14 @@ pub async fn build_update(
         PackageKind::Rpm => "scripts/build-rpm.sh",
         PackageKind::Pacman => "scripts/build-pacman.sh",
     };
+    let current_exe = std::env::current_exe()?;
+    let updater_binary = install::resolve_updater_binary_for_build(&current_exe);
     let mut package = Command::new(bundle.join(script));
     package
         .env("PACKAGE_VERSION", package_version())
         .env("APP_DIR_OVERRIDE", &app)
         .env("DIST_DIR_OVERRIDE", &dist)
-        .env("UPDATER_BINARY_SOURCE", std::env::current_exe()?)
+        .env("UPDATER_BINARY_SOURCE", updater_binary)
         .env("UPDATER_SERVICE_SOURCE", bundle.join("packaging/linux/codex-update-manager.service"))
         .current_dir(&bundle);
     if let Some(config_path) = effective_feature_config_path(config) {

--- a/updater/src/install.rs
+++ b/updater/src/install.rs
@@ -1,6 +1,7 @@
 //! Installation helpers for privileged and non-privileged package application.
 
 use anyhow::{Context, Result};
+use std::ffi::OsStr;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -9,10 +10,13 @@ use std::{
 };
 
 #[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
 use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
 
 const PACKAGE_NAME: &str = "codex-desktop";
 const INSTALLED_UPDATER_BINARY: &str = "/usr/bin/codex-update-manager";
+const DELETED_PATH_SUFFIX: &[u8] = b" (deleted)";
 const APT_CANDIDATES: &[&str] = &["/usr/bin/apt", "/bin/apt"];
 const DNF_CANDIDATES: &[&str] = &["/usr/bin/dnf", "/bin/dnf", "/usr/bin/dnf5", "/bin/dnf5"];
 const DPKG_CANDIDATES: &[&str] = &["/usr/bin/dpkg", "/bin/dpkg"];
@@ -249,7 +253,7 @@ pub fn install_pacman(path: &Path) -> Result<()> {
 
 /// Builds the `pkexec` command used for privileged package installation.
 pub fn pkexec_command(current_exe: &Path, package_path: &Path) -> Command {
-    let updater_binary = updater_binary_for_privileged_install(current_exe);
+    let updater_binary = resolve_updater_binary(current_exe);
     let subcommand = match PackageKind::from_path(package_path) {
         PackageKind::Rpm => "install-rpm",
         PackageKind::Deb => "install-deb",
@@ -568,13 +572,47 @@ fn pacman_install_command(path: &Path) -> Command {
     command
 }
 
-fn updater_binary_for_privileged_install(current_exe: &Path) -> PathBuf {
-    let installed = PathBuf::from(INSTALLED_UPDATER_BINARY);
+pub(crate) fn resolve_updater_binary(current_exe: &Path) -> PathBuf {
+    resolve_updater_binary_at(current_exe, Path::new(INSTALLED_UPDATER_BINARY))
+}
+
+pub(crate) fn resolve_updater_binary_for_build(current_exe: &Path) -> PathBuf {
+    resolve_updater_binary_for_build_at(current_exe, Path::new(INSTALLED_UPDATER_BINARY))
+}
+
+fn resolve_updater_binary_at(current_exe: &Path, installed: &Path) -> PathBuf {
     if installed.is_file() {
-        installed
-    } else {
-        current_exe.to_path_buf()
+        return installed.to_path_buf();
     }
+
+    if current_exe.is_file() {
+        return current_exe.to_path_buf();
+    }
+
+    strip_deleted_path_suffix(current_exe)
+        .filter(|path| path.is_file())
+        .unwrap_or_else(|| current_exe.to_path_buf())
+}
+
+fn resolve_updater_binary_for_build_at(current_exe: &Path, installed: &Path) -> PathBuf {
+    if current_exe.is_file() {
+        return current_exe.to_path_buf();
+    }
+
+    if let Some(recovered) = strip_deleted_path_suffix(current_exe).filter(|path| path.is_file()) {
+        return recovered;
+    }
+
+    if installed.is_file() {
+        return installed.to_path_buf();
+    }
+
+    current_exe.to_path_buf()
+}
+
+pub(crate) fn strip_deleted_path_suffix(path: &Path) -> Option<PathBuf> {
+    let stripped = path.as_os_str().as_bytes().strip_suffix(DELETED_PATH_SUFFIX)?;
+    Some(PathBuf::from(OsStr::from_bytes(stripped)))
 }
 
 fn deb_package_name(path: &Path) -> Result<String> {
@@ -864,15 +902,86 @@ mod tests {
     }
 
     #[test]
-    fn prefers_installed_updater_path_for_pkexec() {
-        let selected =
-            updater_binary_for_privileged_install(Path::new("/tmp/codex-update-manager-old"));
-        let expected = if Path::new("/usr/bin/codex-update-manager").is_file() {
-            PathBuf::from("/usr/bin/codex-update-manager")
-        } else {
-            PathBuf::from("/tmp/codex-update-manager-old")
-        };
-        assert_eq!(selected, expected);
+    fn updater_binary_prefers_installed_copy() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let installed = temp.path().join("installed");
+        let current = temp.path().join("current");
+        fs::write(&installed, b"installed")?;
+        fs::write(&current, b"current")?;
+
+        assert_eq!(resolve_updater_binary_at(&current, &installed), installed);
+        Ok(())
+    }
+
+    #[test]
+    fn updater_binary_recovers_deleted_current_exe_via_installed_copy() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let installed = temp.path().join("codex-update-manager");
+        fs::write(&installed, b"installed")?;
+        let deleted = temp.path().join("codex-update-manager (deleted)");
+
+        assert_eq!(resolve_updater_binary_at(&deleted, &installed), installed);
+        Ok(())
+    }
+
+    #[test]
+    fn updater_binary_uses_live_current_exe_without_installed_copy() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let installed = temp.path().join("missing-installed");
+        let current = temp.path().join("current");
+        fs::write(&current, b"current")?;
+
+        assert_eq!(resolve_updater_binary_at(&current, &installed), current);
+        Ok(())
+    }
+
+    #[test]
+    fn updater_binary_strips_deleted_suffix_without_installed_copy() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let installed = temp.path().join("missing-installed");
+        let current = temp.path().join("current");
+        fs::write(&current, b"current")?;
+        let deleted = PathBuf::from(format!("{} (deleted)", current.display()));
+
+        assert_eq!(resolve_updater_binary_at(&deleted, &installed), current);
+        Ok(())
+    }
+
+    #[test]
+    fn updater_binary_keeps_unresolved_deleted_path() {
+        let current = Path::new("/missing/codex-update-manager (deleted)");
+        let installed = Path::new("/missing/installed-codex-update-manager");
+
+        assert_eq!(resolve_updater_binary_at(current, installed), current);
+    }
+
+    #[test]
+    fn updater_build_prefers_live_current_exe_over_installed_copy() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let installed = temp.path().join("installed");
+        let current = temp.path().join("current");
+        fs::write(&installed, b"installed")?;
+        fs::write(&current, b"current")?;
+
+        assert_eq!(
+            resolve_updater_binary_for_build_at(&current, &installed),
+            current
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn updater_build_recovers_replaced_current_exe() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let installed = temp.path().join("codex-update-manager");
+        fs::write(&installed, b"replacement")?;
+        let deleted = temp.path().join("codex-update-manager (deleted)");
+
+        assert_eq!(
+            resolve_updater_binary_for_build_at(&deleted, &installed),
+            installed
+        );
+        Ok(())
     }
 
     #[test]

--- a/updater/src/install_rollback.rs
+++ b/updater/src/install_rollback.rs
@@ -1,13 +1,12 @@
 //! Explicit rollback package installation helpers.
 
-use crate::install::{stable_validated_package, PackageKind};
+use crate::install::{resolve_updater_binary, stable_validated_package, PackageKind};
 use anyhow::{Context, Result};
 use std::{
     path::{Path, PathBuf},
     process::Command,
 };
 
-const INSTALLED_UPDATER_BINARY: &str = "/usr/bin/codex-update-manager";
 const APT_CANDIDATES: &[&str] = &["/usr/bin/apt", "/bin/apt"];
 const DNF_CANDIDATES: &[&str] = &["/usr/bin/dnf", "/bin/dnf", "/usr/bin/dnf5", "/bin/dnf5"];
 const DPKG_CANDIDATES: &[&str] = &["/usr/bin/dpkg", "/bin/dpkg"];
@@ -70,7 +69,7 @@ pub fn install_pacman(path: &Path) -> Result<()> {
 }
 
 pub fn pkexec_command(current_exe: &Path, package_path: &Path) -> Command {
-    let updater_binary = updater_binary_for_privileged_install(current_exe);
+    let updater_binary = resolve_updater_binary(current_exe);
     let subcommand = match PackageKind::from_path(package_path) {
         PackageKind::Rpm => "install-rollback-rpm",
         PackageKind::Deb => "install-rollback-deb",
@@ -179,15 +178,6 @@ fn package_file_name(path: &Path, label: &str) -> Result<String> {
         .with_context(|| format!("{label} package path has no file name"))?
         .to_string_lossy()
         .into_owned())
-}
-
-fn updater_binary_for_privileged_install(current_exe: &Path) -> PathBuf {
-    let installed = PathBuf::from(INSTALLED_UPDATER_BINARY);
-    if installed.is_file() {
-        installed
-    } else {
-        current_exe.to_path_buf()
-    }
 }
 
 fn program_path(candidates: &[&str], fallback: &str) -> PathBuf {

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -10,6 +10,7 @@ mod install_rollback;
 mod liveness;
 mod logging;
 mod notify;
+mod restart;
 mod rollback;
 mod state;
 #[cfg(test)]

--- a/updater/src/restart.rs
+++ b/updater/src/restart.rs
@@ -1,0 +1,73 @@
+//! Detects when the running updater binary has been replaced on disk.
+
+use crate::install;
+use std::{
+    fs,
+    os::unix::fs::MetadataExt,
+    path::{Path, PathBuf},
+};
+
+const PROC_SELF_EXE: &str = "/proc/self/exe";
+
+/// Returns the replacement path when the running image and its path on disk
+/// no longer refer to the same inode.
+pub fn replacement_binary() -> Option<PathBuf> {
+    let link_target = fs::read_link(PROC_SELF_EXE).ok()?;
+    let installed_path = install::strip_deleted_path_suffix(&link_target).unwrap_or(link_target);
+    replacement_at(Path::new(PROC_SELF_EXE), &installed_path)
+}
+
+fn replacement_at(running_image: &Path, installed_path: &Path) -> Option<PathBuf> {
+    let running = fs::metadata(running_image).ok()?;
+    let installed = fs::metadata(installed_path).ok()?;
+    if running.dev() == installed.dev() && running.ino() == installed.ino() {
+        return None;
+    }
+    Some(installed_path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+
+    #[test]
+    fn same_file_is_not_a_replacement() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let binary = temp.path().join("codex-update-manager");
+        fs::write(&binary, b"current")?;
+
+        assert_eq!(replacement_at(&binary, &binary), None);
+        Ok(())
+    }
+
+    #[test]
+    fn different_inode_is_a_replacement_even_with_identical_contents() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let running = temp.path().join("codex-update-manager.old");
+        let installed = temp.path().join("codex-update-manager");
+        fs::write(&running, b"same updater")?;
+        fs::write(&installed, b"same updater")?;
+
+        assert_eq!(replacement_at(&running, &installed), Some(installed));
+        Ok(())
+    }
+
+    #[test]
+    fn missing_installed_binary_is_not_a_replacement() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let running = temp.path().join("codex-update-manager.old");
+        fs::write(&running, b"current")?;
+
+        assert_eq!(
+            replacement_at(&running, &temp.path().join("codex-update-manager")),
+            None
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn current_test_binary_is_not_reported_as_replaced() {
+        assert_eq!(replacement_binary(), None);
+    }
+}


### PR DESCRIPTION
## Summary

- recover the updater executable path after a package replacement instead of passing the Linux kernel ` (deleted)` path to the package builder
- preserve the live development binary for builds while sharing installed-binary selection for privileged install and rollback
- add a packaged shell fallback for stale daemons and restart the daemon when its on-disk inode changes

## Tests/checks run

- `cargo test -p codex-update-manager`
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `node --test scripts/lib/package-common.test.js`
- `bash tests/scripts_smoke.sh`
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template`
- `./scripts/ci-local.sh pr`
- `git diff --check`

## Notes

- The mutable updater path covers deb, RPM, and pacman packages; AppImage and Nix do not use this update flow.
- Failed-candidate retry policy is intentionally out of scope.

Fixes #1437