### PR TITLE
Fix configurable Default presets in local tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ linux-features/local/
 .idea/
 .claude/
 .codex/
+.agents/skills/
 
 # graphify
 graphify-out/

--- a/linux-features/model-picker-default-presets/README.md
+++ b/linux-features/model-picker-default-presets/README.md
@@ -58,8 +58,9 @@ make install-native
 One available pair makes **Default** a fixed selection. Two or more available
 pairs display the slider. The feature never truncates the configured list.
 The configured list replaces the upstream **Default** slider in both local
-repository tasks and cloud/TPP chats; selecting a model explicitly still uses
-the normal upstream effort choices for that model.
+repository tasks and cloud/TPP chats. Those surfaces use separate upstream
+catalog and slider-config paths, and the feature patches both; selecting a
+model explicitly still uses the normal upstream effort choices for that model.
 
 ## Runtime fallback
 
@@ -75,6 +76,11 @@ policy and its Ultra/XHigh visibility gates:
 
 Selecting **Default** again and creating a new chat both use the resolved
 default pair. Manual model selection remains upstream-owned.
+
+For an unsent local draft, selecting a configured pair is kept in draft state
+instead of being persisted as the account's upstream default. This lets the
+new conversation start with configured combinations that the server accepts
+for a conversation but does not expose as persistable default presets.
 
 ## Updates
 

--- a/linux-features/model-picker-default-presets/README.md
+++ b/linux-features/model-picker-default-presets/README.md
@@ -2,9 +2,9 @@
 
 This opt-in feature replaces the server-provided **Default** model-picker slider
 for ChatGPT-authenticated chats with an ordered list of model and reasoning
-effort pairs. It does not change the manual model list, API-key or Copilot
-sessions, account entitlements, workspace policy, or upstream Ultra/XHigh
-gates.
+effort pairs. It does not change the manual model list, API-key, Copilot, or
+Aeon-managed sessions, account entitlements, workspace policy, or upstream
+Ultra/XHigh gates.
 
 The stock Settings page controls which reasoning efforts are visible and
 whether Ultra may appear in the picker. It does not currently configure the

--- a/linux-features/model-picker-default-presets/patch.js
+++ b/linux-features/model-picker-default-presets/patch.js
@@ -478,12 +478,24 @@ function localComposerResolverSection(source) {
 }
 
 function localComposerSection(source) {
-  return uniqueFunctionWithMarkers(source, [
+  const prefix = uniqueFunctionWithMarkers(source, [
     "sliderModelsConfig:",
     "modelsForPicker(",
     "setDefaultModelAndReasoningEffort:",
     "composer.mode.local.model.custom",
   ]);
+  if (prefix == null) return null;
+  const terminalMarker = source.indexOf("onSelectDefault:", prefix.start);
+  if (terminalMarker < 0) return null;
+  const nextFunction = /function [A-Za-z_$][\w$]*\(/g;
+  nextFunction.lastIndex = terminalMarker;
+  const next = nextFunction.exec(source);
+  if (next == null) return null;
+  return {
+    end: next.index,
+    source: source.slice(prefix.start, next.index),
+    start: prefix.start,
+  };
 }
 
 function localComposerResolverContract(source) {
@@ -491,18 +503,27 @@ function localComposerResolverContract(source) {
   const section = localComposerResolverSection(source);
   if (markerCount === 0) {
     if (section == null) return "drifted";
-    const matches = [
-      ...section.source.matchAll(
-        /if\(([A-Za-z_$][\w$]*)\.length>=3\)return \1/gu,
+    const configParameter = /sliderModelsConfig:([A-Za-z_$][\w$]*)/.exec(
+      section.source,
+    )?.[1];
+    if (configParameter == null) return "drifted";
+    const thresholds =
+      section.source.match(/if\(([A-Za-z_$][\w$]*)\.length>=3\)return \1/gu) ?? [];
+    const configLoopThresholds = section.source.match(
+      new RegExp(
+        `for\\(let [A-Za-z_$][\\w$]* of ${configParameter}\\.presets\\)\\{[\\s\\S]{0,2000}?if\\(([A-Za-z_$][\\w$]*)\\.length>=3\\)return \\1`,
+        "gu",
       ),
-    ];
-    return matches.length === 2 ? "current" : "drifted";
+    );
+    return thresholds.length === 2 && configLoopThresholds?.length === 1
+      ? "current"
+      : "drifted";
   }
   if (
     markerCount === 1 &&
     section != null &&
     section.source.includes(`/*${LOCAL_COMPOSER_RESOLVER_MARKER}*/`) &&
-    section.source.includes("codexLinuxIsConfiguredDefaultPresets?1:3")
+    (section.source.match(/codexLinuxIsConfiguredDefaultPresets\?1:3/g) ?? []).length === 1
   ) {
     return "applied";
   }
@@ -532,8 +553,11 @@ function applyLocalComposerResolverPatch(source, context = {}) {
     `let codexLinuxIsConfiguredDefaultPresets=${configParameter}?.codexLinuxDefaultPresets===!0/*${LOCAL_COMPOSER_RESOLVER_MARKER}*/;$1`,
   );
   patchedSection = patchedSection.replace(
-    /if\(([A-Za-z_$][\w$]*)\.length>=3\)return \1/u,
-    "if($1.length>=(codexLinuxIsConfiguredDefaultPresets?1:3))return $1",
+    new RegExp(
+      `(for\\(let [A-Za-z_$][\\w$]* of ${configParameter}\\.presets\\)\\{[\\s\\S]{0,2000}?)if\\(([A-Za-z_$][\\w$]*)\\.length>=3\\)return \\2`,
+      "u",
+    ),
+    "$1if($2.length>=(codexLinuxIsConfiguredDefaultPresets?1:3))return $2",
   );
   const patchedSource =
     source.slice(0, section.start) + patchedSection + source.slice(section.end);
@@ -586,7 +610,7 @@ function localComposerConfigContract(source) {
   if (markerCount === 0 && draftMarkerCount === 0) {
     if (section == null) return "drifted";
     const configMatches = section.source.match(/sliderModelsConfig:[A-Za-z_$][\w$]*/g) ?? [];
-    const fallbackMatches = source.match(LOCAL_COMPOSER_FALLBACK_PATTERN) ?? [];
+    const fallbackMatches = section.source.match(LOCAL_COMPOSER_FALLBACK_PATTERN) ?? [];
     const selectionMatches =
       section.source.match(
         /[A-Za-z_$][\w$]*\?\.selectModelAndReasoningEffort\?\?[A-Za-z_$][\w$]*/g,
@@ -607,7 +631,7 @@ function localComposerConfigContract(source) {
     draftMarkerCount === 1 &&
     section != null &&
     section.source.includes(":codexLinuxLocalDefaultPresetConfig") &&
-    (source.match(/codexLinuxLocalDefaultPresetFallback\(/g) ?? []).length === 3 &&
+    (section.source.match(/codexLinuxLocalDefaultPresetFallback\(/g) ?? []).length === 2 &&
     (section.source.match(/codexLinuxLocalDefaultPresetSelection\(/g) ?? []).length === 1 &&
     section.source.includes(`/*${LOCAL_DRAFT_SELECTION_MARKER}*/`)
   ) {
@@ -630,7 +654,7 @@ function applyLocalComposerConfigPatch(source, context = {}) {
   }
   const section = localComposerSection(source);
   const configMatch = /sliderModelsConfig:([A-Za-z_$][\w$]*)/u.exec(section.source);
-  const fallbackMatches = [...source.matchAll(LOCAL_COMPOSER_FALLBACK_PATTERN)];
+  const fallbackMatches = [...section.source.matchAll(LOCAL_COMPOSER_FALLBACK_PATTERN)];
   const selectionMatch =
     /([A-Za-z_$][\w$]*)\?\.selectModelAndReasoningEffort\?\?([A-Za-z_$][\w$]*)/u.exec(
       section.source,
@@ -670,7 +694,7 @@ function applyLocalComposerConfigPatch(source, context = {}) {
     `codexLinuxLocalDraftDefaultScope=${conversationVariable}==null?JSON.stringify([${hostVariable}.hostId,${hostVariable}.cwd]):null,` +
     `codexLinuxLocalDraftDefaultSelection=${configVariable}==null?null:codexLinuxLocalDefaultPresetSelection(${defaultSelectionsVariable}),` +
     `codexLinuxLocalDraftSelect=(codexLinuxModel,codexLinuxEffort,codexLinuxCallback)=>(${draftSelectionVariable}?.selectModelAndReasoningEffort??((codexLinuxFallbackModel,codexLinuxFallbackEffort,codexLinuxFallbackCallback)=>${baseSelectionVariable}(codexLinuxFallbackModel,codexLinuxFallbackEffort,codexLinuxFallbackCallback,${configVariable}!=null&&codexLinuxLocalDefaultPresetIds.has(\`${"${codexLinuxFallbackModel}:${codexLinuxFallbackEffort}"}\`)?{persistAsDefault:!1}:void 0)))(codexLinuxModel,codexLinuxEffort,codexLinuxCallback);` +
-    `(0,${reactAlias}.useEffect)(()=>{codexLinuxLocalDraftDefaultScope==null||codexLinuxLocalDraftDefaultSelection==null||codexLinuxLocalDraftDefaultRef.current===codexLinuxLocalDraftDefaultScope||(codexLinuxLocalDraftDefaultRef.current=codexLinuxLocalDraftDefaultScope,codexLinuxLocalDraftSelect(codexLinuxLocalDraftDefaultSelection.model,codexLinuxLocalDraftDefaultSelection.reasoningEffort,()=>{}))},[codexLinuxLocalDraftDefaultScope,codexLinuxLocalDraftDefaultSelection?.id]);` +
+    `(0,${reactAlias}.useEffect)(()=>{if(codexLinuxLocalDraftDefaultScope==null){codexLinuxLocalDraftDefaultRef.current=null;return}codexLinuxLocalDraftDefaultSelection==null||codexLinuxLocalDraftDefaultRef.current===codexLinuxLocalDraftDefaultScope||(codexLinuxLocalDraftDefaultRef.current=codexLinuxLocalDraftDefaultScope,codexLinuxLocalDraftSelect(codexLinuxLocalDraftDefaultSelection.model,codexLinuxLocalDraftDefaultSelection.reasoningEffort,()=>{}))},[codexLinuxLocalDraftDefaultScope,codexLinuxLocalDraftDefaultSelection?.id]);` +
     `let ${selectHandlerVariable}=function`;
   patchedSection = patchedSection.replace(
     selectionDeclaration,
@@ -680,15 +704,15 @@ function applyLocalComposerConfigPatch(source, context = {}) {
         .replace(`return(${selectionExpression})`, "codexLinuxLocalDraftDefaultRef.current=codexLinuxLocalDraftDefaultScope;return codexLinuxLocalDraftSelect") +
       `/*${LOCAL_DRAFT_SELECTION_MARKER}*/`,
   );
-  let patchedSource =
+  patchedSection = patchedSection.replace(
+    LOCAL_COMPOSER_FALLBACK_PATTERN,
+    `$1=$2($3,codexLinuxLocalDefaultPresetFallback(${configVariable}!=null,$3,$4==null?void 0:\`${"${$4.model}:${$4.defaultReasoningEffort}"}\`))`,
+  );
+  const patchedSource =
     source.slice(0, section.start) +
     localComposerRuntime(localComposerConfig(presets)) +
     patchedSection +
     source.slice(section.end);
-  patchedSource = patchedSource.replace(
-    LOCAL_COMPOSER_FALLBACK_PATTERN,
-    `$1=$2($3,codexLinuxLocalDefaultPresetFallback(${configVariable}!=null,$3,$4==null?void 0:\`${"${$4.model}:${$4.defaultReasoningEffort}"}\`))`,
-  );
   if (localComposerConfigContract(patchedSource) !== "applied") {
     warn(
       "Could not apply the complete local composer model picker contract",

--- a/linux-features/model-picker-default-presets/patch.js
+++ b/linux-features/model-picker-default-presets/patch.js
@@ -20,6 +20,10 @@ const EFFORT_TO_THINKING_EFFORT = Object.freeze({
   max: "max",
   ultra: "ultra",
 });
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 const THINKING_EFFORT_TO_EFFORT = Object.freeze(
   Object.fromEntries(
     Object.entries(EFFORT_TO_THINKING_EFFORT).map(([effort, thinkingEffort]) => [
@@ -564,10 +568,11 @@ function localComposerRuntime(config) {
     `/*${LOCAL_COMPOSER_CONFIG_MARKER}*/` +
     `const codexLinuxLocalDefaultPresetConfig=${JSON.stringify(config)},` +
     "codexLinuxLocalDefaultPresetIds=new Set(codexLinuxLocalDefaultPresetConfig.codexLinuxDefaultPresetIds);" +
-    "function codexLinuxLocalDefaultPresetFallback(codexLinuxSelections,codexLinuxUpstreamDefault){" +
+    "function codexLinuxLocalDefaultPresetSelection(codexLinuxSelections){" +
     "let codexLinuxAvailable=codexLinuxSelections.filter(({id:codexLinuxId})=>codexLinuxLocalDefaultPresetIds.has(codexLinuxId));" +
-    "if(codexLinuxAvailable.length===0)return codexLinuxUpstreamDefault;" +
-    "return codexLinuxAvailable.find(({id:codexLinuxId})=>codexLinuxId===codexLinuxLocalDefaultPresetConfig.codexLinuxDefaultPresetId)?.id??codexLinuxAvailable[0].id}"
+    "return codexLinuxAvailable.find(({id:codexLinuxId})=>codexLinuxId===codexLinuxLocalDefaultPresetConfig.codexLinuxDefaultPresetId)??codexLinuxAvailable[0]??null}" +
+    "function codexLinuxLocalDefaultPresetFallback(codexLinuxEnabled,codexLinuxSelections,codexLinuxUpstreamDefault){" +
+    "return codexLinuxEnabled?codexLinuxLocalDefaultPresetSelection(codexLinuxSelections)?.id??codexLinuxUpstreamDefault:codexLinuxUpstreamDefault}"
   );
 }
 
@@ -586,9 +591,14 @@ function localComposerConfigContract(source) {
       section.source.match(
         /[A-Za-z_$][\w$]*\?\.selectModelAndReasoningEffort\?\?[A-Za-z_$][\w$]*/g,
       ) ?? [];
+    const resetContextMatches =
+      section.source.match(
+        /resetContextKey:JSON\.stringify\(\[[A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\.hostId,[A-Za-z_$][\w$]*\.cwd\]\)/g,
+      ) ?? [];
     return configMatches.length === 1 &&
       fallbackMatches.length === 2 &&
-      selectionMatches.length === 1
+      selectionMatches.length === 1 &&
+      resetContextMatches.length === 1
       ? "current"
       : "drifted";
   }
@@ -596,8 +606,9 @@ function localComposerConfigContract(source) {
     markerCount === 1 &&
     draftMarkerCount === 1 &&
     section != null &&
-    section.source.includes("sliderModelsConfig:codexLinuxLocalDefaultPresetConfig") &&
+    section.source.includes(":codexLinuxLocalDefaultPresetConfig") &&
     (source.match(/codexLinuxLocalDefaultPresetFallback\(/g) ?? []).length === 3 &&
+    (section.source.match(/codexLinuxLocalDefaultPresetSelection\(/g) ?? []).length === 1 &&
     section.source.includes(`/*${LOCAL_DRAFT_SELECTION_MARKER}*/`)
   ) {
     return "applied";
@@ -618,15 +629,56 @@ function applyLocalComposerConfigPatch(source, context = {}) {
     return source;
   }
   const section = localComposerSection(source);
+  const configMatch = /sliderModelsConfig:([A-Za-z_$][\w$]*)/u.exec(section.source);
+  const fallbackMatches = [...source.matchAll(LOCAL_COMPOSER_FALLBACK_PATTERN)];
+  const selectionMatch =
+    /([A-Za-z_$][\w$]*)\?\.selectModelAndReasoningEffort\?\?([A-Za-z_$][\w$]*)/u.exec(
+      section.source,
+    );
+  const resetContextMatch =
+    /resetContextKey:JSON\.stringify\(\[([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\.hostId,\2\.cwd\]\)/u.exec(
+      section.source,
+    );
+  const reactAlias = /\(0,([A-Za-z_$][\w$]*)\.useRef\)\(/u.exec(section.source)?.[1];
+  if (
+    configMatch == null ||
+    fallbackMatches.length !== 2 ||
+    selectionMatch == null ||
+    resetContextMatch == null ||
+    reactAlias == null
+  ) {
+    return source;
+  }
+  const configVariable = configMatch[1];
+  const defaultSelectionsVariable = fallbackMatches[1][3];
+  const [selectionExpression, draftSelectionVariable, baseSelectionVariable] = selectionMatch;
+  const [, conversationVariable, hostVariable] = resetContextMatch;
   let patchedSection = section.source.replace(
-    /sliderModelsConfig:[A-Za-z_$][\w$]*/u,
-    "sliderModelsConfig:codexLinuxLocalDefaultPresetConfig",
+    configMatch[0],
+    `sliderModelsConfig:${configVariable}==null?${configVariable}:codexLinuxLocalDefaultPresetConfig`,
   );
+  const selectionOffset = patchedSection.indexOf(selectionExpression);
+  const selectionDeclaration = new RegExp(
+    `,([A-Za-z_$][\\w$]*)=function\\(([A-Za-z_$][\\w$]*),([A-Za-z_$][\\w$]*)\\)\\{return\\(${escapeRegExp(selectionExpression)}\\)`,
+    "u",
+  );
+  const selectionDeclarationMatch = selectionDeclaration.exec(patchedSection);
+  if (selectionOffset < 0 || selectionDeclarationMatch == null) return source;
+  const [, selectHandlerVariable] = selectionDeclarationMatch;
+  const draftRuntime =
+    `;let codexLinuxLocalDraftDefaultRef=(0,${reactAlias}.useRef)(null),` +
+    `codexLinuxLocalDraftDefaultScope=${conversationVariable}==null?JSON.stringify([${hostVariable}.hostId,${hostVariable}.cwd]):null,` +
+    `codexLinuxLocalDraftDefaultSelection=${configVariable}==null?null:codexLinuxLocalDefaultPresetSelection(${defaultSelectionsVariable}),` +
+    `codexLinuxLocalDraftSelect=(codexLinuxModel,codexLinuxEffort,codexLinuxCallback)=>(${draftSelectionVariable}?.selectModelAndReasoningEffort??((codexLinuxFallbackModel,codexLinuxFallbackEffort,codexLinuxFallbackCallback)=>${baseSelectionVariable}(codexLinuxFallbackModel,codexLinuxFallbackEffort,codexLinuxFallbackCallback,${configVariable}!=null&&codexLinuxLocalDefaultPresetIds.has(\`${"${codexLinuxFallbackModel}:${codexLinuxFallbackEffort}"}\`)?{persistAsDefault:!1}:void 0)))(codexLinuxModel,codexLinuxEffort,codexLinuxCallback);` +
+    `(0,${reactAlias}.useEffect)(()=>{codexLinuxLocalDraftDefaultScope==null||codexLinuxLocalDraftDefaultSelection==null||codexLinuxLocalDraftDefaultRef.current===codexLinuxLocalDraftDefaultScope||(codexLinuxLocalDraftDefaultRef.current=codexLinuxLocalDraftDefaultScope,codexLinuxLocalDraftSelect(codexLinuxLocalDraftDefaultSelection.model,codexLinuxLocalDraftDefaultSelection.reasoningEffort,()=>{}))},[codexLinuxLocalDraftDefaultScope,codexLinuxLocalDraftDefaultSelection?.id]);` +
+    `let ${selectHandlerVariable}=function`;
   patchedSection = patchedSection.replace(
-    /([A-Za-z_$][\w$]*)\?\.selectModelAndReasoningEffort\?\?([A-Za-z_$][\w$]*)/u,
-    "($1?.selectModelAndReasoningEffort??((codexLinuxModel,codexLinuxEffort,codexLinuxCallback)=>$2(codexLinuxModel,codexLinuxEffort,codexLinuxCallback,codexLinuxLocalDefaultPresetIds.has(`${codexLinuxModel}:${codexLinuxEffort}`)?{persistAsDefault:!1}:void 0)))/*" +
-      LOCAL_DRAFT_SELECTION_MARKER +
-      "*/",
+    selectionDeclaration,
+    draftRuntime +
+      selectionDeclarationMatch[0]
+        .slice(selectionDeclarationMatch[0].indexOf("("))
+        .replace(`return(${selectionExpression})`, "codexLinuxLocalDraftDefaultRef.current=codexLinuxLocalDraftDefaultScope;return codexLinuxLocalDraftSelect") +
+      `/*${LOCAL_DRAFT_SELECTION_MARKER}*/`,
   );
   let patchedSource =
     source.slice(0, section.start) +
@@ -635,7 +687,7 @@ function applyLocalComposerConfigPatch(source, context = {}) {
     source.slice(section.end);
   patchedSource = patchedSource.replace(
     LOCAL_COMPOSER_FALLBACK_PATTERN,
-    "$1=$2($3,codexLinuxLocalDefaultPresetFallback($3,$4==null?void 0:`${$4.model}:${$4.defaultReasoningEffort}`))",
+    `$1=$2($3,codexLinuxLocalDefaultPresetFallback(${configVariable}!=null,$3,$4==null?void 0:\`${"${$4.model}:${$4.defaultReasoningEffort}"}\`))`,
   );
   if (localComposerConfigContract(patchedSource) !== "applied") {
     warn(

--- a/linux-features/model-picker-default-presets/patch.js
+++ b/linux-features/model-picker-default-presets/patch.js
@@ -531,7 +531,16 @@ function applyLocalComposerResolverPatch(source, context = {}) {
     /if\(([A-Za-z_$][\w$]*)\.length>=3\)return \1/u,
     "if($1.length>=(codexLinuxIsConfiguredDefaultPresets?1:3))return $1",
   );
-  return source.slice(0, section.start) + patchedSection + source.slice(section.end);
+  const patchedSource =
+    source.slice(0, section.start) + patchedSection + source.slice(section.end);
+  if (localComposerResolverContract(patchedSource) !== "applied") {
+    warn(
+      "Could not apply the complete local composer slider config resolver contract",
+      "model picker Default local composer resolver patch",
+    );
+    return source;
+  }
+  return patchedSource;
 }
 
 function localComposerConfig(presets) {
@@ -628,6 +637,13 @@ function applyLocalComposerConfigPatch(source, context = {}) {
     LOCAL_COMPOSER_FALLBACK_PATTERN,
     "$1=$2($3,codexLinuxLocalDefaultPresetFallback($3,$4==null?void 0:`${$4.model}:${$4.defaultReasoningEffort}`))",
   );
+  if (localComposerConfigContract(patchedSource) !== "applied") {
+    warn(
+      "Could not apply the complete local composer model picker contract",
+      "model picker Default local composer config patch",
+    );
+    return source;
+  }
   return patchedSource;
 }
 

--- a/linux-features/model-picker-default-presets/patch.js
+++ b/linux-features/model-picker-default-presets/patch.js
@@ -4,6 +4,12 @@ const CATALOG_PATCH_MARKER = "codexLinuxModelPickerDefaultPresets";
 const CATALOG_PRESET_OPTIONS_KEY = "codexLinuxDefaultPresetOptions";
 const SLIDER_PATCH_MARKER = "codex-linux-model-picker-default-presets-slider-minimum";
 const LOCAL_DEFAULT_PATCH_MARKER = "codex-linux-model-picker-default-presets-local-default";
+const LOCAL_COMPOSER_CONFIG_MARKER =
+  "codex-linux-model-picker-default-presets-local-composer-config";
+const LOCAL_COMPOSER_RESOLVER_MARKER =
+  "codex-linux-model-picker-default-presets-local-composer-resolver";
+const LOCAL_DRAFT_SELECTION_MARKER =
+  "codex-linux-model-picker-default-presets-local-draft-selection";
 const JS_ASSET_PATTERN = /\.js$/;
 const EFFORT_TO_THINKING_EFFORT = Object.freeze({
   none: "zero",
@@ -458,6 +464,173 @@ function applySliderMinimumPatch(source, context = {}) {
   return patchedSource;
 }
 
+function localComposerResolverSection(source) {
+  return uniqueFunctionWithMarkers(source, [
+    "sliderModelsConfig:",
+    "includeUltraInSlider:",
+    "stripGptPrefix:",
+    ".presets){",
+  ]);
+}
+
+function localComposerSection(source) {
+  return uniqueFunctionWithMarkers(source, [
+    "sliderModelsConfig:",
+    "modelsForPicker(",
+    "setDefaultModelAndReasoningEffort:",
+    "composer.mode.local.model.custom",
+  ]);
+}
+
+function localComposerResolverContract(source) {
+  const markerCount = source.split(LOCAL_COMPOSER_RESOLVER_MARKER).length - 1;
+  const section = localComposerResolverSection(source);
+  if (markerCount === 0) {
+    if (section == null) return "drifted";
+    const matches = [
+      ...section.source.matchAll(
+        /if\(([A-Za-z_$][\w$]*)\.length>=3\)return \1/gu,
+      ),
+    ];
+    return matches.length === 2 ? "current" : "drifted";
+  }
+  if (
+    markerCount === 1 &&
+    section != null &&
+    section.source.includes(`/*${LOCAL_COMPOSER_RESOLVER_MARKER}*/`) &&
+    section.source.includes("codexLinuxIsConfiguredDefaultPresets?1:3")
+  ) {
+    return "applied";
+  }
+  return "mixed";
+}
+
+function applyLocalComposerResolverPatch(source, context = {}) {
+  const presets = normalizePresets(context);
+  if (presets.length === 0) return source;
+  const contract = localComposerResolverContract(source);
+  if (contract === "applied") return source;
+  if (contract !== "current") {
+    warn(
+      "Could not find one coherent local composer slider config resolver contract",
+      "model picker Default local composer resolver patch",
+    );
+    return source;
+  }
+  const section = localComposerResolverSection(source);
+  const configParameter = /sliderModelsConfig:([A-Za-z_$][\w$]*)/.exec(section.source)?.[1];
+  if (configParameter == null) return source;
+  let patchedSection = section.source.replace(
+    new RegExp(
+      `(for\\(let [A-Za-z_$][\\w$]* of ${configParameter}\\.presets\\)\\{)`,
+      "u",
+    ),
+    `let codexLinuxIsConfiguredDefaultPresets=${configParameter}?.codexLinuxDefaultPresets===!0/*${LOCAL_COMPOSER_RESOLVER_MARKER}*/;$1`,
+  );
+  patchedSection = patchedSection.replace(
+    /if\(([A-Za-z_$][\w$]*)\.length>=3\)return \1/u,
+    "if($1.length>=(codexLinuxIsConfiguredDefaultPresets?1:3))return $1",
+  );
+  return source.slice(0, section.start) + patchedSection + source.slice(section.end);
+}
+
+function localComposerConfig(presets) {
+  const configured = presets.map(({ modelSlug, thinkingEffort }) => ({
+    model: modelSlug,
+    reasoning_effort: THINKING_EFFORT_TO_EFFORT[thinkingEffort],
+  }));
+  const selectedDefault = presets.find(({ isDefault }) => isDefault);
+  return {
+    codexLinuxDefaultPresets: true,
+    codexLinuxDefaultPresetIds: configured.map(
+      ({ model, reasoning_effort: effort }) => `${model}:${effort}`,
+    ),
+    codexLinuxDefaultPresetId: `${selectedDefault.modelSlug}:${THINKING_EFFORT_TO_EFFORT[selectedDefault.thinkingEffort]}`,
+    presets: [configured],
+  };
+}
+
+function localComposerRuntime(config) {
+  return (
+    `/*${LOCAL_COMPOSER_CONFIG_MARKER}*/` +
+    `const codexLinuxLocalDefaultPresetConfig=${JSON.stringify(config)},` +
+    "codexLinuxLocalDefaultPresetIds=new Set(codexLinuxLocalDefaultPresetConfig.codexLinuxDefaultPresetIds);" +
+    "function codexLinuxLocalDefaultPresetFallback(codexLinuxSelections,codexLinuxUpstreamDefault){" +
+    "let codexLinuxAvailable=codexLinuxSelections.filter(({id:codexLinuxId})=>codexLinuxLocalDefaultPresetIds.has(codexLinuxId));" +
+    "if(codexLinuxAvailable.length===0)return codexLinuxUpstreamDefault;" +
+    "return codexLinuxAvailable.find(({id:codexLinuxId})=>codexLinuxId===codexLinuxLocalDefaultPresetConfig.codexLinuxDefaultPresetId)?.id??codexLinuxAvailable[0].id}"
+  );
+}
+
+const LOCAL_COMPOSER_FALLBACK_PATTERN =
+  /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)==null\?void 0:`\$\{\4\.model\}:\$\{\4\.defaultReasoningEffort\}`\)/gu;
+
+function localComposerConfigContract(source) {
+  const markerCount = source.split(LOCAL_COMPOSER_CONFIG_MARKER).length - 1;
+  const draftMarkerCount = source.split(LOCAL_DRAFT_SELECTION_MARKER).length - 1;
+  const section = localComposerSection(source);
+  if (markerCount === 0 && draftMarkerCount === 0) {
+    if (section == null) return "drifted";
+    const configMatches = section.source.match(/sliderModelsConfig:[A-Za-z_$][\w$]*/g) ?? [];
+    const fallbackMatches = source.match(LOCAL_COMPOSER_FALLBACK_PATTERN) ?? [];
+    const selectionMatches =
+      section.source.match(
+        /[A-Za-z_$][\w$]*\?\.selectModelAndReasoningEffort\?\?[A-Za-z_$][\w$]*/g,
+      ) ?? [];
+    return configMatches.length === 1 &&
+      fallbackMatches.length === 2 &&
+      selectionMatches.length === 1
+      ? "current"
+      : "drifted";
+  }
+  if (
+    markerCount === 1 &&
+    draftMarkerCount === 1 &&
+    section != null &&
+    section.source.includes("sliderModelsConfig:codexLinuxLocalDefaultPresetConfig") &&
+    (source.match(/codexLinuxLocalDefaultPresetFallback\(/g) ?? []).length === 3 &&
+    section.source.includes(`/*${LOCAL_DRAFT_SELECTION_MARKER}*/`)
+  ) {
+    return "applied";
+  }
+  return "mixed";
+}
+
+function applyLocalComposerConfigPatch(source, context = {}) {
+  const presets = normalizePresets(context);
+  if (presets.length === 0) return source;
+  const contract = localComposerConfigContract(source);
+  if (contract === "applied") return source;
+  if (contract !== "current") {
+    warn(
+      "Could not find one coherent local composer model picker contract",
+      "model picker Default local composer config patch",
+    );
+    return source;
+  }
+  const section = localComposerSection(source);
+  let patchedSection = section.source.replace(
+    /sliderModelsConfig:[A-Za-z_$][\w$]*/u,
+    "sliderModelsConfig:codexLinuxLocalDefaultPresetConfig",
+  );
+  patchedSection = patchedSection.replace(
+    /([A-Za-z_$][\w$]*)\?\.selectModelAndReasoningEffort\?\?([A-Za-z_$][\w$]*)/u,
+    "($1?.selectModelAndReasoningEffort??((codexLinuxModel,codexLinuxEffort,codexLinuxCallback)=>$2(codexLinuxModel,codexLinuxEffort,codexLinuxCallback,codexLinuxLocalDefaultPresetIds.has(`${codexLinuxModel}:${codexLinuxEffort}`)?{persistAsDefault:!1}:void 0)))/*" +
+      LOCAL_DRAFT_SELECTION_MARKER +
+      "*/",
+  );
+  let patchedSource =
+    source.slice(0, section.start) +
+    localComposerRuntime(localComposerConfig(presets)) +
+    patchedSection +
+    source.slice(section.end);
+  patchedSource = patchedSource.replace(
+    LOCAL_COMPOSER_FALLBACK_PATTERN,
+    "$1=$2($3,codexLinuxLocalDefaultPresetFallback($3,$4==null?void 0:`${$4.model}:${$4.defaultReasoningEffort}`))",
+  );
+  return patchedSource;
+}
+
 function catalogAssetMatch(source) {
   return catalogPatchContract(source) !== "drifted";
 }
@@ -495,23 +668,55 @@ const descriptors = [
     skipDescription: "model picker Default slider minimum patch",
     apply: applySliderMinimumPatch,
   },
+  {
+    id: "model-picker-default-presets-local-composer-resolver",
+    phase: "webview-asset",
+    order: 20_800,
+    ciPolicy: "optional",
+    pattern: JS_ASSET_PATTERN,
+    enabled: (context = {}) => normalizePresets(context).length > 0,
+    assetMatch: (source) => localComposerResolverContract(source) !== "drifted",
+    missingDescription: "local composer slider config resolver bundle",
+    skipDescription: "model picker Default local composer resolver patch",
+    apply: applyLocalComposerResolverPatch,
+  },
+  {
+    id: "model-picker-default-presets-local-composer-config",
+    phase: "webview-asset",
+    order: 20_801,
+    ciPolicy: "optional",
+    pattern: JS_ASSET_PATTERN,
+    enabled: (context = {}) => normalizePresets(context).length > 0,
+    assetMatch: (source) => localComposerConfigContract(source) !== "drifted",
+    missingDescription: "local composer model picker bundle",
+    skipDescription: "model picker Default local composer config patch",
+    apply: applyLocalComposerConfigPatch,
+  },
 ];
 
 module.exports = {
   CATALOG_PATCH_MARKER,
   CATALOG_PRESET_OPTIONS_KEY,
   EFFORT_TO_THINKING_EFFORT,
+  LOCAL_COMPOSER_CONFIG_MARKER,
+  LOCAL_COMPOSER_RESOLVER_MARKER,
+  LOCAL_DRAFT_SELECTION_MARKER,
   LOCAL_DEFAULT_PATCH_MARKER,
   THINKING_EFFORT_TO_EFFORT,
   JS_ASSET_PATTERN,
   SLIDER_PATCH_MARKER,
   applyCatalogPatch,
+  applyLocalComposerConfigPatch,
+  applyLocalComposerResolverPatch,
   applySliderMinimumPatch,
   catalogAssetMatch,
   catalogPatchContract,
   codexLinuxModelPickerDefaultPresets,
   descriptors,
   normalizePresets,
+  localComposerConfig,
+  localComposerConfigContract,
+  localComposerResolverContract,
   sliderAssetMatch,
   sliderPatchContract,
 };

--- a/linux-features/model-picker-default-presets/test.js
+++ b/linux-features/model-picker-default-presets/test.js
@@ -15,13 +15,20 @@ const {
   CATALOG_PRESET_OPTIONS_KEY,
   EFFORT_TO_THINKING_EFFORT,
   LOCAL_DEFAULT_PATCH_MARKER,
+  LOCAL_COMPOSER_CONFIG_MARKER,
+  LOCAL_COMPOSER_RESOLVER_MARKER,
+  LOCAL_DRAFT_SELECTION_MARKER,
   SLIDER_PATCH_MARKER,
   applyCatalogPatch,
+  applyLocalComposerConfigPatch,
+  applyLocalComposerResolverPatch,
   applySliderMinimumPatch,
   catalogAssetMatch,
   catalogPatchContract,
   codexLinuxModelPickerDefaultPresets,
   normalizePresets,
+  localComposerConfigContract,
+  localComposerResolverContract,
   sliderAssetMatch,
   sliderPatchContract,
 } = require("./patch.js");
@@ -65,6 +72,30 @@ function sliderFixture(name = "Wkr") {
     "show_xhigh_in_simple_picker=true,canInitializePowerPicker=true;",
     "if(powerSelectionsWithXHigh.length>=3)return powerSelectionsWithXHigh;",
     "return fallbackPowerSelection.length>=3?fallbackPowerSelection:[]}",
+    "function Next(){}",
+  ].join("");
+}
+
+function localComposerResolverFixture(name = "LocalPower") {
+  return [
+    `function ${name}(e,{includeUltraInSlider:t=false,removeXHigh:n=false,sliderModelsConfig:r,stripGptPrefix:i=true}={}){`,
+    "if(r!=null){let a=MapModels(e,{stripGptPrefix:i});for(let o of r.presets){",
+    "let r=unique(resolve(o.filter(({reasoning_effort:e})=>(t||e!==`ultra`)&&(!n||e!==`xhigh`)),e,i),({id:e})=>e);",
+    "if(r.length>=3)return r}}let a=fallbackA(e);if(a.length>=3)return a;",
+    "let o=fallbackB(e);return o.length>=3?o:[]}",
+    "function Next(){}",
+  ].join("");
+}
+
+function localComposerFixture(name = "LocalComposer") {
+  return [
+    `function ${name}(available,serverConfig,upstreamDefault){`,
+    "modelsForPicker(available);let{setDefaultModelAndReasoningEffort:setDefault}=selection;",
+    "let He=available.find(Wqr),Ue=Power(available,{includeUltraInSlider:true,sliderModelsConfig:serverConfig,stripGptPrefix:true}),",
+    "Ge=Ue,Ke=zae(Ge,He==null?void 0:`${He.model}:${He.defaultReasoningEffort}`);",
+    "let choose=draft?.selectModelAndReasoningEffort??select,selected=choose(`gpt-5.6-sol`,`high`,()=>{});",
+    "composer.mode.local.model.custom;let reset=zae(Ue,He==null?void 0:`${He.model}:${He.defaultReasoningEffort}`);",
+    "return{powerSelections:Ue,fallback:Ke,reset,selected}}",
     "function Next(){}",
   ].join("");
 }
@@ -361,6 +392,93 @@ test("slider patch fails closed on drift, duplicate, and partial states", () => 
   }
 });
 
+test("local composer uses configured pairs and lowers only its config threshold", () => {
+  const presets = context([
+    { model: "gpt-5.6-sol", effort: "medium", default: true },
+    { model: "gpt-5.6-sol", effort: "high" },
+    { model: "gpt-6-astra", effort: "high" },
+  ]);
+  const resolverSource = localComposerResolverFixture();
+  assert.equal(localComposerResolverContract(resolverSource), "current");
+  const patchedResolver = applyLocalComposerResolverPatch(resolverSource, presets);
+  assert.equal(localComposerResolverContract(patchedResolver), "applied");
+  assert.equal(applyLocalComposerResolverPatch(patchedResolver, presets), patchedResolver);
+  assert.equal(
+    (patchedResolver.match(new RegExp(LOCAL_COMPOSER_RESOLVER_MARKER, "g")) ?? []).length,
+    1,
+  );
+
+  const composerSource = localComposerFixture();
+  assert.equal(localComposerConfigContract(composerSource), "current");
+  const patchedComposer = applyLocalComposerConfigPatch(composerSource, presets);
+  assert.equal(localComposerConfigContract(patchedComposer), "applied");
+  assert.equal(applyLocalComposerConfigPatch(patchedComposer, presets), patchedComposer);
+  assert.equal(
+    (patchedComposer.match(new RegExp(LOCAL_COMPOSER_CONFIG_MARKER, "g")) ?? []).length,
+    1,
+  );
+  assert.equal(
+    (patchedComposer.match(new RegExp(LOCAL_DRAFT_SELECTION_MARKER, "g")) ?? []).length,
+    1,
+  );
+  assert.match(patchedComposer, /gpt-5\.6-sol:medium/);
+  assert.match(patchedComposer, /sliderModelsConfig:codexLinuxLocalDefaultPresetConfig/);
+  const globals = {
+    composer: { mode: { local: { model: { custom: null } } } },
+    draft: null,
+    modelsForPicker() {},
+    selection: { setDefaultModelAndReasoningEffort() {} },
+    Wqr: ({ isDefault }) => isDefault === true,
+    zae: (selections, id) => selections.find((selection) => selection.id === id) ?? selections[0],
+    Power: (available, { sliderModelsConfig }) => {
+      const availableIds = new Set(available.map(({ id }) => id));
+      const configured = sliderModelsConfig.presets[0].flatMap(({ model, reasoning_effort }) => {
+        const id = `${model}:${reasoning_effort}`;
+        return availableIds.has(id) ? [{ id, model, reasoningEffort: reasoning_effort }] : [];
+      });
+      return configured.length > 0 ? configured : available;
+    },
+    select: (_model, _effort, _callback, options) => options ?? null,
+  };
+  const unavailableDefault = plain(
+    evaluate(
+      patchedComposer,
+      "LocalComposer([{id:'gpt-5.6-sol:high',model:'gpt-5.6-sol',reasoningEffort:'high'},{id:'upstream:medium',model:'upstream',defaultReasoningEffort:'medium',isDefault:true}],null,null)",
+      { ...globals },
+    ),
+  );
+  assert.equal(unavailableDefault.fallback.id, "gpt-5.6-sol:high");
+  assert.equal(unavailableDefault.reset.id, "gpt-5.6-sol:high");
+  assert.equal(unavailableDefault.selected.persistAsDefault, false);
+  const completeFallback = plain(
+    evaluate(
+      patchedComposer,
+      "LocalComposer([{id:'upstream:medium',model:'upstream',reasoningEffort:'medium',defaultReasoningEffort:'medium',isDefault:true}],null,null)",
+      { ...globals },
+    ),
+  );
+  assert.equal(completeFallback.fallback.id, "upstream:medium");
+  assert.equal(completeFallback.reset.id, "upstream:medium");
+});
+
+test("local composer patches fail closed on drift, duplicate, and partial states", () => {
+  const presets = context([{ model: "gpt-5.6-sol", effort: "medium", default: true }]);
+  for (const [apply, fixture, marker] of [
+    [applyLocalComposerResolverPatch, localComposerResolverFixture, LOCAL_COMPOSER_RESOLVER_MARKER],
+    [applyLocalComposerConfigPatch, localComposerFixture, LOCAL_COMPOSER_CONFIG_MARKER],
+  ]) {
+    for (const source of [
+      "function unrelated(){}",
+      fixture("One") + fixture("Two"),
+      `${marker};${fixture()}`,
+    ]) {
+      const { result, warnings } = withCapturedWarnings(() => apply(source, presets));
+      assert.equal(result, source);
+      assert.equal(warnings.length, 1);
+    }
+  }
+});
+
 test("empty manifest is a runtime passthrough used for compatibility auditing", () => {
   const passthrough = { feature: { manifest: { presets: [] }, settings: {} } };
   const patchedCatalog = applyCatalogPatch(catalogFixture(), passthrough);
@@ -407,7 +525,7 @@ test("feature descriptors load alone and alongside ui-tweaks", () => {
       featuresRoot: root,
       featuresConfigPath: configPath,
     });
-    assert.equal(alone.length, 2);
+    assert.equal(alone.length, 4);
     assert.ok(alone.every(({ featureId }) => featureId === "model-picker-default-presets"));
     writeConfig(["model-picker-default-presets", "ui-tweaks"]);
     const together = loadLinuxFeaturePatchDescriptors({

--- a/linux-features/model-picker-default-presets/test.js
+++ b/linux-features/model-picker-default-presets/test.js
@@ -407,6 +407,37 @@ test("local composer uses configured pairs and lowers only its config threshold"
     (patchedResolver.match(new RegExp(LOCAL_COMPOSER_RESOLVER_MARKER, "g")) ?? []).length,
     1,
   );
+  const resolverGlobals = {
+    fallbackA: () => [],
+    fallbackB: () => [],
+    MapModels: (models) => models,
+    resolve: (entries) => entries.map(({ model, reasoning_effort: reasoningEffort }) => ({
+      id: `${model}:${reasoningEffort}`,
+      model,
+      reasoningEffort,
+    })),
+    unique: (entries) => entries,
+  };
+  const onePairConfig = {
+    codexLinuxDefaultPresets: true,
+    presets: [[{ model: "gpt-5.6-sol", reasoning_effort: "high" }]],
+  };
+  assert.equal(
+    evaluate(
+      patchedResolver,
+      "LocalPower([],{sliderModelsConfig:config}).length",
+      { ...resolverGlobals, config: onePairConfig },
+    ),
+    1,
+  );
+  assert.equal(
+    evaluate(
+      patchedResolver,
+      "LocalPower([],{sliderModelsConfig:config}).length",
+      { ...resolverGlobals, config: { presets: onePairConfig.presets } },
+    ),
+    0,
+  );
 
   const composerSource = localComposerFixture();
   assert.equal(localComposerConfigContract(composerSource), "current");

--- a/linux-features/model-picker-default-presets/test.js
+++ b/linux-features/model-picker-default-presets/test.js
@@ -98,6 +98,7 @@ function localComposerFixture(name = "LocalComposer") {
     "let selected=manualSelection?choose(`gpt-5.6-sol`,`high`):null;",
     "picker({resetContextKey:JSON.stringify([conversationId,host.hostId,host.cwd])});",
     "composer.mode.local.model.custom;let reset=zae(Ue,He==null?void 0:`${He.model}:${He.defaultReasoningEffort}`);",
+    "render({onSelectDefault:reset});",
     "return{powerSelections:Ue,fallback:Ke,reset,selected}}",
     "function Next(){}",
   ].join("");
@@ -463,18 +464,22 @@ test("local composer uses configured pairs and lowers only its config threshold"
   const runComposer = ({
     available,
     conversationId = null,
+    hookState = { refs: [] },
     serverConfig = {},
     manualSelection = false,
   }) => {
     const effects = [];
     const selections = [];
+    let refIndex = 0;
     const globals = {
       React: {
         useEffect(effect) {
           effects.push(effect);
         },
         useRef(value) {
-          return { current: value };
+          const index = refIndex++;
+          hookState.refs[index] ??= { current: value };
+          return hookState.refs[index];
         },
       },
       available,
@@ -484,6 +489,7 @@ test("local composer uses configured pairs and lowers only its config threshold"
       manualSelection,
       modelsForPicker() {},
       picker() {},
+      render() {},
       selection: { setDefaultModelAndReasoningEffort() {} },
       serverConfig,
       Wqr: ({ isDefault }) => isDefault === true,
@@ -596,6 +602,21 @@ test("local composer uses configured pairs and lowers only its config threshold"
   });
   assert.deepEqual(existingConversation.selections, []);
 
+  const lifecycleHooks = { refs: [] };
+  const lifecycleAvailable = [
+    { id: "gpt-5.6-sol:medium", model: "gpt-5.6-sol", reasoningEffort: "medium" },
+  ];
+  const firstDraft = runComposer({ available: lifecycleAvailable, hookState: lifecycleHooks });
+  const createdConversation = runComposer({
+    available: lifecycleAvailable,
+    conversationId: "created",
+    hookState: lifecycleHooks,
+  });
+  const nextDraft = runComposer({ available: lifecycleAvailable, hookState: lifecycleHooks });
+  assert.equal(firstDraft.selections.length, 1);
+  assert.equal(createdConversation.selections.length, 0);
+  assert.equal(nextDraft.selections.length, 1);
+
   const manuallySelected = runComposer({
     available: [
       { id: "gpt-5.6-sol:medium", model: "gpt-5.6-sol", reasoningEffort: "medium" },
@@ -629,6 +650,19 @@ test("local composer patches fail closed on drift, duplicate, and partial states
       assert.equal(warnings.length, 1);
     }
   }
+
+  const driftedComposer = localComposerFixture().replace(
+    /let reset=zae\([^;]+;/u,
+    "let reset=null;",
+  );
+  const decoy =
+    "function Decoy(y,z){let x=zae(y,z==null?void 0:`${z.model}:${z.defaultReasoningEffort}`);return x}";
+  const driftedWithDecoy = driftedComposer + decoy;
+  const { result, warnings } = withCapturedWarnings(() =>
+    applyLocalComposerConfigPatch(driftedWithDecoy, presets),
+  );
+  assert.equal(result, driftedWithDecoy);
+  assert.equal(warnings.length, 1);
 });
 
 test("empty manifest is a runtime passthrough used for compatibility auditing", () => {

--- a/linux-features/model-picker-default-presets/test.js
+++ b/linux-features/model-picker-default-presets/test.js
@@ -89,11 +89,14 @@ function localComposerResolverFixture(name = "LocalPower") {
 
 function localComposerFixture(name = "LocalComposer") {
   return [
-    `function ${name}(available,serverConfig,upstreamDefault){`,
+    `function ${name}(available,serverConfig,conversationId,manualSelection){`,
+    "let host={hostId:`local`,cwd:`/repo`};",
     "modelsForPicker(available);let{setDefaultModelAndReasoningEffort:setDefault}=selection;",
     "let He=available.find(Wqr),Ue=Power(available,{includeUltraInSlider:true,sliderModelsConfig:serverConfig,stripGptPrefix:true}),",
     "Ge=Ue,Ke=zae(Ge,He==null?void 0:`${He.model}:${He.defaultReasoningEffort}`);",
-    "let choose=draft?.selectModelAndReasoningEffort??select,selected=choose(`gpt-5.6-sol`,`high`,()=>{});",
+    "let scratch=(0,React.useRef)(null),choose=function(e,t){return(draft?.selectModelAndReasoningEffort??select)(e,t,()=>{})};",
+    "let selected=manualSelection?choose(`gpt-5.6-sol`,`high`):null;",
+    "picker({resetContextKey:JSON.stringify([conversationId,host.hostId,host.cwd])});",
     "composer.mode.local.model.custom;let reset=zae(Ue,He==null?void 0:`${He.model}:${He.defaultReasoningEffort}`);",
     "return{powerSelections:Ue,fallback:Ke,reset,selected}}",
     "function Next(){}",
@@ -453,43 +456,161 @@ test("local composer uses configured pairs and lowers only its config threshold"
     1,
   );
   assert.match(patchedComposer, /gpt-5\.6-sol:medium/);
-  assert.match(patchedComposer, /sliderModelsConfig:codexLinuxLocalDefaultPresetConfig/);
-  const globals = {
-    composer: { mode: { local: { model: { custom: null } } } },
-    draft: null,
-    modelsForPicker() {},
-    selection: { setDefaultModelAndReasoningEffort() {} },
-    Wqr: ({ isDefault }) => isDefault === true,
-    zae: (selections, id) => selections.find((selection) => selection.id === id) ?? selections[0],
-    Power: (available, { sliderModelsConfig }) => {
-      const availableIds = new Set(available.map(({ id }) => id));
-      const configured = sliderModelsConfig.presets[0].flatMap(({ model, reasoning_effort }) => {
-        const id = `${model}:${reasoning_effort}`;
-        return availableIds.has(id) ? [{ id, model, reasoningEffort: reasoning_effort }] : [];
-      });
-      return configured.length > 0 ? configured : available;
-    },
-    select: (_model, _effort, _callback, options) => options ?? null,
+  assert.match(
+    patchedComposer,
+    /sliderModelsConfig:serverConfig==null\?serverConfig:codexLinuxLocalDefaultPresetConfig/,
+  );
+  const runComposer = ({
+    available,
+    conversationId = null,
+    serverConfig = {},
+    manualSelection = false,
+  }) => {
+    const effects = [];
+    const selections = [];
+    const globals = {
+      React: {
+        useEffect(effect) {
+          effects.push(effect);
+        },
+        useRef(value) {
+          return { current: value };
+        },
+      },
+      available,
+      composer: { mode: { local: { model: { custom: null } } } },
+      conversationId,
+      draft: null,
+      manualSelection,
+      modelsForPicker() {},
+      picker() {},
+      selection: { setDefaultModelAndReasoningEffort() {} },
+      serverConfig,
+      Wqr: ({ isDefault }) => isDefault === true,
+      zae: (selections, id) =>
+        selections.find((selection) => selection.id === id) ?? selections[0],
+      Power: (models, { sliderModelsConfig }) => {
+        if (sliderModelsConfig == null) return models;
+        const availableIds = new Set(models.map(({ id }) => id));
+        const configured = sliderModelsConfig.presets[0].flatMap(
+          ({ model, reasoning_effort: effort }) => {
+            const id = `${model}:${effort}`;
+            return availableIds.has(id) ? [{ id, model, reasoningEffort: effort }] : [];
+          },
+        );
+        return configured.length > 0 ? configured : models;
+      },
+      select: (model, effort, _callback, options) => {
+        selections.push({ effort, model, options });
+        return options ?? null;
+      },
+    };
+    const result = plain(
+      evaluate(
+        patchedComposer,
+        "LocalComposer(available,serverConfig,conversationId,manualSelection)",
+        globals,
+      ),
+    );
+    for (const effect of effects) effect();
+    return { result, selections: plain(selections) };
   };
-  const unavailableDefault = plain(
-    evaluate(
-      patchedComposer,
-      "LocalComposer([{id:'gpt-5.6-sol:high',model:'gpt-5.6-sol',reasoningEffort:'high'},{id:'upstream:medium',model:'upstream',defaultReasoningEffort:'medium',isDefault:true}],null,null)",
-      { ...globals },
-    ),
-  );
-  assert.equal(unavailableDefault.fallback.id, "gpt-5.6-sol:high");
-  assert.equal(unavailableDefault.reset.id, "gpt-5.6-sol:high");
-  assert.equal(unavailableDefault.selected.persistAsDefault, false);
-  const completeFallback = plain(
-    evaluate(
-      patchedComposer,
-      "LocalComposer([{id:'upstream:medium',model:'upstream',reasoningEffort:'medium',defaultReasoningEffort:'medium',isDefault:true}],null,null)",
-      { ...globals },
-    ),
-  );
-  assert.equal(completeFallback.fallback.id, "upstream:medium");
-  assert.equal(completeFallback.reset.id, "upstream:medium");
+  const unavailableDefault = runComposer({
+    available: [
+      { id: "gpt-5.6-sol:high", model: "gpt-5.6-sol", reasoningEffort: "high" },
+      {
+        id: "upstream:medium",
+        model: "upstream",
+        defaultReasoningEffort: "medium",
+        isDefault: true,
+      },
+    ],
+  });
+  assert.equal(unavailableDefault.result.fallback.id, "gpt-5.6-sol:high");
+  assert.equal(unavailableDefault.result.reset.id, "gpt-5.6-sol:high");
+  assert.deepEqual(unavailableDefault.selections, [
+    {
+      effort: "high",
+      model: "gpt-5.6-sol",
+      options: { persistAsDefault: false },
+    },
+  ]);
+
+  const configuredDefault = runComposer({
+    available: [
+      { id: "gpt-5.6-sol:high", model: "gpt-5.6-sol", reasoningEffort: "high" },
+      { id: "gpt-5.6-sol:medium", model: "gpt-5.6-sol", reasoningEffort: "medium" },
+    ],
+  });
+  assert.deepEqual(configuredDefault.selections[0], {
+    effort: "medium",
+    model: "gpt-5.6-sol",
+    options: { persistAsDefault: false },
+  });
+
+  const gatedOut = runComposer({
+    available: [
+      {
+        id: "upstream:medium",
+        model: "upstream",
+        defaultReasoningEffort: "medium",
+        isDefault: true,
+      },
+    ],
+    serverConfig: null,
+  });
+  assert.equal(gatedOut.result.fallback.id, "upstream:medium");
+  assert.equal(gatedOut.result.reset.id, "upstream:medium");
+  assert.deepEqual(gatedOut.selections, []);
+
+  const gatedManualSelection = runComposer({
+    available: [
+      { id: "gpt-5.6-sol:high", model: "gpt-5.6-sol", reasoningEffort: "high" },
+    ],
+    manualSelection: true,
+    serverConfig: null,
+  });
+  assert.deepEqual(gatedManualSelection.selections, [
+    { effort: "high", model: "gpt-5.6-sol" },
+  ]);
+
+  const completeFallback = runComposer({
+    available: [
+      {
+        id: "upstream:medium",
+        model: "upstream",
+        defaultReasoningEffort: "medium",
+        isDefault: true,
+      },
+    ],
+  });
+  assert.equal(completeFallback.result.fallback.id, "upstream:medium");
+  assert.equal(completeFallback.result.reset.id, "upstream:medium");
+  assert.deepEqual(completeFallback.selections, []);
+
+  const existingConversation = runComposer({
+    available: [
+      { id: "gpt-5.6-sol:medium", model: "gpt-5.6-sol", reasoningEffort: "medium" },
+    ],
+    conversationId: "existing",
+  });
+  assert.deepEqual(existingConversation.selections, []);
+
+  const manuallySelected = runComposer({
+    available: [
+      { id: "gpt-5.6-sol:medium", model: "gpt-5.6-sol", reasoningEffort: "medium" },
+      { id: "gpt-5.6-sol:high", model: "gpt-5.6-sol", reasoningEffort: "high" },
+    ],
+    manualSelection: true,
+  });
+  assert.equal(manuallySelected.result.selected.persistAsDefault, false);
+  assert.deepEqual(manuallySelected.selections, [
+    {
+      effort: "high",
+      model: "gpt-5.6-sol",
+      options: { persistAsDefault: false },
+    },
+  ]);
 });
 
 test("local composer patches fail closed on drift, duplicate, and partial states", () => {


### PR DESCRIPTION
## Summary

- route `model-picker-default-presets` through the actual local composer slider path
- initialize each new local draft from the configured `default: true` pair without trying to persist unsupported model/effort combinations as the account default
- preserve ChatGPT/Aeon/Copilot gates, account availability filtering, manual selections, and complete upstream fallback
- harden semantic matching, idempotence, and fail-closed behavior; ignore local `.agents/skills/` content

## Tests

- `node --test linux-features/model-picker-default-presets/test.js` (15 passed)
- `node --test scripts/patch-linux-window-ui.test.js scripts/lib/linux-features.test.js linux-features/*/test.js` (909 passed, 1 skipped)
- clean official `26.903.71938` ASAR audit with all four feature descriptors applied once
- `git diff --check`

## Notes

The feature remains disabled by default. If configured pairs are unavailable, runtime falls back to the first available configured pair or the complete upstream Default when none are available. Upstream contract drift fails closed during an enabled feature build.
