### PR TITLE
Fix custom Default effort resolution

### DIFF
--- a/linux-features/model-picker-default-presets/README.md
+++ b/linux-features/model-picker-default-presets/README.md
@@ -60,9 +60,10 @@ pairs display the slider. The feature never truncates the configured list.
 
 ## Runtime fallback
 
-At runtime, the feature keeps only exact model/effort pairs present in the
-current account catalog. This preserves account access, workspace policy, and
-server-side effort gates:
+At runtime, the feature keeps only presets whose model is present in the
+current account catalog. It supplies the configured effort variants to the
+existing upstream selection resolver; the picker still applies workspace
+policy and its Ultra/XHigh visibility gates:
 
 - if the configured default is unavailable, the first available configured
   pair becomes the default;

--- a/linux-features/model-picker-default-presets/patch.js
+++ b/linux-features/model-picker-default-presets/patch.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const CATALOG_PATCH_MARKER = "codexLinuxModelPickerDefaultPresets";
+const CATALOG_PRESET_OPTIONS_KEY = "codexLinuxDefaultPresetOptions";
 const SLIDER_PATCH_MARKER = "codex-linux-model-picker-default-presets-slider-minimum";
 const JS_ASSET_PATTERN = /\.js$/;
 const EFFORT_TO_THINKING_EFFORT = Object.freeze({
@@ -109,24 +110,23 @@ function codexLinuxModelPickerDefaultPresets(catalog, configured) {
     ...(catalog?.internalOptions ?? []),
     ...(catalog?.versionOptions?.flatMap((version) => version?.options ?? []) ?? []),
   ];
-  const supported = configured.filter((preset) =>
-    options.some(
-      (option) =>
-        option?.slug === preset.modelSlug &&
-        (option.thinkingEffort ??
-          catalog?.defaultThinkingEffortByModelSlug?.[option.slug] ??
-          null) === preset.thinkingEffort,
-    ),
-  );
+  const supported = configured.flatMap((preset) => {
+    const option = options.find((candidate) => candidate?.slug === preset.modelSlug);
+    return option == null
+      ? []
+      : [{ preset, option: { ...option, thinkingEffort: preset.thinkingEffort } }];
+  });
   if (supported.length === 0) {
     return catalog;
   }
-  const selectedDefault = supported.find((preset) => preset.isDefault) ?? supported[0];
+  const selectedDefault =
+    supported.find(({ preset }) => preset.isDefault)?.preset ?? supported[0].preset;
   return {
     ...catalog,
-    sliderSettings: supported.map(({ modelSlug, thinkingEffort }) => ({
-      modelSlug,
-      thinkingEffort,
+    codexLinuxDefaultPresetOptions: supported.map(({ option }) => option),
+    sliderSettings: supported.map(({ preset }) => ({
+      modelSlug: preset.modelSlug,
+      thinkingEffort: preset.thinkingEffort,
     })),
     defaultModelSlug: selectedDefault.modelSlug,
     defaultThinkingEffortByModelSlug: {
@@ -166,16 +166,42 @@ function catalogNormalizerSection(source) {
   ]);
 }
 
+function catalogSelectionResolverSection(source) {
+  return uniqueFunctionWithMarkers(source, [
+    "internalOptions??[]",
+    "versionOptions?.flatMap(",
+    "defaultThinkingEffortByModelSlug",
+    "thinkingEffort!=null",
+  ]);
+}
+
+function matchingSquareBracket(source, openingIndex) {
+  let depth = 0;
+  for (let index = openingIndex; index < source.length; index += 1) {
+    if (source[index] === "[") depth += 1;
+    if (source[index] === "]") {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
 function catalogPatchContract(source) {
   const markerCount = source.split(CATALOG_PATCH_MARKER).length - 1;
-  const section = catalogNormalizerSection(source);
-  if (markerCount === 0) {
-    return section == null ? "drifted" : "current";
+  const presetOptionsCount = source.split(CATALOG_PRESET_OPTIONS_KEY).length - 1;
+  const normalizer = catalogNormalizerSection(source);
+  const resolver = catalogSelectionResolverSection(source);
+  if (markerCount === 0 && presetOptionsCount === 0) {
+    return normalizer == null || resolver == null ? "drifted" : "current";
   }
   if (
     markerCount === 2 &&
-    section != null &&
-    section.source.includes(`return ${CATALOG_PATCH_MARKER}({`)
+    presetOptionsCount === 2 &&
+    normalizer != null &&
+    resolver != null &&
+    normalizer.source.includes(`return ${CATALOG_PATCH_MARKER}({`) &&
+    resolver.source.includes(`?.${CATALOG_PRESET_OPTIONS_KEY}??[]`)
   ) {
     return "applied";
   }
@@ -205,10 +231,11 @@ function applyCatalogPatch(source, context = {}) {
     return source;
   }
 
-  const section = catalogNormalizerSection(source);
+  const normalizer = catalogNormalizerSection(source);
+  const resolver = catalogSelectionResolverSection(source);
   const returnMarker = ";return{";
-  const returnIndex = section.source.indexOf(returnMarker);
-  const closingIndex = section.source.lastIndexOf("}");
+  const returnIndex = normalizer.source.indexOf(returnMarker);
+  const closingIndex = normalizer.source.lastIndexOf("}");
   if (returnIndex < 0 || closingIndex <= returnIndex) {
     warn(
       "Could not locate the ChatGPT model catalog return object",
@@ -217,17 +244,46 @@ function applyCatalogPatch(source, context = {}) {
     return source;
   }
 
-  const patchedSection =
-    section.source.slice(0, returnIndex) +
+  const resolverSignature = /^function [A-Za-z_$][\w$]*\(([A-Za-z_$][\w$]*)[,)]/u.exec(
+    resolver.source,
+  );
+  const resolverOptionsStart = resolver.source.indexOf("=[", resolverSignature?.[0].length ?? 0) + 1;
+  const resolverOptionsEnd = matchingSquareBracket(resolver.source, resolverOptionsStart);
+  if (resolverSignature == null || resolverOptionsStart <= 0 || resolverOptionsEnd < 0) {
+    warn(
+      "Could not locate the ChatGPT model selection option array",
+      "model picker Default catalog patch",
+    );
+    return source;
+  }
+
+  const patchedNormalizer =
+    normalizer.source.slice(0, returnIndex) +
     `;return ${CATALOG_PATCH_MARKER}({` +
-    section.source.slice(returnIndex + returnMarker.length, closingIndex) +
+    normalizer.source.slice(returnIndex + returnMarker.length, closingIndex) +
     ",codexLinuxDefaultPresetsConfigured)" +
-    section.source.slice(closingIndex);
+    normalizer.source.slice(closingIndex);
+  const catalogParameter = resolverSignature[1];
+  const patchedResolver =
+    resolver.source.slice(0, resolverOptionsEnd) +
+    `,...${catalogParameter}?.${CATALOG_PRESET_OPTIONS_KEY}??[]` +
+    resolver.source.slice(resolverOptionsEnd);
+  const replacements = [
+    { ...normalizer, source: patchedNormalizer },
+    { ...resolver, source: patchedResolver },
+  ].sort((left, right) => right.start - left.start);
+  let patchedSource = source;
+  for (const replacement of replacements) {
+    patchedSource =
+      patchedSource.slice(0, replacement.start) +
+      replacement.source +
+      patchedSource.slice(replacement.end);
+  }
+  const helperIndex = Math.min(normalizer.start, resolver.start);
   return (
-    source.slice(0, section.start) +
+    patchedSource.slice(0, helperIndex) +
     catalogRuntimeHelper(presets) +
-    patchedSection +
-    source.slice(section.end)
+    patchedSource.slice(helperIndex)
   );
 }
 
@@ -341,6 +397,7 @@ const descriptors = [
 
 module.exports = {
   CATALOG_PATCH_MARKER,
+  CATALOG_PRESET_OPTIONS_KEY,
   EFFORT_TO_THINKING_EFFORT,
   THINKING_EFFORT_TO_EFFORT,
   JS_ASSET_PATTERN,

--- a/linux-features/model-picker-default-presets/test.js
+++ b/linux-features/model-picker-default-presets/test.js
@@ -12,6 +12,7 @@ const { loadLinuxFeaturePatchDescriptors } = require("../../scripts/lib/linux-fe
 const { patchExtractedApp } = require("../../scripts/patches/runner.js");
 const {
   CATALOG_PATCH_MARKER,
+  CATALOG_PRESET_OPTIONS_KEY,
   EFFORT_TO_THINKING_EFFORT,
   SLIDER_PATCH_MARKER,
   applyCatalogPatch,
@@ -42,6 +43,11 @@ function catalogFixture(name = "FOr") {
     "defaultThinkingEffortByModelSlug:f,defaultModelSlug:p,",
     "internalOptions:e.internalOptions,options:e.options,sliderSettings:d,",
     "versionOptions:e.versionOptions,workspaceModelPolicy:e.workspaceModelPolicy}}",
+    "function ZL(e,t){let n=[...e?.options??[],...e?.internalOptions??[],",
+    "...e?.versionOptions?.flatMap(e=>e.options)??[]],",
+    "r=t.thinkingEffort??e?.defaultThinkingEffortByModelSlug?.[t.slug]??null,",
+    "i=n.find(e=>e.slug===t.slug&&(e.thinkingEffort??null)===r);",
+    "return i!=null||t.thinkingEffort!=null?i:n.find(e=>e.slug===t.slug)}",
     "function Next(){}",
   ].join("");
 }
@@ -91,7 +97,6 @@ function catalog(overrides = {}) {
       { slug: "upstream-default", thinkingEffort: "standard" },
       { slug: "gpt-6-astra", thinkingEffort: "standard" },
       { slug: "gpt-5.6-sol", thinkingEffort: "min" },
-      { slug: "gpt-5.6-sol", thinkingEffort: "extended" },
     ],
     sliderSettings: [{ modelSlug: "upstream-default", thinkingEffort: "standard" }],
     versionOptions: [
@@ -164,7 +169,7 @@ test("rejects malformed preset settings", () => {
   }
 });
 
-test("runtime preserves order and the rest of the upstream catalog", () => {
+test("runtime preserves order and resolves configured efforts from available models", () => {
   const upstream = catalog();
   const configured = normalizePresets(
     context([
@@ -183,6 +188,18 @@ test("runtime preserves order and the rest of the upstream catalog", () => {
   ]);
   assert.equal(result.defaultModelSlug, "gpt-6-astra");
   assert.equal(result.defaultThinkingEffortByModelSlug["gpt-6-astra"], "standard");
+  assert.deepEqual(
+    result.codexLinuxDefaultPresetOptions.map(({ slug, thinkingEffort }) => ({
+      slug,
+      thinkingEffort,
+    })),
+    [
+      { slug: "gpt-5.6-sol", thinkingEffort: "extended" },
+      { slug: "version-model", thinkingEffort: "xhigh" },
+      { slug: "gpt-6-astra", thinkingEffort: "standard" },
+      { slug: "internal-model", thinkingEffort: "extended" },
+    ],
+  );
   assert.strictEqual(result.options, upstream.options);
   assert.strictEqual(result.internalOptions, upstream.internalOptions);
   assert.strictEqual(result.versionOptions, upstream.versionOptions);
@@ -190,7 +207,7 @@ test("runtime preserves order and the rest of the upstream catalog", () => {
   assert.strictEqual(result.categories, upstream.categories);
 });
 
-test("runtime filters unavailable pairs and falls back from an unavailable default", () => {
+test("runtime filters unavailable models and falls back from an unavailable default", () => {
   const configured = normalizePresets(
     context([
       { model: "missing", effort: "medium", default: true },
@@ -201,6 +218,7 @@ test("runtime filters unavailable pairs and falls back from an unavailable defau
   const result = codexLinuxModelPickerDefaultPresets(catalog(), configured);
   assert.deepEqual(result.sliderSettings, [
     { modelSlug: "gpt-5.6-sol", thinkingEffort: "extended" },
+    { modelSlug: "gpt-5.6-sol", thinkingEffort: "ultra" },
   ]);
   assert.equal(result.defaultModelSlug, "gpt-5.6-sol");
   assert.equal(result.defaultThinkingEffortByModelSlug["gpt-5.6-sol"], "extended");
@@ -225,6 +243,7 @@ test("catalog patch has one semantic target, is executable, and is idempotent", 
   const patched = applyCatalogPatch(source, presets);
   assert.equal(catalogPatchContract(patched), "applied");
   assert.equal((patched.match(new RegExp(CATALOG_PATCH_MARKER, "g")) ?? []).length, 2);
+  assert.equal((patched.match(new RegExp(CATALOG_PRESET_OPTIONS_KEY, "g")) ?? []).length, 2);
   assert.equal(applyCatalogPatch(patched, presets), patched);
   const result = plain(evaluate(patched, "FOr(input)", { input: catalog({ slider_settings: [] }) }));
   assert.deepEqual(result.sliderSettings, [
@@ -232,6 +251,12 @@ test("catalog patch has one semantic target, is executable, and is idempotent", 
     { modelSlug: "gpt-5.6-sol", thinkingEffort: "extended" },
   ]);
   assert.equal(result.defaultModelSlug, "gpt-6-astra");
+  assert.equal(
+    plain(evaluate(patched, "ZL(result,{slug:'gpt-5.6-sol',thinkingEffort:'extended'})", {
+      result,
+    })).thinkingEffort,
+    "extended",
+  );
 });
 
 test("catalog patch fails closed on drift, duplicate, and partial states", () => {
@@ -240,6 +265,7 @@ test("catalog patch fails closed on drift, duplicate, and partial states", () =>
     "function unrelated(){}",
     catalogFixture("One") + catalogFixture("Two"),
     `${CATALOG_PATCH_MARKER};${catalogFixture()}`,
+    `${CATALOG_PRESET_OPTIONS_KEY};${catalogFixture()}`,
   ]) {
     const { result, warnings } = withCapturedWarnings(() => applyCatalogPatch(source, presets));
     assert.equal(result, source);


### PR DESCRIPTION
## Summary
- resolve configured effort variants for account-visible models instead of requiring each pair in the server recommended set
- expose private resolver options without changing the manual model list
- keep upstream workspace and Ultra/XHigh gates, and document the corrected fallback behavior

## Tests
- `node --test linux-features/model-picker-default-presets/test.js`
- `node --test scripts/patch-linux-window-ui.test.js scripts/lib/linux-features.test.js linux-features/*/test.js` (907 passed, 1 skipped)
- official Linux feature audit against signed `26.903.61454` ASAR
- isolated configured patch against signed `26.903.61454` ASAR
- `git diff --check`

## Notes
- Manual model options remain upstream-owned; only the Default slider receives synthesized resolver entries for configured efforts.