### PR TITLE
HEROX-1442: Restore retryable pkexec authentication state

### DIFF
--- a/docs/updater.md
+++ b/docs/updater.md
@@ -42,7 +42,10 @@ immediately previous managed package remains the rollback target.
 
 Automated user-local operations cannot override the running-app guard or
 silently accept unverified input. A failed privileged installation remains
-failed until an explicit retry or a newer candidate.
+failed until an explicit retry or a newer candidate. If `pkexec` authentication
+is cancelled before package mutation, the candidate instead remains ready; the
+updater suppresses repeat prompts until an explicit retry or another app-exit
+cycle.
 
 Legacy schema state is treated as an incompatible pending candidate and reset;
 the installed package and recorded rollback artifact are preserved.

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -27,15 +27,14 @@ pub async fn run(cli: Cli) -> Result<()> {
     let config = RuntimeConfig::load_or_default(&paths)?;
     let mut state = PersistedState::load_or_default(&paths.state_file, config.auto_install_on_app_exit)?;
     state.installed_version = install::installed_package_version();
-    state.save_updater(&paths.state_file)?;
 
     match cli.command {
         Commands::Daemon => daemon(&config, &mut state, &paths).await,
         Commands::CheckNow => check(&config, &mut state, &paths).await,
         Commands::Status { json } => status(&state, json),
         Commands::Diagnose { json } => diagnose(&config, &state, &paths, json),
-        Commands::InstallReady => install_ready(&config, &mut state, &paths, true).await,
-        Commands::Rollback => rollback::run(&config, &mut state, &paths).await,
+        Commands::InstallReady => run_install_ready(&config, &mut state, &paths).await,
+        Commands::Rollback => run_rollback(&config, &mut state, &paths).await,
         Commands::InstallDeb { .. }
         | Commands::InstallRpm { .. }
         | Commands::InstallPacman { .. }
@@ -77,12 +76,85 @@ async fn daemon(config: &RuntimeConfig, state: &mut PersistedState, paths: &Runt
 
         tokio::select! {
             _ = checks.tick() => if let Err(error) = check(config, state, paths).await { error!(?error, "periodic update check failed"); },
-            _ = reconcile.tick() => if state.status == UpdateStatus::WaitingForAppExit && !liveness::is_app_running(config)? {
-                if let Err(error) = install_ready(config, state, paths, false).await { error!(?error, "deferred install failed"); }
+            _ = reconcile.tick() => if let Err(error) = reconcile_pending_install(config, state, paths).await {
+                error!(?error, "deferred install failed");
             },
             signal = tokio::signal::ctrl_c() => { signal?; break; }
         }
     }
+    Ok(())
+}
+
+async fn reconcile_pending_install(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    let _lock = match CheckLock::try_acquire(&paths.state_dir.join("check.lock"))? {
+        Some(lock) => lock,
+        None => return Ok(()),
+    };
+    reload_state(config, state, paths)?;
+    match state.status {
+        UpdateStatus::WaitingForAppExit if !liveness::is_app_running(config)? => {
+            install_ready_locked(config, state, paths, false).await?;
+        }
+        UpdateStatus::ReadyToInstall
+            if state.install_auth_retry_is_blocked()
+                && (config.auto_install_on_app_exit
+                    || state.install_after_app_exit_requested)
+                && liveness::is_app_running(config)? =>
+        {
+            state.clear_install_auth_retry_block();
+            state.status = UpdateStatus::WaitingForAppExit;
+            state.waiting_for_app_exit_auto_install =
+                !state.install_after_app_exit_requested && config.auto_install_on_app_exit;
+            state.save_updater(&paths.state_file)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+async fn run_install_ready(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    let _lock = loop {
+        match CheckLock::try_acquire(&paths.state_dir.join("check.lock"))? {
+            Some(lock) => break lock,
+            None => time::sleep(Duration::from_millis(50)).await,
+        }
+    };
+    reload_state(config, state, paths)?;
+    install_ready_locked(config, state, paths, true).await
+}
+
+async fn run_rollback(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    let _lock = loop {
+        match CheckLock::try_acquire(&paths.state_dir.join("check.lock"))? {
+            Some(lock) => break lock,
+            None => time::sleep(Duration::from_millis(50)).await,
+        }
+    };
+    reload_state(config, state, paths)?;
+    rollback::run(config, state, paths).await
+}
+
+fn reload_state(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    *state = PersistedState::load_or_default(
+        &paths.state_file,
+        config.auto_install_on_app_exit,
+    )?;
     Ok(())
 }
 
@@ -91,20 +163,21 @@ async fn check(config: &RuntimeConfig, state: &mut PersistedState, paths: &Runti
         Some(lock) => lock,
         None => { info!("another update check is active"); return Ok(()); }
     };
+    reload_state(config, state, paths)?;
+    recover_interrupted_check(state);
+    let previous_state = state.clone();
     let previous_status = state.status.clone();
-    let previous_candidate = state.candidate_version.clone();
     let previous_sha256 = state.upstream_package_sha256.clone();
     let previous_error = state.error_message.clone();
+    let previous_waiting_auto_install = state.waiting_for_app_exit_auto_install;
     state.installed_version = install::installed_package_version();
-    state.status = UpdateStatus::CheckingUpstream;
-    state.last_check_at = Some(Utc::now());
-    state.error_message = None;
+    mark_check_started(state);
     state.save_updater(&paths.state_file)?;
 
     let package_cache = paths.cache_dir.join("packages");
     let metadata = match upstream::resolve_metadata(&config.builder_bundle_root, &config.repository_url, &package_cache).await {
         Ok(value) => value,
-        Err(error) => return fail(state, paths, error),
+        Err(error) => return fail_check(state, paths, previous_state, error),
     };
     state.last_successful_check_at = Some(Utc::now());
     let _ = cache_cleanup::prune(&paths.cache_dir, state);
@@ -117,16 +190,16 @@ async fn check(config: &RuntimeConfig, state: &mut PersistedState, paths: &Runti
     if already_installed || same_failed_candidate {
         state.status = if same_failed_candidate { UpdateStatus::Failed } else { UpdateStatus::Idle };
         if same_failed_candidate { state.error_message = previous_error; }
+        if already_installed { state.clear_install_auth_retry_block(); }
         state.save_updater(&paths.state_file)?;
         return Ok(());
     }
 
-    if previous_candidate.as_deref() == Some(metadata.version.as_str())
-        && previous_sha256.as_deref() == Some(metadata.sha256.as_str())
-        && matches!(previous_status, UpdateStatus::ReadyToInstall | UpdateStatus::WaitingForAppExit)
-    {
+    if same_pending_candidate(&previous_state, &metadata.version, &metadata.sha256) {
         state.status = previous_status;
-        return install_ready(config, state, paths, false).await;
+        state.error_message = previous_error;
+        state.waiting_for_app_exit_auto_install = previous_waiting_auto_install;
+        return install_ready_locked(config, state, paths, false).await;
     }
 
     rollback::record_current_package_as_known_good(state);
@@ -134,6 +207,8 @@ async fn check(config: &RuntimeConfig, state: &mut PersistedState, paths: &Runti
     state.candidate_architecture = Some(metadata.architecture.clone());
     state.candidate_repository_path = Some(metadata.repository_path.clone());
     state.upstream_package_sha256 = Some(metadata.sha256.clone());
+    state.clear_install_auth_retry_block();
+    state.install_after_app_exit_requested = false;
     state.status = UpdateStatus::DownloadingPackage;
     state.save_updater(&paths.state_file)?;
 
@@ -154,10 +229,33 @@ async fn check(config: &RuntimeConfig, state: &mut PersistedState, paths: &Runti
     if config.notifications {
         let _ = notify::send("codex-desktop update ready", &format!("Version {} has been rebuilt from OpenAI's signed Linux package.", metadata.version));
     }
-    install_ready(config, state, paths, false).await
+    install_ready_locked(config, state, paths, false).await
 }
 
-async fn install_ready(
+fn mark_check_started(state: &mut PersistedState) {
+    if !state.install_auth_retry_is_blocked() {
+        state.status = UpdateStatus::CheckingUpstream;
+        state.error_message = None;
+    }
+    state.last_check_at = Some(Utc::now());
+}
+
+fn recover_interrupted_check(state: &mut PersistedState) {
+    if state.status == UpdateStatus::CheckingUpstream && state.install_auth_retry_is_blocked() {
+        state.status = UpdateStatus::ReadyToInstall;
+    }
+}
+
+fn same_pending_candidate(state: &PersistedState, version: &str, sha256: &str) -> bool {
+    state.candidate_version.as_deref() == Some(version)
+        && state.upstream_package_sha256.as_deref() == Some(sha256)
+        && matches!(
+            state.status,
+            UpdateStatus::ReadyToInstall | UpdateStatus::WaitingForAppExit
+        )
+}
+
+async fn install_ready_locked(
     config: &RuntimeConfig,
     state: &mut PersistedState,
     paths: &RuntimePaths,
@@ -172,19 +270,46 @@ async fn install_ready(
     }
     let package = state.artifact_paths.package_path.clone().context("ready state has no package")?;
     anyhow::ensure!(package.is_file(), "rebuilt package is missing: {}", package.display());
+    let auth_retry_blocked = state.install_auth_retry_is_blocked();
+    let install_after_app_exit_requested = state.install_after_app_exit_requested;
     if liveness::is_app_running(config)? {
+        if !explicit_retry
+            && !install_after_app_exit_requested
+            && !config.auto_install_on_app_exit
+        {
+            state.status = UpdateStatus::ReadyToInstall;
+            state.waiting_for_app_exit_auto_install = false;
+            state.save_updater(&paths.state_file)?;
+            return Ok(());
+        }
+        state.clear_install_auth_retry_block();
         state.status = UpdateStatus::WaitingForAppExit;
-        state.waiting_for_app_exit_auto_install = config.auto_install_on_app_exit;
+        state.install_after_app_exit_requested =
+            explicit_retry || install_after_app_exit_requested;
+        state.waiting_for_app_exit_auto_install =
+            !state.install_after_app_exit_requested && config.auto_install_on_app_exit;
         state.save_updater(&paths.state_file)?;
         println!("Update is ready; close ChatGPT Community to install it.");
         return Ok(());
     }
-    if !explicit_retry && !config.auto_install_on_app_exit {
+    if !explicit_retry && auth_retry_blocked {
+        state.status = UpdateStatus::ReadyToInstall;
+        state.waiting_for_app_exit_auto_install = false;
+        state.save_updater(&paths.state_file)?;
+        return Ok(());
+    }
+    if !explicit_retry
+        && !install_after_app_exit_requested
+        && !config.auto_install_on_app_exit
+    {
         state.status = UpdateStatus::ReadyToInstall;
         state.save_updater(&paths.state_file)?;
         return Ok(());
     }
 
+    let explicit_install = explicit_retry || install_after_app_exit_requested;
+    state.clear_install_auth_retry_block();
+    state.install_after_app_exit_requested = false;
     state.status = UpdateStatus::Installing;
     state.error_message = None;
     state.save_updater(&paths.state_file)?;
@@ -193,10 +318,24 @@ async fn install_ready(
         .output()
         .context("Failed to launch privileged package install")?;
     if !output.status.success() {
-        return fail(state, paths, anyhow::anyhow!(
-            "privileged install failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
+        let mut message = format!("privileged install exited with status {}", output.status);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        if !stderr.is_empty() {
+            message.push_str(": ");
+            message.push_str(stderr);
+        }
+        let error = anyhow::anyhow!(message);
+        if pkexec_authentication_was_not_obtained(&output.status) {
+            state.status = UpdateStatus::ReadyToInstall;
+            state.waiting_for_app_exit_auto_install = false;
+            state.error_message = Some(format!("{error:#}"));
+            state.block_install_auth_retry();
+            state.install_after_app_exit_requested = explicit_install;
+            state.save_updater(&paths.state_file)?;
+            return Err(error);
+        }
+        return fail(state, paths, error);
     }
 
     let installed_upstream_version = state.candidate_version.clone();
@@ -211,12 +350,36 @@ async fn install_ready(
     state.candidate_repository_path = None;
     state.waiting_for_app_exit_auto_install = false;
     state.error_message = None;
+    state.clear_install_auth_retry_block();
+    state.install_after_app_exit_requested = false;
     state.save_updater(&paths.state_file)?;
     let _ = cache_cleanup::prune(&paths.cache_dir, state);
     if config.notifications {
         let _ = notify::send("codex-desktop updated", &format!("Installed {}.", state.installed_version));
     }
     Ok(())
+}
+
+fn pkexec_authentication_was_not_obtained(status: &std::process::ExitStatus) -> bool {
+    matches!(status.code(), Some(126 | 127))
+}
+
+fn fail_check<T>(
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    mut previous_state: PersistedState,
+    error: anyhow::Error,
+) -> Result<T> {
+    if matches!(
+        previous_state.status,
+        UpdateStatus::ReadyToInstall | UpdateStatus::WaitingForAppExit
+    ) {
+        previous_state.last_check_at = state.last_check_at;
+        *state = previous_state;
+        state.save_updater(&paths.state_file)?;
+        return Err(error);
+    }
+    fail(state, paths, error)
 }
 
 fn fail<T>(state: &mut PersistedState, paths: &RuntimePaths, error: anyhow::Error) -> Result<T> {
@@ -270,3 +433,226 @@ impl CheckLock {
     }
 }
 impl Drop for CheckLock { fn drop(&mut self) { let _ = self.0.unlock(); } }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{os::unix::fs::PermissionsExt, path::PathBuf};
+
+    fn test_paths(root: &Path) -> RuntimePaths {
+        RuntimePaths {
+            config_file: root.join("config/config.toml"),
+            state_file: root.join("state/state.json"),
+            log_file: root.join("state/service.log"),
+            cache_dir: root.join("cache"),
+            state_dir: root.join("state"),
+            config_dir: root.join("config"),
+        }
+    }
+
+    fn ready_state(package: PathBuf) -> PersistedState {
+        let mut state = PersistedState::new(true);
+        state.candidate_version = Some("2026.09.10.120000".into());
+        state.upstream_package_sha256 = Some("candidate-sha256".into());
+        state.artifact_paths.package_path = Some(package);
+        state.status = UpdateStatus::ReadyToInstall;
+        state
+    }
+
+    fn write_fake_pkexec(root: &Path) -> Result<PathBuf> {
+        let path = root.join("pkexec");
+        fs::write(
+            &path,
+            "#!/bin/sh\nprintf x >> \"$CODEX_UPDATE_MANAGER_TEST_PKEXEC_COUNT\"\nexit \"$CODEX_UPDATE_MANAGER_TEST_PKEXEC_EXIT\"\n",
+        )?;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700))?;
+        Ok(path)
+    }
+
+    #[test]
+    fn pkexec_authentication_failures_are_retryable() -> Result<()> {
+        for code in [126, 127] {
+            let status = std::process::Command::new("/bin/sh")
+                .arg("-c")
+                .arg(format!("exit {code}"))
+                .status()?;
+            assert!(pkexec_authentication_was_not_obtained(&status));
+        }
+
+        let status = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg("exit 1")
+            .status()?;
+        assert!(!pkexec_authentication_was_not_obtained(&status));
+        Ok(())
+    }
+
+    #[test]
+    fn auth_cancel_retries_only_after_another_app_exit() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&[
+            "CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH",
+            "CODEX_UPDATE_MANAGER_TEST_PKEXEC_COUNT",
+            "CODEX_UPDATE_MANAGER_TEST_PKEXEC_EXIT",
+        ]);
+        let runtime = tokio::runtime::Runtime::new()?;
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let package = temp.path().join("codex-desktop.deb");
+        fs::write(&package, b"package")?;
+        let fake_pkexec = write_fake_pkexec(temp.path())?;
+        let invocation_count = temp.path().join("pkexec-count");
+        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", fake_pkexec);
+        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_PKEXEC_COUNT", &invocation_count);
+        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_PKEXEC_EXIT", "126");
+
+        let mut config = RuntimeConfig::default_with_paths(&paths);
+        config.auto_install_on_app_exit = false;
+        config.notifications = false;
+        config.app_executable_path = temp.path().join("not-running");
+        let mut state = ready_state(package);
+        let mut daemon_state = PersistedState::new(false);
+
+        let error = runtime
+            .block_on(install_ready_locked(&config, &mut state, &paths, true))
+            .expect_err("authentication cancellation should be reported");
+        assert!(error.to_string().contains("status exit status: 126"));
+        assert_eq!(state.status, UpdateStatus::ReadyToInstall);
+        assert!(state.install_auth_retry_is_blocked());
+        assert!(state.install_after_app_exit_requested);
+        assert_eq!(fs::read_to_string(&invocation_count)?, "x");
+
+        runtime.block_on(reconcile_pending_install(&config, &mut daemon_state, &paths))?;
+        state = daemon_state;
+        assert_eq!(state.status, UpdateStatus::ReadyToInstall);
+        assert!(state.install_auth_retry_is_blocked());
+        assert!(state.install_after_app_exit_requested);
+        assert_eq!(fs::read_to_string(&invocation_count)?, "x");
+
+        runtime
+            .block_on(install_ready_locked(&config, &mut state, &paths, true))
+            .expect_err("an explicit retry should bypass the authentication block");
+        assert_eq!(state.status, UpdateStatus::ReadyToInstall);
+        assert!(state.install_auth_retry_is_blocked());
+        assert!(state.install_after_app_exit_requested);
+        assert_eq!(fs::read_to_string(&invocation_count)?, "xx");
+
+        config.app_executable_path = std::env::current_exe()?;
+        runtime.block_on(reconcile_pending_install(&config, &mut state, &paths))?;
+        assert_eq!(state.status, UpdateStatus::WaitingForAppExit);
+        assert!(!state.install_auth_retry_is_blocked());
+        assert!(state.install_after_app_exit_requested);
+        assert_eq!(fs::read_to_string(&invocation_count)?, "xx");
+
+        runtime.block_on(install_ready_locked(&config, &mut state, &paths, false))?;
+        assert_eq!(state.status, UpdateStatus::WaitingForAppExit);
+        assert!(!state.waiting_for_app_exit_auto_install);
+        assert_eq!(fs::read_to_string(&invocation_count)?, "xx");
+
+        config.app_executable_path = temp.path().join("not-running");
+        runtime
+            .block_on(reconcile_pending_install(&config, &mut state, &paths))
+            .expect_err("the next app exit should permit one retry");
+        assert_eq!(state.status, UpdateStatus::ReadyToInstall);
+        assert!(state.install_auth_retry_is_blocked());
+        assert!(state.install_after_app_exit_requested);
+        assert_eq!(fs::read_to_string(&invocation_count)?, "xxx");
+        Ok(())
+    }
+
+    #[test]
+    fn non_authentication_install_failure_is_terminal() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&[
+            "CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH",
+            "CODEX_UPDATE_MANAGER_TEST_PKEXEC_COUNT",
+            "CODEX_UPDATE_MANAGER_TEST_PKEXEC_EXIT",
+        ]);
+        let runtime = tokio::runtime::Runtime::new()?;
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let package = temp.path().join("codex-desktop.deb");
+        fs::write(&package, b"package")?;
+        std::env::set_var(
+            "CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH",
+            write_fake_pkexec(temp.path())?,
+        );
+        std::env::set_var(
+            "CODEX_UPDATE_MANAGER_TEST_PKEXEC_COUNT",
+            temp.path().join("pkexec-count"),
+        );
+        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_PKEXEC_EXIT", "1");
+
+        let mut config = RuntimeConfig::default_with_paths(&paths);
+        config.notifications = false;
+        config.app_executable_path = temp.path().join("not-running");
+        let mut state = ready_state(package);
+
+        runtime
+            .block_on(install_ready_locked(&config, &mut state, &paths, true))
+            .expect_err("ordinary install failures should remain terminal");
+        assert_eq!(state.status, UpdateStatus::Failed);
+        assert!(!state.install_auth_retry_is_blocked());
+        assert!(!state.install_after_app_exit_requested);
+        Ok(())
+    }
+
+    #[test]
+    fn failed_check_preserves_pending_auth_retry_state() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let package = temp.path().join("codex-desktop.deb");
+        fs::write(&package, b"package")?;
+
+        let mut previous = ready_state(package);
+        previous.error_message = Some("authentication was not obtained".into());
+        previous.block_install_auth_retry();
+        let mut checking = previous.clone();
+        checking.status = UpdateStatus::CheckingUpstream;
+        checking.last_check_at = Some(Utc::now());
+
+        fail_check::<()>(
+            &mut checking,
+            &paths,
+            previous,
+            anyhow::anyhow!("temporary repository failure"),
+        )
+        .expect_err("the check error should still be reported");
+
+        assert_eq!(checking.status, UpdateStatus::ReadyToInstall);
+        assert!(checking.install_auth_retry_is_blocked());
+        assert_eq!(
+            checking.error_message.as_deref(),
+            Some("authentication was not obtained")
+        );
+        assert!(checking.last_check_at.is_some());
+        let loaded = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert!(loaded.install_auth_retry_is_blocked());
+        Ok(())
+    }
+
+    #[test]
+    fn interrupted_check_keeps_auth_retry_suppressed() {
+        let mut state = ready_state(Path::new("/tmp/codex-desktop.deb").to_path_buf());
+        state.block_install_auth_retry();
+        state.status = UpdateStatus::CheckingUpstream;
+        state.error_message = None;
+
+        recover_interrupted_check(&mut state);
+        let previous_status = state.status.clone();
+        mark_check_started(&mut state);
+
+        assert_eq!(previous_status, UpdateStatus::ReadyToInstall);
+        assert!(same_pending_candidate(
+            &state,
+            "2026.09.10.120000",
+            "candidate-sha256"
+        ));
+        assert_eq!(state.status, UpdateStatus::ReadyToInstall);
+        assert!(state.install_auth_retry_is_blocked());
+        assert!(state.last_check_at.is_some());
+    }
+}

--- a/updater/src/state.rs
+++ b/updater/src/state.rs
@@ -56,6 +56,8 @@ pub struct PersistedState {
     pub last_known_good_upstream_sha256: Option<String>,
     pub rollback_blocked_candidate_version: Option<String>,
     pub rollback_blocked_package_sha256: Option<String>,
+    pub install_auth_blocked_package_sha256: Option<String>,
+    pub install_after_app_exit_requested: bool,
 }
 
 impl Default for PersistedState {
@@ -87,6 +89,8 @@ impl PersistedState {
             last_known_good_upstream_sha256: None,
             rollback_blocked_candidate_version: None,
             rollback_blocked_package_sha256: None,
+            install_auth_blocked_package_sha256: None,
+            install_after_app_exit_requested: false,
         }
     }
 
@@ -140,6 +144,21 @@ impl PersistedState {
         self.status = UpdateStatus::Failed;
         self.error_message = Some(message.into());
         self.waiting_for_app_exit_auto_install = false;
+        self.install_auth_blocked_package_sha256 = None;
+        self.install_after_app_exit_requested = false;
+    }
+
+    pub fn install_auth_retry_is_blocked(&self) -> bool {
+        self.upstream_package_sha256.is_some()
+            && self.install_auth_blocked_package_sha256 == self.upstream_package_sha256
+    }
+
+    pub fn block_install_auth_retry(&mut self) {
+        self.install_auth_blocked_package_sha256 = self.upstream_package_sha256.clone();
+    }
+
+    pub fn clear_install_auth_retry_block(&mut self) {
+        self.install_auth_blocked_package_sha256 = None;
     }
 
 }
@@ -164,6 +183,53 @@ mod tests {
         assert_eq!(state.candidate_version, None);
         assert_eq!(state.installed_version, "1.2.3");
         assert_eq!(state.artifact_paths.rollback_package_path, Some(PathBuf::from("/tmp/good.deb")));
+        Ok(())
+    }
+
+    #[test]
+    fn install_auth_retry_block_is_scoped_to_package_hash() {
+        let mut state = PersistedState::new(true);
+        state.upstream_package_sha256 = Some("candidate-a".into());
+
+        assert!(!state.install_auth_retry_is_blocked());
+        state.block_install_auth_retry();
+        assert!(state.install_auth_retry_is_blocked());
+
+        state.upstream_package_sha256 = Some("candidate-b".into());
+        assert!(!state.install_auth_retry_is_blocked());
+    }
+
+    #[test]
+    fn schema_v2_state_defaults_and_round_trips_install_auth_retry_block() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state_path = dir.path().join("state.json");
+        fs::write(&state_path, r#"{"schema_version":2}"#)?;
+
+        let mut state = PersistedState::load_or_default(&state_path, true)?;
+        assert_eq!(state.install_auth_blocked_package_sha256, None);
+        assert!(!state.install_after_app_exit_requested);
+
+        state.upstream_package_sha256 = Some("candidate".into());
+        state.block_install_auth_retry();
+        state.save_updater(&state_path)?;
+        let loaded = PersistedState::load_or_default(&state_path, true)?;
+        assert!(loaded.install_auth_retry_is_blocked());
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_waiting_state_does_not_gain_explicit_install_consent() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state_path = dir.path().join("state.json");
+        fs::write(
+            &state_path,
+            r#"{"schema_version":2,"status":"waiting_for_app_exit","waiting_for_app_exit_auto_install":false}"#,
+        )?;
+
+        let state = PersistedState::load_or_default(&state_path, false)?;
+        assert_eq!(state.status, UpdateStatus::WaitingForAppExit);
+        assert!(!state.waiting_for_app_exit_auto_install);
+        assert!(!state.install_after_app_exit_requested);
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- preserve ready candidates when pkexec authentication is cancelled
- suppress automatic repeat prompts until an explicit retry or the next app-exit cycle
- serialize updater state transitions and recover interrupted checks without losing retry state
- document the retry behavior and add regression coverage

## Tests/checks
- `cargo test -p codex-update-manager` (73 passed)
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `bash tests/scripts_smoke.sh` (71 passed)
- `git diff --check`

## Notes / risks
- State schema remains version 2; new fields use serde defaults for backward compatibility.
- Exit codes other than pkexec 126/127 remain terminal install failures.

Fixes #1442