### PR TITLE
Fix COSMIC window control and shared CUA runtime integration

### DIFF
--- a/computer-use-linux/Cargo.toml
+++ b/computer-use-linux/Cargo.toml
@@ -42,7 +42,7 @@ sha2 = "0.11.0"
 tokio = { version = "1.51.1", features = ["io-util", "macros", "net", "process", "rt", "sync", "time"] }
 tokio-tungstenite = { version = "0.29.0", default-features = false, features = ["handshake"] }
 wayland-client = "0.31.11"
-wayland-protocols = { version = "0.32.9", features = ["client", "staging"] }
+wayland-protocols = { version = "0.32.9", features = ["client", "staging", "unstable"] }
 wayland-protocols-wlr = { version = "0.3.12", features = ["client"] }
 xkeysym = "0.2.1"
 zbus = "5.14.0"

--- a/computer-use-linux/src/bin/codex-computer-use-cosmic.rs
+++ b/computer-use-linux/src/bin/codex-computer-use-cosmic.rs
@@ -6,16 +6,17 @@ use cosmic_protocols::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use wayland_client::{
     event_created_child,
     globals::{registry_queue_init, GlobalListContents},
-    protocol::{wl_registry, wl_seat},
+    protocol::{wl_output, wl_registry, wl_seat},
     Connection, Dispatch, Proxy, QueueHandle, WEnum,
 };
 use wayland_protocols::ext::foreign_toplevel_list::v1::client::{
     ext_foreign_toplevel_handle_v1, ext_foreign_toplevel_list_v1,
 };
+use wayland_protocols::xdg::xdg_output::zv1::client::{zxdg_output_manager_v1, zxdg_output_v1};
 use wayland_protocols_wlr::output_management::v1::client::{
     zwlr_output_head_v1, zwlr_output_manager_v1, zwlr_output_mode_v1,
 };
@@ -39,7 +40,7 @@ struct WindowInfo {
     backend: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct WindowBounds {
     x: Option<i32>,
     y: Option<i32>,
@@ -92,6 +93,14 @@ struct OutputModeState {
     size: Option<(i32, i32)>,
 }
 
+#[derive(Debug, Default)]
+struct LogicalOutput {
+    position: Option<(i32, i32)>,
+    done: bool,
+}
+
+type RelativeGeometry = (i32, i32, i32, i32);
+
 #[derive(Debug, Clone, Default)]
 struct ToplevelRecord {
     foreign: Option<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1>,
@@ -101,10 +110,13 @@ struct ToplevelRecord {
     app_id: Option<String>,
     focused: bool,
     hidden: bool,
+    geometries: HashMap<u32, RelativeGeometry>,
+    received_state: bool,
 }
 
 impl ToplevelRecord {
-    fn to_window(&self) -> Option<WindowInfo> {
+    fn to_window(&self, outputs: &HashMap<u32, LogicalOutput>) -> Option<WindowInfo> {
+        self.foreign.as_ref()?;
         let identifier = self.identifier.as_deref()?;
         Some(WindowInfo {
             window_id: stable_window_id(identifier),
@@ -112,7 +124,7 @@ impl ToplevelRecord {
             app_id: self.app_id.clone().filter(|value| !value.trim().is_empty()),
             wm_class: None,
             pid: None,
-            bounds: None,
+            bounds: global_window_bounds(&self.geometries, outputs),
             workspace: None,
             focused: self.focused,
             hidden: self.hidden,
@@ -132,6 +144,10 @@ struct AppData {
     records: Vec<ToplevelRecord>,
     by_foreign_id: HashMap<u32, usize>,
     by_cosmic_id: HashMap<u32, usize>,
+    logical_output_manager: Option<zxdg_output_manager_v1::ZxdgOutputManagerV1>,
+    output_proxies: HashMap<u32, wl_output::WlOutput>,
+    logical_outputs: HashMap<u32, LogicalOutput>,
+    toplevel_info_done: bool,
     output_manager: Option<zwlr_output_manager_v1::ZwlrOutputManagerV1>,
     output_layout_ready: bool,
     output_manager_finished: bool,
@@ -279,8 +295,19 @@ impl Snapshot {
         snapshot.app_data.output_manager = globals
             .bind::<zwlr_output_manager_v1::ZwlrOutputManagerV1, _, _>(&qh, 1..=4, ())
             .ok();
+        snapshot.app_data.logical_output_manager = globals
+            .bind::<zxdg_output_manager_v1::ZxdgOutputManagerV1, _, _>(&qh, 1..=3, ())
+            .ok();
         globals.contents().with_list(|entries| {
             for global in entries {
+                if global.interface == "wl_output" {
+                    snapshot.app_data.bind_output(
+                        globals.registry(),
+                        global.name,
+                        global.version,
+                        &qh,
+                    );
+                }
                 if global.interface == "wl_seat" {
                     snapshot
                         .app_data
@@ -313,6 +340,20 @@ impl Snapshot {
                 .roundtrip(&mut self.app_data)
                 .context("Wayland roundtrip failed")?;
         }
+        // COSMIC publishes extension properties from its refresh cycle, not
+        // necessarily before wl_display.sync. Four fast roundtrips can finish
+        // before any state/geometry arrives. Wait for the protocol's snapshot
+        // boundary, bounded below the parent's helper timeout.
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while !self.app_data.toplevel_snapshot_ready() {
+            if Instant::now() >= deadline {
+                bail!("COSMIC toplevel properties did not complete a snapshot");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+            self.event_queue
+                .roundtrip(&mut self.app_data)
+                .context("Wayland roundtrip waiting for toplevel properties failed")?;
+        }
         Ok(())
     }
 
@@ -320,7 +361,7 @@ impl Snapshot {
         self.app_data
             .records
             .iter()
-            .filter_map(ToplevelRecord::to_window)
+            .filter_map(|record| record.to_window(&self.app_data.logical_outputs))
             .collect()
     }
 
@@ -384,6 +425,121 @@ impl Snapshot {
             .roundtrip(&mut self.app_data)
             .context("Wayland roundtrip after activation failed")?;
         Ok(())
+    }
+}
+
+// COSMIC geometry is output-relative in logical pixels. Never guess an origin
+// from wl_output's physical geometry or select an arbitrary spanning output.
+fn global_window_bounds(
+    geometries: &HashMap<u32, RelativeGeometry>,
+    outputs: &HashMap<u32, LogicalOutput>,
+) -> Option<WindowBounds> {
+    let mut result = None;
+    for (output_id, &(x, y, width, height)) in geometries {
+        let output = outputs.get(output_id)?;
+        if !output.done || width <= 0 || height <= 0 {
+            return None;
+        }
+        let (output_x, output_y) = output.position?;
+        let bounds = WindowBounds {
+            x: Some(output_x.checked_add(x)?),
+            y: Some(output_y.checked_add(y)?),
+            width: u32::try_from(width).ok()?,
+            height: u32::try_from(height).ok()?,
+        };
+        if result.as_ref().is_some_and(|previous| previous != &bounds) {
+            return None;
+        }
+        result = Some(bounds);
+    }
+    result
+}
+
+fn toplevel_properties_ready(info_done: bool, states: impl IntoIterator<Item = bool>) -> bool {
+    let mut states = states.into_iter().peekable();
+    states.peek().is_none() || (info_done && states.all(|received| received))
+}
+
+impl AppData {
+    fn toplevel_snapshot_ready(&self) -> bool {
+        toplevel_properties_ready(
+            self.toplevel_info_done,
+            self.records
+                .iter()
+                .filter(|record| record.foreign.is_some())
+                .map(|record| record.received_state),
+        )
+    }
+
+    fn bind_output(
+        &mut self,
+        registry: &wl_registry::WlRegistry,
+        name: u32,
+        version: u32,
+        qh: &QueueHandle<Self>,
+    ) {
+        if self.output_proxies.contains_key(&name) {
+            return;
+        }
+        let output = registry.bind::<wl_output::WlOutput, _, _>(name, version.min(4), qh, ());
+        let id = output.id().protocol_id();
+        self.logical_outputs.insert(id, LogicalOutput::default());
+        if let Some(manager) = &self.logical_output_manager {
+            manager.get_xdg_output(&output, qh, id);
+        }
+        self.output_proxies.insert(name, output);
+    }
+}
+
+impl Dispatch<wl_output::WlOutput, ()> for AppData {
+    fn event(
+        state: &mut Self,
+        output: &wl_output::WlOutput,
+        event: wl_output::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let wl_output::Event::Done = event {
+            if let Some(logical) = state.logical_outputs.get_mut(&output.id().protocol_id()) {
+                logical.done = true;
+            }
+        }
+    }
+}
+
+impl Dispatch<zxdg_output_manager_v1::ZxdgOutputManagerV1, ()> for AppData {
+    fn event(
+        _: &mut Self,
+        _: &zxdg_output_manager_v1::ZxdgOutputManagerV1,
+        _: zxdg_output_manager_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<zxdg_output_v1::ZxdgOutputV1, u32> for AppData {
+    fn event(
+        state: &mut Self,
+        _: &zxdg_output_v1::ZxdgOutputV1,
+        event: zxdg_output_v1::Event,
+        id: &u32,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let Some(output) = state.logical_outputs.get_mut(id) else {
+            return;
+        };
+        match event {
+            zxdg_output_v1::Event::LogicalPosition { x, y } => {
+                output.position = Some((x, y));
+                output.done = false;
+            }
+            zxdg_output_v1::Event::Done => output.done = true,
+            _ => {}
+        }
     }
 }
 
@@ -538,7 +694,7 @@ impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for AppData {
         if let wl_registry::Event::Global {
             name,
             interface,
-            version: _,
+            version,
         } = event
         {
             match interface.as_str() {
@@ -571,12 +727,17 @@ impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for AppData {
                             ),
                     );
                 }
+                "wl_output" => app_data.bind_output(registry, name, version, qh),
                 "wl_seat" => {
                     app_data
                         .seats
                         .push(registry.bind::<wl_seat::WlSeat, _, _>(name, 9, qh, ()));
                 }
                 _ => {}
+            }
+        } else if let wl_registry::Event::GlobalRemove { name } = event {
+            if let Some(output) = app_data.output_proxies.remove(&name) {
+                app_data.logical_outputs.remove(&output.id().protocol_id());
             }
         }
     }
@@ -599,6 +760,7 @@ impl Dispatch<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, ()> for Ap
                     ..Default::default()
                 };
                 if let Some(info) = app_data.toplevel_info.as_ref() {
+                    app_data.toplevel_info_done = false;
                     let cosmic = info.get_cosmic_toplevel(&toplevel, qh, ());
                     app_data
                         .by_cosmic_id
@@ -663,13 +825,16 @@ impl Dispatch<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, ()> fo
 
 impl Dispatch<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1, ()> for AppData {
     fn event(
-        _app_data: &mut Self,
+        app_data: &mut Self,
         _info: &zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1,
-        _event: zcosmic_toplevel_info_v1::Event,
+        event: zcosmic_toplevel_info_v1::Event,
         _: &(),
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
+        if let zcosmic_toplevel_info_v1::Event::Done = event {
+            app_data.toplevel_info_done = true;
+        }
     }
 
     event_created_child!(
@@ -700,12 +865,13 @@ impl Dispatch<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1, ()> for AppDa
         let record = &mut app_data.records[index];
         match event {
             zcosmic_toplevel_handle_v1::Event::State { state } => {
+                record.received_state = true;
                 record.focused = false;
                 record.hidden = false;
-                for value in state.chunks_exact(4) {
-                    if let Ok(parsed) = zcosmic_toplevel_handle_v1::State::try_from(
-                        u32::from_ne_bytes(value.try_into().unwrap()),
-                    ) {
+                for value in state.as_chunks::<4>().0 {
+                    if let Ok(parsed) =
+                        zcosmic_toplevel_handle_v1::State::try_from(u32::from_ne_bytes(*value))
+                    {
                         if parsed == zcosmic_toplevel_handle_v1::State::Activated {
                             record.focused = true;
                         }
@@ -715,9 +881,21 @@ impl Dispatch<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1, ()> for AppDa
                     }
                 }
             }
-            zcosmic_toplevel_handle_v1::Event::Geometry { .. }
-            | zcosmic_toplevel_handle_v1::Event::OutputEnter { .. }
-            | zcosmic_toplevel_handle_v1::Event::OutputLeave { .. }
+            zcosmic_toplevel_handle_v1::Event::Geometry {
+                output,
+                x,
+                y,
+                width,
+                height,
+            } => {
+                record
+                    .geometries
+                    .insert(output.id().protocol_id(), (x, y, width, height));
+            }
+            zcosmic_toplevel_handle_v1::Event::OutputLeave { output } => {
+                record.geometries.remove(&output.id().protocol_id());
+            }
+            zcosmic_toplevel_handle_v1::Event::OutputEnter { .. }
             | zcosmic_toplevel_handle_v1::Event::WorkspaceEnter { .. }
             | zcosmic_toplevel_handle_v1::Event::WorkspaceLeave { .. }
             | zcosmic_toplevel_handle_v1::Event::ExtWorkspaceEnter { .. }
@@ -948,6 +1126,75 @@ mod tests {
         )]);
 
         assert!(monitor_layout_from_state(&heads, &modes).is_none());
+    }
+
+    fn logical_output(x: i32, y: i32) -> LogicalOutput {
+        LogicalOutput {
+            position: Some((x, y)),
+            done: true,
+        }
+    }
+
+    #[test]
+    fn window_geometry_is_translated_from_output_to_desktop() {
+        let outputs = HashMap::from([(1, logical_output(-1920, 120))]);
+        let geometry = HashMap::from([(1, (100, 30, 800, 600))]);
+        assert_eq!(
+            global_window_bounds(&geometry, &outputs),
+            Some(WindowBounds {
+                x: Some(-1820),
+                y: Some(150),
+                width: 800,
+                height: 600,
+            })
+        );
+    }
+
+    #[test]
+    fn spanning_window_requires_consistent_global_geometry() {
+        let outputs = HashMap::from([(1, logical_output(-1920, 0)), (2, logical_output(0, 0))]);
+        let mut geometry = HashMap::from([(1, (1800, 50, 800, 600)), (2, (-120, 50, 800, 600))]);
+        assert_eq!(
+            global_window_bounds(&geometry, &outputs).unwrap().x,
+            Some(-120)
+        );
+        geometry.insert(2, (-100, 50, 800, 600));
+        assert!(global_window_bounds(&geometry, &outputs).is_none());
+    }
+
+    #[test]
+    fn window_geometry_rejects_missing_unfinished_invalid_and_overflowing_outputs() {
+        let geometry = HashMap::from([(1, (100, 30, 800, 600))]);
+        assert!(global_window_bounds(&geometry, &HashMap::new()).is_none());
+        let mut outputs = HashMap::from([(1, LogicalOutput::default())]);
+        assert!(global_window_bounds(&geometry, &outputs).is_none());
+        outputs.insert(
+            1,
+            LogicalOutput {
+                position: Some((0, 0)),
+                done: false,
+            },
+        );
+        assert!(global_window_bounds(&geometry, &outputs).is_none());
+        outputs.insert(1, logical_output(i32::MAX, 0));
+        assert!(global_window_bounds(&geometry, &outputs).is_none());
+        outputs.insert(1, logical_output(0, 0));
+        for size in [(0, 600), (-1, 600), (800, 0), (800, -1)] {
+            assert!(
+                global_window_bounds(&HashMap::from([(1, (0, 0, size.0, size.1))]), &outputs)
+                    .is_none()
+            );
+        }
+        assert!(global_window_bounds(&HashMap::new(), &outputs).is_none());
+    }
+
+    #[test]
+    fn snapshot_waits_for_refresh_properties_and_protocol_done() {
+        assert!(!toplevel_properties_ready(false, [false, false]));
+        assert!(!toplevel_properties_ready(true, [true, false]));
+        assert!(!toplevel_properties_ready(false, [true, true]));
+        assert!(toplevel_properties_ready(true, [true, true]));
+        assert!(toplevel_properties_ready(false, []));
     }
 
     #[test]

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -19,7 +19,7 @@ use crate::terminal::{terminal_paste_shortcut, TerminalPasteShortcut};
 use crate::windowing::registry;
 use crate::windows::{
     focus_window_target, focused_window, list_windows, resolve_window_target,
-    window_permission_hint, WindowFocusResult, WindowInfo, WindowTarget,
+    window_permission_hint, WindowFocusResult, WindowInfo, WindowTarget, COSMIC_WAYLAND_BACKEND,
     GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND, KWIN_BACKEND,
 };
 use crate::ydotool;
@@ -1320,12 +1320,31 @@ impl ComputerUseLinux {
                 });
             }
         };
+        // Use the same absolute pointer as clicks to position the wheel.
+        // ydotool emulates absolute movement with accelerated relative motion,
+        // which can leave the cursor outside the requested COSMIC window.
+        let absolute_position = target_point.is_some() && self.ensure_abs_pointer().await;
+        let abs_pointer = Arc::clone(&self.abs_pointer);
         let mut sequence = Vec::new();
-        if let Some((x, y)) = target_point {
+        if let Some((x, y)) = target_point.filter(|_| !absolute_position) {
             sequence.push(absolute_mousemove_args(x, y));
         }
         sequence.push(wheel_mousemove_args(dx, dy));
         let (input_guard, result) = run_cancellation_safe_input(input_guard, async move {
+            if let Some((x, y)) = target_point.filter(|_| absolute_position) {
+                {
+                    let mut guard = abs_pointer
+                        .lock()
+                        .map_err(|_| "Absolute pointer lock failed".to_string())?;
+                    let pointer = guard
+                        .as_mut()
+                        .ok_or_else(|| "Absolute pointer unavailable".to_string())?;
+                    pointer
+                        .move_to(x, y)
+                        .map_err(|error| format!("Scroll positioning failed: {error:#}"))?;
+                }
+                sleep(Duration::from_millis(35)).await;
+            }
             run_ydotool_sequence(&sequence).await
         })
         .await;
@@ -2871,6 +2890,14 @@ impl ComputerUseLinux {
                         .map(|monitor| (monitor.x, monitor.y, monitor.width, monitor.height))
                         .collect()
                 })
+        } else if window.backend == COSMIC_WAYLAND_BACKEND {
+            Some(
+                crate::cosmic_helper::monitor_layout()
+                    .await?
+                    .into_iter()
+                    .map(|monitor| (monitor.x, monitor.y, monitor.width, monitor.height))
+                    .collect(),
+            )
         } else if window.backend == KWIN_BACKEND {
             Some(vec![
                 crate::windowing::backends::kwin::logical_desktop_rect()
@@ -2908,7 +2935,10 @@ impl ComputerUseLinux {
             .unwrap_or(&focus.requested_window);
         if !matches!(
             window.backend.as_str(),
-            GNOME_SHELL_EXTENSION_BACKEND | GNOME_SHELL_INTROSPECT_BACKEND | KWIN_BACKEND
+            GNOME_SHELL_EXTENSION_BACKEND
+                | GNOME_SHELL_INTROSPECT_BACKEND
+                | KWIN_BACKEND
+                | COSMIC_WAYLAND_BACKEND
         ) {
             let full_capture_rect = window
                 .bounds
@@ -5754,6 +5784,27 @@ mod tests {
 
         assert_eq!(mapping.capture_rect, (2000, 200, 1600, 1200));
         assert_eq!(mapping.portal_point(2400, 500), Some((1300, 200)));
+    }
+
+    #[test]
+    fn cosmic_logical_geometry_maps_scaled_nonzero_origin_to_capture_and_input() {
+        let bounds = WindowBounds {
+            x: Some(-1820),
+            y: Some(150),
+            width: 800,
+            height: 600,
+        };
+        let logical = window_crop_rect(&bounds).unwrap();
+        let capture =
+            logical_window_crop_rect(&bounds, &[(-1920, 120, 1920, 1080)], 3840, 2160).unwrap();
+        assert_eq!(capture, (200, 60, 1600, 1200));
+        let map = WindowCoordinateMap {
+            capture_rect: capture,
+            full_capture_rect: capture,
+            portal_rect: Some(logical),
+        };
+        assert_eq!(map.capture_rect, (200, 60, 1600, 1200));
+        assert_eq!(map.portal_point(600, 360), Some((-1620, 300)));
     }
 
     #[test]

--- a/linux-features/computer-use-linux/README.md
+++ b/linux-features/computer-use-linux/README.md
@@ -29,6 +29,13 @@ Click and scroll coordinates are window-relative; use the coordinate dimensions
 reported with screenshots. Accessibility bounds are screen coordinates and must
 not be passed directly to input methods because display scaling can differ.
 Accessibility observations retain `window_context` for geometry inspection.
+On COSMIC, snapshots wait for the toplevel protocol completion event because
+properties may arrive after the initial Wayland roundtrips. Output-relative
+toplevel geometry is translated through XDG logical output positions; screenshots
+and relative input use the logical monitor layout to account for scaling and nonzero desktop origins. Missing or inconsistent
+geometry is rejected rather than returning a full-desktop screenshot. The
+ydotool scroll fallback positions the cursor with the same absolute pointer as
+clicks when available, so wheel events reach the requested window.
 Element-index actions, drag, rich-text paste, selection editing, and secondary
 accessibility actions are not exposed by the in-app API.
 
@@ -53,7 +60,10 @@ Linux does not provide saved per-app approvals through this integration.
 The adapter and native helpers are packaged together inside the upstream
 `unified-computer-use` plugin. The separate `computer-use` component stores the
 Any App setting and exposes no MCP tools. Upstream owns browser control.
-Missing or ambiguous bundle contracts abort an enabled build.
+The app-managed CUA configuration supplies a native bootstrap and trusted
+service only when the Linux native surface is selected. The shared upstream
+CUA launcher and browser factory stay unchanged. Missing or ambiguous bundle
+contracts abort an enabled build.
 
 `make install-native` builds `codex-computer-use-linux` and
 `codex-computer-use-cosmic` once before staging the package. Direct

--- a/linux-features/computer-use-linux/native-client.mjs
+++ b/linux-features/computer-use-linux/native-client.mjs
@@ -1,4 +1,4 @@
-// Installed after upstream setupCUA; browser ownership remains upstream.
+// Installed after the upstream CUA factory; browser ownership remains upstream.
 export function installLinuxComputerUse(cua) {
   const runtime = globalThis.nodeRepl;
   if (typeof runtime?.rpc !== 'function') throw new Error('Linux Computer Use requires trusted nodeRepl RPC');

--- a/linux-features/computer-use-linux/native-launch.mjs
+++ b/linux-features/computer-use-linux/native-launch.mjs
@@ -1,16 +1,11 @@
-import { fileURLToPath } from "node:url";
+import { pathToFileURL } from "node:url";
+import { installLinuxComputerUse } from "./native-client.mjs";
 
-export function linuxNativeEnvironment({ browser, computer }, banner) {
-  if (!computer) return { NODE_REPL_JS_BANNER: banner };
-  const client = new URL("./native-client.mjs", import.meta.url).href;
-  return {
-    NODE_REPL_TRUSTED_RPC_ENABLED: "1",
-    NODE_REPL_TRUSTED_SERVICES: JSON.stringify({
-      ...(browser ? { browser: "@oai/browser-desktop/service" } : {}),
-      sky: fileURLToPath(new URL("./native-service.mjs", import.meta.url)),
-    }),
-    NODE_REPL_JS_BANNER:
-      `await (await import("@oai/cua/tinyskyAlt")).setupCUA(${JSON.stringify({ browser, computer: false })});\n` +
-      `await (await import(${JSON.stringify(client)})).installLinuxComputerUse(cua);`,
-  };
+// Use the upstream browser factory without starting its macOS native client.
+export async function setupLinuxComputerUse({ browser, factoryPath }) {
+  const { create_tinysky_alt } = await import(pathToFileURL(factoryPath).href);
+  const cua = await create_tinysky_alt({ browser, computer: false });
+  globalThis.cua = cua;
+  installLinuxComputerUse(cua);
+  cua.initialize = cua.getState;
 }

--- a/linux-features/computer-use-linux/native-launch.test.js
+++ b/linux-features/computer-use-linux/native-launch.test.js
@@ -1,23 +1,24 @@
 "use strict";
 const assert = require("node:assert/strict");
 const test = require("node:test");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
 
-test("native launcher retains browser and enables only the selected surfaces", async () => {
-  const { linuxNativeEnvironment } = await import("./native-launch.mjs");
-  const browserOnly = linuxNativeEnvironment({ browser: true, computer: false }, "official browser banner");
-  assert.deepEqual(browserOnly, { NODE_REPL_JS_BANNER: "official browser banner" });
+test("native bootstrap retains upstream browser methods and disables upstream native control", async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "native-bootstrap-"));
+  t.after(() => fs.rmSync(dir, {recursive: true, force: true}));
+  const factoryPath = path.join(dir, "factory.mjs");
+  fs.writeFileSync(factoryPath, 'export async function create_tinysky_alt(options) { return {options, getBrowser: () => "upstream", getState: async () => ({apps: [], browsers: []})}; }');
+  const { setupLinuxComputerUse } = await import("./native-launch.mjs");
+  const oldRuntime = globalThis.nodeRepl, oldCua = globalThis.cua;
+  t.after(() => { globalThis.nodeRepl = oldRuntime; globalThis.cua = oldCua; });
+  globalThis.nodeRepl = {rpc: async () => ({}), write: () => {}};
   for (const browser of [true, false]) {
-    const env = linuxNativeEnvironment({ browser, computer: true }, "unused");
-    const services = JSON.parse(env.NODE_REPL_TRUSTED_SERVICES);
-    assert.equal(services.browser, browser ? "@oai/browser-desktop/service" : undefined);
-    assert.match(services.sky, /\/native-service\.mjs$/);
-    let options, installed = false;
-    const run = new (Object.getPrototypeOf(async function() {}).constructor)("load", "cua",
-      env.NODE_REPL_JS_BANNER.replaceAll("import(", "load("));
-    await run(async name => name === "@oai/cua/tinyskyAlt"
-      ? { setupCUA: async value => { options = value; } }
-      : { installLinuxComputerUse: async () => { installed = true; } }, {});
-    assert.deepEqual(options, { browser, computer: false });
-    assert.equal(installed, true);
+    await setupLinuxComputerUse({browser, factoryPath});
+    assert.deepEqual(globalThis.cua.options, {browser, computer: false});
+    assert.equal(globalThis.cua.getBrowser(), "upstream");
+    assert.equal(typeof globalThis.cua.getApp, "function");
+    assert.equal(globalThis.cua.initialize, globalThis.cua.getState);
   }
 });

--- a/linux-features/computer-use-linux/patch.js
+++ b/linux-features/computer-use-linux/patch.js
@@ -14,7 +14,10 @@ const {
 const { applyNativeSettingsAvailabilityPatch, applyNativeSettingsVisibilityPatch } = require("./settings.js");
 const { applyUnifiedComputerUsePatch } = require("./unified.js");
 
+const { applyNativeRuntimeEnvironmentPatch } = require("./runtime-env.js");
+
 module.exports = [
+  mainBundlePatch({ id: "native-runtime-environment", order: 20_116, apply: applyNativeRuntimeEnvironmentPatch }),
   mainBundlePatch({
     id: "unified-runtime",
     order: 20_115,

--- a/linux-features/computer-use-linux/runtime-env.js
+++ b/linux-features/computer-use-linux/runtime-env.js
@@ -1,0 +1,31 @@
+"use strict";
+
+function applyNativeRuntimeEnvironmentPatch(source) {
+  const cachePattern = /(?<path>[\w$]+\.default)\.join\((?<cache>[\w$]+),`\.mcp\.json`\)/g;
+  const commandPattern = /(?<options>[\w$]+)\.nodeRepl!=null&&\((?<config>[\w$]+)\.command=\k<options>\.nodeRepl\.env\[[\w$]+\.[\w$]+\],\k<config>\.args=\[(?<path>[\w$]+\.default)\.join\(\k<options>\.nodeRepl\.env\[(?<root>[\w$]+\.[\w$]+)\],`@oai\/cua-repl\/bin\/cua-repl\.mjs`\)\]\)/g;
+  const caches = [...source.matchAll(cachePattern)];
+  const commands = [...source.matchAll(commandPattern)];
+  if (caches.length !== 1 || commands.length !== 1 || caches[0].groups.path !== commands[0].groups.path) {
+    throw new Error("Linux unified Computer Use contract drift: expected one app-managed CUA launcher");
+  }
+  const { options: o, config: c, path: p, root } = commands[0].groups;
+  const { cache } = caches[0].groups;
+  const envPattern = /(?<config>[\w$]+)\.env=\{\.\.\.(?<options>[\w$]+)\.nodeRepl\?\.env,CUA_REPL_NODE_REPL_PATH:\k<options>\.nodeRepl\?\.command,CUA_REPL_ENABLED_SURFACES:\k<options>\.surfaces\.join\(`,`\),\[(?<services>[\w$]+\.[\w$]+)\]:JSON\.stringify\((?<map>[\w$]+)\),/g;
+  const envs = [...source.matchAll(envPattern)];
+  if (envs.length !== 1 || envs[0].groups.config !== c || envs[0].groups.options !== o) {
+    throw new Error("Linux unified Computer Use contract drift: changed CUA environment");
+  }
+  const { services, map } = envs[0].groups;
+  const bootstrap = `${p}.join(${cache},\`scripts/native-launch.mjs\`)`;
+  const factory = `${p}.join(${o}.nodeRepl.env[${root}],\`@oai/cua/dist/lib/js/oai_js_cua/src/tinysky_alt/create_tinysky_alt.js\`)`;
+  const injection = `,/*linux-native-cua*/process.platform===\`linux\`&&${o}.nodeRepl!=null&&${o}.surfaces.includes(\`computer\`)&&Object.assign(${c}.env,{NODE_REPL_TRUSTED_RPC_ENABLED:\`1\`,[${services}]:JSON.stringify({...${map},sky:${p}.join(${cache},\`scripts/native-service.mjs\`)}),NODE_REPL_JS_BANNER:\`await (await import(\`+JSON.stringify((await import(\`node:url\`)).pathToFileURL(${bootstrap}).href)+\`)).setupLinuxComputerUse(\`+JSON.stringify({browser:${o}.surfaces.includes(\`browser\`),factoryPath:${factory}})+\`);\`})`;
+  const anchor = commands[0][0];
+  if (source.includes("/*linux-native-cua*/")) {
+    if (source.split("/*linux-native-cua*/").length !== 2 || !source.includes(anchor + injection)) {
+      throw new Error("Linux unified Computer Use contract drift: partial CUA environment patch");
+    }
+    return source;
+  }
+  return source.replace(anchor, anchor + injection);
+}
+module.exports = { applyNativeRuntimeEnvironmentPatch };

--- a/linux-features/computer-use-linux/runtime-env.test.js
+++ b/linux-features/computer-use-linux/runtime-env.test.js
@@ -1,0 +1,50 @@
+"use strict";
+const assert = require("node:assert/strict");
+const vm = require("node:vm");
+const test = require("node:test");
+const path = require("node:path");
+const {applyNativeRuntimeEnvironmentPatch: patch} = require("./runtime-env");
+const source = 'async function configure(e){let i="/plugin cache",a=p.default.join(i,`.mcp.json`),c={},l={};e.surfaces.includes(`browser`)&&(l.browser=`@oai/browser-desktop/service`),e.surfaces.includes(`computer`)&&(l.sky=`@oai/sky/service`),c.env={...e.nodeRepl?.env,CUA_REPL_NODE_REPL_PATH:e.nodeRepl?.command,CUA_REPL_ENABLED_SURFACES:e.surfaces.join(`,`),[n.Il]:JSON.stringify(l),[Wt]:e.browserBackends.join(`,`)},e.nodeRepl!=null&&(c.command=e.nodeRepl.env[n.jl],c.args=[p.default.join(e.nodeRepl.env[n.Al],`@oai/cua-repl/bin/cua-repl.mjs`)]);return c}';
+test("app-managed CUA environment patch preserves upstream command and browser-only configuration", async () => {
+  const patched = patch(source);
+  assert.equal(patch(patched), patched);
+  const configure = vm.runInNewContext(`(${patched})`, {process: {platform: "linux"}, p: {default: path}, n: {Il: "NODE_REPL_TRUSTED_SERVICES", jl: "NODE", Al: "MODULES"}, Wt: "BROWSERS"});
+  const config = await configure({surfaces: ["browser"], browserBackends: ["iab"], nodeRepl: {command: "/runtime/repl", env: {NODE: "/runtime/node", MODULES: "/runtime/modules"}}});
+  assert.deepEqual(Array.from(config.args), ["/runtime/modules/@oai/cua-repl/bin/cua-repl.mjs"]);
+  assert.equal(config.command, "/runtime/node");
+  assert.equal(config.env.NODE_REPL_JS_BANNER, undefined);
+  assert.deepEqual(JSON.parse(config.env.NODE_REPL_TRUSTED_SERVICES), {browser: "@oai/browser-desktop/service"});
+});
+test("app-managed CUA patch fails closed on drift, ambiguity, and partial patches", () => {
+  for (const broken of [source.replace("cua-repl.mjs", "changed.mjs"), source + source, source.replace("CUA_REPL_ENABLED_SURFACES", "CHANGED"), patch(source).replace("native-service.mjs", "changed.mjs")]) {
+    assert.throws(() => patch(broken), /contract drift/);
+  }
+});
+
+test("native surfaces receive scoped service and bootstrap paths, including paths with spaces", async (t) => {
+  const fs = require("node:fs"), os = require("node:os");
+  const {pathToFileURL} = require("node:url");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cua-env-"));
+  t.after(() => fs.rmSync(dir, {recursive: true, force: true}));
+  const modulePath = path.join(dir, "configuration.mjs");
+  fs.writeFileSync(modulePath, 'import path from "node:path"; const p={default:path}, n={Il:"NODE_REPL_TRUSTED_SERVICES",jl:"NODE",Al:"MODULES"}, Wt="BROWSERS";' + patch(source) + '\nexport default configure;');
+  const {default: configure} = await import(pathToFileURL(modulePath).href);
+  for (const surfaces of [["computer"], ["browser", "computer"]]) {
+    const config = await configure({surfaces, browserBackends: [], nodeRepl: {command: "/runtime/repl", env: {NODE: "/runtime/node", MODULES: "/runtime modules"}}});
+    const services = JSON.parse(config.env.NODE_REPL_TRUSTED_SERVICES);
+    assert.equal(services.sky, "/plugin cache/scripts/native-service.mjs");
+    assert.equal(services.browser, surfaces.includes("browser") ? "@oai/browser-desktop/service" : undefined);
+    assert.equal(config.env.CUA_REPL_ENABLED_SURFACES, surfaces.join(","));
+    assert.equal(config.env.NODE_REPL_TRUSTED_RPC_ENABLED, "1");
+    assert.match(config.env.NODE_REPL_JS_BANNER, /file:\/\/\/plugin%20cache\/scripts\/native-launch\.mjs/);
+    assert.match(config.env.NODE_REPL_JS_BANNER, /"factoryPath":"\/runtime modules\/@oai\/cua\//);
+    assert.deepEqual(config.args, ["/runtime modules/@oai/cua-repl/bin/cua-repl.mjs"]);
+  }
+});
+
+test("CUA matching tolerates minifier identifiers containing dollar signs", () => {
+  const renamed = source.replace(/\be\b/g, () => "$options").replace(/\bc\b/g, () => "$config");
+  const result = patch(renamed);
+  assert.notEqual(result, renamed);
+  assert.equal(patch(result), result);
+});

--- a/linux-features/computer-use-linux/stage.js
+++ b/linux-features/computer-use-linux/stage.js
@@ -6,12 +6,7 @@ const target = path.join(process.env.INSTALL_DIR, "resources/plugins/openai-bund
 const marketplacePath = path.join(target, "../../.agents/plugins/marketplace.json");
 const settingsTarget = path.join(target, "../computer-use");
 const settingsSource = path.join(process.env.SCRIPT_DIR, "plugins/openai-bundled/plugins/computer-use");
-const launcherPath = path.join(target, "scripts/launch.mjs");
 const manifestPath = path.join(target, ".codex-plugin/plugin.json");
-const anchor = "NODE_REPL_JS_BANNER: banner,";
-const replacement = "...linuxNativeEnvironment(setupOptions, banner),";
-const importLine = 'import { linuxNativeEnvironment } from "./native-launch.mjs";\n';
-let launcher;
 let manifest;
 let marketplace;
 try {
@@ -19,31 +14,28 @@ try {
   if (!Array.isArray(marketplace.plugins) || marketplace.plugins.filter(p => p.name === "unified-computer-use").length !== 1) {
     throw new Error("missing or ambiguous unified marketplace entry");
   }
-  launcher = fs.readFileSync(launcherPath, "utf8");
   manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const mcp = JSON.parse(fs.readFileSync(path.join(target, ".mcp.json"), "utf8"));
+  const server = mcp.mcpServers?.cua_repl;
   if (manifest.name !== "unified-computer-use" || typeof manifest.version !== "string" ||
-      !launcher.includes('"@oai/sky/service"')) throw new Error("unexpected unified plugin");
-  const setupOptionsPattern = /const setupOptions\s*=\s*\{\s*browser:\s*([\w$]+)\.has\("browser"\),\s*computer:\s*\1\.has\("computer"\)\s*\};/g;
-  if ([...launcher.matchAll(setupOptionsPattern)].length !== 1) {
-    throw new Error("missing or changed unified surface options");
+      manifest.mcpServers !== "./.mcp.json" || server?.command !== "node" ||
+      !Array.isArray(server.args) || server.args.length !== 0 || server.enabled !== false) {
+    throw new Error("unexpected app-managed unified plugin");
   }
-  const pristine = launcher.split(anchor).length - 1;
-  const patched = launcher.split(replacement).length - 1;
-  if (pristine === 1 && patched === 0 && !launcher.includes(importLine)) {
-    launcher = importLine + launcher.replace(anchor, replacement);
-  } else if (pristine !== 0 || patched !== 1 || !launcher.startsWith(importLine)) {
-    throw new Error("unexpected unified launcher");
+  const factory = path.join(process.env.INSTALL_DIR, "resources/cua_node/lib/node_modules/@oai/cua/dist/lib/js/oai_js_cua/src/tinysky_alt/create_tinysky_alt.js");
+  if (!/export\{[\w$]+ as create_tinysky_alt\}/.test(fs.readFileSync(factory, "utf8"))) {
+    throw new Error("missing upstream CUA factory");
   }
 } catch (error) {
   throw new Error(`Linux unified Computer Use contract drift: ${error.message}`);
 }
 
 // The app materializes bundled plugin caches by version, not resource contents.
-manifest.version = manifest.version.replace(/-linux-native\.\d+$/, "") + "-linux-native.3";
+manifest.version = manifest.version.replace(/-linux-native\.\d+$/, "") + "-linux-native.4";
+fs.mkdirSync(path.join(target, "scripts"), { recursive: true });
 for (const name of ["native-launch.mjs", "native-client.mjs", "native-service.mjs"]) {
   fs.copyFileSync(path.join(__dirname, name), path.join(target, "scripts", name));
 }
-fs.writeFileSync(launcherPath, launcher);
 fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
 
 // Keep the native toggle's existing plugin state, but expose no legacy MCP tools.

--- a/linux-features/computer-use-linux/test.js
+++ b/linux-features/computer-use-linux/test.js
@@ -21,6 +21,7 @@ test("computer-use-linux is opt-in and owns the current Linux descriptors", () =
   assert.deepEqual(
     descriptors.map(({ id }) => id),
     [
+      "native-runtime-environment",
       "unified-runtime",
       "avatar-cursor",
       "ui-feature",
@@ -50,32 +51,32 @@ test("staging extends the hidden unified plugin and invalidates the browser-only
   fs.writeFileSync(marketplacePath, marketplace);
   fs.mkdirSync(path.join(target, "scripts"), { recursive: true });
   fs.mkdirSync(path.join(target, ".codex-plugin"));
-  fs.writeFileSync(path.join(target, ".codex-plugin/plugin.json"), JSON.stringify({ name: "unified-computer-use", version: "26.901.41600" }));
-  fs.writeFileSync(path.join(target, "scripts/launch.mjs"), 'const surfaces = new Set(["browser", "computer"]); const setupOptions = {browser: surfaces.has("browser"), computer: surfaces.has("computer")}; const env = {NODE_REPL_TRUSTED_SERVICES: JSON.stringify({sky:"@oai/sky/service"}),NODE_REPL_JS_BANNER: banner,};');
+  fs.writeFileSync(path.join(target, ".codex-plugin/plugin.json"), JSON.stringify({ name: "unified-computer-use", version: "26.908.31748", mcpServers: "./.mcp.json" }));
+  const mcpPath = path.join(target, ".mcp.json");
+  const mcp = {mcpServers: {cua_repl: {command: "node", args: [], enabled: false}}};
+  fs.writeFileSync(mcpPath, JSON.stringify(mcp));
+  const factory = path.join(installDir, "resources/cua_node/lib/node_modules/@oai/cua/dist/lib/js/oai_js_cua/src/tinysky_alt/create_tinysky_alt.js");
+  fs.mkdirSync(path.dirname(factory), {recursive: true});
+  fs.writeFileSync(factory, "export{n as create_tinysky_alt};");
   const backend = path.join(workspace, "backend");
   fs.writeFileSync(backend, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
   const env = { ...process.env, SCRIPT_DIR: path.resolve(__dirname, "../.."), INSTALL_DIR: installDir,
     CODEX_COMPUTER_USE_BINARY_SOURCE: backend, CODEX_COMPUTER_USE_COSMIC_BINARY_SOURCE: backend };
   const stage = () => execFileSync("bash", [path.join(__dirname, "stage.sh")], { env, stdio: "pipe" });
-  const launcherPath = path.join(target, "scripts/launch.mjs");
-  const originalLauncher = fs.readFileSync(launcherPath, "utf8");
   const originalManifest = fs.readFileSync(path.join(target, ".codex-plugin/plugin.json"), "utf8");
-  for (const invalid of [
-    originalLauncher.replaceAll("setupOptions", "selectedSurfaces"),
-    originalLauncher.replace(/const setupOptions = \{[^}]+\}; /, ""),
-    originalLauncher.replace('computer: surfaces.has("computer")', 'computer: surfaces.has("browser")'),
-  ]) {
-    fs.writeFileSync(launcherPath, invalid);
+  for (const invalid of [{}, {mcpServers: {cua_repl: {command: "other", args: [], enabled: false}}},
+    {mcpServers: {cua_repl: {command: "node", args: ["old-launcher"], enabled: false}}}]) {
+    fs.writeFileSync(mcpPath, JSON.stringify(invalid));
     assert.throws(stage, /unified.*contract/i);
-    assert.equal(fs.readFileSync(launcherPath, "utf8"), invalid);
+    assert.equal(fs.readFileSync(mcpPath, "utf8"), JSON.stringify(invalid));
     assert.equal(fs.readFileSync(path.join(target, ".codex-plugin/plugin.json"), "utf8"), originalManifest);
     assert.equal(fs.readFileSync(marketplacePath, "utf8"), marketplace);
     assert.equal(fs.existsSync(path.join(target, "scripts/native-service.mjs")), false);
   }
-  fs.writeFileSync(launcherPath, originalLauncher);
+  fs.writeFileSync(mcpPath, JSON.stringify(mcp));
   stage();
   const version = JSON.parse(fs.readFileSync(path.join(target, ".codex-plugin/plugin.json"))).version;
-  assert.equal(version, "26.901.41600-linux-native.3");
+  assert.equal(version, "26.908.31748-linux-native.4");
   assert.deepEqual(JSON.parse(fs.readFileSync(marketplacePath)).plugins.map(p => p.name), ["unified-computer-use", "browser", "computer-use"]);
   const settingsManifest = JSON.parse(fs.readFileSync(path.join(target, "../computer-use/.codex-plugin/plugin.json")));
   assert.equal(settingsManifest.mcpServers, undefined);
@@ -90,13 +91,13 @@ test("staging extends the hidden unified plugin and invalidates the browser-only
   assert.equal(JSON.parse(fs.readFileSync(path.join(target, ".codex-plugin/plugin.json"))).version, version);
   const manifestPath = path.join(target, ".codex-plugin/plugin.json");
   const previousManifest = JSON.parse(fs.readFileSync(manifestPath));
-  previousManifest.version = "26.901.41600-linux-native.1";
+  previousManifest.version = "26.908.31748-linux-native.1";
   fs.writeFileSync(manifestPath, JSON.stringify(previousManifest));
   stage();
   assert.equal(JSON.parse(fs.readFileSync(manifestPath)).version, version);
   stage();
   assert.equal(JSON.parse(fs.readFileSync(manifestPath)).version, version);
-  fs.writeFileSync(path.join(target, "scripts/launch.mjs"), "upstream drift");
+  fs.writeFileSync(factory, "upstream drift");
   assert.throws(stage, /unified.*contract/i);
 });
 


### PR DESCRIPTION
COSMIC windows were listed without bounds or reliable focus because the helper ignored output-relative geometry and finished its initial roundtrips before the compositor published toplevel properties. This waits for the completed snapshot, translates geometry through XDG logical output positions, and uses the COSMIC logical monitor layout for screenshot/input mapping. The ydotool scroll fallback now positions the cursor with the same absolute pointer used by clicks.

The latest signed stable package (26.908.31748) moved CUA startup out of the plugin. Replace the obsolete launcher-file patch with a scoped app-managed environment patch and native bootstrap, retaining the upstream shared launcher and browser factory. Missing, ambiguous, or partially patched contracts fail closed. The feature remains opt-in and the bundled plugin cache version advances to linux-native.4.

Validation:
- 279 Rust library tests, 11 COSMIC helper tests, rustfmt, and clippy with warnings denied.
- 63 adjacent feature tests, including runtime configuration, bootstrap, drift, and browser-only isolation cases.
- Official-bundle build with only computer-use-linux enabled, plus amd64 Debian package build. The input was resolved and verified through signed stable APT metadata before reuse for the build.
- Verified 4,079 official runtime/native files unchanged and both packaged helpers identical to the tested release binaries.
- Live COSMIC session with rebuilt helpers: target-window screenshots, focus, clicks, typing, Ctrl+A/Backspace, and scrolling passed; 20 consecutive snapshots returned valid window bounds.
- Latest packaged CUA runtime initialized successfully with native-only and combined browser/native surfaces.

Live desktop validation used one 1920×1080 display at scale 1. Negative origins and scaled mapping have automated coverage. A full desktop restart into the rebuilt package and other architectures/package formats have not been tested.