### PR TITLE
HEROX-1445: Fix Read Aloud builtin alias collisions

### DIFF
--- a/linux-features/read-aloud/patch.js
+++ b/linux-features/read-aloud/patch.js
@@ -45,14 +45,10 @@ function applyMainBundlePatch(source) {
   }
 
   const childProcessVar = "require(`node:child_process`)";
-  const fsVar = requireName(source, "node:fs");
-  const pathVar = requireName(source, "node:path");
-  const osVar = requireName(source, "node:os") ?? requireName(source, "os");
+  const fsVar = "require(`node:fs`)";
+  const pathVar = "require(`node:path`)";
+  const osVar = "require(`node:os`)";
   const electronVar = requireName(source, "electron");
-  if (fsVar == null || pathVar == null || osVar == null) {
-    warn("Could not find node:fs/node:path/node:os dependencies", "read aloud main-bundle patch");
-    return source;
-  }
 
   const helper = [
     `function codexLinuxReadAloudCleanText(e){return typeof e!==\`string\`?\`\`:e.replace(/\\r\\n/g,\`\\n\`).replace(new RegExp(\`\\\`\\\`\\\`[\\\\s\\\\S]*?\\\`\\\`\\\`\`,\`gu\`),\` code block. \`).replace(/\\[([^\\]]+)\\]\\(([^)]+)\\)/gu,\`$1\`).replace(/[*_#>~]/gu,\`\`).replace(/\\n{3,}/gu,\`\\n\\n\`).trim().slice(0,8e3)}`,

--- a/linux-features/read-aloud/test.js
+++ b/linux-features/read-aloud/test.js
@@ -163,6 +163,41 @@ test("main handler does not capture a function-local child-process alias from an
   assert.doesNotMatch(patched, /let child=__codexChild\.spawn\(command,args/);
 });
 
+for (const [label, prefix] of [
+  ["Record & Replay helper", require("../record-and-replay/patch.js").recordReplayHelperSource({
+    fsVar: "require(`node:fs`)", pathVar: "require(`node:path`)",
+  }) + 'let f=require(`node:fs`),p=require(`node:path`),o=require(`node:os`);'],
+  ["nested builtin aliases", 'function injectedFeature(){let nestedFs=require(`node:fs`),nestedPath=require(`node:path`),nestedOs=require(`node:os`);return [nestedFs,nestedPath,nestedOs]}'],
+  ["local-name collisions", 'let e=require(`node:fs`),n=require(`node:path`),t=require(`node:os`);'],
+  ["no existing builtin aliases", ""],
+]) {
+  test(`main helper resolves builtins independently of ${label}`, () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-read-aloud-alias-"));
+    try {
+      const source = prefix + 'var h={handlers:{"set-vs-context":async()=>{},"native-desktop-apps":async()=>({apps:[]})}};';
+      const patched = twice(applyMainBundlePatch, source);
+      const runtime = new Function("require", "process", `${patched};return {
+        home:codexLinuxReadAloudHome,
+        settingsPath:codexLinuxReadAloudSettingsPath,
+        writeSettings:codexLinuxReadAloudWriteSettings,
+        settings:codexLinuxReadAloudSettings,
+        model:codexLinuxReadAloudKokoroModel,
+        python:codexLinuxReadAloudKokoroPython
+      };`)(name => name === "node:os" ? { homedir: () => root } : require(name), {
+        platform: "linux", env: {},
+      });
+      assert.equal(runtime.home(), root);
+      assert.equal(runtime.settingsPath(), path.join(root, ".config", "codex-desktop", "settings.json"));
+      runtime.writeSettings({ "codex-linux-read-aloud-enabled": true });
+      assert.deepEqual(runtime.settings(), { "codex-linux-read-aloud-enabled": true });
+      assert.equal(runtime.model(), path.join(root, ".local", "share", "kokoro", "kokoro-v1.0.onnx"));
+      assert.equal(runtime.python(), path.join(root, ".local", "share", "codex-desktop", "read-aloud", "kokoro-venv", "bin", "python"));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+}
+
 test("main bundle helper preserves the official Electron binding across patch reruns", () => {
   const source = [
     '"use strict";',


### PR DESCRIPTION
Read Aloud could capture function-local Node.js aliases from earlier injected helpers, causing settings-path errors and preventing speech. Resolve fs, path, and os directly with require(), as already done for child_process; preserve the Electron binding logic.

Fixes #1445.

Validation:
- Four executable regression cases fail before the fix and pass afterward, including the actual Record & Replay helper and local-name collisions.
- 148 tests passed across the patch engine, feature framework, Read Aloud, Read Aloud MCP, and Record & Replay.
- Signed stable 26.901.51231 amd64 builds passed with Read Aloud alone and with Read Aloud + Record & Replay.
- Two independent full-diff reviews found no actionable findings; git diff --check passed.

Scope: optional Read Aloud patch only, shared by package formats. Live audio playback and arm64 builds were not tested.
