### PR TITLE
Fix filesystem-root task follow-ups with an opt-in feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ requirements, known limitations, configuration, and tests.
 | `computer-use-linux` | Linux desktop-control UI and native MCP backend | [Docs](linux-features/computer-use-linux/README.md) |
 | `copilot-reasoning-effort` | Persistent reasoning-effort defaults for Copilot-auth sessions | [Docs](linux-features/copilot-reasoning-effort/README.md) |
 | `directory-only-working-tree-watch` | Bounded Watchbound working-tree watching | [Docs](linux-features/directory-only-working-tree-watch/README.md) |
+| `filesystem-root-follow-ups` | Allow follow-ups in existing local tasks rooted at `/` | [Docs](linux-features/filesystem-root-follow-ups/README.md) |
 | `flatpak-chrome-native-messaging` | Bridge the official Chrome extension into Flatpak Google Chrome | [Docs](linux-features/flatpak-chrome-native-messaging/README.md) |
 | `frameless-titlebar` | Hide official Linux overlay buttons for compositor-managed decorations | [Docs](linux-features/frameless-titlebar/README.md) |
 | `global-dictation` | X11 and XDG portal global dictation hotkeys | [Docs](linux-features/global-dictation/README.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -209,6 +209,7 @@ Nix 用户应从 profile、Home Manager 配置或 NixOS module 中删除该包�
 | `computer-use-linux` | Linux desktop-control UI 与原生 MCP backend | [文档](linux-features/computer-use-linux/README.md) |
 | `copilot-reasoning-effort` | Copilot auth 的 reasoning-effort 默认值 | [文档](linux-features/copilot-reasoning-effort/README.md) |
 | `directory-only-working-tree-watch` | 有界 Watchbound 工作树监听 | [文档](linux-features/directory-only-working-tree-watch/README.md) |
+| `filesystem-root-follow-ups` | 允许工作目录为 `/` 的现有本地任务继续发送消息 | [文档](linux-features/filesystem-root-follow-ups/README.md) |
 | `flatpak-chrome-native-messaging` | 将官方 Chrome 扩展连接到 Flatpak Google Chrome | [文档](linux-features/flatpak-chrome-native-messaging/README.md) |
 | `frameless-titlebar` | 隐藏官方 Linux overlay 按钮，改由 compositor 管理窗口装饰 | [文档](linux-features/frameless-titlebar/README.md) |
 | `global-dictation` | X11 / XDG portal 全局听写快捷键 | [文档](linux-features/global-dictation/README.md) |

--- a/linux-features/filesystem-root-follow-ups/README.md
+++ b/linux-features/filesystem-root-follow-ups/README.md
@@ -1,0 +1,51 @@
+# Filesystem Root Follow-ups
+
+Optional workaround for existing local tasks whose working directory is `/`.
+The current official desktop composer rejects follow-ups with **Unable to send
+message — Select a project to continue**, even when `/` is a saved project.
+The submission guard treats `["/"]` as a missing-workspace placeholder.
+
+This feature accepts `/` only for an existing local follow-up in local mode.
+New-task placeholders, empty roots, projectless policy, cloud/worktree mode,
+and the remaining submission checks retain their upstream behavior. It changes
+neither task/project records nor filesystem permissions. It does not recover a
+lost project association: a detached task already reporting `/` remains at `/`.
+
+Related upstream reports:
+[openai/codex#43845](https://github.com/openai/codex/issues/43845) and
+[openai/codex#36548](https://github.com/openai/codex/issues/36548).
+
+## Enable
+
+The feature is disabled by default. Add it to `linux-features/features.json`
+and rebuild the app:
+
+```json
+{
+  "enabled": ["filesystem-root-follow-ups"]
+}
+```
+
+```bash
+./install.sh
+```
+
+Fully exit the running app and launch the rebuilt installation. Changing the
+feature configuration alone does not update an already running renderer.
+Remove the feature ID and rebuild to disable it; no user data cleanup is needed.
+
+## Validation and limitations
+
+The patch targets the current signed stable Linux package `26.903.61454` on
+`amd64` and `arm64`. It has no display-server-specific behavior. A prior local
+workaround was confirmed to restore follow-ups on CachyOS/X11 with Nix and
+package `26.901.51231`; no obsolete package-specific branch is retained here.
+
+The matcher requires one complete guard with the current semantics. Unknown,
+ambiguous, or partially patched guards remain byte-identical and cause the
+enabled feature's normal build enforcement to reject the candidate. Remove or
+update the feature when upstream fixes or changes this guard.
+
+```bash
+node --test linux-features/filesystem-root-follow-ups/test.js
+```

--- a/linux-features/filesystem-root-follow-ups/feature.json
+++ b/linux-features/filesystem-root-follow-ups/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "filesystem-root-follow-ups",
+  "title": "Filesystem Root Follow-ups",
+  "description": "Allow follow-up messages in existing local tasks whose working directory is /.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/filesystem-root-follow-ups/patch.js
+++ b/linux-features/filesystem-root-follow-ups/patch.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const identifier = "[A-Za-z_$][\\w$]*";
+const followUpAlias = "codexLinuxRootFollowUp";
+
+// Match the complete current guard, including its dependencies and return
+// expression. Capture minified aliases rather than pinning bundle symbols.
+const guardParts = [
+  String.raw`function (?<name>${identifier})\(\{composerMode:(?<mode>${identifier}),workspaceRootsLoading:(?<loading>${identifier}),workspaceRootsForSubmit:(?<roots>${identifier}),`,
+  String.raw`canUseProjectlessThreads:(?<canProjectless>${identifier}),isProjectlessConversation:(?<projectless>${identifier}),isBrowserEnvironmentSelectionActive:(?<browser>${identifier}),isRemoteProjectExecution:(?<remote>${identifier})(?<followUp>,followUp:${followUpAlias})?\}\)\{`,
+  String.raw`let (?<rootless>${identifier})=(?<predicate>${identifier})\(\k<roots>\),(?<allowed>${identifier})=\k<mode>===\x60local\x60&&\(\k<projectless>\|\|\k<canProjectless>&&\k<rootless>\),`,
+  String.raw`(?<selected>${identifier})=\(\k<roots>\.some\((?<item>${identifier})=>\k<item>!==\x60/\x60\)\|\|\k<remote>`,
+  String.raw`(?<addition>\|\|\k<mode>===\x60local\x60&&${followUpAlias}\?\.type===\x60local\x60&&\k<roots>\.includes\(\x60/\x60\))?\)&&!\k<rootless>;`,
+  String.raw`return \k<mode>!==\x60cloud\x60&&!\k<loading>&&!\k<selected>&&!\k<allowed>&&!\(\k<mode>===\x60local\x60&&\k<browser>\)\}`,
+];
+const guardStartPattern = new RegExp(guardParts.slice(0, 2).join(""), "g");
+const guardPattern = new RegExp(guardParts.join(""), "g");
+
+function findGuard(source) {
+  if ([...source.matchAll(guardStartPattern)].length !== 1) return null;
+  const matches = [...source.matchAll(guardPattern)];
+  if (matches.length !== 1) return null;
+  const [match] = matches;
+  const { followUp, addition } = match.groups;
+  if (Boolean(followUp) !== Boolean(addition)) return null;
+  if (!followUp && match[0].includes(followUpAlias)) return null;
+  return match;
+}
+
+function applyFilesystemRootFollowUpsPatch(source) {
+  const match = findGuard(source);
+  if (match == null) {
+    console.warn("WARN: Could not uniquely match the current workspace submission guard - skipping filesystem root follow-ups patch");
+    return source;
+  }
+  if (match.groups.followUp) return source;
+
+  const { mode, roots, remote, rootless } = match.groups;
+  const patched = match[0]
+    .replace(`isRemoteProjectExecution:${remote}}`, `isRemoteProjectExecution:${remote},followUp:${followUpAlias}}`)
+    .replace(
+      `||${remote})&&!${rootless}`,
+      `||${remote}||${mode}===\`local\`&&${followUpAlias}?.type===\`local\`&&${roots}.includes(\`/\`))&&!${rootless}`,
+    );
+  return source.slice(0, match.index) + patched + source.slice(match.index + match[0].length);
+}
+
+const descriptors = [{
+  id: "workspace-submission",
+  phase: "webview-asset",
+  order: 20_910,
+  ciPolicy: "optional",
+  pattern: /^app-primary-[^.]+\.js$/,
+  assetMatch: (source) => findGuard(source) != null,
+  missingDescription: "filesystem root follow-ups workspace guard",
+  skipDescription: "filesystem root follow-ups patch",
+  apply: applyFilesystemRootFollowUpsPatch,
+}];
+
+module.exports = { applyFilesystemRootFollowUpsPatch, descriptors };

--- a/linux-features/filesystem-root-follow-ups/test.js
+++ b/linux-features/filesystem-root-follow-ups/test.js
@@ -1,0 +1,140 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+const { loadLinuxFeaturePatchDescriptors } = require("../../scripts/lib/linux-features.js");
+const { patchExtractedApp } = require("../../scripts/patches/runner.js");
+const { createPatchReport, enabledFeatureFailuresFromReport } = require("../../scripts/lib/patch-report.js");
+const { applyFilesystemRootFollowUpsPatch: applyPatch } = require("./patch.js");
+
+// Current signed 26.903.61454 amd64/arm64 guard, with descriptive helper names.
+const guard = "function missingWorkspace({composerMode:e,workspaceRootsLoading:t,workspaceRootsForSubmit:n,canUseProjectlessThreads:r,isProjectlessConversation:i,isBrowserEnvironmentSelectionActive:a,isRemoteProjectExecution:o}){let s=isRootless(n),c=e===`local`&&(i||r&&s),l=(n.some(e=>e!==`/`)||o)&&!s;return e!==`cloud`&&!t&&!l&&!c&&!(e===`local`&&a)}";
+const predicate = "function isRootless(roots){return roots.length===0||roots.length===1&&roots[0]===`~`}";
+const base = {
+  composerMode: "local", workspaceRootsLoading: false,
+  workspaceRootsForSubmit: ["/"], canUseProjectlessThreads: false,
+  isProjectlessConversation: false, isBrowserEnvironmentSelectionActive: false,
+  isRemoteProjectExecution: false, followUp: { type: "local" },
+};
+
+function evaluate(source) {
+  return vm.runInNewContext(`${predicate};${source};missingWorkspace`);
+}
+
+function captureWarnings(fn) {
+  const original = console.warn;
+  const warnings = [];
+  console.warn = (message) => warnings.push(message);
+  try {
+    return { value: fn(), warnings };
+  } finally {
+    console.warn = original;
+  }
+}
+
+test("reproduces the root follow-up blocker and permits the existing local task", () => {
+  assert.equal(evaluate(guard)(base), true);
+  assert.equal(evaluate(applyPatch(guard))(base), false);
+});
+
+for (const [name, overrides, blocked] of [
+  ["ordinary project", { workspaceRootsForSubmit: ["/work/project"] }, false],
+  ["empty roots", { workspaceRootsForSubmit: [] }, true],
+  ["new root placeholder", { followUp: undefined }, true],
+  ["null follow-up", { followUp: null }, true],
+  ["cloud follow-up in local mode", { followUp: { type: "cloud" } }, true],
+  ["worktree placeholder", { composerMode: "worktree" }, true],
+  ["projectless disabled", { workspaceRootsForSubmit: ["~"] }, true],
+  ["projectless enabled", { workspaceRootsForSubmit: ["~"], canUseProjectlessThreads: true }, false],
+  ["existing projectless conversation", { workspaceRootsForSubmit: [], isProjectlessConversation: true }, false],
+  ["remote root", { isRemoteProjectExecution: true }, false],
+  ["browser environment", { isBrowserEnvironmentSelectionActive: true }, false],
+  ["cloud mode", { composerMode: "cloud" }, false],
+  ["loading roots", { workspaceRootsLoading: true }, false],
+]) {
+  test(`preserves ${name}`, () => {
+    const input = { ...base, ...overrides };
+    assert.equal(evaluate(guard)(input), blocked);
+    assert.equal(evaluate(applyPatch(guard))(input), blocked);
+  });
+}
+
+test("supports renamed minified symbols and is idempotent", () => {
+  const renamed = guard.replace(/\b[e-n]\b|\b[o-st]\b/g, (name) => `${name}$renamed`);
+  const patched = applyPatch(renamed);
+  assert.notEqual(patched, renamed);
+  assert.equal(evaluate(patched)(base), false);
+  const second = captureWarnings(() => applyPatch(patched));
+  assert.equal(second.value, patched);
+  assert.deepEqual(second.warnings, []);
+});
+
+test("drift, ambiguity, partial patches and alias collisions remain byte-identical", () => {
+  const patched = applyPatch(guard);
+  for (const source of [
+    guard.replace("!==`/`", "!==`~`"),
+    guard.replace("&&!t", "&&t"),
+    guard.replace("&&a)", "&&!a)"),
+    guard + guard,
+    guard + guard.replace("!==`/`", "!==`~`"),
+    guard + patched,
+    patched + patched,
+    patched.replace(",followUp:codexLinuxRootFollowUp", ""),
+    guard.replace("isRemoteProjectExecution:o", "isRemoteProjectExecution:o,followUp:codexLinuxRootFollowUp"),
+    guard.replaceAll("missingWorkspace", "codexLinuxRootFollowUp"),
+    "const unrelated = true;",
+  ]) {
+    const { value, warnings } = captureWarnings(() => applyPatch(source));
+    assert.equal(value, source);
+    assert.equal(warnings.length, 1);
+  }
+});
+
+function withApp(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "filesystem-root-follow-ups-"));
+  const assets = path.join(dir, "webview/assets");
+  fs.mkdirSync(assets, { recursive: true });
+  const config = path.join(dir, "features.json");
+  fs.writeFileSync(config, JSON.stringify({ enabled: ["filesystem-root-follow-ups"] }));
+  const options = { featuresRoot: path.resolve(__dirname, ".."), featuresConfigPath: config };
+  try {
+    fn({ dir, assets, config, options });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("disabled feature preserves assets, enabled feature patches through the runner", () => {
+  withApp(({ dir, assets, config, options }) => {
+    const filename = path.join(assets, "app-primary-current.js");
+    fs.writeFileSync(filename, guard);
+    fs.writeFileSync(config, JSON.stringify({ enabled: [] }));
+    assert.equal(loadLinuxFeaturePatchDescriptors(options).length, 0);
+    patchExtractedApp(dir, options);
+    assert.equal(fs.readFileSync(filename, "utf8"), guard);
+
+    fs.writeFileSync(config, JSON.stringify({ enabled: ["filesystem-root-follow-ups"] }));
+    const report = createPatchReport();
+    patchExtractedApp(dir, { ...options, report });
+    assert.deepEqual(enabledFeatureFailuresFromReport(report), []);
+    assert.equal(report.patches.length, 1);
+    assert.equal(evaluate(fs.readFileSync(filename, "utf8"))(base), false);
+  });
+});
+
+test("enabled feature reports drift and ambiguous assets without writing either", () => {
+  for (const copies of [0, 2]) {
+    withApp(({ dir, assets, options }) => {
+      const files = copies === 0 ? ["unrelated.js"] : ["app-primary-one.js", "app-primary-two.js"];
+      for (const filename of files) fs.writeFileSync(path.join(assets, filename), guard);
+      const report = createPatchReport();
+      captureWarnings(() => patchExtractedApp(dir, { ...options, report }));
+      assert.equal(enabledFeatureFailuresFromReport(report).length, 1);
+      for (const filename of files) assert.equal(fs.readFileSync(path.join(assets, filename), "utf8"), guard);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

An existing local task rooted at `/` can accept its initial prompt but rejects follow-ups with **Unable to send message — Select a project to continue**. The current renderer treats `["/"]` as the missing-workspace placeholder even for an existing local follow-up.

Add the disabled-by-default `filesystem-root-follow-ups` feature. It recognizes the complete current submission guard and permits `/` only when both the composer mode and follow-up type are local. New-task placeholders, empty roots, projectless policy, cloud/worktree behavior, and other submission checks are preserved. Task records and filesystem permissions are not changed. This does not reattach a detached task to its former project.

Related upstream reports: https://github.com/openai/codex/issues/43845 and https://github.com/openai/codex/issues/36548. This is an opt-in downstream workaround; it does not close those upstream issues.

The matcher captures minified identifiers instead of pinning bundle hashes or function names, is idempotent, and leaves ambiguous, drifted, or partially patched guards untouched. Existing enabled-feature enforcement rejects a candidate on a missed match. English and Chinese feature listings and an adjacent README document activation and removal.

Scope: one optional ASAR feature for the current signed stable Linux package, `26.903.61454`, on `amd64` and `arm64`. No launcher, package-format, updater, dependency, or default-feature changes.

## Validation

- Adjacent regression tests: **18 passed**, including reproduction of the original root blocker, surrounding submission cases, renamed aliases, duplicate/partial guards, idempotence, disabled behavior, and patch-runner enforcement.
- Patch/descriptor/feature suite: **898 passed** using a headless environment:

  ```bash
  env -u CODEX_OZONE_PLATFORM -u WAYLAND_DISPLAY -u DISPLAY -u XDG_SESSION_TYPE \
    node --test scripts/patch-linux-window-ui.test.js scripts/patches/descriptor.test.js \
    scripts/lib/linux-features.test.js linux-features/*/test.js
  ```

  Clearing those inherited desktop variables avoids an existing MCP-reaper test assuming no Ozone flag; the test itself is unchanged.
- Verified signed `InRelease`, indexed package hashes, and both official `26.903.61454` packages with the repository's resolver. Ran `install.sh` into isolated output directories with only this feature enabled on each architecture; both candidates passed enforcement and built successfully.
- Compared all **9,023 logical ASAR file contents** per architecture: only the primary webview bundle contents changed. `ChatGPT`, `codex`, `rg`, and the code-mode host remained byte-identical. The final matcher produces exactly the verified built bundle on both architectures.
- `node --check` for the new JavaScript files, new documentation links, and `git diff --check` passed.
- Manual evidence: an equivalent local workaround restored actual follow-up submission on CachyOS/X11 with Nix and package `26.901.51231`, confirmed by the affected user. The latest-package checks above validate both builds and their bundled guard; GUI submission on `26.903.61454` and an ARM GUI session were not exercised.

GitHub CI is pending. The final diff was reviewed; a separately configured maximum-reasoning-effort review has not been run.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest signed stable OpenAI Linux package and removes obsolete fallback code and tests.
- [ ] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [ ] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
