### PR TITLE
fix(node-repl-reaper): preserve helpers with live Codex ancestors

### DIFF
--- a/linux-features/node-repl-reaper/README.md
+++ b/linux-features/node-repl-reaper/README.md
@@ -6,12 +6,22 @@ reap them: helpers accumulate over long sessions and survive their owner
 over a day under a hidden-to-tray instance). Each holds memory and file
 descriptors indefinitely.
 
-This feature reaps **leaked** helpers — those whose parent is no longer a
-live Codex owner process. Helpers with a live Desktop `codex app-server` parent
-or a live CLI Codex parent such as `codex resume` are never touched, so active
+This feature reaps **leaked** helpers — those with no live Codex owner in their
+process ancestry. Helpers with a live Desktop `codex app-server` ancestor
+or a live CLI Codex ancestor such as `codex resume` are never touched, so active
 Browser Use sessions are unaffected. Matching is scoped to this install's
 `resources/cua_node/bin/node_repl` path, so side-by-side installs reap
 independently.
+
+The unified Computer Use launcher starts helpers through Node, so the direct
+parent need not be Codex. The reaper follows up to 64 ancestors and leaves the
+helper alone if process information is unreadable, an ancestor disappears,
+or traversal does not reach a root within that bound. It checks ownership again before
+each signal. A surviving launcher does not protect the helper after its Codex
+ancestor exits.
+
+The walk also passes through `codex-linux-sandbox` and
+`codex-mcp-helper-reaper`. These processes do not count as Codex owners.
 
 ## How it runs
 
@@ -25,9 +35,11 @@ independently.
 - **App exit**: the after-exit hook runs one immediate pass.
 - Reaping sends SIGTERM, then SIGKILL after a grace period
   (`CODEX_NODE_REPL_REAPER_KILL_GRACE` seconds, default 5), re-checking
-  process identity before escalating to guard against pid reuse.
+  process identity and ancestry before escalating.
 
 ## Compatibility
+
+This feature requires Bash 4.4 or newer.
 
 This feature can be enabled together with `mcp-helper-reaper`. If that feature
 wraps `resources/cua_node/bin/node_repl`, this reaper also matches

--- a/linux-features/node-repl-reaper/reaper.sh
+++ b/linux-features/node-repl-reaper/reaper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Reap Browser Use node_repl helper processes leaked by Codex owners. A helper
-# counts as leaked when its parent is no longer a live Codex process — its
-# owner exited without cleaning it up. Helpers whose Codex parent is alive are
+# counts as leaked when no ancestor is a live Codex process — its
+# owner exited without cleaning it up. Helpers whose Codex ancestor is alive are
 # never touched, so active Browser Use sessions in Desktop and CLI Codex
 # sessions are unaffected. Matching is scoped to this install's node_repl
 # binary path, so side-by-side installs reap independently.
@@ -55,11 +55,13 @@ proc_ppid() {
 
 parent_is_live_codex_owner() {
     local ppid="$1"
-    [ -n "$ppid" ] && [ -d "/proc/$ppid" ] || return 1
+    [ -n "$ppid" ] && [ -d "/proc/$ppid" ] || return 2
     local args argv0 argv1 name script_name
-    args="$(tr '\0' ' ' < "/proc/$ppid/cmdline" 2>/dev/null)" || return 1
-    argv0="$(tr '\0' '\n' < "/proc/$ppid/cmdline" 2>/dev/null | sed -n '1p')" || argv0=""
-    argv1="$(tr '\0' '\n' < "/proc/$ppid/cmdline" 2>/dev/null | sed -n '2p')" || argv1=""
+    local -a argv=()
+    mapfile -d '' -t argv 2>/dev/null < "/proc/$ppid/cmdline" || return 2
+    args="${argv[*]}"
+    argv0="${argv[0]:-}"
+    argv1="${argv[1]:-}"
     name="${argv0##*/}"
     script_name="${argv1##*/}"
     case "$name" in
@@ -80,15 +82,36 @@ parent_is_live_codex_owner() {
     return 1
 }
 
+node_repl_is_leaked() {
+    local pid="$1" ancestor next status depth=0 seen=" "
+    proc_is_install_node_repl "$pid" || return 1
+    ancestor="$(proc_ppid "$pid")" || return 1
+    while [ "$ancestor" != 0 ]; do
+        case "$ancestor" in ''|*[!0-9]*) return 1 ;; esac
+        case "$seen" in *" $ancestor "*) return 1 ;; esac
+        [ "$depth" -lt 64 ] || return 1
+        seen="$seen$ancestor "
+        depth=$((depth + 1))
+        status=0
+        parent_is_live_codex_owner "$ancestor" || status=$?
+        case "$status" in
+            0) return 1 ;;
+            1) ;;
+            *) return 1 ;;
+        esac
+        next="$(proc_ppid "$ancestor")" || return 1
+        ancestor="$next"
+    done
+    return 0
+}
+
 leaked_node_repl_pids() {
-    local proc pid ppid
+    local proc pid
     for proc in /proc/[0-9]*/cmdline; do
         [ -e "$proc" ] || continue
         pid="${proc#/proc/}"
         pid="${pid%/cmdline}"
-        proc_is_install_node_repl "$pid" || continue
-        ppid="$(proc_ppid "$pid")" || continue
-        parent_is_live_codex_owner "$ppid" && continue
+        node_repl_is_leaked "$pid" || continue
         printf '%s\n' "$pid"
     done
 }
@@ -97,6 +120,7 @@ reap_leaked_node_repls() {
     local pid termed=""
     while IFS= read -r pid; do
         [ -n "$pid" ] || continue
+        node_repl_is_leaked "$pid" || continue
         echo "node-repl-reaper: reaping leaked node_repl pid=$pid"
         kill "$pid" 2>/dev/null || continue
         termed="$termed $pid"
@@ -105,8 +129,7 @@ reap_leaked_node_repls() {
     [ -n "$termed" ] || return 0
     sleep "$KILL_GRACE_SECONDS"
     for pid in $termed; do
-        # Re-check identity before SIGKILL in case the pid was recycled.
-        proc_is_install_node_repl "$pid" || continue
+        node_repl_is_leaked "$pid" || continue
         echo "node-repl-reaper: escalating to SIGKILL for node_repl pid=$pid"
         kill -9 "$pid" 2>/dev/null || true
     done

--- a/linux-features/node-repl-reaper/test.js
+++ b/linux-features/node-repl-reaper/test.js
@@ -83,6 +83,132 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function spawnOrphan(nodeReplBin) {
+  const launcher = spawn(BASH, ["-c", '"$1" -e "setInterval(() => {}, 1000)" </dev/null >/dev/null 2>&1 & printf "%s" "$!"', "test", nodeReplBin], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  launcher.stdout.on("data", (chunk) => { output += chunk; });
+  await new Promise((resolve, reject) => {
+    launcher.once("error", reject);
+    launcher.once("close", (code) => code === 0 ? resolve() : reject(new Error(`orphan launcher exited ${code}`)));
+  });
+  assert.match(output, /^\d+$/);
+  const pid = Number(output);
+  try {
+    await waitForFileContent(`/proc/${pid}/cmdline`, (content) => content.split("\0")[0] === nodeReplBin);
+    return pid;
+  } catch (error) {
+    if (pidAlive(pid)) process.kill(pid, "SIGKILL");
+    throw error;
+  }
+}
+
+function runReaperFunctions(fixture) {
+  const source = fs.readFileSync(REAPER, "utf8");
+  const main = source.lastIndexOf('\nif [ "$MODE" = "watch" ]; then');
+  assert.ok(main > 0);
+  return spawnSync(BASH, ["-c", `${source.slice(0, main)}\n${fixture}`, "test", "/tmp/test-reaper-app"], { encoding: "utf8" });
+}
+
+test("ancestry checks preserve helpers on cycles, unreadable processes, and bounded traversal", () => {
+  const cases = [
+    ["proc_ppid() { echo 0; }", 0],
+    ["proc_ppid() { echo 17; }", 1],
+    ["proc_ppid() { return 1; }", 1],
+    ["proc_ppid() { echo invalid; }", 1],
+    ["proc_ppid() { echo $(($1 + 1)); }", 1],
+    ["proc_ppid() { echo 17; }; parent_is_live_codex_owner() { return 2; }", 1],
+    ["proc_ppid() { echo 17; }; parent_is_live_codex_owner() { return 0; }", 1],
+  ];
+  for (const [fixture, expected] of cases) {
+    const result = runReaperFunctions(`proc_is_install_node_repl() { return 0; }\nparent_is_live_codex_owner() { return 1; }\n${fixture}\nnode_repl_is_leaked 10`);
+    assert.equal(result.status, expected, `${fixture}\n${result.stderr}`);
+  }
+});
+
+test("rechecks ownership before SIGTERM and before escalation", () => {
+  const beforeTerm = runReaperFunctions(`
+    leaked_node_repl_pids() { echo 10; }
+    node_repl_is_leaked() { return 1; }
+    kill() { echo unexpected-signal; }
+    reap_leaked_node_repls
+  `);
+  assert.equal(beforeTerm.status, 0, beforeTerm.stderr);
+  assert.equal(beforeTerm.stdout, "");
+  const beforeKill = runReaperFunctions(`
+    changed=0
+    leaked_node_repl_pids() { echo 10; }
+    node_repl_is_leaked() { [ "$changed" = 0 ]; }
+    kill() { echo "signal:$*"; }
+    sleep() { changed=1; }
+    reap_leaked_node_repls
+  `);
+  assert.equal(beforeKill.status, 0, beforeKill.stderr);
+  assert.match(beforeKill.stdout, /signal:10/);
+  assert.doesNotMatch(beforeKill.stdout, /SIGKILL|signal:-9/);
+});
+
+for (const { wrapped, executableOwner, launcherName } of [
+  { wrapped: false, executableOwner: false, launcherName: "node" },
+  { wrapped: true, executableOwner: false, launcherName: "node" },
+  { wrapped: false, executableOwner: true, launcherName: "node" },
+  { wrapped: false, executableOwner: true, launcherName: "codex-linux-sandbox" },
+  { wrapped: false, executableOwner: true, launcherName: "codex-mcp-helper-reaper" },
+]) {
+  test(`preserves a ${wrapped ? "wrapped " : ""}helper through ${launcherName} until its ${executableOwner ? "executable" : "script"} Codex owner exits`, async () => {
+    const { appDir, nodeReplBin } = makeFakeApp();
+    const helperBin = wrapped ? `${nodeReplBin}.codex-linux-original` : nodeReplBin;
+    if (wrapped) fs.symlinkSync(process.execPath, helperBin);
+    const launcher = path.join(appDir, "launch.mjs");
+    fs.writeFileSync(launcher, `
+      import { spawn } from "node:child_process";
+      const child = spawn(${JSON.stringify(helperBin)}, ${JSON.stringify(LONG_RUNNING_NODE_ARGS)}, { stdio: "ignore" });
+      child.once("spawn", () => console.log("launcher=" + process.pid + " child=" + child.pid));
+      setInterval(() => {}, 1000);
+    `);
+    const fakeCodex = path.join(appDir, "codex");
+    let ownerArgs;
+    if (executableOwner) {
+      fs.symlinkSync(process.execPath, fakeCodex);
+      const launcherBin = path.join(appDir, launcherName);
+      fs.symlinkSync(process.execPath, launcherBin);
+      ownerArgs = ["-e", `require("node:child_process").spawn(${JSON.stringify(launcherBin)}, [${JSON.stringify(launcher)}], { stdio: "inherit" });`, "app-server"];
+    } else {
+      fs.writeFileSync(fakeCodex, `#!${BASH}\n"${process.execPath}" "${launcher}" &\nwait\n`);
+      fs.chmodSync(fakeCodex, 0o755);
+      ownerArgs = ["app-server"];
+    }
+    const owner = spawn(fakeCodex, ownerArgs, { stdio: ["ignore", "pipe", "ignore"] });
+    let launcherPid;
+    let childPid;
+    try {
+      ({ launcherPid, childPid } = await new Promise((resolve, reject) => {
+        let buffer = "";
+        owner.stdout.on("data", (chunk) => {
+          buffer += chunk;
+          const match = buffer.match(/launcher=(\d+) child=(\d+)/);
+          if (match) resolve({ launcherPid: Number(match[1]), childPid: Number(match[2]) });
+        });
+        owner.once("exit", () => reject(new Error("fake Codex exited before launcher startup")));
+      }));
+      const output = runReaperOnce(appDir);
+      assert.doesNotMatch(output, new RegExp(`pid=${childPid}\\b`));
+      assert.ok(pidAlive(childPid), "live launcher's helper was killed");
+      owner.kill("SIGKILL");
+      await waitForExit(owner.pid);
+      assert.ok(pidAlive(launcherPid), "launcher must remain alive to test ancestor ownership");
+      assert.match(runReaperOnce(appDir), new RegExp(`reaping leaked node_repl pid=${childPid}\\b`));
+      await waitForExit(childPid);
+    } finally {
+      for (const pid of [childPid, launcherPid, owner.pid]) {
+        if (pid && pidAlive(pid)) process.kill(pid, "SIGKILL");
+      }
+      fs.rmSync(appDir, { recursive: true, force: true });
+    }
+  });
+}
+
 async function waitForFileContent(file, predicate, timeoutMs = 2000) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -137,16 +263,15 @@ printf '%s %s\\n' "$1" "$2" >> "${callLog}"
   fs.rmSync(root, { recursive: true, force: true });
 });
 
-test("reaps a node_repl whose parent is not a live codex app-server", async () => {
+test("reaps an orphaned node_repl after its launching process exits", async () => {
   const { appDir, nodeReplBin } = makeFakeApp();
-  const leaked = spawn(nodeReplBin, LONG_RUNNING_NODE_ARGS, { stdio: "ignore" });
+  const leakedPid = await spawnOrphan(nodeReplBin);
   try {
-    await new Promise((resolve) => leaked.once("spawn", resolve));
     const output = runReaperOnce(appDir);
-    assert.match(output, new RegExp(`reaping leaked node_repl pid=${leaked.pid}\\b`));
-    await waitForExit(leaked.pid);
+    assert.match(output, new RegExp(`reaping leaked node_repl pid=${leakedPid}\\b`));
+    await waitForExit(leakedPid);
   } finally {
-    try { leaked.kill("SIGKILL"); } catch {}
+    if (pidAlive(leakedPid)) process.kill(leakedPid, "SIGKILL");
     fs.rmSync(appDir, { recursive: true, force: true });
   }
 });
@@ -155,14 +280,13 @@ test("reaps a wrapped node_repl running from the original backup path", async ()
   const { appDir } = makeFakeApp();
   const originalNodeReplBin = path.join(appDir, "resources", "cua_node", "bin", "node_repl.codex-linux-original");
   fs.symlinkSync(process.execPath, originalNodeReplBin);
-  const leaked = spawn(originalNodeReplBin, LONG_RUNNING_NODE_ARGS, { stdio: "ignore" });
+  const leakedPid = await spawnOrphan(originalNodeReplBin);
   try {
-    await new Promise((resolve) => leaked.once("spawn", resolve));
     const output = runReaperOnce(appDir);
-    assert.match(output, new RegExp(`reaping leaked node_repl pid=${leaked.pid}\\b`));
-    await waitForExit(leaked.pid);
+    assert.match(output, new RegExp(`reaping leaked node_repl pid=${leakedPid}\\b`));
+    await waitForExit(leakedPid);
   } finally {
-    try { leaked.kill("SIGKILL"); } catch {}
+    if (pidAlive(leakedPid)) process.kill(leakedPid, "SIGKILL");
     fs.rmSync(appDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

Fix `node-repl-reaper` terminating a live Browser/Computer Use helper when a Node launcher sits between the helper and its Codex owner.

The change is limited to the optional, disabled-by-default `node-repl-reaper` feature: its cleanup script, tests, and README. It does not change `mcp-helper-reaper`, the upstream app payload, package configuration, or sandbox permissions.

### Problem and cause

On Fedora 43 x86_64 with signed OpenAI Linux package `26.901.51231` and bundled Codex `0.153.4`, browser calls failed with `Transport closed`. The cleanup log recorded live `node_repl` processes being killed at the same times.

The bundled unified Computer Use plugin starts this process chain:

```text
codex app-server → node launch.mjs → node_repl
```

The old cleanup rule checked only the helper's immediate parent. It rejected the Node launcher and classified the live helper as leaked. Direct Codex children were already protected; indirect children were not.

### Fix

- Follow up to 64 process ancestors to find a live Codex owner.
- Keep the helper when process information cannot be read or the walk cannot establish that it reached the root.
- Check identity and ancestry again before both SIGTERM and SIGKILL.
- Pass through `codex-linux-sandbox` and `codex-mcp-helper-reaper` without treating them as Codex owners.
- Preserve cleanup after the Codex owner exits, including when a non-Codex launcher remains alive.

The orphan fixtures now launch from a shell that exits and wait for the helper's executable path before running cleanup. This avoids treating the test runner's own live Codex ancestor as an orphan and removes an exec timing race.

### Related work

- #482 introduced this optional feature.
- #960 and #965 addressed a similar live-helper termination in the separate `mcp-helper-reaper` feature. This PR does not change that implementation or reopen that resolved report.
- #1427 corrected lifecycle hook context. This PR retains those hooks and changes the process ownership check only.

I checked open PRs and searched issues and PRs for `node_repl`, `node-repl`, `reaper`, and `Transport closed`; I found no open duplicate for this ownership case.

## Validation

- The two Node-launcher regression cases failed against the original script before the fix.
- `node --test linux-features/node-repl-reaper/test.js`: 14 tests passed on two consecutive runs after review changes. Coverage includes script and executable Codex owners, both excluded intermediate process names, wrapped helpers, owner exit with a surviving launcher, unreadable/cyclic/bounded ancestry, and checks before signals.
- `bash tests/scripts_smoke.sh`: passed.
- `bash -n linux-features/node-repl-reaper/*.sh`: passed.
- `node --check linux-features/node-repl-reaper/test.js`: passed.
- `git diff --cached --check`: passed.
- A feature-only build against signed OpenAI Linux `26.901.51231` passed. The built cleanup script matched source, and upstream `resources/app.asar` remained byte-identical. Subsequent review changes touched tests and documentation only.

### Live A/B check

In a disposable Agent Workspace with networking disabled and a read-only project mount, the real bundled Codex app-server launched the real bundled Node CUA launcher and `node_repl`. MCP initialization and `tools/list` succeeded. The same helper replied to an MCP ping after each of three fixed cleanup passes. Running the original script then killed that helper (exit 143), and further transport writes failed. The test workspace was stopped afterward; the installed host app was not replaced.

The built ChatGPT window also opened in that workspace with a fresh user-data directory. This was separate from the transport check, not a full signed-in browser navigation test.

### Limits and risk

Not run: installed-host browser recovery, the full five-minute timer interval in the live A/B check, live subreaper scenarios, arm64, other distributions, or a package-format install matrix. The shared feature script applies across package formats when enabled, but those installations were not tested here. The script requires Bash 4.4 or newer. An uncertain ancestry can leave a leaked helper alive; `/proc` reads and signals are not atomic, so this does not claim to eliminate all process races.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed CONTRIBUTING.md, kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] The reproduced failure uses the current signed stable OpenAI Linux package; no alternate upstream format or version-specific fallback was added.
- [ ] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass. Local checks pass; PR CI is pending.
- [ ] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests. Review findings were supplied and addressed, and tests were rerun; the maximum-effort setting has not been verified.

## Disclosure

This contribution is AI-assisted. An AI coding agent helped investigate the failure, implement the fix and regression tests, run the isolated live check, address review findings, and prepare this description. I reviewed the work and requested submission. The validation above distinguishes measured results from checks that were not run.
