### PR TITLE
Fix custom Default presets in local tasks

### DIFF
--- a/linux-features/model-picker-default-presets/README.md
+++ b/linux-features/model-picker-default-presets/README.md
@@ -57,6 +57,9 @@ make install-native
 
 One available pair makes **Default** a fixed selection. Two or more available
 pairs display the slider. The feature never truncates the configured list.
+The configured list replaces the upstream **Default** slider in both local
+repository tasks and cloud/TPP chats; selecting a model explicitly still uses
+the normal upstream effort choices for that model.
 
 ## Runtime fallback
 

--- a/linux-features/model-picker-default-presets/patch.js
+++ b/linux-features/model-picker-default-presets/patch.js
@@ -3,6 +3,7 @@
 const CATALOG_PATCH_MARKER = "codexLinuxModelPickerDefaultPresets";
 const CATALOG_PRESET_OPTIONS_KEY = "codexLinuxDefaultPresetOptions";
 const SLIDER_PATCH_MARKER = "codex-linux-model-picker-default-presets-slider-minimum";
+const LOCAL_DEFAULT_PATCH_MARKER = "codex-linux-model-picker-default-presets-local-default";
 const JS_ASSET_PATTERN = /\.js$/;
 const EFFORT_TO_THINKING_EFFORT = Object.freeze({
   none: "zero",
@@ -296,19 +297,75 @@ function sliderResolverSection(source) {
   ]);
 }
 
+function powerSelectionResolverSection(source) {
+  return uniqueFunctionWithMarkers(source, [
+    ".sliderSettings?.filter(",
+    "isTppConversation:",
+    "selectionMode:",
+    "powerSettings:",
+  ]);
+}
+
+function firstFunctionParameter(section) {
+  return /^function [A-Za-z_$][\w$]*\(([A-Za-z_$][\w$]*)[,)]/u.exec(
+    section?.source ?? "",
+  )?.[1] ?? null;
+}
+
+function upstreamDefaultSliderCondition(section) {
+  const catalogParameter = firstFunctionParameter(section);
+  if (catalogParameter == null) return null;
+  const pattern =
+    /([A-Za-z_$][\w$]*)&&([A-Za-z_$][\w$]*)===([`'"])default\3&&([A-Za-z_$][\w$]*)\.length>0\?\4:/gu;
+  const matches = [...section.source.matchAll(pattern)];
+  if (matches.length !== 1) return null;
+  return {
+    catalogParameter,
+    match: matches[0][0],
+    selectionMode: matches[0][2],
+    sliderSettings: matches[0][4],
+    tppMode: matches[0][1],
+  };
+}
+
+function upstreamSliderFilterCondition(section, defaultCondition) {
+  const quotedDefault = "([`'\"])default\\1";
+  const pattern = new RegExp(
+    `${defaultCondition.tppMode}&&${defaultCondition.selectionMode}===${quotedDefault}\\|\\|`,
+    "gu",
+  );
+  const matches = [...section.source.matchAll(pattern)];
+  return matches.length === 1 ? matches[0][0] : null;
+}
+
 function sliderPatchContract(source) {
   const markerCount = source.split(SLIDER_PATCH_MARKER).length - 1;
-  const section = sliderResolverSection(source);
-  if (markerCount === 0) {
-    if (section == null) return "drifted";
-    return (section.source.match(/\.length>=3/g) ?? []).length === 2 ? "current" : "drifted";
+  const localMarkerCount = source.split(LOCAL_DEFAULT_PATCH_MARKER).length - 1;
+  const sliderSection = sliderResolverSection(source);
+  const powerSection = powerSelectionResolverSection(source);
+  const catalogParameter = firstFunctionParameter(powerSection);
+  if (markerCount === 0 && localMarkerCount === 0) {
+    if (sliderSection == null || powerSection == null) return "drifted";
+    const defaultCondition = upstreamDefaultSliderCondition(powerSection);
+    return (sliderSection.source.match(/\.length>=3/g) ?? []).length === 2 &&
+      defaultCondition != null &&
+      upstreamSliderFilterCondition(powerSection, defaultCondition) != null
+      ? "current"
+      : "drifted";
   }
   if (
     markerCount === 1 &&
-    section != null &&
-    section.source.includes(`/*${SLIDER_PATCH_MARKER}*/`) &&
-    (section.source.match(/\.length>=codexLinuxDefaultPresetMinimum\(/g) ?? []).length === 2 &&
-    !section.source.includes(".length>=3")
+    localMarkerCount === 1 &&
+    sliderSection != null &&
+    powerSection != null &&
+    sliderSection.source.includes(`/*${SLIDER_PATCH_MARKER}*/`) &&
+    powerSection.source.includes(`/*${LOCAL_DEFAULT_PATCH_MARKER}*/`) &&
+    (sliderSection.source.match(/\.length>=codexLinuxDefaultPresetMinimum\(/g) ?? []).length === 2 &&
+    !sliderSection.source.includes(".length>=3") &&
+    powerSection.source.includes(
+      `let codexLinuxHasDefaultPresets=${catalogParameter}?.${CATALOG_PRESET_OPTIONS_KEY}!=null`,
+    ) &&
+    (powerSection.source.match(/codexLinuxHasDefaultPresets/g) ?? []).length === 3
   ) {
     return "applied";
   }
@@ -337,12 +394,23 @@ function applySliderMinimumPatch(source, context = {}) {
     return source;
   }
 
-  const section = sliderResolverSection(source);
+  const sliderSection = sliderResolverSection(source);
+  const powerSection = powerSelectionResolverSection(source);
+  const defaultCondition = upstreamDefaultSliderCondition(powerSection);
+  const filterCondition =
+    defaultCondition == null ? null : upstreamSliderFilterCondition(powerSection, defaultCondition);
+  if (defaultCondition == null || filterCondition == null) {
+    warn(
+      "Could not locate the local Default power-selection branch",
+      "model picker Default slider patch",
+    );
+    return source;
+  }
   const configuredIds = presets.map(
     ({ modelSlug, thinkingEffort }) =>
       `${modelSlug}:${THINKING_EFFORT_TO_EFFORT[thinkingEffort]}`,
   );
-  const patchedSection = section.source
+  const patchedSliderSection = sliderSection.source
     .replace(
       "{",
       `{/*${SLIDER_PATCH_MARKER}*/let codexLinuxDefaultPresetIds=new Set(${JSON.stringify(
@@ -353,7 +421,41 @@ function applySliderMinimumPatch(source, context = {}) {
       /([A-Za-z_$][\w$]*)\.length>=3/g,
       "$1.length>=codexLinuxDefaultPresetMinimum($1)",
     );
-  return source.slice(0, section.start) + patchedSection + source.slice(section.end);
+  const configuredDefaultCondition =
+    `codexLinuxHasDefaultPresets&&${defaultCondition.selectionMode}===\`default\``;
+  let patchedPowerSection = powerSection.source
+    .replace(filterCondition, `${configuredDefaultCondition}||`)
+    .replace(
+      defaultCondition.match,
+      `${configuredDefaultCondition}&&${defaultCondition.sliderSettings}.length>0?${defaultCondition.sliderSettings}:`,
+    );
+  const bodyOpening = patchedPowerSection.lastIndexOf(
+    "){",
+    patchedPowerSection.indexOf(".sliderSettings"),
+  ) + 1;
+  if (bodyOpening <= 0 || patchedPowerSection[bodyOpening] !== "{") {
+    warn(
+      "Could not locate the power-selection resolver body",
+      "model picker Default slider patch",
+    );
+    return source;
+  }
+  patchedPowerSection =
+    patchedPowerSection.slice(0, bodyOpening + 1) +
+    `/*${LOCAL_DEFAULT_PATCH_MARKER}*/let codexLinuxHasDefaultPresets=${defaultCondition.catalogParameter}?.${CATALOG_PRESET_OPTIONS_KEY}!=null;` +
+    patchedPowerSection.slice(bodyOpening + 1);
+  const replacements = [
+    { ...sliderSection, source: patchedSliderSection },
+    { ...powerSection, source: patchedPowerSection },
+  ].sort((left, right) => right.start - left.start);
+  let patchedSource = source;
+  for (const replacement of replacements) {
+    patchedSource =
+      patchedSource.slice(0, replacement.start) +
+      replacement.source +
+      patchedSource.slice(replacement.end);
+  }
+  return patchedSource;
 }
 
 function catalogAssetMatch(source) {
@@ -399,6 +501,7 @@ module.exports = {
   CATALOG_PATCH_MARKER,
   CATALOG_PRESET_OPTIONS_KEY,
   EFFORT_TO_THINKING_EFFORT,
+  LOCAL_DEFAULT_PATCH_MARKER,
   THINKING_EFFORT_TO_EFFORT,
   JS_ASSET_PATTERN,
   SLIDER_PATCH_MARKER,

--- a/linux-features/model-picker-default-presets/test.js
+++ b/linux-features/model-picker-default-presets/test.js
@@ -14,6 +14,7 @@ const {
   CATALOG_PATCH_MARKER,
   CATALOG_PRESET_OPTIONS_KEY,
   EFFORT_TO_THINKING_EFFORT,
+  LOCAL_DEFAULT_PATCH_MARKER,
   SLIDER_PATCH_MARKER,
   applyCatalogPatch,
   applySliderMinimumPatch,
@@ -54,6 +55,11 @@ function catalogFixture(name = "FOr") {
 
 function sliderFixture(name = "Wkr") {
   return [
+    "function Power(e,t,n,{includeUltraInSlider:r=false,isTppConversation:i=false,selectionMode:a=`default`}={}){",
+    "let l=e?.options??t??[],u=l.flatMap(({slug:e,thinkingEffort:t})=>[{modelSlug:e,thinkingEffort:t??null}]),",
+    "d=e?.sliderSettings?.filter(({modelSlug:e})=>i&&a===`default`||l.some(({slug:t})=>t===e))??[],",
+    "f=(i&&a===`default`&&d.length>0?d:[...u,...d]);",
+    "return{powerSettings:f,selectionMode:a}}",
     `function ${name}(e){`,
     "let powerSelectionsWithXHigh=e,fallbackPowerSelection=e,",
     "show_xhigh_in_simple_picker=true,canInitializePowerPicker=true;",
@@ -287,7 +293,32 @@ test("slider minimum makes two entries a slider while one stays fixed", () => {
   const patched = applySliderMinimumPatch(source, presets);
   assert.equal(sliderPatchContract(patched), "applied");
   assert.equal((patched.match(new RegExp(SLIDER_PATCH_MARKER, "g")) ?? []).length, 1);
+  assert.equal((patched.match(new RegExp(LOCAL_DEFAULT_PATCH_MARKER, "g")) ?? []).length, 1);
   assert.equal(applySliderMinimumPatch(patched, presets), patched);
+  const catalogWithCustomDefault = {
+    codexLinuxDefaultPresetOptions: [{}],
+    options: [{ slug: "server", thinkingEffort: "min" }],
+    sliderSettings: [
+      { modelSlug: "gpt-6-astra", thinkingEffort: "standard" },
+      { modelSlug: "gpt-5.6-sol", thinkingEffort: "extended" },
+    ],
+  };
+  assert.deepEqual(
+    plain(evaluate(patched, "Power(input,null,null,{isTppConversation:false,selectionMode:'default'}).powerSettings", {
+      input: catalogWithCustomDefault,
+    })),
+    catalogWithCustomDefault.sliderSettings,
+  );
+  assert.equal(
+    plain(
+      evaluate(
+        patched,
+        "Power(input,null,null,{isTppConversation:false,selectionMode:'model'}).powerSettings.length",
+        { input: catalogWithCustomDefault },
+      ),
+    ),
+    1,
+  );
   const configured = [
     { id: "gpt-6-astra:medium" },
     { id: "gpt-5.6-sol:high" },
@@ -320,6 +351,7 @@ test("slider patch fails closed on drift, duplicate, and partial states", () => 
     "function unrelated(){}",
     sliderFixture("One") + sliderFixture("Two"),
     sliderFixture().replace("{", `{/*${SLIDER_PATCH_MARKER}*/`),
+    sliderFixture().replace("f=(", `f=(/*${LOCAL_DEFAULT_PATCH_MARKER}*/`),
   ]) {
     const { result, warnings } = withCapturedWarnings(() =>
       applySliderMinimumPatch(source, presets),


### PR DESCRIPTION
## Summary
- make configured Default presets replace upstream slider positions in local repository tasks as well as cloud/TPP chats
- keep explicit model selection behavior unchanged
- add fail-closed semantic coverage and a local-mode runtime regression fixture

## Tests
- `node --test linux-features/model-picker-default-presets/test.js`
- `node --test scripts/patch-linux-window-ui.test.js scripts/lib/linux-features.test.js linux-features/*/test.js` (907 passed, 1 skipped)
- latest signed stable `26.903.71938` configured ASAR patch
- official Linux feature audit (33 features)
- `git diff --check`

## Notes
The previous implementation used the configured slider exclusively only when `isTppConversation` was true. Local tasks merged upstream power positions back in, producing the old six-position slider.