### PR TITLE
Add experimental Alpine x86_64 host packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install smoke-test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ripgrep
+          sudo apt-get install -y --no-install-recommends ripgrep gcc binutils patchelf python3
       - name: Shell syntax
         run: |
           bash -n install.sh launcher/start.sh.template scripts/lib/*.sh
@@ -37,6 +37,10 @@ jobs:
             scripts/lib/linux-features.test.js linux-features/*/test.js
       - name: Smoke tests
         run: bash tests/scripts_smoke.sh
+      - name: Alpine packaging regression tests (offline fixtures)
+        run: |
+          node --test packaging/alpine/*.test.cjs
+          python3 -B -m unittest discover -s packaging/alpine -p 'test_*.py'
 
   rust:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ cd codex-desktop-linux
 For an experimental **Alpine Linux x86_64 host build**, see
 [Alpine packaging](packaging/alpine/README.md). It supplies private glibc
 libraries while repository commands run directly on Alpine; it uses no container.
+The Alpine guide includes offline regression checks and desktop-install failure
+recovery limits; this remains an experimental, manually updated build.
 
 The recommended native installation is:
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ cd codex-desktop-linux
 | NixOS or another Nix system | `nix run github:ilysenko/codex-desktop-linux` | Builds and runs the flake output; see [Nix](docs/nix.md) |
 | Atomic desktops or another distribution | `make build-app && make appimage` | Produces a local AppImage without the native updater |
 
+For an experimental **Alpine Linux x86_64 host build**, see
+[Alpine packaging](packaging/alpine/README.md). It supplies private glibc
+libraries while repository commands run directly on Alpine; it uses no container.
+
 The recommended native installation is:
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,6 +56,10 @@ cd codex-desktop-linux
 | NixOS 或其他 Nix 系统 | `nix run github:ilysenko/codex-desktop-linux` | 构建并运行 flake；参阅 [Nix](docs/nix.md) |
 | Atomic 桌面或其他发行版 | `make build-app && make appimage` | 生成不含原生更新器的本地 AppImage |
 
+实验性的 **Alpine Linux x86_64 宿主机构建**参见
+[Alpine 打包说明](packaging/alpine/README.md)。此方案为桌面应用提供私有 glibc
+库，仓库命令仍直接在 Alpine 上执行，不使用容器。
+
 推荐的原生安装命令：
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -59,6 +59,8 @@ cd codex-desktop-linux
 实验性的 **Alpine Linux x86_64 宿主机构建**参见
 [Alpine 打包说明](packaging/alpine/README.md)。此方案为桌面应用提供私有 glibc
 库，仓库命令仍直接在 Alpine 上执行，不使用容器。
+Alpine 指南还包含离线回归测试和桌面安装失败后的恢复限制；此构建仍属于实验性方案，
+需要手动更新。
 
 推荐的原生安装命令：
 

--- a/packaging/alpine/README.md
+++ b/packaging/alpine/README.md
@@ -118,6 +118,10 @@ repository, and the Alpine packaging tests executed through `command/exec`.
   build and must be investigated rather than bypassed.
 - Optional Qt shims cannot load Alpine Qt. The app uses the supplied GTK
   libraries, so native KDE theming may differ.
+- The upstream process sampler may still select BusyBox `ps` despite the
+  native procps helper and log unsupported-option warnings. This did not block
+  the desktop, Git, or command execution checks; sampler integration needs
+  further investigation.
 - As with other Community builds, do not run a separate official ChatGPT app
   against the same `Codex` profile simultaneously.
 

--- a/packaging/alpine/README.md
+++ b/packaging/alpine/README.md
@@ -56,6 +56,20 @@ and forwards user arguments and deep-link URIs. It does not set
 `LD_LIBRARY_PATH`, replace the host shell, or disable Chromium's sandbox.
 On KDE, run `kbuildsycoca6 --noincremental` if the menu has not refreshed.
 
+The desktop installer checks existing destinations (including dangling
+symlinks) before writing helpers. It publishes complete launcher/menu files
+without overwriting a concurrently created destination. On a caught error it
+removes only files and empty directories created by that attempt, so an ordinary
+failure can be retried after resolving its cause. Existing user files and
+replacements made by another writer are preserved; incomplete cleanup is
+reported with the affected paths. This is not a crash-recovery journal:
+power loss or an uncaught signal, including SIGKILL, can leave partial state.
+Inspect any reported existing `host-bin`, `launch.sh`, menu entry, or
+`.alpine-install-*` staging directory before moving it aside; do not blindly
+delete conflicts or user data. Installation filesystems must support hard links.
+Spaces and shell metacharacters are quoted; control characters and `=` in the
+desktop executable path are rejected.
+
 Because the desktop refreshes PATH from the login shell, the installer also
 exposes native Alpine procps as `~/.local/bin/ps`. An existing command at that
 path is validated and never overwritten. This user-level helper becomes the
@@ -81,27 +95,48 @@ compatibility, not a security isolation boundary.
 
 ```sh
 python3 -m unittest discover -s packaging/alpine -p 'test_*.py'
+node --test packaging/alpine/*.test.cjs
 node --test scripts/ci/elf-runtime.test.js scripts/ci/relocate-elf-interpreter.test.js
 
 "$alpine_app/opt/codex-desktop/resources/cua_node/bin/node" \
   packaging/alpine/verify-host.cjs "$alpine_app/opt/codex-desktop" /absolute/repository
 
-# Optionally execute a repository check through the bundled app-server:
+# Optionally execute a read-only repository check through the app-server:
 "$alpine_app/opt/codex-desktop/resources/cua_node/bin/node" \
   packaging/alpine/verify-host.cjs "$alpine_app/opt/codex-desktop" "$PWD" \
-  python3 -m unittest discover -s packaging/alpine -p 'test_*.py'
+  git diff --check
 ```
+
+The Alpine Node tests require an x86_64 host with `cc`, `readelf`, and
+`patchelf` in PATH, in addition to Node. They run offline in disposable
+directories and never install into the real user profile. The build tests
+compile tiny ELF fixtures and exercise actual copying, symlink preservation,
+patchelf changes, per-DSO RUNPATH and NODEFLIB, and unchanged ASAR/static/musl
+payloads. Only the official inventory contract and dependency-loader execution
+are substituted for these fixtures; they are not a GUI launch or an audit of
+the real Debian library closure. Installer tests inject write/publish failures,
+exercise retries and concurrent conflicts, and execute a fixture launcher to
+check argument forwarding and the host environment. CI runs these tests on its
+x86_64 Linux runner; direct Alpine host validation remains a separate check.
 
 The host probe launches the packaged glibc Node, then the bundled Codex
 app-server, and issues `command/exec` without creating an agent thread or
 contacting a model. It compares OS, repository, command paths, and musl loader
 output with the direct host result. The optional check uses the repository's
-real host toolchain and has a 90-second timeout.
+real host toolchain and has a 90-second timeout. It does not request additional
+sandbox permissions: the standalone app-server defaults to read-only execution.
+Tests that create temporary files can fail with EROFS, and Node child-process
+creation can fail with EPERM in that sandbox. Run the fixture suites directly
+on the host as shown above; their success must not be reported as a successful
+writable app-server test run.
 
 Validated locally on Alpine 3.24.1 x86_64, KDE Plasma 6.6.6 Wayland/XWayland,
 with official upstream 26.903.61454: rendered desktop UI, existing account
 session, local app-server, Git access, Cargo workspace metadata in a host
-repository, and the Alpine packaging tests executed through `command/exec`.
+repository, and direct-host packaging tests. A follow-up attempt to run the
+Node fixture suites through standalone `command/exec` was blocked by the
+read-only sandbox described above. Connections also worked in user testing;
+this is observational evidence, not an automated connection-recovery test.
 
 ## Current limits
 

--- a/packaging/alpine/README.md
+++ b/packaging/alpine/README.md
@@ -1,0 +1,128 @@
+# Experimental Alpine host build
+
+This opt-in packaging path runs ChatGPT Community directly on Alpine Linux
+x86_64. It supplies a private glibc library closure for the official desktop
+runtime while repository commands continue to use Alpine's shell, musl,
+compiler, Git, and filesystem. It creates no container, chroot, or alternate
+operating-system namespace and does not require root.
+
+The regular installer still verifies OpenAI's signed stable repository and
+builds the Community app. The Alpine packager reuses the Nix ELF inventory,
+interpreter relocation, and dependency audit. It changes ELF loading metadata,
+preserves `resources/app.asar`, and does not rebuild upstream native modules.
+It is a manual packaging experiment, not a supported `apk` package or updater.
+
+## Prerequisites
+
+Alpine 3.24 x86_64, a working KDE/X11 or KDE/Wayland desktop with XWayland,
+unprivileged user namespaces, Git, Bash, Node.js 20+, Python 3, GnuPG, curl,
+and patchelf. Keep several GB free for package downloads and extracted copies.
+The scripts have been exercised with Node 24 and Python 3.14.
+
+`prepare-tools.cjs` needs apk-tools 3 and the host's trusted Alpine repository
+configuration. It downloads and verifies native Alpine tools with `apk verify`
+and extracts them with `apk extract --no-chown`. It does not install packages
+into the OS or run package scripts. GNU flock/tar/coreutils are needed because
+their BusyBox replacements lack options used by the upstream builder. Native
+Alpine procps supplies the desktop's `ps -ax` process sampler.
+
+## Build and install
+
+Run from the checkout. Use fresh output directories; these scripts deliberately
+refuse to overwrite a previous build. All paths are permanent once built:
+ELF interpreters and library paths contain their absolute locations.
+
+```sh
+alpine_tools="$HOME/.local/share/codex-desktop/alpine-tools"
+alpine_runtime="$HOME/.local/share/codex-desktop/alpine-runtime"
+alpine_app="$HOME/.local/share/codex-desktop/alpine-build"
+
+node packaging/alpine/prepare-tools.cjs "$alpine_tools"
+
+PATH="$alpine_tools/root/usr/bin:$alpine_tools/root/bin:$PATH" \
+  python3 packaging/alpine/fetch-runtime.py --output "$alpine_runtime"
+
+PATH="$alpine_tools/root/usr/bin:$alpine_tools/root/bin:$PATH" \
+  bash ./install.sh
+
+node packaging/alpine/build.cjs ./codex-app "$alpine_runtime" "$alpine_app"
+node packaging/alpine/install-desktop.cjs "$alpine_app" "$alpine_tools"
+"$alpine_app/launch.sh"
+```
+
+The application menu entry is **ChatGPT Community**. The generated launcher
+selects GTK 3 and XWayland, adds only the native Alpine `ps` command to PATH,
+and forwards user arguments and deep-link URIs. It does not set
+`LD_LIBRARY_PATH`, replace the host shell, or disable Chromium's sandbox.
+On KDE, run `kbuildsycoca6 --noincremental` if the menu has not refreshed.
+
+Because the desktop refreshes PATH from the login shell, the installer also
+exposes native Alpine procps as `~/.local/bin/ps`. An existing command at that
+path is validated and never overwritten. This user-level helper becomes the
+default `ps` when `~/.local/bin` precedes `/bin`; it remains an Alpine musl
+binary. Ensure that the user bin directory is in the login shell's PATH.
+
+The runtime downloader verifies Debian 13 archive keys against pinned primary
+fingerprints, verifies each `InRelease`, checks metadata expiry when provided,
+and checks index and package SHA-256 and size. It combines trixie,
+trixie-updates, and trixie-security. Package data is extracted without executing
+maintainer scripts. Only library and shared-data directories enter the final
+application build; Debian executables never enter the launch PATH. The package
+manifest records origins, versions, architectures, and hashes. No application
+or runtime binaries should be committed to this repository.
+
+ELF `NODEFLIB` prevents missing optional dependencies (particularly Qt on KDE)
+from falling back to incompatible libraries in Alpine's `/usr/lib`. Every
+private shared library receives its own RUNPATH; preserving relative symlinks
+is essential so they resolve to those adjusted copies. This is library
+compatibility, not a security isolation boundary.
+
+## Validation
+
+```sh
+python3 -m unittest discover -s packaging/alpine -p 'test_*.py'
+node --test scripts/ci/elf-runtime.test.js scripts/ci/relocate-elf-interpreter.test.js
+
+"$alpine_app/opt/codex-desktop/resources/cua_node/bin/node" \
+  packaging/alpine/verify-host.cjs "$alpine_app/opt/codex-desktop" /absolute/repository
+
+# Optionally execute a repository check through the bundled app-server:
+"$alpine_app/opt/codex-desktop/resources/cua_node/bin/node" \
+  packaging/alpine/verify-host.cjs "$alpine_app/opt/codex-desktop" "$PWD" \
+  python3 -m unittest discover -s packaging/alpine -p 'test_*.py'
+```
+
+The host probe launches the packaged glibc Node, then the bundled Codex
+app-server, and issues `command/exec` without creating an agent thread or
+contacting a model. It compares OS, repository, command paths, and musl loader
+output with the direct host result. The optional check uses the repository's
+real host toolchain and has a 90-second timeout.
+
+Validated locally on Alpine 3.24.1 x86_64, KDE Plasma 6.6.6 Wayland/XWayland,
+with official upstream 26.903.61454: rendered desktop UI, existing account
+session, local app-server, Git access, Cargo workspace metadata in a host
+repository, and the Alpine packaging tests executed through `command/exec`.
+
+## Current limits
+
+- amd64 only; ARM64 is not implemented or tested.
+- XWayland is the tested path. Native Wayland, hardware video decoding,
+  accelerated graphics, microphone/voice, keyring integration, computer use,
+  and the full browser workflow are not validated. GPU and GTK module warnings
+  can appear without preventing the basic desktop workflow.
+- There is no automated update or rollback manager for this output. Build to
+  a fresh prefix for each upstream or library update; keep the old prefix
+  until validation passes. The desktop installer refuses to overwrite an
+  existing menu entry, so switch it explicitly after reviewing a new build.
+- This reuses Nix's current upstream ELF contract. Inventory drift rejects the
+  build and must be investigated rather than bypassed.
+- Optional Qt shims cannot load Alpine Qt. The app uses the supplied GTK
+  libraries, so native KDE theming may differ.
+- As with other Community builds, do not run a separate official ChatGPT app
+  against the same `Codex` profile simultaneously.
+
+To uninstall, close ChatGPT Community and remove its generated
+`codex-desktop.desktop` menu entry and the exact build/tools/runtime prefixes
+you selected. Remove `~/.local/bin/ps` only if it is the symlink this installer
+created into your selected tools prefix. Keep `~/.codex` and
+`~/.config/Codex`; they contain user data.

--- a/packaging/alpine/build.cjs
+++ b/packaging/alpine/build.cjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+"use strict";
+
+// Experimental direct-host packaging. Like the Nix build, this changes only
+// ELF loading metadata; host tools never inherit a foreign PATH or libc.
+const fs = require("node:fs");
+const path = require("node:path");
+const cp = require("node:child_process");
+const crypto = require("node:crypto");
+const elf = require("../../nix/elf-runtime.cjs");
+
+function run(command, args) {
+  cp.execFileSync(command, args, { stdio: "inherit" });
+}
+
+function main(argv) {
+  const [source, runtimeSource, destination] = argv;
+  if (!source || !runtimeSource || !destination || argv.length !== 3)
+    throw new Error("usage: build.cjs VERIFIED-APP VERIFIED-RUNTIME NEW-OUTPUT");
+  if (process.arch !== "x64") throw new Error("Alpine prototype currently validates amd64 only");
+  const appSource = fs.realpathSync(source);
+  const runtime = fs.realpathSync(runtimeSource);
+  const output = path.resolve(destination);
+  if (fs.existsSync(output)) throw new Error("output must not already exist");
+  for (const input of [appSource, runtime])
+    if (output.startsWith(input + path.sep))
+      throw new Error("output must be outside both input trees");
+  for (const required of [".codex-linux/build-info.json", "start.sh"])
+    if (!fs.statSync(path.join(appSource, required)).isFile())
+      throw new Error(`not a built Community app: ${required}`);
+  const runtimeManifest = JSON.parse(fs.readFileSync(path.join(runtime, "manifest.json"), "utf8"));
+  if (!runtimeManifest.some((item) => item.Package === "libc6" && item.Architecture === "amd64"))
+    throw new Error("runtime manifest has no amd64 libc6");
+  elf.validateUpstreamInventory(appSource, "amd64");
+  fs.mkdirSync(output, { recursive: true });
+  const app = path.join(output, "opt/codex-desktop");
+  const libraryRoot = path.join(output, "runtime");
+  fs.cpSync(appSource, app, { recursive: true, verbatimSymlinks: true });
+  fs.cpSync(path.join(runtime, "root/usr/lib"), path.join(libraryRoot, "lib"), { recursive: true, verbatimSymlinks: true });
+  fs.cpSync(path.join(runtime, "root/usr/share"), path.join(libraryRoot, "share"), { recursive: true, verbatimSymlinks: true });
+  fs.copyFileSync(path.join(runtime, "manifest.json"), path.join(libraryRoot, "manifest.json"));
+  const libraryPath = [path.join(libraryRoot, "lib/x86_64-linux-gnu"), path.join(libraryRoot, "lib")].join(":");
+  const linker = path.join(libraryRoot, "lib/x86_64-linux-gnu/ld-linux-x86-64.so.2");
+  const asarPath = path.join(app, "resources/app.asar");
+  const originalAsar = crypto.createHash("sha256").update(fs.readFileSync(asarPath)).digest("hex");
+
+  for (const item of elf.inventoryTree(libraryRoot, "amd64")) {
+    if (item.target && item.platform === "glibc" && item.linkage === "dynamic-object") {
+      if (item.absolutePath === linker) continue;
+      // Give every dependency its own search path; do not export LD_LIBRARY_PATH
+      // into musl shells, compilers, tests, or child processes.
+      run("patchelf", ["--no-default-lib", "--add-rpath", libraryPath, item.absolutePath]);
+    }
+  }
+  for (const item of elf.inventoryTree(app, "amd64")) {
+    if (item.target && item.platform === "glibc" &&
+        ["dynamic-object", "dynamic-executable"].includes(item.linkage))
+      run("patchelf", ["--no-default-lib", item.absolutePath]);
+  }
+  elf.applyFixups({
+    root: app, architecture: "amd64", dynamicLinker: linker,
+    runtimeLibraryPath: libraryPath,
+    chatgptRelocator: path.resolve(__dirname, "../../nix/relocate-elf-interpreter.cjs"),
+  });
+  elf.auditFixedTree({
+    root: app, architecture: "amd64", dynamicLinker: linker,
+    runtimeLibraryPath: libraryPath, checkDependencies: true,
+    // FHS shebangs deliberately resolve to the actual Alpine host.
+    checkShebangs: false,
+  });
+  const finalAsar = crypto.createHash("sha256").update(fs.readFileSync(asarPath)).digest("hex");
+  if (finalAsar !== originalAsar) throw new Error("ASAR changed during ELF fixups");
+  fs.writeFileSync(path.join(output, "alpine-build.json"), JSON.stringify({
+    architecture: "amd64", source: appSource, runtimeSource: runtime,
+    libraryPath, linker, asarSha256: finalAsar,
+    hostOs: fs.readFileSync("/etc/os-release", "utf8"),
+  }, null, 2) + "\n");
+  console.log(`Alpine host app: ${app}/start.sh`);
+}
+
+if (require.main === module) {
+  try { main(process.argv.slice(2)); }
+  catch (error) { console.error(error.message); process.exitCode = 1; }
+}

--- a/packaging/alpine/build.cjs
+++ b/packaging/alpine/build.cjs
@@ -82,3 +82,5 @@ if (require.main === module) {
   try { main(process.argv.slice(2)); }
   catch (error) { console.error(error.message); process.exitCode = 1; }
 }
+
+module.exports = { main };

--- a/packaging/alpine/build.test.cjs
+++ b/packaging/alpine/build.test.cjs
@@ -1,0 +1,137 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const cp = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const elf = require("../../nix/elf-runtime.cjs");
+const { main: build } = require("./build.cjs");
+
+// Real, tiny ELF fixtures, not copies of the proprietary application. No
+// downloads or installed desktop are required. Only the upstream manifest and
+// loader execution are substituted; copies, inventory, patchelf, and metadata
+// audits run for real. verify-host.cjs covers the actual installed runtime.
+function fixture(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "alpine-build-test-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const source = path.join(root, "source");
+  const runtime = path.join(root, "runtime source");
+  const output = path.join(root, "output with spaces");
+  const lib = path.join(runtime, "root/usr/lib/x86_64-linux-gnu");
+  for (const directory of [path.join(source, ".codex-linux"), path.join(source, "resources"), lib, path.join(runtime, "root/usr/share")])
+    fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(path.join(source, ".codex-linux/build-info.json"), "{}");
+  fs.writeFileSync(path.join(source, "start.sh"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  fs.writeFileSync(path.join(source, "resources/app.asar"), "fixture ASAR: preserve these bytes");
+  fs.writeFileSync(path.join(runtime, "manifest.json"), JSON.stringify([{ Package: "libc6", Architecture: "amd64" }]));
+  const librarySource = path.join(root, "library.c");
+  const executableSource = path.join(root, "executable.c");
+  const staticSource = path.join(root, "static.c");
+  fs.writeFileSync(librarySource, "int sample(void) { return 42; }\n");
+  fs.writeFileSync(executableSource, "extern int sample(void); void _start(void) { (void)sample(); }\n");
+  fs.writeFileSync(staticSource, "void _start(void) {}\n");
+  const run = (command, args) => cp.execFileSync(command, args, { encoding: "utf8" });
+  run("cc", ["-shared", "-nostdlib", "-fPIC", librarySource, "-Wl,-soname,libsample.so.1", "-o", path.join(lib, "libsample.so.1")]);
+  fs.symlinkSync("libsample.so.1", path.join(lib, "libsample.so"));
+  run("cc", ["-shared", "-nostdlib", "-fPIC", executableSource, "-Wl,--no-as-needed", `-L${lib}`, "-l:libsample.so.1", "-o", path.join(lib, "libdependent.so")]);
+  // The fixture loader is never executed. Its exclusion from library patching
+  // is checked byte-for-byte below.
+  fs.copyFileSync(path.join(lib, "libsample.so.1"), path.join(lib, "ld-linux-x86-64.so.2"));
+  run("cc", ["-pie", "-nostdlib", executableSource, "-Wl,--dynamic-linker,/lib64/ld-linux-x86-64.so.2", `-L${lib}`, "-l:libsample.so.1", "-o", path.join(source, "fixture-app")]);
+  run("cc", ["-pie", "-nostdlib", executableSource, "-Wl,--dynamic-linker,/lib/ld-musl-x86_64.so.1", `-L${lib}`, "-l:libsample.so.1", "-o", path.join(source, "fixture-musl")]);
+  run("cc", ["-static", "-nostdlib", "-no-pie", staticSource, "-o", path.join(source, "fixture-static")]);
+  run("cc", ["-static-pie", "-nostdlib", staticSource, "-o", path.join(source, "fixture-static-pie")]);
+  fs.copyFileSync(path.join(lib, "libdependent.so"), path.join(source, "fixture-module.so"));
+
+  const manifest = { schemaVersion: 1, architectures: { amd64: {
+    machine: 62, requiredDynamicExecutables: ["fixture-app"], interpreterStrategies: {},
+  } } };
+  const validate = elf.validateUpstreamInventory;
+  const fix = elf.applyFixups;
+  const audit = elf.auditFixedTree;
+  t.mock.method(elf, "validateUpstreamInventory", (directory, architecture) => validate(directory, architecture, manifest));
+  t.mock.method(elf, "applyFixups", (options) => fix({ ...options, manifest }));
+  t.mock.method(elf, "auditFixedTree", (options) => {
+    assert.equal(options.checkDependencies, true, "production must retain the real loader audit");
+    assert.equal(options.checkShebangs, false, "host FHS shebangs must be preserved");
+    return audit({ ...options, manifest, checkDependencies: false });
+  });
+  return { source, runtime, output, lib, run, build: () => build([source, runtime, output]) };
+}
+
+test("runtime symlinks resolve to patched copies and source bytes remain unchanged", (t) => {
+  const f = fixture(t);
+  const before = fs.readFileSync(path.join(f.lib, "libsample.so.1"));
+  f.build();
+  const copiedLib = path.join(f.output, "runtime/lib/x86_64-linux-gnu");
+  assert.equal(fs.readlinkSync(path.join(copiedLib, "libsample.so")), "libsample.so.1");
+  assert.equal(fs.realpathSync(path.join(copiedLib, "libsample.so")), path.join(copiedLib, "libsample.so.1"));
+  assert.notDeepEqual(fs.readFileSync(path.join(copiedLib, "libsample.so")), before);
+  assert.deepEqual(fs.readFileSync(path.join(f.lib, "libsample.so.1")), before);
+  assert.deepEqual(fs.readFileSync(path.join(copiedLib, "ld-linux-x86-64.so.2")), before);
+});
+
+test("every private DSO gets RUNPATH and NODEFLIB, including transitive dependencies", (t) => {
+  const f = fixture(t);
+  f.build();
+  const lib = path.join(f.output, "runtime/lib/x86_64-linux-gnu");
+  const expectedPath = `${lib}:${path.join(f.output, "runtime/lib")}`;
+  for (const file of [path.join(lib, "libsample.so.1"), path.join(lib, "libdependent.so"), path.join(f.output, "opt/codex-desktop/fixture-module.so"), path.join(f.output, "opt/codex-desktop/fixture-app")]) {
+    assert.equal(f.run("patchelf", ["--print-rpath", file]).trim(), expectedPath);
+    assert.match(f.run("readelf", ["-d", file]), /\(FLAGS_1\).*NODEFLIB/);
+  }
+  assert.match(f.run("patchelf", ["--print-needed", path.join(lib, "libdependent.so")]), /libsample\.so\.1/);
+  assert.equal(f.run("patchelf", ["--print-interpreter", path.join(f.output, "opt/codex-desktop/fixture-app")]).trim(), path.join(lib, "ld-linux-x86-64.so.2"));
+});
+
+test("ASAR, host shebangs, static binaries, and musl binaries are preserved", (t) => {
+  const f = fixture(t);
+  const libraryEnvironment = process.env.LD_LIBRARY_PATH;
+  f.build();
+  assert.equal(elf.inspectFile(path.join(f.source, "fixture-static-pie")).linkage, "static-pie");
+  for (const file of ["resources/app.asar", "start.sh", "fixture-static", "fixture-static-pie", "fixture-musl"])
+    assert.deepEqual(fs.readFileSync(path.join(f.output, "opt/codex-desktop", file)), fs.readFileSync(path.join(f.source, file)));
+  assert.equal(process.env.LD_LIBRARY_PATH, libraryEnvironment);
+  assert.equal(JSON.parse(fs.readFileSync(path.join(f.output, "alpine-build.json"))).architecture, "amd64");
+});
+
+test("an ELF patch failure cannot produce a successful build marker", (t) => {
+  const f = fixture(t);
+  const execute = cp.execFileSync;
+  t.mock.method(cp, "execFileSync", (command, args, options) => {
+    if (command === "patchelf") throw new Error("injected patchelf failure");
+    return execute(command, args, options);
+  });
+  assert.throws(f.build, /injected patchelf failure/);
+  assert.equal(fs.existsSync(path.join(f.output, "alpine-build.json")), false);
+  assert.throws(f.build, /must not already exist/);
+});
+
+test("a failed dependency audit cannot produce a successful build marker", (t) => {
+  const f = fixture(t);
+  elf.auditFixedTree.mock.mockImplementation(() => { throw new Error("injected unresolved dependency"); });
+  assert.throws(f.build, /injected unresolved dependency/);
+  assert.equal(fs.existsSync(path.join(f.output, "alpine-build.json")), false);
+});
+
+test("unexpected ASAR changes fail closed without a successful build marker", (t) => {
+  const f = fixture(t);
+  elf.auditFixedTree.mock.mockImplementation((options) => {
+    fs.appendFileSync(path.join(options.root, "resources/app.asar"), "unexpected mutation");
+  });
+  assert.throws(f.build, /ASAR changed/);
+  assert.equal(fs.existsSync(path.join(f.output, "alpine-build.json")), false);
+  assert.equal(fs.readFileSync(path.join(f.source, "resources/app.asar"), "utf8"), "fixture ASAR: preserve these bytes");
+});
+
+test("invalid runtime architecture and nested output fail before writing output", (t) => {
+  const f = fixture(t);
+  fs.writeFileSync(path.join(f.runtime, "manifest.json"), JSON.stringify([{ Package: "libc6", Architecture: "arm64" }]));
+  assert.throws(f.build, /no amd64 libc6/);
+  assert.equal(fs.existsSync(f.output), false);
+  const nested = path.join(f.source, "nested");
+  assert.throws(() => build([f.source, f.runtime, nested]), /outside both input trees/);
+  assert.equal(fs.existsSync(nested), false);
+});

--- a/packaging/alpine/fetch-runtime.py
+++ b/packaging/alpine/fetch-runtime.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Extract a verified Debian library closure for a direct Alpine host launch.
+
+No package scripts are run, and no chroot/container is created. This is an
+experimental library provider for packaging/alpine/build.cjs, not an OS install.
+"""
+
+import argparse
+import concurrent.futures
+import datetime
+import email.utils
+import hashlib
+import json
+import lzma
+import pathlib
+import re
+import subprocess
+import urllib.request
+
+
+KEYS = {
+    "archive-key-12": "B8B80B5B623EAB6AD8775C45B7C5D7D6350947F8",
+    "archive-key-12-security": "05AB90340C0C5E797F44A8C8254CF3B5AEC0A8F0",
+    "archive-key-13": "04B54C3CDCA79751B16BC6B5225629DF75B188BD",
+    "archive-key-13-security": "5E04A1E3223A19A20706E20F9904613D4CCE68C6",
+    "release-13": "41587F7DB8C774BCCF131416762F67A0B2C39DE4",
+}
+SOURCES = [
+    ("https://deb.debian.org/debian", "trixie"),
+    ("https://deb.debian.org/debian", "trixie-updates"),
+    ("https://deb.debian.org/debian-security", "trixie-security"),
+]
+ROOT_PACKAGES = """
+libc6 libgtk-3-0t64 libnotify4 libnss3 libatspi2.0-0t64 libdrm2 libgbm1
+libxcb-dri3-0 libasound2t64 libatk-bridge2.0-0t64 libatk1.0-0t64 libcairo2
+libcups2t64 libdbus-1-3 libexpat1 libgcc-s1 libgdk-pixbuf-2.0-0 libgl1
+libglib2.0-0t64 libnspr4 libpango-1.0-0 libstdc++6 libudev1 libusb-1.0-0
+libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxdamage1 libxext6 libxfixes3
+libxkbcommon0 libxrandr2 libwayland-client0 libwayland-cursor0 libwayland-egl1
+libsecret-1-0 libssl3t64 libpipewire-0.3-0t64 libxss1 libxtst6 libxcursor1
+libxi6 libzstd1 liblzma5 zlib1g libfontconfig1 libcurl3t64-gnutls
+mesa-libgallium mesa-vulkan-drivers libgl1-mesa-dri libasound2-plugins
+""".split()
+
+
+def run(*args, **kwargs):
+    result = subprocess.run(args, capture_output=True, **kwargs)
+    if result.returncode:
+        raise RuntimeError(f"{args[0]} failed: {result.stderr.decode(errors='replace').strip()}")
+    return result.stdout
+
+
+def fetch(url):
+    with urllib.request.urlopen(url, timeout=90) as response:
+        if not response.url.startswith("https://"):
+            raise ValueError("download redirected outside HTTPS")
+        return response.read()
+
+
+def checked_bytes(url, sha256, size):
+    data = fetch(url)
+    if len(data) != int(size) or hashlib.sha256(data).hexdigest() != sha256:
+        raise ValueError(f"size/SHA256 mismatch: {url}")
+    return data
+
+
+def paragraphs(text):
+    for paragraph in text.split("\n\n"):
+        fields = {}
+        key = None
+        for line in paragraph.splitlines():
+            if line.startswith(" ") and key:
+                fields[key] += "\n" + line[1:]
+            elif ": " in line:
+                key, value = line.split(": ", 1)
+                fields[key] = value
+            elif line.endswith(":"):
+                key = line[:-1]
+                fields[key] = ""
+        if fields:
+            yield fields
+
+
+def safe_repository_path(value):
+    if not value or value.startswith("/") or ".." in value.split("/"):
+        raise ValueError(f"unsafe repository path: {value}")
+    if not re.fullmatch(r"[A-Za-z0-9_+./~%-]+", value):
+        raise ValueError(f"invalid repository path: {value}")
+    return value
+
+
+def keyring(cache):
+    binary_keys = []
+    for name, expected in KEYS.items():
+        data = fetch(f"https://ftp-master.debian.org/keys/{name}.asc")
+        info = run("gpg", "--batch", "--with-colons", "--show-keys", input=data).decode()
+        actual = next(line.split(":")[9] for line in info.splitlines() if line.startswith("fpr:"))
+        if actual != expected:
+            raise ValueError(f"unexpected Debian key fingerprint: {actual}")
+        binary_keys.append(run("gpg", "--batch", "--dearmor", input=data))
+    result = cache / "debian-archive.gpg"
+    result.write_bytes(b"".join(binary_keys))
+    return result
+
+
+def package_index(base, suite, arch, cache, keys):
+    release_path = cache / f"{suite}.InRelease"
+    release_path.write_bytes(fetch(f"{base}/dists/{suite}/InRelease"))
+    release = run("gpgv", "--keyring", str(keys), "--output", "-", str(release_path)).decode()
+    fields = next(paragraphs(release))
+    now = datetime.datetime.now(datetime.timezone.utc)
+    if email.utils.parsedate_to_datetime(fields["Date"]) > now + datetime.timedelta(days=1):
+        raise ValueError(f"future repository metadata: {suite}")
+    if "Valid-Until" in fields and email.utils.parsedate_to_datetime(fields["Valid-Until"]) < now:
+        raise ValueError(f"expired repository metadata: {suite}")
+    target = f"main/binary-{arch}/Packages.xz"
+    entries = [line.split() for line in fields["SHA256"].splitlines() if line.strip()]
+    sha, size, _ = next(entry for entry in entries if entry[2] == target)
+    data = checked_bytes(f"{base}/dists/{suite}/{target}", sha, size)
+    packages = list(paragraphs(lzma.decompress(data).decode()))
+    for package in packages:
+        package["Repository"] = base
+    return packages
+
+
+def newer(left, right):
+    return subprocess.run(["dpkg", "--compare-versions", left, "gt", right], check=False).returncode == 0
+
+
+def dependency_closure(packages, roots):
+    # Every provider choice comes from the same verified Debian architecture.
+    # Version predicates are checked by dpkg; unsupported syntax fails closed.
+    providers = {}
+    for name, package in packages.items():
+        for item in package.get("Provides", "").split(","):
+            if item.strip():
+                providers.setdefault(item.strip().split()[0], []).append(name)
+    selected = {}
+
+    def resolve(group):
+        for alternative in group.split("|"):
+            match = re.fullmatch(r"\s*([a-z0-9][a-z0-9+.-]*)(?::(?:any|native))?\s*(?:\((<<|<=|=|>=|>>)\s*([^ )]+)\))?\s*", alternative)
+            if not match:
+                raise ValueError(f"unsupported dependency: {alternative}")
+            name, op, version = match.groups()
+            if name in packages:
+                if op and subprocess.run(["dpkg", "--compare-versions", packages[name]["Version"], op, version], check=False).returncode:
+                    continue
+                return name
+            if not op and name in providers:
+                return sorted(providers[name])[0]
+        raise ValueError(f"unresolved dependency: {group}")
+
+    pending = list(roots)
+    while pending:
+        name = pending.pop()
+        if name in selected:
+            continue
+        package = packages[name]
+        selected[name] = package
+        for field in ("Pre-Depends", "Depends"):
+            for group in package.get(field, "").split(","):
+                if group.strip():
+                    pending.append(resolve(group))
+    return selected
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    parser.add_argument("--cache", type=pathlib.Path)
+    parser.add_argument("--arch", choices=["amd64"], default="amd64")
+    args = parser.parse_args()
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    cache = args.cache.resolve() if args.cache else output / "packages"
+    cache.mkdir(parents=True, exist_ok=True)
+    keys = keyring(cache)
+    packages = {}
+    for base, suite in SOURCES:
+        print(f"Verifying {suite}/{args.arch}", flush=True)
+        for package in package_index(base, suite, args.arch, cache, keys):
+            name = package["Package"]
+            if name not in packages or newer(package["Version"], packages[name]["Version"]):
+                packages[name] = package
+    selected = dependency_closure(packages, ROOT_PACKAGES)
+    print(f"Downloading {len(selected)} verified packages", flush=True)
+
+    def download(item):
+        name, package = item
+        filename = safe_repository_path(package["Filename"])
+        target = cache / pathlib.PurePosixPath(filename).name
+        if not target.is_file() or target.stat().st_size != int(package["Size"]) or hashlib.sha256(target.read_bytes()).hexdigest() != package["SHA256"]:
+            target.write_bytes(checked_bytes(package["Repository"] + "/" + filename, package["SHA256"], package["Size"]))
+        return name, package, target
+
+    library_root = output / "root"
+    library_root.mkdir()
+    manifest = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        for name, package, target in executor.map(download, sorted(selected.items())):
+            # dpkg-deb only extracts data; postinst and triggers are never run.
+            run("dpkg-deb", "--extract", str(target), str(library_root))
+            manifest.append({key: package[key] for key in ("Package", "Version", "Architecture", "SHA256", "Filename", "Repository")})
+    (output / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    print(f"Library root: {library_root}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/alpine/install-desktop.cjs
+++ b/packaging/alpine/install-desktop.cjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const cp = require("node:child_process");
+
+const [outputArg, toolsArg] = process.argv.slice(2);
+if (!outputArg || !toolsArg || process.argv.length !== 4)
+  throw new Error("usage: install-desktop.cjs BUILT-OUTPUT ALPINE-TOOLS");
+const output = fs.realpathSync(outputArg);
+const tools = fs.realpathSync(toolsArg);
+const app = path.join(output, "opt/codex-desktop");
+if (!fs.statSync(path.join(output, "alpine-build.json")).isFile())
+  throw new Error("output has not passed the Alpine build audit");
+const ps = path.join(tools, "root/bin/ps");
+cp.execFileSync(ps, ["-ax", "-o", "pid=,ppid="], { stdio: "ignore" });
+// The desktop refreshes PATH from the user's login shell. Expose the native
+// Alpine helper in the conventional user bin directory as well as launch PATH.
+const userBin = path.join(process.env.HOME, ".local/bin");
+fs.mkdirSync(userBin, { recursive: true });
+const userPs = path.join(userBin, "ps");
+let existingPs = false;
+try { fs.lstatSync(userPs); existingPs = true; }
+catch (error) { if (error.code !== "ENOENT") throw error; }
+if (existingPs)
+  cp.execFileSync(userPs, ["-ax", "-o", "pid=,ppid="], { stdio: "ignore" });
+else
+  fs.symlinkSync(ps, userPs);
+const hostBin = path.join(output, "host-bin");
+fs.mkdirSync(hostBin);
+fs.symlinkSync(ps, path.join(hostBin, "ps"));
+const quote = (value) => "'" + value.replaceAll("'", "'\\''") + "'";
+const launcher = path.join(output, "launch.sh");
+fs.writeFileSync(launcher, `#!/bin/sh\n# Only Alpine's native ps is added; all other host tools retain their PATH.\nexport PATH=${quote(hostBin)}:"$PATH"\nexec ${quote(path.join(app, "start.sh"))} --ui-toolkit=gtk --gtk-version=3 --ozone-platform=x11 "$@"\n`, { mode: 0o755, flag: "wx" });
+const data = process.env.XDG_DATA_HOME || path.join(process.env.HOME, ".local/share");
+const applications = path.join(data, "applications");
+fs.mkdirSync(applications, { recursive: true });
+// Desktop Exec uses its own quoting rules, not shell quoting.
+const desktopQuote = (value) => '"' + value.replaceAll("%", "%%").replaceAll("\\", "\\\\\\\\").replaceAll('"', '\\"').replaceAll("`", "\\`").replaceAll("$", "\\$") + '"';
+const desktop = path.join(applications, "codex-desktop.desktop");
+fs.writeFileSync(desktop, `[Desktop Entry]\nName=ChatGPT Community\nComment=ChatGPT Community on Alpine Linux\nExec=${desktopQuote(launcher)} %u\nIcon=${path.join(app, ".codex-linux/codex-desktop.png")}\nTerminal=false\nType=Application\nCategories=Development;\nMimeType=x-scheme-handler/codex;x-scheme-handler/codex-browser-sidebar;\nStartupNotify=true\nStartupWMClass=codex-desktop\n`, { flag: "wx" });
+console.log(`Installed ${desktop}`);
+console.log(`Launch with ${launcher}`);

--- a/packaging/alpine/install-desktop.cjs
+++ b/packaging/alpine/install-desktop.cjs
@@ -5,40 +5,118 @@ const fs = require("node:fs");
 const path = require("node:path");
 const cp = require("node:child_process");
 
-const [outputArg, toolsArg] = process.argv.slice(2);
-if (!outputArg || !toolsArg || process.argv.length !== 4)
-  throw new Error("usage: install-desktop.cjs BUILT-OUTPUT ALPINE-TOOLS");
-const output = fs.realpathSync(outputArg);
-const tools = fs.realpathSync(toolsArg);
-const app = path.join(output, "opt/codex-desktop");
-if (!fs.statSync(path.join(output, "alpine-build.json")).isFile())
-  throw new Error("output has not passed the Alpine build audit");
-const ps = path.join(tools, "root/bin/ps");
-cp.execFileSync(ps, ["-ax", "-o", "pid=,ppid="], { stdio: "ignore" });
-// The desktop refreshes PATH from the user's login shell. Expose the native
-// Alpine helper in the conventional user bin directory as well as launch PATH.
-const userBin = path.join(process.env.HOME, ".local/bin");
-fs.mkdirSync(userBin, { recursive: true });
-const userPs = path.join(userBin, "ps");
-let existingPs = false;
-try { fs.lstatSync(userPs); existingPs = true; }
-catch (error) { if (error.code !== "ENOENT") throw error; }
-if (existingPs)
-  cp.execFileSync(userPs, ["-ax", "-o", "pid=,ppid="], { stdio: "ignore" });
-else
-  fs.symlinkSync(ps, userPs);
-const hostBin = path.join(output, "host-bin");
-fs.mkdirSync(hostBin);
-fs.symlinkSync(ps, path.join(hostBin, "ps"));
-const quote = (value) => "'" + value.replaceAll("'", "'\\''") + "'";
-const launcher = path.join(output, "launch.sh");
-fs.writeFileSync(launcher, `#!/bin/sh\n# Only Alpine's native ps is added; all other host tools retain their PATH.\nexport PATH=${quote(hostBin)}:"$PATH"\nexec ${quote(path.join(app, "start.sh"))} --ui-toolkit=gtk --gtk-version=3 --ozone-platform=x11 "$@"\n`, { mode: 0o755, flag: "wx" });
-const data = process.env.XDG_DATA_HOME || path.join(process.env.HOME, ".local/share");
-const applications = path.join(data, "applications");
-fs.mkdirSync(applications, { recursive: true });
-// Desktop Exec uses its own quoting rules, not shell quoting.
-const desktopQuote = (value) => '"' + value.replaceAll("%", "%%").replaceAll("\\", "\\\\\\\\").replaceAll('"', '\\"').replaceAll("`", "\\`").replaceAll("$", "\\$") + '"';
-const desktop = path.join(applications, "codex-desktop.desktop");
-fs.writeFileSync(desktop, `[Desktop Entry]\nName=ChatGPT Community\nComment=ChatGPT Community on Alpine Linux\nExec=${desktopQuote(launcher)} %u\nIcon=${path.join(app, ".codex-linux/codex-desktop.png")}\nTerminal=false\nType=Application\nCategories=Development;\nMimeType=x-scheme-handler/codex;x-scheme-handler/codex-browser-sidebar;\nStartupNotify=true\nStartupWMClass=codex-desktop\n`, { flag: "wx" });
-console.log(`Installed ${desktop}`);
-console.log(`Launch with ${launcher}`);
+function installDesktop(outputArg, toolsArg, {
+  userHome = process.env.HOME,
+  dataHome = process.env.XDG_DATA_HOME || (userHome && path.join(userHome, ".local/share")),
+} = {}) {
+  if (!outputArg || !toolsArg)
+    throw new Error("usage: install-desktop.cjs BUILT-OUTPUT ALPINE-TOOLS");
+  const output = fs.realpathSync(outputArg);
+  const tools = fs.realpathSync(toolsArg);
+  for (const value of [output, tools, userHome, dataHome]) {
+    if (typeof value !== "string" || !path.isAbsolute(value) || /[\x00-\x1f\x7f]/.test(value))
+      throw new Error("installation paths must be absolute and contain no control characters");
+  }
+  // '=' is forbidden in the executable path by the Desktop Entry specification.
+  if (output.includes("=")) throw new Error("desktop executable path cannot contain '='");
+  const app = path.join(output, "opt/codex-desktop");
+  for (const file of [path.join(output, "alpine-build.json"), path.join(app, "start.sh"), path.join(app, ".codex-linux/codex-desktop.png")])
+    if (!fs.statSync(file).isFile()) throw new Error(`required build file is not a file: ${file}`);
+
+  const userBin = path.join(userHome, ".local/bin");
+  const userPs = path.join(userBin, "ps");
+  const hostBin = path.join(output, "host-bin");
+  const launcher = path.join(output, "launch.sh");
+  const applications = path.join(dataHome, "applications");
+  const desktop = path.join(applications, "codex-desktop.desktop");
+  const stat = (target) => fs.lstatSync(target, { throwIfNoEntry: false });
+  // Check *all* conflicts before modifying anything, including dangling links.
+  for (const target of [hostBin, launcher, desktop])
+    if (stat(target)) throw new Error(`destination already exists: ${target}`);
+  const ps = path.join(tools, "root/bin/ps");
+  const checkPs = (command) => cp.execFileSync(command, ["-ax", "-o", "pid=,ppid="], { stdio: "ignore", timeout: 10000 });
+  checkPs(ps);
+  const existingPs = stat(userPs);
+  if (existingPs) checkPs(userPs);
+
+  const quote = (value) => "'" + value.replaceAll("'", "'\\''") + "'";
+  // Exec argument escaping is decoded AFTER desktop string escaping.
+  // https://specifications.freedesktop.org/desktop-entry/latest/exec-variables.html
+  const desktopString = (value) => value.replaceAll("\\", "\\\\");
+  const desktopQuote = (value) => desktopString('"' + value.replaceAll("%", "%%").replace(/[\\"`$]/g, "\\$&") + '"');
+  const launcherText = `#!/bin/sh\n# Only Alpine's native ps is added; all other host tools retain their PATH.\nexport PATH=${quote(hostBin)}:"$PATH"\nexec ${quote(path.join(app, "start.sh"))} --ui-toolkit=gtk --gtk-version=3 --ozone-platform=x11 "$@"\n`;
+  const desktopText = `[Desktop Entry]\nName=ChatGPT Community\nComment=ChatGPT Community on Alpine Linux\nExec=${desktopQuote(launcher)} %u\nIcon=${desktopString(path.join(app, ".codex-linux/codex-desktop.png"))}\nTerminal=false\nType=Application\nCategories=Development;\nMimeType=x-scheme-handler/codex;x-scheme-handler/codex-browser-sidebar;\nStartupNotify=true\nStartupWMClass=codex-desktop\n`;
+
+  // Roll back caught failures, never pre-existing or replaced paths. This is
+  // not a power-loss/SIGKILL recovery journal. Directories are only rmdir'ed;
+  // no recursive removal can swallow another process's files.
+  const owned = [];
+  const remember = (target, info = stat(target)) => owned.push({ target, info });
+  function mkdir(target) {
+    if (stat(target)) {
+      if (!fs.statSync(target).isDirectory()) throw new Error(`not a directory: ${target}`);
+      return;
+    }
+    mkdir(path.dirname(target));
+    fs.mkdirSync(target);
+    remember(target);
+  }
+  function symlink(source, target) {
+    fs.symlinkSync(source, target);
+    remember(target);
+  }
+  function publish(target, contents, mode) {
+    const staging = fs.mkdtempSync(path.join(path.dirname(target), ".alpine-install-"));
+    remember(staging);
+    const temporary = path.join(staging, "entry");
+    const fd = fs.openSync(temporary, "wx", mode);
+    const info = fs.fstatSync(fd);
+    remember(temporary, info);
+    try { fs.writeFileSync(fd, contents); }
+    finally { fs.closeSync(fd); }
+    // Same-filesystem link publishes the complete file without overwriting a
+    // destination created after preflight (rename would silently overwrite).
+    fs.linkSync(temporary, target);
+    remember(target, info);
+    fs.unlinkSync(temporary);
+    owned.splice(owned.findIndex((entry) => entry.target === temporary), 1);
+    fs.rmdirSync(staging);
+    owned.splice(owned.findIndex((entry) => entry.target === staging), 1);
+  }
+  try {
+    mkdir(userBin);
+    mkdir(applications);
+    // The desktop refreshes PATH from the login shell; expose native procps
+    // in the user bin directory as well as the launcher's narrow host-bin.
+    if (!existingPs) symlink(ps, userPs);
+    fs.mkdirSync(hostBin);
+    remember(hostBin);
+    symlink(ps, path.join(hostBin, "ps"));
+    publish(launcher, launcherText, 0o755);
+    publish(desktop, desktopText, 0o644);
+  } catch (error) {
+    const failures = [];
+    for (const { target, info } of owned.reverse()) {
+      try {
+        const current = stat(target);
+        if (!current || current.dev !== info.dev || current.ino !== info.ino) continue;
+        if (current.isDirectory()) fs.rmdirSync(target);
+        else fs.unlinkSync(target);
+      } catch (cleanupError) { failures.push(`${target}: ${cleanupError.message}`); }
+    }
+    if (failures.length) throw new Error(`${error.message}; cleanup incomplete: ${failures.join("; ")}`, { cause: error });
+    throw error;
+  }
+  return { desktop, launcher };
+}
+
+if (require.main === module) {
+  try {
+    if (process.argv.length !== 4) throw new Error("usage: install-desktop.cjs BUILT-OUTPUT ALPINE-TOOLS");
+    const { desktop, launcher } = installDesktop(...process.argv.slice(2));
+    console.log(`Installed ${desktop}`);
+    console.log(`Launch with ${launcher}`);
+  } catch (error) { console.error(error.message); process.exitCode = 1; }
+}
+
+module.exports = { installDesktop };

--- a/packaging/alpine/install-desktop.test.cjs
+++ b/packaging/alpine/install-desktop.test.cjs
@@ -1,0 +1,222 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const cp = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const { installDesktop } = require("./install-desktop.cjs");
+
+function fixture(t, name = "app") {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "alpine-desktop-test-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const output = path.join(root, name);
+  const tools = path.join(root, "tools");
+  const userHome = path.join(root, "user");
+  const dataHome = path.join(root, "data");
+  const app = path.join(output, "opt/codex-desktop");
+  const desktop = path.join(dataHome, "applications/codex-desktop.desktop");
+  const userPs = path.join(userHome, ".local/bin/ps");
+  fs.mkdirSync(path.join(app, ".codex-linux"), { recursive: true });
+  fs.mkdirSync(path.join(tools, "root/bin"), { recursive: true });
+  fs.mkdirSync(userHome);
+  fs.writeFileSync(path.join(output, "alpine-build.json"), "{}");
+  fs.writeFileSync(path.join(app, ".codex-linux/codex-desktop.png"), "icon");
+  fs.writeFileSync(path.join(app, "start.sh"), '#!/bin/sh\nprintf "%s\\n" "$PATH" "${LD_LIBRARY_PATH-unset}" "$@"\n', { mode: 0o755 });
+  fs.writeFileSync(path.join(tools, "root/bin/ps"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  return { output, tools, userHome, dataHome, desktop, userPs,
+    install: () => installDesktop(output, tools, { userHome, dataHome }) };
+}
+
+function assertNoInstall(f) {
+  for (const target of [f.userPs, path.join(f.output, "host-bin"), path.join(f.output, "launch.sh")])
+    assert.equal(fs.lstatSync(target, { throwIfNoEntry: false }), undefined, `left behind ${target}`);
+  assert.deepEqual(fs.readdirSync(f.output).sort(), ["alpine-build.json", "opt"]);
+}
+
+test("an existing desktop entry is rejected before any installation writes", (t) => {
+  const f = fixture(t);
+  fs.mkdirSync(path.dirname(f.desktop), { recursive: true });
+  fs.writeFileSync(f.desktop, "user-owned entry");
+  assert.throws(f.install, /exist/i);
+  assert.equal(fs.readFileSync(f.desktop, "utf8"), "user-owned entry");
+  assertNoInstall(f);
+});
+
+test("a dangling desktop symlink is also an occupied destination", (t) => {
+  const f = fixture(t);
+  fs.mkdirSync(path.dirname(f.desktop), { recursive: true });
+  fs.symlinkSync("missing-user-file", f.desktop);
+  assert.throws(f.install, /exist/i);
+  assert.equal(fs.readlinkSync(f.desktop), "missing-user-file");
+  assertNoInstall(f);
+});
+
+test("a conflicting launcher is preserved without creating helpers", (t) => {
+  const f = fixture(t);
+  const launcher = path.join(f.output, "launch.sh");
+  fs.writeFileSync(launcher, "user-owned launcher");
+  assert.throws(f.install, /exist/i);
+  assert.equal(fs.readFileSync(launcher, "utf8"), "user-owned launcher");
+  assert.equal(fs.existsSync(f.userPs), false);
+  assert.equal(fs.existsSync(path.join(f.output, "host-bin")), false);
+});
+
+test("an invalid existing ps is never replaced", (t) => {
+  const f = fixture(t);
+  fs.mkdirSync(path.dirname(f.userPs), { recursive: true });
+  fs.writeFileSync(f.userPs, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+  assert.throws(f.install);
+  assert.equal(fs.readFileSync(f.userPs, "utf8"), "#!/bin/sh\nexit 1\n");
+  assert.equal(fs.existsSync(path.join(f.output, "host-bin")), false);
+  assert.equal(fs.existsSync(f.desktop), false);
+});
+
+test("the launcher forwards arguments and keeps host tools and library environment", (t) => {
+  const f = fixture(t, "app with 'quotes' and spaces");
+  const { launcher } = f.install();
+  const args = ["codex://test?value=a b&next=$literal", "--literal='quoted'", ""];
+  const env = { ...process.env };
+  delete env.LD_LIBRARY_PATH;
+  const lines = cp.execFileSync(launcher, args, { env, encoding: "utf8" }).split("\n");
+  assert.equal(lines[0], `${path.join(f.output, "host-bin")}:${env.PATH}`);
+  assert.equal(lines[1], "unset");
+  assert.deepEqual(lines.slice(2, -1), ["--ui-toolkit=gtk", "--gtk-version=3", "--ozone-platform=x11", ...args]);
+  assert.deepEqual(fs.readdirSync(path.join(f.output, "host-bin")), ["ps"]);
+  assert.equal(fs.readlinkSync(f.userPs), path.join(f.tools, "root/bin/ps"));
+});
+
+test("a late publishing error rolls back owned paths and allows a clean retry", (t) => {
+  const f = fixture(t);
+  const link = fs.linkSync;
+  const fault = t.mock.method(fs, "linkSync", (source, target) => {
+    if (target === f.desktop) throw new Error("injected publish failure");
+    return link(source, target);
+  });
+  assert.throws(f.install, /injected publish failure/);
+  assertNoInstall(f);
+  assert.equal(fs.existsSync(f.dataHome), false);
+  assert.deepEqual(fs.readdirSync(f.userHome), []);
+  fault.mock.restore();
+  assert.equal(f.install().desktop, f.desktop);
+});
+
+test("a partial file write is cleaned up before retry", (t) => {
+  const f = fixture(t);
+  const write = fs.writeFileSync;
+  const fault = t.mock.method(fs, "writeFileSync", (target, contents, ...rest) => {
+    if (typeof target === "number") {
+      write(target, contents.slice(0, 12), ...rest);
+      throw new Error("injected disk full");
+    }
+    return write(target, contents, ...rest);
+  });
+  assert.throws(f.install, /injected disk full/);
+  assertNoInstall(f);
+  assert.equal(fs.existsSync(f.desktop), false);
+  fault.mock.restore();
+  assert.ok(fs.existsSync(f.install().launcher));
+});
+
+test("a desktop entry created after preflight is not overwritten or removed", (t) => {
+  const f = fixture(t);
+  const link = fs.linkSync;
+  t.mock.method(fs, "linkSync", (source, target) => {
+    if (target === f.desktop) fs.writeFileSync(target, "concurrent entry", { flag: "wx" });
+    return link(source, target);
+  });
+  assert.throws(f.install, /EEXIST/);
+  assert.equal(fs.readFileSync(f.desktop, "utf8"), "concurrent entry");
+  assertNoInstall(f);
+});
+
+test("rollback preserves existing ps and unrelated files", (t) => {
+  const f = fixture(t);
+  fs.mkdirSync(path.dirname(f.userPs), { recursive: true });
+  fs.copyFileSync(path.join(f.tools, "root/bin/ps"), f.userPs);
+  const before = fs.statSync(f.userPs);
+  fs.mkdirSync(path.dirname(f.desktop), { recursive: true });
+  const unrelated = path.join(path.dirname(f.desktop), "other.desktop");
+  fs.writeFileSync(unrelated, "unrelated");
+  const link = fs.linkSync;
+  t.mock.method(fs, "linkSync", (source, target) => {
+    if (target === f.desktop) throw new Error("injected publish failure");
+    return link(source, target);
+  });
+  assert.throws(f.install, /injected publish failure/);
+  assert.equal(fs.statSync(f.userPs).ino, before.ino);
+  assert.equal(fs.readFileSync(unrelated, "utf8"), "unrelated");
+  assert.deepEqual(fs.readdirSync(f.output).sort(), ["alpine-build.json", "opt"]);
+});
+
+test("rollback does not delete an owned path replaced by another writer", (t) => {
+  const f = fixture(t);
+  fs.mkdirSync(path.dirname(f.userPs), { recursive: true });
+  const link = fs.linkSync;
+  t.mock.method(fs, "linkSync", (source, target) => {
+    if (target === f.desktop) {
+      fs.renameSync(f.userPs, path.join(f.userHome, "original-ps"));
+      fs.symlinkSync("replacement", f.userPs);
+      throw new Error("injected publish failure");
+    }
+    return link(source, target);
+  });
+  assert.throws(f.install, /injected publish failure/);
+  assert.equal(fs.readlinkSync(f.userPs), "replacement");
+});
+
+test("repeating a successful installation refuses to overwrite its files", (t) => {
+  const f = fixture(t);
+  const { launcher, desktop } = f.install();
+  const before = [launcher, desktop, f.userPs].map((file) => fs.lstatSync(file).ino);
+  assert.throws(f.install, /already exists/);
+  assert.deepEqual([launcher, desktop, f.userPs].map((file) => fs.lstatSync(file).ino), before);
+});
+
+test("a file replaced immediately after publication is not owned by rollback", (t) => {
+  const f = fixture(t);
+  const launcher = path.join(f.output, "launch.sh");
+  const link = fs.linkSync;
+  t.mock.method(fs, "linkSync", (source, target) => {
+    if (target === f.desktop) throw new Error("injected publish failure");
+    link(source, target);
+    if (target === launcher) {
+      fs.unlinkSync(target);
+      fs.writeFileSync(target, "replacement launcher", { flag: "wx" });
+    }
+  });
+  assert.throws(f.install, /injected publish failure/);
+  assert.equal(fs.readFileSync(launcher, "utf8"), "replacement launcher");
+});
+
+test("desktop Exec and Icon escape backslashes and shell metacharacters", (t) => {
+  const f = fixture(t, 'app "quoted" \\backslash $dollar `tick` %u');
+  const { launcher, desktop } = f.install();
+  const entry = fs.readFileSync(desktop, "utf8");
+  // Independent two-stage decoder, following Desktop Entry sections 4 and 7.
+  const decodeValue = (value) => value.replace(/\\([sntr\\])/g, (_, c) => ({ s: " ", n: "\n", t: "\t", r: "\r", "\\": "\\" })[c]);
+  const exec = decodeValue(entry.match(/^Exec=(.*)$/m)[1]);
+  const match = exec.match(/^"((?:\\.|[^"\\])*)" %u$/);
+  assert.ok(match, "Exec must have one quoted executable followed by the URI field");
+  const executable = match[1].replace(/\\(["`$\\])/g, "$1").replaceAll("%%", "%");
+  assert.equal(executable, launcher);
+  assert.equal(decodeValue(entry.match(/^Icon=(.*)$/m)[1]), path.join(f.output, "opt/codex-desktop/.codex-linux/codex-desktop.png"));
+  assert.equal(entry.includes("\\\\$dollar"), true);
+  assert.equal(entry.includes('\\\\"quoted\\\\"'), true);
+  assert.equal(cp.spawnSync(launcher, [], { encoding: "utf8" }).status, 0);
+});
+
+for (const name of ["app\nExec=injected", "app=invalid"]) {
+  test("unrepresentable desktop path is rejected: " + JSON.stringify(name), (t) => {
+    const f = fixture(t, name);
+    assert.throws(f.install, /path/);
+    assertNoInstall(f);
+  });
+}
+
+test("relative XDG data directory is rejected before writes", (t) => {
+  const f = fixture(t);
+  assert.throws(() => installDesktop(f.output, f.tools, { userHome: f.userHome, dataHome: "relative" }), /absolute/);
+  assertNoInstall(f);
+});

--- a/packaging/alpine/prepare-tools.cjs
+++ b/packaging/alpine/prepare-tools.cjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const cp = require("node:child_process");
+const { inventoryTree } = require("../../nix/elf-runtime.cjs");
+
+const output = path.resolve(process.argv[2] || "");
+if (process.argv.length !== 3 || fs.existsSync(output)) {
+  console.error("usage: prepare-tools.cjs NEW-OUTPUT (requires apk-tools 3, node, patchelf)");
+  process.exit(1);
+}
+const run = (command, args) => cp.execFileSync(command, args, { stdio: "inherit" });
+const cache = path.join(output, "packages");
+const root = path.join(output, "root");
+fs.mkdirSync(cache, { recursive: true });
+fs.mkdirSync(root);
+run("apk", ["fetch", "--recursive", "--output", cache,
+  "dpkg", "gpgv", "flock", "coreutils", "findutils", "grep", "sed", "tar", "procps"]);
+const packages = fs.readdirSync(cache).filter((file) => file.endsWith(".apk"))
+  .sort().map((file) => path.join(cache, file));
+run("apk", ["verify", ...packages]);
+run("apk", ["extract", "--no-chown", "--destination", root, ...packages]);
+const libraryPath = [path.join(root, "usr/lib"), path.join(root, "lib")].join(":");
+for (const item of inventoryTree(root, "amd64")) {
+  if (item.target && item.hasDynamic && item.needed.length)
+    run("patchelf", ["--add-rpath", libraryPath, item.absolutePath]);
+}
+console.log(`Build tool PATH prefix: ${root}/usr/bin:${root}/bin`);
+console.log(`Native host ps: ${root}/bin/ps`);

--- a/packaging/alpine/test_fetch_runtime.py
+++ b/packaging/alpine/test_fetch_runtime.py
@@ -1,0 +1,68 @@
+import hashlib
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+from unittest.mock import patch
+
+spec = importlib.util.spec_from_file_location("runtime", pathlib.Path(__file__).with_name("fetch-runtime.py"))
+runtime = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(runtime)
+
+
+class RuntimeTests(unittest.TestCase):
+    def test_download_rejects_wrong_hash_or_length(self):
+        with patch.object(runtime, "fetch", return_value=b"payload"):
+            sha = hashlib.sha256(b"payload").hexdigest()
+            self.assertEqual(runtime.checked_bytes("https://example.test/file", sha, 7), b"payload")
+            for digest, size in [("0" * 64, 7), (sha, 8)]:
+                with self.assertRaises(ValueError):
+                    runtime.checked_bytes("https://example.test/file", digest, size)
+
+    def test_repository_path_rejects_escape_and_urls(self):
+        for value in ["/etc/passwd", "pool/../../etc/passwd", "https://other.test/file", "pool/file?x=1"]:
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                runtime.safe_repository_path(value)
+        self.assertEqual(runtime.safe_repository_path("pool/a/liba_1.2+deb13u1_amd64.deb"), "pool/a/liba_1.2+deb13u1_amd64.deb")
+
+    def test_deb822_continuation_and_checksums(self):
+        parsed = list(runtime.paragraphs("Package: a\nDepends: b,\n c\nSHA256:\n abc 4 file\n\nPackage: b\n"))
+        self.assertEqual(parsed[0]["Depends"], "b,\nc")
+        self.assertEqual(parsed[0]["SHA256"].strip(), "abc 4 file")
+        self.assertEqual(parsed[1]["Package"], "b")
+
+    def test_closure_resolves_alternatives_cycles_and_virtual_providers(self):
+        packages = {
+            "app": {"Depends": "missing | liba, virtual"},
+            "liba": {"Pre-Depends": "app"},
+            "provider": {"Provides": "virtual"},
+        }
+        self.assertEqual(set(runtime.dependency_closure(packages, ["app"])), set(packages))
+
+    def test_missing_or_unsupported_dependency_fails(self):
+        for depends in ["not-present", "liba [amd64]"]:
+            with self.subTest(depends=depends), self.assertRaises(ValueError):
+                runtime.dependency_closure({"app": {"Depends": depends}}, ["app"])
+
+    def test_version_predicate_cannot_select_unsuitable_package(self):
+        packages = {"app": {"Depends": "liba (>= 2) | libb"}, "liba": {"Version": "1"}, "libb": {}}
+        with patch.object(runtime.subprocess, "run") as run:
+            run.return_value.returncode = 1
+            self.assertEqual(set(runtime.dependency_closure(packages, ["app"])), {"app", "libb"})
+            self.assertEqual(run.call_args.args[0], ["dpkg", "--compare-versions", "1", ">=", "2"])
+
+    def test_wrong_signing_key_is_rejected_before_import(self):
+        with tempfile.TemporaryDirectory() as directory, patch.object(runtime, "fetch", return_value=b"key"), patch.object(runtime, "run", return_value=b"fpr:::::::::WRONG:\n"):
+            with self.assertRaisesRegex(ValueError, "fingerprint"):
+                runtime.keyring(pathlib.Path(directory))
+            self.assertFalse((pathlib.Path(directory) / "debian-archive.gpg").exists())
+
+    def test_invalid_signature_stops_index_download(self):
+        with tempfile.TemporaryDirectory() as directory, patch.object(runtime, "fetch", return_value=b"bad-signature") as fetch, patch.object(runtime, "run", side_effect=RuntimeError("bad signature")):
+            with self.assertRaisesRegex(RuntimeError, "bad signature"):
+                runtime.package_index("https://example.test", "trixie", "amd64", pathlib.Path(directory), pathlib.Path(directory) / "key.gpg")
+            self.assertEqual(fetch.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packaging/alpine/verify-host.cjs
+++ b/packaging/alpine/verify-host.cjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+"use strict";
+
+// Run this using the packaged glibc Node. Requests use the real bundled Codex
+// app-server, without creating an agent thread or contacting a model.
+const cp = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const readline = require("node:readline");
+const assert = require("node:assert/strict");
+
+async function main() {
+  const [appArg, repositoryArg, ...command] = process.argv.slice(2);
+  assert.ok(appArg && repositoryArg, "usage: verify-host.cjs APP REPOSITORY [COMMAND...]");
+  const [app, repository] = [appArg, repositoryArg].map((value) => fs.realpathSync(value));
+  assert.equal(process.env.LD_LIBRARY_PATH, undefined, "foreign libraries must not reach host commands");
+  const hostOs = fs.readFileSync("/etc/os-release", "utf8");
+  assert.match(hostOs, /^ID=alpine$/m);
+  const probe = ["/bin/sh", "-c", "cat /etc/os-release; pwd; git rev-parse --show-toplevel; command -v sh; command -v cargo; ldd /bin/busybox"];
+  const expected = cp.execFileSync(probe[0], probe.slice(1), { cwd: repository, encoding: "utf8" });
+  const server = cp.spawn(path.join(app, "resources/codex"), ["app-server", "--stdio"], { stdio: ["pipe", "pipe", "pipe"] });
+  const pending = new Map();
+  let nextId = 0;
+  let errors = "";
+  server.stderr.on("data", (data) => { errors = (errors + data).slice(-8192); });
+  readline.createInterface({ input: server.stdout }).on("line", (line) => {
+    const message = JSON.parse(line);
+    const waiter = pending.get(message.id);
+    if (waiter) {
+      pending.delete(message.id);
+      message.error ? waiter.reject(new Error(JSON.stringify(message.error))) : waiter.resolve(message.result);
+    }
+  });
+  server.on("error", (error) => { for (const waiter of pending.values()) waiter.reject(error); });
+  server.on("exit", () => { for (const waiter of pending.values()) waiter.reject(new Error(`app-server exited: ${errors}`)); });
+  const request = (method, params) => new Promise((resolve, reject) => {
+    const id = ++nextId;
+    pending.set(id, { resolve, reject });
+    server.stdin.write(JSON.stringify({ id, method, params }) + "\n");
+  });
+  const timeout = setTimeout(() => server.kill("SIGKILL"), 120000);
+  try {
+    await request("initialize", { clientInfo: { name: "alpine-host-verification", version: "1" }, capabilities: { experimentalApi: true } });
+    server.stdin.write(JSON.stringify({ method: "initialized", params: {} }) + "\n");
+    const result = await request("command/exec", { command: probe, cwd: repository, timeoutMs: 10000 });
+    assert.equal(result.exitCode, 0, JSON.stringify(result));
+    const withoutAslr = (text) => text.replace(/0x[0-9a-f]+/g, "<address>");
+    assert.equal(withoutAslr(result.stdout), withoutAslr(expected), "app-server must execute against the same host repository and tools");
+    assert.match(result.stdout, /ld-musl/);
+    console.log(result.stdout);
+    console.log("PASS: packaged glibc Node → bundled Codex app-server → Alpine musl shell and host repository");
+    if (command.length) {
+      const check = await request("command/exec", { command, cwd: repository, timeoutMs: 90000 });
+      console.log(check.stdout);
+      if (check.stderr) console.error(check.stderr);
+      assert.equal(check.exitCode, 0, "host repository verification command failed");
+    }
+  } finally {
+    clearTimeout(timeout);
+    server.stdin.end();
+    server.kill("SIGTERM");
+  }
+}
+main().catch((error) => { console.error(error); process.exitCode = 1; });


### PR DESCRIPTION
Alpine's musl host cannot load the official glibc desktop runtime, and a desktop running inside another distribution would not exercise repositories against Alpine's own toolchain. This adds an opt-in, rootless packaging path that runs ChatGPT Community directly on Alpine with private glibc libraries while commands continue to use the host shell and repositories.

The packaging reuses the existing signed OpenAI installer and Nix ELF inventory/fixup/audit helpers. Debian runtime metadata and packages are signature/hash verified; only extracted library/shared-data directories enter the output. Per-object RUNPATH and NODEFLIB prevent incompatible fallback into Alpine's libraries. app.asar remains unchanged, upstream native modules are not rebuilt, and Chromium sandboxing is not disabled. Native Alpine build tools and procps are prepared separately. No existing package format or core launcher is changed.

Validation on Alpine 3.24.1 x86_64, KDE Plasma 6.6.6 with XWayland, upstream 26.903.61454:

- Built from the signed stable OpenAI repository; passed ELF dependency audit and ASAR identity check.
- Launched the desktop UI twice, with the existing account and local app-server; installed the Community application-menu launcher.
- Verified packaged Node → bundled Codex app-server → command/exec sees the same Alpine OS, musl shell, repository, and host command paths.
- Ran Cargo workspace metadata in a host repository. Follow-up validation confirms the standalone command/exec probe is read-only; see the explicit limitation below.
- Passed 55 direct-host tests: 23 new Alpine Node regression tests, 24 existing ELF/interpreter helper tests, and 8 runtime-downloader tests; JavaScript syntax checks and git diff --check also pass.

This is explicitly experimental/manual packaging: amd64 and XWayland only, no automatic updater. Hardware acceleration, voice/audio, native Wayland, and full browser/computer-use workflows are unvalidated. The upstream process sampler can still select BusyBox ps despite the native helper and log warnings; tested desktop/Git/command workflows work. The container-based cross-distro CI suite was not run locally. Reproduction steps and limits are documented in packaging/alpine/README.md.

## Regression coverage and installer hardening (da55d5c)

Three regression tests reproduced partial installations before the fix: an existing desktop entry, a dangling desktop symlink, and an existing launcher all left newly created helpers behind.

- Validate all install destinations before writes, including dangling symlinks.
- Publish complete launcher/menu files using same-filesystem, no-clobber hard links, with the menu entry last.
- Roll back caught failures using recorded file identities, preserving pre-existing and replaced files. Remove only owned files and empty directories; report incomplete cleanup. No power-loss or uncaught-signal recovery guarantee.
- Correct Desktop Entry string/Exec escaping and icon backslashes; preserve shell argument/URI forwarding.
- Add 16 installer tests covering conflicts, partial writes, publish failures, retry, concurrent replacements, path validation/quoting, and host PATH/library-environment behavior.
- Add 7 build tests using tiny compiled ELF fixtures and real copying/patchelf operations: relative symlink targets, per-DSO RUNPATH/NODEFLIB, transitive dependencies, private interpreter, unchanged ASAR/static/static-PIE/musl payloads, and fail-closed build markers. Fixture tests substitute the official inventory contract and dependency-loader execution; they do not replace the real bundle audit.
- Wire the Alpine Node/Python suites into the existing x86_64 Linux CI job. This CI addition is not an Alpine GUI test.

Reproduced directly on Alpine, without containers:

```sh
python3 -B -m unittest discover -s packaging/alpine -p 'test_*.py'
node --test packaging/alpine/*.test.cjs scripts/ci/elf-runtime.test.js scripts/ci/relocate-elf-interpreter.test.js
node --check packaging/alpine/build.cjs
node --check packaging/alpine/install-desktop.cjs
git diff --check
```

The installed packaged Node → bundled app-server → Alpine shell/repository identity probe and a read-only `git diff --check` also pass. Trying to run the Node fixture suites through standalone `command/exec` failed: temporary-file creation returned EROFS and Node child-process creation returned EPERM in its default read-only sandbox. No sandbox permissions were relaxed. The guide now uses a read-only example and explicitly separates direct-host test success from writable app-server validation.

The user reports connections working during normal use. This is not a connection-recovery or long-duration stability test. The running desktop/profile were not changed by this follow-up, and no new full application build was needed: production ELF packaging behavior is unchanged; the builder only gains a testable export. Cross-distro/container, sustained GUI, power-loss, and writable app-server test coverage remain unverified.
