### PR TITLE
Add configurable model picker Default presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ requirements, known limitations, configuration, and tests.
 | `global-dictation` | X11 and XDG portal global dictation hotkeys | [Docs](linux-features/global-dictation/README.md) |
 | `linux-performance-workarounds` | Measured renderer workarounds for affected systems | [Docs](linux-features/linux-performance-workarounds/README.md) |
 | `mcp-helper-reaper` | Reap orphaned MCP helpers without touching live sessions | [Docs](linux-features/mcp-helper-reaper/README.md) |
+| `model-picker-default-presets` | Configure ordered model/effort pairs behind ChatGPT Default | [Docs](linux-features/model-picker-default-presets/README.md) |
 | `node-repl-reaper` | Reap Browser Use `node_repl` helpers leaked after owner exit | [Docs](linux-features/node-repl-reaper/README.md) |
 | `omarchy-theme` | Load CSS generated from the current Omarchy theme | [Docs](linux-features/omarchy-theme/README.md) |
 | `persistent-status-panel` | Keep the `/status` panel across thread switches and restarts | [Docs](linux-features/persistent-status-panel/README.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -215,6 +215,7 @@ Nix 用户应从 profile、Home Manager 配置或 NixOS module 中删除该包�
 | `global-dictation` | X11 / XDG portal 全局听写快捷键 | [文档](linux-features/global-dictation/README.md) |
 | `linux-performance-workarounds` | 针对受影响系统的 renderer workaround | [文档](linux-features/linux-performance-workarounds/README.md) |
 | `mcp-helper-reaper` | 安全清理孤立 MCP helper | [文档](linux-features/mcp-helper-reaper/README.md) |
+| `model-picker-default-presets` | 配置 ChatGPT Default 的有序 model/effort 组合 | [文档](linux-features/model-picker-default-presets/README.md) |
 | `node-repl-reaper` | 清理 owner 退出后泄漏的 Browser Use `node_repl` | [文档](linux-features/node-repl-reaper/README.md) |
 | `omarchy-theme` | 加载当前 Omarchy 主题生成的 CSS | [文档](linux-features/omarchy-theme/README.md) |
 | `persistent-status-panel` | 在线程切换和重启后保留 `/status` panel | [文档](linux-features/persistent-status-panel/README.md) |

--- a/linux-features/model-picker-default-presets/README.md
+++ b/linux-features/model-picker-default-presets/README.md
@@ -1,0 +1,86 @@
+# Model Picker Default Presets
+
+This opt-in feature replaces the server-provided **Default** model-picker slider
+for ChatGPT-authenticated chats with an ordered list of model and reasoning
+effort pairs. It does not change the manual model list, API-key or Copilot
+sessions, account entitlements, workspace policy, or upstream Ultra/XHigh
+gates.
+
+The stock Settings page controls which reasoning efforts are visible and
+whether Ultra may appear in the picker. It does not currently configure the
+model/effort pairs behind **Default**.
+
+## Configure
+
+Add the feature and its settings to the gitignored
+`linux-features/features.json`:
+
+```json
+{
+  "enabled": ["model-picker-default-presets"],
+  "settings": {
+    "model-picker-default-presets": {
+      "presets": [
+        {
+          "model": "gpt-6-astra",
+          "effort": "medium",
+          "default": true
+        },
+        {
+          "model": "gpt-5.6-sol",
+          "effort": "high"
+        }
+      ]
+    }
+  }
+}
+```
+
+`presets` is an ordered array with no feature-defined maximum. Its order is the
+slider order. Each entry has:
+
+- `model`: a non-empty upstream model slug;
+- `effort`: `none`, `low`, `medium`, `high`, `xhigh`, `max`, or `ultra`;
+- optional `default`: exactly one entry must set it to `true`.
+
+An explicitly configured array must contain at least one entry. Duplicate
+model/effort pairs, unknown fields, invalid efforts, and any other malformed
+structure stop the feature build with a descriptive error. The tracked empty
+manifest default exists only so CI can audit the current upstream bundle; it
+does not define a user configuration.
+
+Rebuild and reinstall after editing the file:
+
+```bash
+make install-native
+```
+
+One available pair makes **Default** a fixed selection. Two or more available
+pairs display the slider. The feature never truncates the configured list.
+
+## Runtime fallback
+
+At runtime, the feature keeps only exact model/effort pairs present in the
+current account catalog. This preserves account access, workspace policy, and
+server-side effort gates:
+
+- if the configured default is unavailable, the first available configured
+  pair becomes the default;
+- if every configured pair is unavailable, the complete upstream **Default**
+  configuration is returned unchanged.
+
+Selecting **Default** again and creating a new chat both use the resolved
+default pair. Manual model selection remains upstream-owned.
+
+## Updates
+
+The update manager preserves the gitignored feature configuration during its
+rebuild. Each upstream update is patched against semantic catalog and picker
+contracts; drift or ambiguous matches fail closed and are reported instead of
+partially changing the app.
+
+## Test
+
+```bash
+node --test linux-features/model-picker-default-presets/test.js
+```

--- a/linux-features/model-picker-default-presets/feature.json
+++ b/linux-features/model-picker-default-presets/feature.json
@@ -1,0 +1,10 @@
+{
+  "id": "model-picker-default-presets",
+  "title": "Model Picker Default Presets",
+  "description": "Opt-in ChatGPT Default model-picker presets configured as ordered model and effort pairs.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  },
+  "presets": []
+}

--- a/linux-features/model-picker-default-presets/patch.js
+++ b/linux-features/model-picker-default-presets/patch.js
@@ -1,0 +1,357 @@
+"use strict";
+
+const CATALOG_PATCH_MARKER = "codexLinuxModelPickerDefaultPresets";
+const SLIDER_PATCH_MARKER = "codex-linux-model-picker-default-presets-slider-minimum";
+const JS_ASSET_PATTERN = /\.js$/;
+const EFFORT_TO_THINKING_EFFORT = Object.freeze({
+  none: "zero",
+  low: "min",
+  medium: "standard",
+  high: "extended",
+  xhigh: "xhigh",
+  max: "max",
+  ultra: "ultra",
+});
+const THINKING_EFFORT_TO_EFFORT = Object.freeze(
+  Object.fromEntries(
+    Object.entries(EFFORT_TO_THINKING_EFFORT).map(([effort, thinkingEffort]) => [
+      thinkingEffort,
+      effort,
+    ]),
+  ),
+);
+
+function warn(message, patchName) {
+  console.warn(`WARN: ${message} - skipping ${patchName}`);
+}
+
+function own(object, key) {
+  return object != null && Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function configuredPresetInput(context = {}) {
+  const settings = context?.feature?.settings;
+  if (own(settings, "presets")) {
+    return { raw: settings.presets, userConfigured: true };
+  }
+  return {
+    raw: context?.feature?.manifest?.presets ?? [],
+    userConfigured: false,
+  };
+}
+
+function normalizePresets(context = {}) {
+  const { raw, userConfigured } = configuredPresetInput(context);
+  if (!Array.isArray(raw)) {
+    throw new Error("model-picker-default-presets presets must be an array");
+  }
+  if (userConfigured && raw.length === 0) {
+    throw new Error("model-picker-default-presets user presets must contain at least one entry");
+  }
+
+  const normalized = [];
+  const pairs = new Set();
+  let defaultCount = 0;
+  for (const [index, entry] of raw.entries()) {
+    if (entry == null || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`model-picker-default-presets presets[${index}] must be an object`);
+    }
+    const unknownKeys = Object.keys(entry).filter(
+      (key) => !["model", "effort", "default"].includes(key),
+    );
+    if (unknownKeys.length > 0) {
+      throw new Error(
+        `model-picker-default-presets presets[${index}] contains unknown field '${unknownKeys[0]}'`,
+      );
+    }
+    if (typeof entry.model !== "string" || entry.model.trim().length === 0) {
+      throw new Error(`model-picker-default-presets presets[${index}].model must be a non-empty string`);
+    }
+    if (!own(EFFORT_TO_THINKING_EFFORT, entry.effort)) {
+      throw new Error(
+        `model-picker-default-presets presets[${index}].effort must be one of ${Object.keys(
+          EFFORT_TO_THINKING_EFFORT,
+        ).join(", ")}`,
+      );
+    }
+    if (own(entry, "default") && typeof entry.default !== "boolean") {
+      throw new Error(`model-picker-default-presets presets[${index}].default must be a boolean`);
+    }
+
+    const preset = {
+      modelSlug: entry.model.trim(),
+      thinkingEffort: EFFORT_TO_THINKING_EFFORT[entry.effort],
+      isDefault: entry.default === true,
+    };
+    const pair = `${preset.modelSlug}\0${preset.thinkingEffort}`;
+    if (pairs.has(pair)) {
+      throw new Error(
+        `model-picker-default-presets contains duplicate model/effort pair at presets[${index}]`,
+      );
+    }
+    pairs.add(pair);
+    defaultCount += preset.isDefault ? 1 : 0;
+    normalized.push(preset);
+  }
+
+  if (normalized.length > 0 && defaultCount !== 1) {
+    throw new Error("model-picker-default-presets presets must contain exactly one default entry");
+  }
+  return normalized;
+}
+
+function codexLinuxModelPickerDefaultPresets(catalog, configured) {
+  if (configured.length === 0) {
+    return catalog;
+  }
+  const options = [
+    ...(catalog?.options ?? []),
+    ...(catalog?.internalOptions ?? []),
+    ...(catalog?.versionOptions?.flatMap((version) => version?.options ?? []) ?? []),
+  ];
+  const supported = configured.filter((preset) =>
+    options.some(
+      (option) =>
+        option?.slug === preset.modelSlug &&
+        (option.thinkingEffort ??
+          catalog?.defaultThinkingEffortByModelSlug?.[option.slug] ??
+          null) === preset.thinkingEffort,
+    ),
+  );
+  if (supported.length === 0) {
+    return catalog;
+  }
+  const selectedDefault = supported.find((preset) => preset.isDefault) ?? supported[0];
+  return {
+    ...catalog,
+    sliderSettings: supported.map(({ modelSlug, thinkingEffort }) => ({
+      modelSlug,
+      thinkingEffort,
+    })),
+    defaultModelSlug: selectedDefault.modelSlug,
+    defaultThinkingEffortByModelSlug: {
+      ...catalog.defaultThinkingEffortByModelSlug,
+      [selectedDefault.modelSlug]: selectedDefault.thinkingEffort,
+    },
+  };
+}
+
+function functionSections(source) {
+  const starts = [];
+  const pattern = /function [A-Za-z_$][\w$]*\(/g;
+  let match;
+  while ((match = pattern.exec(source)) != null) {
+    starts.push(match.index);
+  }
+  return starts.map((start, index) => ({
+    end: starts[index + 1] ?? source.length,
+    source: source.slice(start, starts[index + 1] ?? source.length),
+    start,
+  }));
+}
+
+function uniqueFunctionWithMarkers(source, markers) {
+  const matches = functionSections(source).filter((section) =>
+    markers.every((marker) => section.source.includes(marker)),
+  );
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function catalogNormalizerSection(source) {
+  return uniqueFunctionWithMarkers(source, [
+    ".slider_settings.flatMap(",
+    "defaultThinkingEffortByModelSlug",
+    "defaultModelSlug",
+    "workspaceModelPolicy",
+  ]);
+}
+
+function catalogPatchContract(source) {
+  const markerCount = source.split(CATALOG_PATCH_MARKER).length - 1;
+  const section = catalogNormalizerSection(source);
+  if (markerCount === 0) {
+    return section == null ? "drifted" : "current";
+  }
+  if (
+    markerCount === 2 &&
+    section != null &&
+    section.source.includes(`return ${CATALOG_PATCH_MARKER}({`)
+  ) {
+    return "applied";
+  }
+  return "mixed";
+}
+
+function catalogRuntimeHelper(presets) {
+  return `${codexLinuxModelPickerDefaultPresets.toString()}const codexLinuxDefaultPresetsConfigured=${JSON.stringify(presets)};`;
+}
+
+function applyCatalogPatch(source, context = {}) {
+  const presets = normalizePresets(context);
+  if (typeof source !== "string") {
+    warn("Asset source is not a string", "model picker Default catalog patch");
+    return source;
+  }
+
+  const contract = catalogPatchContract(source);
+  if (contract === "applied") {
+    return source;
+  }
+  if (contract !== "current") {
+    warn(
+      "Could not find one coherent ChatGPT model catalog normalizer contract",
+      "model picker Default catalog patch",
+    );
+    return source;
+  }
+
+  const section = catalogNormalizerSection(source);
+  const returnMarker = ";return{";
+  const returnIndex = section.source.indexOf(returnMarker);
+  const closingIndex = section.source.lastIndexOf("}");
+  if (returnIndex < 0 || closingIndex <= returnIndex) {
+    warn(
+      "Could not locate the ChatGPT model catalog return object",
+      "model picker Default catalog patch",
+    );
+    return source;
+  }
+
+  const patchedSection =
+    section.source.slice(0, returnIndex) +
+    `;return ${CATALOG_PATCH_MARKER}({` +
+    section.source.slice(returnIndex + returnMarker.length, closingIndex) +
+    ",codexLinuxDefaultPresetsConfigured)" +
+    section.source.slice(closingIndex);
+  return (
+    source.slice(0, section.start) +
+    catalogRuntimeHelper(presets) +
+    patchedSection +
+    source.slice(section.end)
+  );
+}
+
+function sliderResolverSection(source) {
+  return uniqueFunctionWithMarkers(source, [
+    "powerSelectionsWithXHigh",
+    "fallbackPowerSelection",
+    "show_xhigh_in_simple_picker",
+    "canInitializePowerPicker",
+  ]);
+}
+
+function sliderPatchContract(source) {
+  const markerCount = source.split(SLIDER_PATCH_MARKER).length - 1;
+  const section = sliderResolverSection(source);
+  if (markerCount === 0) {
+    if (section == null) return "drifted";
+    return (section.source.match(/\.length>=3/g) ?? []).length === 2 ? "current" : "drifted";
+  }
+  if (
+    markerCount === 1 &&
+    section != null &&
+    section.source.includes(`/*${SLIDER_PATCH_MARKER}*/`) &&
+    (section.source.match(/\.length>=codexLinuxDefaultPresetMinimum\(/g) ?? []).length === 2 &&
+    !section.source.includes(".length>=3")
+  ) {
+    return "applied";
+  }
+  return "mixed";
+}
+
+function applySliderMinimumPatch(source, context = {}) {
+  const presets = normalizePresets(context);
+  if (presets.length === 0) {
+    return source;
+  }
+  if (typeof source !== "string") {
+    warn("Asset source is not a string", "model picker Default slider minimum patch");
+    return source;
+  }
+
+  const contract = sliderPatchContract(source);
+  if (contract === "applied") {
+    return source;
+  }
+  if (contract !== "current") {
+    warn(
+      "Could not find one coherent ChatGPT model picker slider resolver contract",
+      "model picker Default slider minimum patch",
+    );
+    return source;
+  }
+
+  const section = sliderResolverSection(source);
+  const configuredIds = presets.map(
+    ({ modelSlug, thinkingEffort }) =>
+      `${modelSlug}:${THINKING_EFFORT_TO_EFFORT[thinkingEffort]}`,
+  );
+  const patchedSection = section.source
+    .replace(
+      "{",
+      `{/*${SLIDER_PATCH_MARKER}*/let codexLinuxDefaultPresetIds=new Set(${JSON.stringify(
+        configuredIds,
+      )}),codexLinuxDefaultPresetMinimum=codexLinuxSelections=>codexLinuxSelections.every(codexLinuxSelection=>codexLinuxDefaultPresetIds.has(codexLinuxSelection.id))?2:3;`,
+    )
+    .replace(
+      /([A-Za-z_$][\w$]*)\.length>=3/g,
+      "$1.length>=codexLinuxDefaultPresetMinimum($1)",
+    );
+  return source.slice(0, section.start) + patchedSection + source.slice(section.end);
+}
+
+function catalogAssetMatch(source) {
+  return catalogPatchContract(source) !== "drifted";
+}
+
+function sliderAssetMatch(source, _assetName, context = {}) {
+  const presets = normalizePresets(context);
+  return presets.length > 0 && sliderPatchContract(source) !== "drifted";
+}
+
+const descriptors = [
+  {
+    id: "model-picker-default-presets-catalog",
+    phase: "webview-asset",
+    order: 20_798,
+    ciPolicy: "optional",
+    pattern: JS_ASSET_PATTERN,
+    assetMatch: catalogAssetMatch,
+    missingDescription: "ChatGPT model catalog normalizer bundle",
+    skipDescription: "model picker Default catalog patch",
+    enabled: (context = {}) => {
+      normalizePresets(context);
+      return true;
+    },
+    apply: applyCatalogPatch,
+  },
+  {
+    id: "model-picker-default-presets-slider-minimum",
+    phase: "webview-asset",
+    order: 20_799,
+    ciPolicy: "optional",
+    pattern: JS_ASSET_PATTERN,
+    enabled: (context = {}) => normalizePresets(context).length > 0,
+    assetMatch: sliderAssetMatch,
+    missingDescription: "ChatGPT model picker slider resolver bundle",
+    skipDescription: "model picker Default slider minimum patch",
+    apply: applySliderMinimumPatch,
+  },
+];
+
+module.exports = {
+  CATALOG_PATCH_MARKER,
+  EFFORT_TO_THINKING_EFFORT,
+  THINKING_EFFORT_TO_EFFORT,
+  JS_ASSET_PATTERN,
+  SLIDER_PATCH_MARKER,
+  applyCatalogPatch,
+  applySliderMinimumPatch,
+  catalogAssetMatch,
+  catalogPatchContract,
+  codexLinuxModelPickerDefaultPresets,
+  descriptors,
+  normalizePresets,
+  sliderAssetMatch,
+  sliderPatchContract,
+};

--- a/linux-features/model-picker-default-presets/test.js
+++ b/linux-features/model-picker-default-presets/test.js
@@ -1,0 +1,389 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const { loadLinuxFeaturePatchDescriptors } = require("../../scripts/lib/linux-features.js");
+const { patchExtractedApp } = require("../../scripts/patches/runner.js");
+const {
+  CATALOG_PATCH_MARKER,
+  EFFORT_TO_THINKING_EFFORT,
+  SLIDER_PATCH_MARKER,
+  applyCatalogPatch,
+  applySliderMinimumPatch,
+  catalogAssetMatch,
+  catalogPatchContract,
+  codexLinuxModelPickerDefaultPresets,
+  normalizePresets,
+  sliderAssetMatch,
+  sliderPatchContract,
+} = require("./patch.js");
+
+function context(presets) {
+  return {
+    feature: {
+      manifest: { presets: [] },
+      settings: { presets },
+    },
+  };
+}
+
+function catalogFixture(name = "FOr") {
+  return [
+    `function ${name}(e){`,
+    "let d=e.slider_settings.flatMap(e=>e),",
+    "f=e.defaultThinkingEffortByModelSlug,p=e.defaultModelSlug;",
+    "return{categories:e.categories,modelConfigBySlug:e.modelConfigBySlug,",
+    "defaultThinkingEffortByModelSlug:f,defaultModelSlug:p,",
+    "internalOptions:e.internalOptions,options:e.options,sliderSettings:d,",
+    "versionOptions:e.versionOptions,workspaceModelPolicy:e.workspaceModelPolicy}}",
+    "function Next(){}",
+  ].join("");
+}
+
+function sliderFixture(name = "Wkr") {
+  return [
+    `function ${name}(e){`,
+    "let powerSelectionsWithXHigh=e,fallbackPowerSelection=e,",
+    "show_xhigh_in_simple_picker=true,canInitializePowerPicker=true;",
+    "if(powerSelectionsWithXHigh.length>=3)return powerSelectionsWithXHigh;",
+    "return fallbackPowerSelection.length>=3?fallbackPowerSelection:[]}",
+    "function Next(){}",
+  ].join("");
+}
+
+function evaluate(source, expression, globals = {}) {
+  return vm.runInNewContext(`${source};${expression}`, globals);
+}
+
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function withCapturedWarnings(callback) {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => warnings.push(String(message));
+  try {
+    return { result: callback(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+function catalog(overrides = {}) {
+  return {
+    categories: ["manual-category"],
+    defaultModelSlug: "upstream-default",
+    defaultThinkingEffortByModelSlug: {
+      "upstream-default": "standard",
+      "gpt-6-astra": "standard",
+      "gpt-5.6-sol": "min",
+    },
+    internalOptions: [{ slug: "internal-model", thinkingEffort: "extended" }],
+    modelConfigBySlug: { "gpt-6-astra": { title: "Astra" } },
+    options: [
+      { slug: "upstream-default", thinkingEffort: "standard" },
+      { slug: "gpt-6-astra", thinkingEffort: "standard" },
+      { slug: "gpt-5.6-sol", thinkingEffort: "min" },
+      { slug: "gpt-5.6-sol", thinkingEffort: "extended" },
+    ],
+    sliderSettings: [{ modelSlug: "upstream-default", thinkingEffort: "standard" }],
+    versionOptions: [
+      {
+        id: "version",
+        options: [{ slug: "version-model", thinkingEffort: "xhigh" }],
+      },
+    ],
+    workspaceModelPolicy: { newThreadPrecedence: "prefer_policy" },
+    ...overrides,
+  };
+}
+
+test("normalizes every public effort without imposing a preset limit", () => {
+  const entries = Object.keys(EFFORT_TO_THINKING_EFFORT).map((effort, index) => ({
+    model: `model-${index}`,
+    effort,
+    ...(index === 4 ? { default: true } : {}),
+  }));
+  const normalized = normalizePresets(context(entries));
+  assert.equal(normalized.length, entries.length);
+  assert.deepEqual(
+    normalized.map(({ thinkingEffort }) => thinkingEffort),
+    ["zero", "min", "standard", "extended", "xhigh", "max", "ultra"],
+  );
+  assert.equal(normalized[4].isDefault, true);
+
+  const longList = Array.from({ length: 256 }, (_, index) => ({
+    model: `arbitrary-model-${index}`,
+    effort: "medium",
+    ...(index === 127 ? { default: true } : {}),
+  }));
+  assert.equal(normalizePresets(context(longList)).length, 256);
+});
+
+test("allows the empty manifest default only as a compatibility passthrough", () => {
+  assert.deepEqual(
+    normalizePresets({ feature: { manifest: { presets: [] }, settings: {} } }),
+    [],
+  );
+  assert.throws(() => normalizePresets(context([])), /must contain at least one entry/);
+});
+
+test("rejects malformed preset settings", () => {
+  const invalid = [
+    ["not-an-array", /must be an array/],
+    [[null], /presets\[0\] must be an object/],
+    [[{ model: "", effort: "low", default: true }], /model must be a non-empty string/],
+    [[{ model: "m", effort: "minimal", default: true }], /effort must be one of/],
+    [[{ model: "m", effort: "low", default: "yes" }], /default must be a boolean/],
+    [[{ model: "m", effort: "low", default: true, extra: 1 }], /unknown field 'extra'/],
+    [[{ model: "m", effort: "low" }], /exactly one default entry/],
+    [
+      [
+        { model: "m", effort: "low", default: true },
+        { model: "n", effort: "high", default: true },
+      ],
+      /exactly one default entry/,
+    ],
+    [
+      [
+        { model: " m ", effort: "low", default: true },
+        { model: "m", effort: "low" },
+      ],
+      /duplicate model\/effort pair/,
+    ],
+  ];
+  for (const [presets, message] of invalid) {
+    assert.throws(() => normalizePresets(context(presets)), message);
+  }
+});
+
+test("runtime preserves order and the rest of the upstream catalog", () => {
+  const upstream = catalog();
+  const configured = normalizePresets(
+    context([
+      { model: "gpt-5.6-sol", effort: "high" },
+      { model: "version-model", effort: "xhigh" },
+      { model: "gpt-6-astra", effort: "medium", default: true },
+      { model: "internal-model", effort: "high" },
+    ]),
+  );
+  const result = codexLinuxModelPickerDefaultPresets(upstream, configured);
+  assert.deepEqual(result.sliderSettings, [
+    { modelSlug: "gpt-5.6-sol", thinkingEffort: "extended" },
+    { modelSlug: "version-model", thinkingEffort: "xhigh" },
+    { modelSlug: "gpt-6-astra", thinkingEffort: "standard" },
+    { modelSlug: "internal-model", thinkingEffort: "extended" },
+  ]);
+  assert.equal(result.defaultModelSlug, "gpt-6-astra");
+  assert.equal(result.defaultThinkingEffortByModelSlug["gpt-6-astra"], "standard");
+  assert.strictEqual(result.options, upstream.options);
+  assert.strictEqual(result.internalOptions, upstream.internalOptions);
+  assert.strictEqual(result.versionOptions, upstream.versionOptions);
+  assert.strictEqual(result.workspaceModelPolicy, upstream.workspaceModelPolicy);
+  assert.strictEqual(result.categories, upstream.categories);
+});
+
+test("runtime filters unavailable pairs and falls back from an unavailable default", () => {
+  const configured = normalizePresets(
+    context([
+      { model: "missing", effort: "medium", default: true },
+      { model: "gpt-5.6-sol", effort: "high" },
+      { model: "gpt-5.6-sol", effort: "ultra" },
+    ]),
+  );
+  const result = codexLinuxModelPickerDefaultPresets(catalog(), configured);
+  assert.deepEqual(result.sliderSettings, [
+    { modelSlug: "gpt-5.6-sol", thinkingEffort: "extended" },
+  ]);
+  assert.equal(result.defaultModelSlug, "gpt-5.6-sol");
+  assert.equal(result.defaultThinkingEffortByModelSlug["gpt-5.6-sol"], "extended");
+});
+
+test("runtime returns the exact upstream catalog when every pair is unavailable", () => {
+  const upstream = catalog();
+  const configured = normalizePresets(
+    context([{ model: "missing", effort: "ultra", default: true }]),
+  );
+  assert.strictEqual(codexLinuxModelPickerDefaultPresets(upstream, configured), upstream);
+});
+
+test("catalog patch has one semantic target, is executable, and is idempotent", () => {
+  const presets = context([
+    { model: "gpt-6-astra", effort: "medium", default: true },
+    { model: "gpt-5.6-sol", effort: "high" },
+  ]);
+  const source = catalogFixture();
+  assert.equal(catalogPatchContract(source), "current");
+  assert.equal(catalogAssetMatch(source), true);
+  const patched = applyCatalogPatch(source, presets);
+  assert.equal(catalogPatchContract(patched), "applied");
+  assert.equal((patched.match(new RegExp(CATALOG_PATCH_MARKER, "g")) ?? []).length, 2);
+  assert.equal(applyCatalogPatch(patched, presets), patched);
+  const result = plain(evaluate(patched, "FOr(input)", { input: catalog({ slider_settings: [] }) }));
+  assert.deepEqual(result.sliderSettings, [
+    { modelSlug: "gpt-6-astra", thinkingEffort: "standard" },
+    { modelSlug: "gpt-5.6-sol", thinkingEffort: "extended" },
+  ]);
+  assert.equal(result.defaultModelSlug, "gpt-6-astra");
+});
+
+test("catalog patch fails closed on drift, duplicate, and partial states", () => {
+  const presets = context([{ model: "gpt-6-astra", effort: "medium", default: true }]);
+  for (const source of [
+    "function unrelated(){}",
+    catalogFixture("One") + catalogFixture("Two"),
+    `${CATALOG_PATCH_MARKER};${catalogFixture()}`,
+  ]) {
+    const { result, warnings } = withCapturedWarnings(() => applyCatalogPatch(source, presets));
+    assert.equal(result, source);
+    assert.equal(warnings.length, 1);
+  }
+});
+
+test("slider minimum makes two entries a slider while one stays fixed", () => {
+  const presets = context([
+    { model: "gpt-6-astra", effort: "medium", default: true },
+    { model: "gpt-5.6-sol", effort: "high" },
+    { model: "model-low", effort: "low" },
+    { model: "model-none", effort: "none" },
+    { model: "model-max", effort: "max" },
+  ]);
+  const source = sliderFixture();
+  assert.equal(sliderPatchContract(source), "current");
+  assert.equal(sliderAssetMatch(source, "fixture.js", presets), true);
+  const patched = applySliderMinimumPatch(source, presets);
+  assert.equal(sliderPatchContract(patched), "applied");
+  assert.equal((patched.match(new RegExp(SLIDER_PATCH_MARKER, "g")) ?? []).length, 1);
+  assert.equal(applySliderMinimumPatch(patched, presets), patched);
+  const configured = [
+    { id: "gpt-6-astra:medium" },
+    { id: "gpt-5.6-sol:high" },
+    { id: "model-low:low" },
+    { id: "model-none:none" },
+    { id: "model-max:max" },
+  ];
+  assert.deepEqual(plain(evaluate(patched, "Wkr(input)", { input: configured.slice(0, 1) })), []);
+  assert.deepEqual(
+    plain(evaluate(patched, "Wkr(input)", { input: configured.slice(0, 2) })),
+    configured.slice(0, 2),
+  );
+  assert.deepEqual(
+    plain(evaluate(patched, "Wkr(input)", { input: configured })),
+    configured,
+  );
+  assert.deepEqual(
+    plain(
+      evaluate(patched, "Wkr(input)", {
+        input: [{ id: "server-a:low" }, { id: "server-b:high" }],
+      }),
+    ),
+    [],
+  );
+});
+
+test("slider patch fails closed on drift, duplicate, and partial states", () => {
+  const presets = context([{ model: "gpt-6-astra", effort: "medium", default: true }]);
+  for (const source of [
+    "function unrelated(){}",
+    sliderFixture("One") + sliderFixture("Two"),
+    sliderFixture().replace("{", `{/*${SLIDER_PATCH_MARKER}*/`),
+  ]) {
+    const { result, warnings } = withCapturedWarnings(() =>
+      applySliderMinimumPatch(source, presets),
+    );
+    assert.equal(result, source);
+    assert.equal(warnings.length, 1);
+  }
+});
+
+test("empty manifest is a runtime passthrough used for compatibility auditing", () => {
+  const passthrough = { feature: { manifest: { presets: [] }, settings: {} } };
+  const patchedCatalog = applyCatalogPatch(catalogFixture(), passthrough);
+  const upstream = catalog({ slider_settings: [{ modelSlug: "server", thinkingEffort: "min" }] });
+  assert.deepEqual(plain(evaluate(patchedCatalog, "FOr(input)", { input: upstream })), {
+    categories: upstream.categories,
+    modelConfigBySlug: upstream.modelConfigBySlug,
+    defaultThinkingEffortByModelSlug: upstream.defaultThinkingEffortByModelSlug,
+    defaultModelSlug: upstream.defaultModelSlug,
+    internalOptions: upstream.internalOptions,
+    options: upstream.options,
+    sliderSettings: upstream.slider_settings,
+    versionOptions: upstream.versionOptions,
+    workspaceModelPolicy: upstream.workspaceModelPolicy,
+  });
+  assert.equal(applySliderMinimumPatch(sliderFixture(), passthrough), sliderFixture());
+  assert.equal(sliderAssetMatch(sliderFixture(), "fixture.js", passthrough), false);
+});
+
+test("feature descriptors load alone and alongside ui-tweaks", () => {
+  const root = path.resolve(__dirname, "..");
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "model-picker-presets-"));
+  const configPath = path.join(temporaryDirectory, "features.json");
+  const writeConfig = (enabled) =>
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        enabled,
+        settings: {
+          "model-picker-default-presets": {
+            presets: [{ model: "gpt-6-astra", effort: "medium", default: true }],
+          },
+        },
+      })}\n`,
+    );
+  try {
+    writeConfig([]);
+    assert.deepEqual(
+      loadLinuxFeaturePatchDescriptors({ featuresRoot: root, featuresConfigPath: configPath }),
+      [],
+    );
+    writeConfig(["model-picker-default-presets"]);
+    const alone = loadLinuxFeaturePatchDescriptors({
+      featuresRoot: root,
+      featuresConfigPath: configPath,
+    });
+    assert.equal(alone.length, 2);
+    assert.ok(alone.every(({ featureId }) => featureId === "model-picker-default-presets"));
+    writeConfig(["model-picker-default-presets", "ui-tweaks"]);
+    const together = loadLinuxFeaturePatchDescriptors({
+      featuresRoot: root,
+      featuresConfigPath: configPath,
+    });
+    assert.ok(together.some(({ featureId }) => featureId === "model-picker-default-presets"));
+    assert.ok(together.some(({ featureId }) => featureId === "ui-tweaks"));
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("invalid user settings stop an enabled feature build", () => {
+  const root = path.resolve(__dirname, "..");
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "model-picker-invalid-"));
+  const configPath = path.join(temporaryDirectory, "features.json");
+  fs.writeFileSync(
+    configPath,
+    `${JSON.stringify({
+      enabled: ["model-picker-default-presets"],
+      settings: { "model-picker-default-presets": { presets: "invalid" } },
+    })}\n`,
+  );
+  try {
+    assert.throws(
+      () =>
+        patchExtractedApp(temporaryDirectory, {
+          featuresRoot: root,
+          featuresConfigPath: configPath,
+        }),
+      /presets must be an array/,
+    );
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- add the disabled-by-default model-picker-default-presets Linux feature
- validate and translate an ordered, unbounded model/effort preset list
- replace ChatGPT Default at runtime while preserving catalog access, workspace policy, effort gates, manual models, and full upstream fallback
- lower the slider minimum only for configured preset IDs and document configuration/update behavior

## Tests/checks

- node --test linux-features/model-picker-default-presets/test.js
- node --test scripts/lib/upstream-linux-package.test.js
- node --test scripts/patch-linux-window-ui.test.js scripts/lib/linux-features.test.js linux-features/*/test.js
- official Linux feature audit: 33 ASAR features
- feature-only build from signed stable 26.903.61454
- clean no-feature build app.asar byte-for-byte comparison
- git diff --check

## Notes

Disabled by default. Runtime filtering falls back to the first available configured pair, or returns the complete upstream Default catalog when none are available. The signed stable package SHA-256 matched the repository pin.