### PR TITLE
HEROX-1454: Bound Linux accessibility observations

### DIFF
--- a/docs/linux-computer-use.md
+++ b/docs/linux-computer-use.md
@@ -26,6 +26,13 @@ It supports:
 - pointer-direction feedback for the built-in V2 pet after successful click,
   scroll, and drag actions
 
+The in-app adapter returns a compact accessibility projection and suppresses an
+unchanged compact projection on repeated reads. Use `disableDiffing: true` for a
+fresh compact tree, or `compact: false` for complete backend metadata.
+`maxNodes`/`maxDepth` bound accessibility traversal; screenshot calls accept
+`maxWidth`, `maxHeight`, `maxBytes`, `scale`, `format`, and `quality`. Screenshot
+methods already emit the image and should not be emitted a second time.
+
 ## Runtime Dependencies
 
 Install `ydotool` 1.0.3 or newer when you need the fallback input path. The

--- a/linux-features/computer-use-linux/README.md
+++ b/linux-features/computer-use-linux/README.md
@@ -32,6 +32,18 @@ Accessibility observations retain `window_context` for geometry inspection.
 Element-index actions, drag, rich-text paste, selection editing, and secondary
 accessibility actions are not exposed by the in-app API.
 
+`getApp()` emits one compact accessibility observation. Later `getAXState()`
+calls omit an unchanged compact projection; pass `disableDiffing: true` for a fresh
+compact tree or `compact: false` for the complete backend node metadata. Bound
+tree traversal with `maxNodes` (1–2000) and `maxDepth` (0–64). The equivalent
+`max_nodes` and `max_depth` spellings are accepted for direct backend parity.
+
+Screenshot methods emit their image, so do not emit the returned bytes again.
+They accept `maxWidth`, `maxHeight`, `maxBytes`, `scale`, `format`, and `quality`;
+`getAXStateAndScreenshot()` accepts both the accessibility and screenshot option
+sets. Use these limits to request more detail deliberately instead of repeatedly
+loading a large default observation.
+
 Native control retains OS permission requirements and target-window focus
 checks. Consequential-action approval remains the host/model's responsibility;
 Linux does not provide saved per-app approvals through this integration.

--- a/linux-features/computer-use-linux/native-client.mjs
+++ b/linux-features/computer-use-linux/native-client.mjs
@@ -4,6 +4,50 @@ export function installLinuxComputerUse(cua) {
   if (typeof runtime?.rpc !== 'function') throw new Error('Linux Computer Use requires trusted nodeRepl RPC');
   const call = (method, app, params = {}) => runtime.rpc('sky', { method, ...(app === undefined ? {} : { app }), params });
   const emit = (value, options) => { if (options?.emit !== false) runtime.write(value); return value; };
+  const option = (options, camel, snake) => {
+    const camelSet = Object.hasOwn(options, camel);
+    const snakeSet = Object.hasOwn(options, snake);
+    if (camelSet && snakeSet && options[camel] !== options[snake]) throw new Error(`Conflicting ${camel} and ${snake} options`);
+    return camelSet ? options[camel] : options[snake];
+  };
+  const backendOptions = (options, entries) => Object.fromEntries(entries.flatMap(([camel, snake]) => {
+    const value = option(options, camel, snake);
+    return value === undefined ? [] : [[snake, value]];
+  }));
+  const axBackendOptions = options => backendOptions(options, [['maxNodes', 'max_nodes'], ['maxDepth', 'max_depth']]);
+  const screenshotBackendOptions = options => backendOptions(options, [
+    ['maxWidth', 'max_width'], ['maxHeight', 'max_height'], ['maxBytes', 'max_bytes'],
+    ['scale', 'scale'], ['format', 'format'], ['quality', 'quality'],
+  ]);
+  const meaningful = value => typeof value === 'string' ? value.replaceAll('\uFFFC', '').trim() || undefined : undefined;
+  const compactNode = node => {
+    const states = Array.isArray(node.states) ? node.states.map(meaningful).filter(Boolean) : [];
+    const actionNames = Array.isArray(node.actions) ? node.actions.map(action => meaningful(action?.name)).filter(Boolean) : [];
+    const textContent = meaningful(node.text?.content);
+    const text = node.text && {
+      ...(Number.isInteger(node.text.character_count) && node.text.character_count > 0 ? { character_count: node.text.character_count } : {}),
+      ...(Number.isInteger(node.text.caret_offset) && node.text.caret_offset >= 0 ? { caret_offset: node.text.caret_offset } : {}),
+      ...(textContent ? { content: textContent } : {}),
+      ...(node.text.truncated ? { truncated: true } : {}),
+      ...(Array.isArray(node.text.selections) && node.text.selections.length ? { selections: node.text.selections } : {}),
+    };
+    return {
+      index: node.index,
+      ...(node.parent_index === null || node.parent_index === undefined ? {} : { parent_index: node.parent_index }),
+      ...(node.depth ? { depth: node.depth } : {}),
+      role: node.role,
+      ...(meaningful(node.name) ? { name: meaningful(node.name) } : {}),
+      ...(meaningful(node.description) ? { description: meaningful(node.description) } : {}),
+      ...(node.child_count > 0 ? { child_count: node.child_count } : {}),
+      ...(node.bounds && node.bounds.width > 0 && node.bounds.height > 0 ? { bounds: node.bounds } : {}),
+      ...(states.length ? { states: states.join(' ') } : {}),
+      ...(Array.isArray(node.actions) && node.actions.length ? { actionable: true } : {}),
+      ...(actionNames.length ? { actions: actionNames } : {}),
+      ...(node.value ? { value: Object.fromEntries(Object.entries(node.value).filter(([, value]) => value !== null && value !== undefined)) } : {}),
+      ...(text && Object.keys(text).length ? { text } : {}),
+      ...(node.supports_editable_text ? { editable: true } : {}),
+    };
+  };
   const browserState = cua.getState?.bind(cua);
   cua.listApps = async (options = {}) => emit(await call('list_apps'), options);
   cua.getState = async (options = {}) => {
@@ -13,13 +57,39 @@ export function installLinuxComputerUse(cua) {
   cua.getApp = async (app) => {
     if (typeof app !== 'string' || !app.trim()) throw new Error('getApp requires a non-empty app id');
     const unsupported = async () => { throw new Error('This native Linux Computer Use operation is not supported'); };
-    const state = () => call('get_app_state', app, { include_screenshot: false });
+    const state = options => call('get_app_state', app, { include_screenshot: false, ...axBackendOptions(options) });
+    let previousAccessibilityState;
     const screenshotMetadata = (result) => result.screenshot ? {
       width: result.screenshot.width, height: result.screenshot.height,
       coordinate_width: result.screenshot.coordinate_width,
       coordinate_height: result.screenshot.coordinate_height,
     } : undefined;
-    const axText = (result) => JSON.stringify({ accessibility_tree: result.accessibility_tree, window_context: result.window_context, coordinates: { accessibility_bounds: 'screen', input: 'window-relative screenshot capture coordinates', guidance: 'Do not pass accessibility bounds directly to click or scroll; display scaling can differ. Use screenshot coordinate_width and coordinate_height.' }, accessibility_error: result.accessibility_error, window_error: result.window_error, screenshot_error: result.screenshot_error, screenshot: screenshotMetadata(result) });
+    const axText = (result, options) => {
+      const compactTree = Array.isArray(result.accessibility_tree) ? result.accessibility_tree.map(compactNode) : [];
+      const accessibilityState = {
+        accessibility_tree: compactTree,
+        window_context: result.window_context,
+        accessibility_error: result.accessibility_error,
+        window_error: result.window_error,
+      };
+      const signature = JSON.stringify(accessibilityState);
+      const unchanged = options?.disableDiffing !== true && options?.compact !== false && signature === previousAccessibilityState;
+      previousAccessibilityState = signature;
+      if (unchanged) return JSON.stringify({
+        accessibility_tree_unchanged: true,
+        screenshot_error: result.screenshot_error,
+        screenshot: screenshotMetadata(result),
+      });
+      return JSON.stringify({
+        accessibility_tree: options?.compact === false ? result.accessibility_tree : compactTree,
+        window_context: result.window_context,
+        coordinates: { accessibility_bounds: 'screen', input: 'window-relative screenshot capture coordinates', guidance: 'Do not pass accessibility bounds directly to click or scroll; display scaling can differ. Use screenshot coordinate_width and coordinate_height.' },
+        accessibility_error: result.accessibility_error,
+        window_error: result.window_error,
+        screenshot_error: result.screenshot_error,
+        screenshot: screenshotMetadata(result),
+      });
+    };
     const screenshot = async (result, options) => {
       const url = result.screenshot?.data_url;
       if (!url) throw new Error(result.screenshot_error || 'Native app screenshot is unavailable');
@@ -35,16 +105,16 @@ export function installLinuxComputerUse(cua) {
       return { x: target[0], y: target[1] };
     };
     const target = {
-      getAXState: async (options = {}) => emit(axText(await state()), options),
-      getScreenshot: async (options = {}) => screenshot(await call('screenshot', app), options),
+      getAXState: async (options = {}) => emit(axText(await state(options), options), options),
+      getScreenshot: async (options = {}) => screenshot(await call('screenshot', app, screenshotBackendOptions(options)), options),
       getAXStateAndScreenshot: async (options = {}) => {
         // Capture raises the target first, so the passive AX observation sees
         // its resulting window state. Failed capture is reported, never retried.
         let capture;
-        try { capture = await call('screenshot', app); }
+        try { capture = await call('screenshot', app, screenshotBackendOptions(options)); }
         catch (error) { capture = { screenshot_error: error.message }; }
-        const result = { ...await state(), ...capture };
-        return { state: emit(axText(result), options), ...(result.screenshot ? { screenshot: await screenshot(result, options) } : {}) };
+        const result = { ...await state(options), ...capture };
+        return { state: emit(axText(result, options), options), ...(result.screenshot ? { screenshot: await screenshot(result, options) } : {}) };
       },
       click: (location, options = {}) => call('click', app, { ...point(location), button: options.mouseButton ?? 'left', click_count: options.clickCount ?? 1, relative: true }),
       pressKey: key => call('press_key', app, { key }),
@@ -56,7 +126,7 @@ export function installLinuxComputerUse(cua) {
       },
       drag: unsupported, selectText: unsupported, setValue: unsupported, performSecondaryAction: unsupported,
     };
-    emit('Linux native app APIs: getAXState(), getScreenshot(), getAXStateAndScreenshot(), click([x,y], {mouseButton?,clickCount?}), pressKey(key), typeText(text), scroll([x,y], direction, pages?), paste(text). Screenshot APIs bring the selected window forward; getAXState() remains passive. Click/scroll coordinates are window-relative in the reported screenshot coordinate_width/coordinate_height space; screenshots may be downscaled. Accessibility bounds are screen coordinates and must not be passed directly to click/scroll; display scaling can differ. Native window_context is retained for geometry inspection. Element-index actions, drag, rich paste, selectText, setValue, and secondary actions are unsupported. Input uses the Linux backend and may require OS permissions.');
+    emit('Linux native app APIs: getAXState({disableDiffing?,compact?,maxNodes?,maxDepth?}), getScreenshot({maxWidth?,maxHeight?,maxBytes?,scale?,format?,quality?}), getAXStateAndScreenshot() with both option sets, click([x,y], {mouseButton?,clickCount?}), pressKey(key), typeText(text), scroll([x,y], direction, pages?), paste(text). AX state is compact and unchanged compact projections are suppressed by default; pass disableDiffing:true for a fresh compact tree or compact:false for full backend node metadata. Screenshot APIs bring the selected window forward and emit images themselves; getAXState() remains passive. Click/scroll coordinates are window-relative in the reported screenshot coordinate_width/coordinate_height space; screenshots may be downscaled. Accessibility bounds are screen coordinates and must not be passed directly to click/scroll; display scaling can differ. Native window_context is retained for geometry inspection. Element-index actions, drag, rich paste, selectText, setValue, and secondary actions are unsupported. Input uses the Linux backend and may require OS permissions.');
     await target.getAXState();
     return target;
   };

--- a/linux-features/computer-use-linux/native-service.mjs
+++ b/linux-features/computer-use-linux/native-service.mjs
@@ -4,13 +4,30 @@ import { fileURLToPath } from 'node:url';
 
 const parameters = {
   list_apps: [],
-  get_app_state: ['include_screenshot'],
-  screenshot: [],
+  get_app_state: ['include_screenshot', 'max_nodes', 'max_depth', 'max_width', 'max_height', 'max_bytes', 'scale', 'format', 'quality'],
+  screenshot: ['max_width', 'max_height', 'max_bytes', 'scale', 'format', 'quality'],
   click: ['x', 'y', 'button', 'click_count', 'relative'],
   scroll: ['x', 'y', 'direction', 'pages', 'relative'],
   press_key: ['key'],
   type_text: ['text'],
 };
+
+function validateParameters(params) {
+  const integer = (name, minimum, maximum) => {
+    if (params[name] !== undefined && (!Number.isInteger(params[name]) || params[name] < minimum || params[name] > maximum)) {
+      throw new Error(`Invalid native ${name} parameter`);
+    }
+  };
+  if (params.include_screenshot !== undefined && typeof params.include_screenshot !== 'boolean') throw new Error('Invalid native include_screenshot parameter');
+  integer('max_nodes', 1, 2000);
+  integer('max_depth', 0, 64);
+  integer('max_width', 1, 4096);
+  integer('max_height', 1, 4096);
+  integer('max_bytes', 1024, 4 * 1024 * 1024);
+  integer('quality', 1, 95);
+  if (params.scale !== undefined && (typeof params.scale !== 'number' || !Number.isFinite(params.scale) || params.scale <= 0 || params.scale > 1)) throw new Error('Invalid native scale parameter');
+  if (params.format !== undefined && !['png', 'jpeg'].includes(params.format)) throw new Error('Invalid native format parameter');
+}
 
 // This service runs in the official Node 24 code-mode host, which provides
 // JSON source access and rawJSON. Keep u64 window IDs beyond JS's safe range as
@@ -83,6 +100,7 @@ export function createNativeService({
     const { method, app, params = {} } = input ?? {};
     if (!Object.hasOwn(parameters, method)) throw new Error('This native Linux Computer Use operation is not supported');
     if (!params || typeof params !== 'object' || Array.isArray(params) || Object.keys(params).some(key => !parameters[method].includes(key))) throw new Error('Unsupported native operation parameter');
+    validateParameters(params);
     if (method === 'screenshot' && app === undefined) throw new Error('A non-empty native app id is required');
     let target = {};
     if (app !== undefined) {

--- a/linux-features/computer-use-linux/native.test.js
+++ b/linux-features/computer-use-linux/native.test.js
@@ -29,6 +29,14 @@ test('trusted service validates requests before backend launch', async () => {
   const { handleRpc } = await import('./native-service.mjs');
   await assert.rejects(handleRpc({ method: 'drag', app: 'editor', params: {} }), /not supported/);
   await assert.rejects(handleRpc({ method: 'click', app: 'editor', params: { window_id: 22 } }), /parameter/);
+  for (const params of [
+    {max_nodes:0}, {max_nodes:2001}, {max_depth:-1}, {max_depth:65},
+    {max_width:0}, {max_height:4097}, {max_bytes:1023}, {max_bytes:4194305},
+    {scale:0}, {scale:1.1}, {format:'webp'}, {quality:0}, {quality:96},
+  ]) {
+    const method = Object.keys(params)[0].startsWith('max_n') || Object.hasOwn(params, 'max_depth') ? 'get_app_state' : 'screenshot';
+    await assert.rejects(handleRpc({method, app:'editor', params}), /Invalid native/);
+  }
 });
 
 const { mkdtemp, writeFile, readFile, rm } = require('node:fs/promises');
@@ -94,6 +102,108 @@ test('MCP initialization, exact window IDs, targeted inputs and desktop inputs',
   assert.deepEqual(desktop.arguments, {key:'ESC'});
 });
 
+test('trusted service forwards bounded observation options exactly', async t => {
+  const stateService = await fixture(t);
+  const state = await stateService.handleRpc({method:'get_app_state',app:'editor',params:{include_screenshot:true,max_nodes:20,max_depth:5,max_width:800,max_height:600,max_bytes:65536,scale:0.5,format:'jpeg',quality:70}});
+  assert.deepEqual(state.arguments, {include_screenshot:true,max_nodes:20,max_depth:5,max_width:800,max_height:600,max_bytes:65536,scale:0.5,format:'jpeg',quality:70,app_id:'editor'});
+
+  const captureService = await fixture(t, {capture:true});
+  await captureService.handleRpc({method:'screenshot',app:'editor',params:{max_width:800,max_height:600,max_bytes:65536,scale:0.5,format:'jpeg',quality:70}});
+  const calls = await captureService.readCalls();
+  assert.deepEqual(calls.at(-1).arguments, {max_width:800,max_height:600,max_bytes:65536,scale:0.5,format:'jpeg',quality:70,app_id:'editor'});
+});
+
+test('native client compacts and suppresses repeated large accessibility observations', async () => {
+  const { installLinuxComputerUse } = await import('./native-client.mjs');
+  const original = globalThis.nodeRepl;
+  const calls = [], writes = [];
+  const tree = Array.from({length:237}, (_, index) => ({
+    index,
+    parent_index:index ? index - 1 : null,
+    depth:index,
+    object_ref:`:1.234/org/a11y/atspi/accessible/${'metadata'.repeat(8)}/${index}`,
+    role:index === 236 ? 'button' : 'section',
+    name:index === 236 ? 'Save' : null,
+    description:null,
+    child_count:index === 236 ? 0 : 1,
+    bounds:index === 236 ? {x:40,y:50,width:80,height:30} : null,
+    states:['enabled','sensitive','showing','visible','focusable',...(index === 236 ? ['focused','selected'] : [])],
+    actions:[{index:0,name:index === 236 ? 'click' : '',description:'',keybinding:''}],
+    value:null,
+    text:{character_count:1,caret_offset:0,content:' \uFFFC ',truncated:false,selections:[]},
+    supports_editable_text:true,
+  }));
+  let response = {accessibility_tree:tree,window_context:{focused:true}};
+  globalThis.nodeRepl = {
+    write:value=>writes.push(value),
+    rpc:async (_, request)=>{calls.push(request); return response;},
+  };
+  try {
+    const app = await installLinuxComputerUse({}).getApp('editor');
+    const initial = writes.find(value => typeof value === 'string' && value.startsWith('{'));
+    const compact = JSON.parse(initial);
+    const button = compact.accessibility_tree.at(-1);
+    assert.ok(initial.length < JSON.stringify(response).length / 2);
+    assert.equal(button.index,236);
+    assert.equal(button.parent_index,235);
+    assert.deepEqual(button.bounds,{x:40,y:50,width:80,height:30});
+    assert.equal(button.states,'enabled sensitive showing visible focusable focused selected');
+    assert.deepEqual(button.actions,['click']);
+    assert.equal(button.actionable,true);
+    assert.equal(button.editable,true);
+    assert.equal(button.object_ref,undefined);
+    assert.equal(button.text.content,undefined);
+
+    const repeated = JSON.parse(await app.getAXState({emit:false,maxNodes:20,maxDepth:5}));
+    assert.deepEqual(repeated,{accessibility_tree_unchanged:true});
+    assert.deepEqual(calls.at(-1).params,{include_screenshot:false,max_nodes:20,max_depth:5});
+
+    const refreshed = JSON.parse(await app.getAXState({emit:false,disableDiffing:true,max_nodes:21,max_depth:6}));
+    assert.equal(refreshed.accessibility_tree.length,237);
+    assert.deepEqual(calls.at(-1).params,{include_screenshot:false,max_nodes:21,max_depth:6});
+
+    const full = JSON.parse(await app.getAXState({emit:false,compact:false}));
+    assert.match(full.accessibility_tree[0].object_ref,/org\/a11y/);
+
+    response = {...response,accessibility_tree:tree.map((node,index) => index === 236
+      ? {...node,states:node.states.filter(state => state !== 'enabled' && state !== 'showing')}
+      : node)};
+    const disabled = JSON.parse(await app.getAXState({emit:false}));
+    assert.doesNotMatch(disabled.accessibility_tree.at(-1).states,/enabled|showing/);
+
+    response = {...response,window_context:{focused:false}};
+    const changed = JSON.parse(await app.getAXState({emit:false}));
+    assert.equal(changed.window_context.focused,false);
+    await assert.rejects(app.getAXState({maxNodes:20,max_nodes:21}),/Conflicting maxNodes/);
+  } finally { globalThis.nodeRepl=original; }
+});
+
+test('native client routes screenshot limits separately from accessibility limits', async () => {
+  const { installLinuxComputerUse } = await import('./native-client.mjs');
+  const original = globalThis.nodeRepl;
+  const calls = [];
+  globalThis.nodeRepl = {
+    write(){},
+    emitImage:async()=>{},
+    rpc:async (_, request) => {
+      calls.push(request);
+      return request.method === 'screenshot'
+        ? {screenshot:{data_url:'data:image/png;base64,AQID',width:100,height:50,coordinate_width:100,coordinate_height:50}}
+        : {accessibility_tree:[]};
+    },
+  };
+  try {
+    const app = await installLinuxComputerUse({}).getApp('editor');
+    await app.getAXStateAndScreenshot({
+      emit:false, disableDiffing:true, maxNodes:40, maxDepth:7,
+      maxWidth:800, maxHeight:600, maxBytes:65536, scale:0.5, format:'jpeg', quality:70,
+    });
+    const [capture, state] = calls.slice(-2);
+    assert.deepEqual(capture.params,{max_width:800,max_height:600,max_bytes:65536,scale:0.5,format:'jpeg',quality:70});
+    assert.deepEqual(state.params,{include_screenshot:false,max_nodes:40,max_depth:7});
+  } finally { globalThis.nodeRepl=original; }
+});
+
 for (const structured of [false, true]) {
   for (const windowId of ['1017417960236020624', '18446744073709551615']) {
     test(`u64 window IDs round trip exactly through ${structured ? 'structuredContent' : 'text JSON'}: ${windowId}`, async t => {
@@ -153,7 +263,7 @@ test('native observations return image bytes and expose screenshot errors and co
   globalThis.nodeRepl = {write(){},emitImage:async value=>images.push(value),rpc:async()=>response};
   try {
     const app=await installLinuxComputerUse({}).getApp('linux-window:22');
-    const observed=await app.getAXStateAndScreenshot({emit:false});
+    const observed=await app.getAXStateAndScreenshot({emit:false,disableDiffing:true});
     assert.deepEqual([...observed.screenshot],[1,2,3]);
     const state = JSON.parse(observed.state);
     assert.deepEqual(state.accessibility_tree, tree);
@@ -180,8 +290,8 @@ for (const api of ['getScreenshot', 'getAXStateAndScreenshot']) {
     globalThis.nodeRepl = { write: value => writes.push(value), emitImage: async value => images.push(value), rpc: (_, request) => service.handleRpc(request) };
     try {
       const app = await installLinuxComputerUse({}).getApp('linux-window:18446744073709551615');
-      assert.equal(JSON.parse(await app.getAXState({emit:false})).window_context.focused, false);
-      const result = await app[api]();
+      assert.equal(JSON.parse(await app.getAXState({emit:false,disableDiffing:true})).window_context.focused, false);
+      const result = await app[api](api === 'getAXStateAndScreenshot' ? {disableDiffing:true} : {});
       assert.deepEqual([...(api === 'getScreenshot' ? result : result.screenshot)], [1,2,3]);
       assert.deepEqual(images, ['data:image/png;base64,AQID']);
       assert.deepEqual(writes.find(value => value?.screenshot)?.screenshot, {width:100,height:50,coordinate_width:200,coordinate_height:100});

--- a/linux-features/computer-use-linux/stage.js
+++ b/linux-features/computer-use-linux/stage.js
@@ -39,7 +39,7 @@ try {
 }
 
 // The app materializes bundled plugin caches by version, not resource contents.
-manifest.version = manifest.version.replace(/-linux-native\.\d+$/, "") + "-linux-native.2";
+manifest.version = manifest.version.replace(/-linux-native\.\d+$/, "") + "-linux-native.3";
 for (const name of ["native-launch.mjs", "native-client.mjs", "native-service.mjs"]) {
   fs.copyFileSync(path.join(__dirname, name), path.join(target, "scripts", name));
 }

--- a/linux-features/computer-use-linux/test.js
+++ b/linux-features/computer-use-linux/test.js
@@ -75,7 +75,7 @@ test("staging extends the hidden unified plugin and invalidates the browser-only
   fs.writeFileSync(launcherPath, originalLauncher);
   stage();
   const version = JSON.parse(fs.readFileSync(path.join(target, ".codex-plugin/plugin.json"))).version;
-  assert.equal(version, "26.901.41600-linux-native.2");
+  assert.equal(version, "26.901.41600-linux-native.3");
   assert.deepEqual(JSON.parse(fs.readFileSync(marketplacePath)).plugins.map(p => p.name), ["unified-computer-use", "browser", "computer-use"]);
   const settingsManifest = JSON.parse(fs.readFileSync(path.join(target, "../computer-use/.codex-plugin/plugin.json")));
   assert.equal(settingsManifest.mcpServers, undefined);


### PR DESCRIPTION
## Summary
- compact Linux accessibility observations while preserving actionable metadata and state changes
- suppress exact repeated trees and expose validated AX/screenshot bounds
- bump the staged plugin revision and document the new behavior

## Tests
- `node --test linux-features/computer-use-linux/native.test.js linux-features/computer-use-linux/test.js` (59 passed)
- `./scripts/ci-local.sh pr` (908 core tests; deb, RPM, and pacman builds passed)
- feature-only build against signed upstream `26.903.71938` on amd64
- independent clean-diff review and upstream adapter smoke test

## Notes
- Live AT-SPI/Zotero interaction was not available; the regression uses a 237-node Zotero-like fixture.

Fixes #1454