### PR TITLE
Repair official Linux 26.903.71938 drift

### DIFF
--- a/linux-features/shared-app-server-socket/test.js
+++ b/linux-features/shared-app-server-socket/test.js
@@ -1830,23 +1830,27 @@ test("attached CLI record publishes atomically for default and override sockets"
       fs.writeFileSync(recordPath, priorRecord, { mode: 0o600 });
       const renameCalls = [];
       const fsImpl = Object.create(fs);
+      const socketStat = {
+        dev: 1,
+        ino: name === "default" ? 1 : 2,
+        uid: typeof process.getuid === "function" ? process.getuid() : undefined,
+        isSocket: () => true,
+      };
+      let authoritySpawned = false;
+      fsImpl.lstatSync = (target, ...args) =>
+        target === socketPath && authoritySpawned ? socketStat : fs.lstatSync(target, ...args);
       fsImpl.renameSync = (from, to) => {
         renameCalls.push({ from, to, lock: fs.readFileSync(`${socketPath}.lock`, "utf8") });
         return fs.renameSync(from, to);
       };
-      let server;
       let child;
       const { Transport } = loadInjectedTransport({
         fsImpl,
-        spawnImpl(_command, args) {
+        spawnImpl() {
           child = fakeChild();
+          authoritySpawned = true;
           // Publication must retain the executable selected before asynchronous startup.
           process.env.CODEX_CLI_PATH = "/fake/replacement-codex";
-          const target = args.at(-1).replace("unix://", "");
-          queueMicrotask(async () => {
-            fs.mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
-            server = await listenUnix(target);
-          });
           return child;
         },
       });
@@ -1880,15 +1884,12 @@ test("attached CLI record publishes atomically for default and override sockets"
           assert.equal(renameCalls[0].to, recordPath);
           assert.match(renameCalls[0].lock, new RegExp(`^${process.pid} \\d+ ${process.pid} \\d+\\n$`));
         } finally {
-          await closeServer(server);
-          server = null;
           if (child != null) {
             child.exitCode = 0;
             child.emit("exit", 0, null);
           }
         }
       });
-      await closeServer(server);
     }
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/nix/upstream-linux-packages.json
+++ b/nix/upstream-linux-packages.json
@@ -1,13 +1,13 @@
 {
-  "version": "26.903.61454",
+  "version": "26.903.71938",
   "amd64": {
-    "repositoryPath": "pool/main/c/chatgpt/chatgpt_26.903.61454_amd64.deb",
-    "sha256": "2caa7df314ce37e9048359d8e6a4a78e24574a3b54d6bf510f17754b66dda775",
-    "sri": "sha256-LKp98xTON+kEg1nY5qSnjiRXSjtU1r9RDxd1S2bdp3U="
+    "repositoryPath": "pool/main/c/chatgpt/chatgpt_26.903.71938_amd64.deb",
+    "sha256": "13f46df73b06df6e13e9e750b2f3c89a985863741ea825d2d356f52559f55abd",
+    "sri": "sha256-E/Rt9zsG324T6edQsvPImphYY3QeqCXS01b1JVn1Wr0="
   },
   "arm64": {
-    "repositoryPath": "pool/main/c/chatgpt/chatgpt_26.903.61454_arm64.deb",
-    "sha256": "e545cd78672e1313ff3f0d377772dd4ee7444400357ca85313d732da8d7e6693",
-    "sri": "sha256-5UXNeGcuExP/Pw03d3LdTudERAA1fKhTE9cy2o1+ZpM="
+    "repositoryPath": "pool/main/c/chatgpt/chatgpt_26.903.71938_arm64.deb",
+    "sha256": "1ea59b0287a9c7f07a1aa317cfe68e63876bb2261087f0381c85c5d07b253fe1",
+    "sri": "sha256-HqWbAoepx/B6GqMXz+aOY4drsiYQh/A4HIXF0HslP+E="
   }
 }


### PR DESCRIPTION
<!-- official-linux-watchdog:d77fe58f80fec61a80fa501a32e06a2b5911d6c5f080420afdd8032fb6c4471f -->
## Summary

Repair drift for signed Linux release `26.903.71938`.

## Evidence

- Campaign: `d77fe58f80fec61a80fa501a32e06a2b5911d6c5f080420afdd8032fb6c4471f`
- Acceptance source head: `27dca52501c3979e8078a1a198d7b767866254d8`
- Package SHA-256: `13f46df73b06df6e13e9e750b2f3c89a985863741ea825d2d356f52559f55abd`
- ASAR SHA-256: `46722f946dbe0d54c26ea883b47834c5bc511d8f1f662fcf8dbb874eab688b3e`
- Internal review binding: `f1fe9706a5781b3f0d91ab4a8904661ec97961f2179b4612f5365a31619f9cc8`
- Reviewed diff SHA-256: `d1562dcf51382b0a3c6191550b3fc29611db28b24723555af8a197e840140b1e`

The GitHub approval requirement is not weakened. This unattended merge uses the
repository's existing admin bypass only after evidence-bound independent review.