### PR TITLE
Fix configured model selection resets in existing chats

### DIFF
--- a/linux-features/model-picker-default-presets/README.md
+++ b/linux-features/model-picker-default-presets/README.md
@@ -6,6 +6,12 @@ effort pairs. It does not change the manual model list, API-key, Copilot, or
 Aeon-managed sessions, account entitlements, workspace policy, or upstream
 Ultra/XHigh gates.
 
+For an existing chat, configured pairs are kept as the composer's optimistic
+selection after the upstream next-turn settings RPC completes. This avoids a
+race where a long conversation can briefly expose stale thread metadata and
+reset the picker. Selecting a model/effort pair outside this feature's list
+removes that local override and restores the normal upstream behavior.
+
 The stock Settings page controls which reasoning efforts are visible and
 whether Ultra may appear in the picker. It does not currently configure the
 model/effort pairs behind **Default**.

--- a/linux-features/model-picker-default-presets/patch.js
+++ b/linux-features/model-picker-default-presets/patch.js
@@ -10,6 +10,9 @@ const LOCAL_COMPOSER_RESOLVER_MARKER =
   "codex-linux-model-picker-default-presets-local-composer-resolver";
 const LOCAL_DRAFT_SELECTION_MARKER =
   "codex-linux-model-picker-default-presets-local-draft-selection";
+const EXISTING_CHAT_OPTIMISTIC_MARKER =
+  "codex-linux-model-picker-default-presets-existing-chat-optimistic-selection";
+const EXISTING_CHAT_PRESET_IDS_KEY = "codexLinuxExistingChatDefaultPresetIds";
 const JS_ASSET_PATTERN = /\.js$/;
 const EFFORT_TO_THINKING_EFFORT = Object.freeze({
   none: "zero",
@@ -640,6 +643,168 @@ function localComposerConfigContract(source) {
   return "mixed";
 }
 
+function optimisticSelectionCleanupSection(source) {
+  const candidates = functionSections(source).filter(
+    (section) =>
+      section.source.includes('.target[0]==="default"') &&
+      section.source.includes(".selection") &&
+      optimisticSelectionCleanupTarget(section) != null,
+  );
+  return candidates.length === 1 ? candidates[0] : null;
+}
+
+function optimisticSelectionCleanupTarget(section) {
+  const signature =
+    /^function [A-Za-z_$][\w$]*\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)/u.exec(
+      section?.source ?? "",
+    );
+  if (signature == null) return null;
+  const [, store, entry] = signature;
+  const pattern = new RegExp(
+    `${store}\\.get\\(([A-Za-z_$][\\w$]*),${entry}\\.target\\)===${entry}\\.selection&&${store}\\.set\\(\\1,${entry}\\.target,null\\)`,
+    "gu",
+  );
+  const matches = [...section.source.matchAll(pattern)];
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function modelSettingsStateSection(source) {
+  return uniqueFunctionWithMarkers(source, [
+    "hasManagedNewThreadSettings:",
+    "setModelAndReasoningEffortForNextTurn:",
+    "No conversation available for next-turn model update",
+    "reasoningEffort:",
+    "serviceTier:",
+  ]);
+}
+
+function modelSettingsSelectionTarget(section) {
+  const source = section?.source ?? "";
+  const pattern =
+    /return [A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*,([A-Za-z_$][\w$]*),\{model:([A-Za-z_$][\w$]*),reasoningEffort:([A-Za-z_$][\w$]*),serviceTier:([A-Za-z_$][\w$]*)\},\(\)=>[A-Za-z_$][\w$]*\(/gu;
+  const matches = [...source.matchAll(pattern)];
+  if (matches.length !== 1) return null;
+  const [match, target, model, effort] = matches[0];
+  return {
+    effort,
+    match,
+    model,
+    serviceTier: matches[0][4],
+    target,
+  };
+}
+
+function chatGptAuthVariable(section) {
+  const matches = [
+    ...(section?.source ?? "").matchAll(
+      /([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\?\.authMethod===`chatgpt`/gu,
+    ),
+  ];
+  return matches.length === 1 ? matches[0][1] : null;
+}
+
+function existingChatPresetRuntime(presets) {
+  const ids = new Set();
+  for (const { modelSlug, thinkingEffort } of presets) {
+    ids.add(`${modelSlug}:${THINKING_EFFORT_TO_EFFORT[thinkingEffort]}`);
+    ids.add(`${modelSlug}:${thinkingEffort}`);
+  }
+  return `const ${EXISTING_CHAT_PRESET_IDS_KEY}=new Set(${JSON.stringify([...ids])});`;
+}
+
+function existingChatOptimisticContract(source) {
+  const markerCount = source.split(EXISTING_CHAT_OPTIMISTIC_MARKER).length - 1;
+  const presetIdsCount = source.split(EXISTING_CHAT_PRESET_IDS_KEY).length - 1;
+  const cleanup = optimisticSelectionCleanupSection(source);
+  const modelState = modelSettingsStateSection(source);
+  if (markerCount === 0 && presetIdsCount === 0) {
+    if (cleanup == null || modelState == null) return "drifted";
+    return modelSettingsSelectionTarget(modelState) != null &&
+      chatGptAuthVariable(modelState) != null
+      ? "current"
+      : "drifted";
+  }
+  if (
+    markerCount === 2 &&
+    presetIdsCount === 2 &&
+    cleanup != null &&
+    modelState != null &&
+    cleanup.source.includes(".selection?.codexLinuxKeepOptimisticSelection!==!0") &&
+    modelState.source.includes(`&&${EXISTING_CHAT_PRESET_IDS_KEY}.has(`)
+  ) {
+    return "applied";
+  }
+  return "mixed";
+}
+
+function applyExistingChatOptimisticPatch(source, context = {}) {
+  const presets = normalizePresets(context);
+  if (presets.length === 0) return source;
+  const contract = existingChatOptimisticContract(source);
+  if (contract === "applied") return source;
+  if (contract !== "current") {
+    warn(
+      "Could not find one coherent existing-chat optimistic model-selection contract",
+      "model picker Default existing-chat selection patch",
+    );
+    return source;
+  }
+
+  const cleanup = optimisticSelectionCleanupSection(source);
+  const modelState = modelSettingsStateSection(source);
+  const cleanupTarget = optimisticSelectionCleanupTarget(cleanup);
+  const selectionTarget = modelSettingsSelectionTarget(modelState);
+  const chatGptAuth = chatGptAuthVariable(modelState);
+  const entry =
+    /^function [A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*,([A-Za-z_$][\w$]*)\)/u.exec(
+      cleanup.source,
+    )?.[1];
+  if (
+    cleanupTarget == null ||
+    selectionTarget == null ||
+    chatGptAuth == null ||
+    entry == null
+  ) {
+    return source;
+  }
+
+  const patchedCleanup = cleanup.source.replace(
+    cleanupTarget[0],
+    `${entry}.selection?.codexLinuxKeepOptimisticSelection!==!0&&${cleanupTarget[0]}/*${EXISTING_CHAT_OPTIMISTIC_MARKER}*/`,
+  );
+  const patchedModelState = modelState.source.replace(
+    selectionTarget.match,
+    selectionTarget.match.replace(
+      `serviceTier:${selectionTarget.serviceTier}`,
+      `serviceTier:${selectionTarget.serviceTier},codexLinuxKeepOptimisticSelection:${chatGptAuth}&&${selectionTarget.target}[0]===\`conversation\`&&${EXISTING_CHAT_PRESET_IDS_KEY}.has(${selectionTarget.model}+\`:\`+${selectionTarget.effort})/*${EXISTING_CHAT_OPTIMISTIC_MARKER}*/`,
+    ),
+  );
+  const replacements = [
+    { ...cleanup, source: patchedCleanup },
+    { ...modelState, source: patchedModelState },
+  ].sort((left, right) => right.start - left.start);
+  let patchedSource = source;
+  for (const replacement of replacements) {
+    patchedSource =
+      patchedSource.slice(0, replacement.start) +
+      replacement.source +
+      patchedSource.slice(replacement.end);
+  }
+  const helperIndex = Math.min(cleanup.start, modelState.start);
+  patchedSource =
+    patchedSource.slice(0, helperIndex) +
+    existingChatPresetRuntime(presets) +
+    patchedSource.slice(helperIndex);
+  if (existingChatOptimisticContract(patchedSource) !== "applied") {
+    warn(
+      "Could not apply the complete existing-chat optimistic model-selection contract",
+      "model picker Default existing-chat selection patch",
+    );
+    return source;
+  }
+  return patchedSource;
+}
+
 function applyLocalComposerConfigPatch(source, context = {}) {
   const presets = normalizePresets(context);
   if (presets.length === 0) return source;
@@ -693,7 +858,7 @@ function applyLocalComposerConfigPatch(source, context = {}) {
     `;let codexLinuxLocalDraftDefaultRef=(0,${reactAlias}.useRef)(null),` +
     `codexLinuxLocalDraftDefaultScope=${conversationVariable}==null?JSON.stringify([${hostVariable}.hostId,${hostVariable}.cwd]):null,` +
     `codexLinuxLocalDraftDefaultSelection=${configVariable}==null?null:codexLinuxLocalDefaultPresetSelection(${defaultSelectionsVariable}),` +
-    `codexLinuxLocalDraftSelect=(codexLinuxModel,codexLinuxEffort,codexLinuxCallback)=>(${draftSelectionVariable}?.selectModelAndReasoningEffort??((codexLinuxFallbackModel,codexLinuxFallbackEffort,codexLinuxFallbackCallback)=>${baseSelectionVariable}(codexLinuxFallbackModel,codexLinuxFallbackEffort,codexLinuxFallbackCallback,${configVariable}!=null&&codexLinuxLocalDefaultPresetIds.has(\`${"${codexLinuxFallbackModel}:${codexLinuxFallbackEffort}"}\`)?{persistAsDefault:!1}:void 0)))(codexLinuxModel,codexLinuxEffort,codexLinuxCallback);` +
+    `codexLinuxLocalDraftSelect=(codexLinuxModel,codexLinuxEffort,codexLinuxCallback)=>(${draftSelectionVariable}?.selectModelAndReasoningEffort??${baseSelectionVariable})(codexLinuxModel,codexLinuxEffort,codexLinuxCallback,${configVariable}!=null&&${conversationVariable}==null&&codexLinuxLocalDefaultPresetIds.has(\`${"${codexLinuxModel}:${codexLinuxEffort}"}\`)?{persistAsDefault:!1}:void 0);` +
     `(0,${reactAlias}.useEffect)(()=>{if(codexLinuxLocalDraftDefaultScope==null){codexLinuxLocalDraftDefaultRef.current=null;return}codexLinuxLocalDraftDefaultSelection==null||codexLinuxLocalDraftDefaultRef.current===codexLinuxLocalDraftDefaultScope||(codexLinuxLocalDraftDefaultRef.current=codexLinuxLocalDraftDefaultScope,codexLinuxLocalDraftSelect(codexLinuxLocalDraftDefaultSelection.model,codexLinuxLocalDraftDefaultSelection.reasoningEffort,()=>{}))},[codexLinuxLocalDraftDefaultScope,codexLinuxLocalDraftDefaultSelection?.id]);` +
     `let ${selectHandlerVariable}=function`;
   patchedSection = patchedSection.replace(
@@ -773,9 +938,21 @@ const descriptors = [
     apply: applyLocalComposerResolverPatch,
   },
   {
-    id: "model-picker-default-presets-local-composer-config",
+    id: "model-picker-default-presets-existing-chat-optimistic-selection",
     phase: "webview-asset",
     order: 20_801,
+    ciPolicy: "optional",
+    pattern: JS_ASSET_PATTERN,
+    enabled: (context = {}) => normalizePresets(context).length > 0,
+    assetMatch: (source) => existingChatOptimisticContract(source) !== "drifted",
+    missingDescription: "existing-chat model settings state bundle",
+    skipDescription: "model picker Default existing-chat selection patch",
+    apply: applyExistingChatOptimisticPatch,
+  },
+  {
+    id: "model-picker-default-presets-local-composer-config",
+    phase: "webview-asset",
+    order: 20_802,
     ciPolicy: "optional",
     pattern: JS_ASSET_PATTERN,
     enabled: (context = {}) => normalizePresets(context).length > 0,
@@ -790,6 +967,7 @@ module.exports = {
   CATALOG_PATCH_MARKER,
   CATALOG_PRESET_OPTIONS_KEY,
   EFFORT_TO_THINKING_EFFORT,
+  EXISTING_CHAT_OPTIMISTIC_MARKER,
   LOCAL_COMPOSER_CONFIG_MARKER,
   LOCAL_COMPOSER_RESOLVER_MARKER,
   LOCAL_DRAFT_SELECTION_MARKER,
@@ -798,6 +976,7 @@ module.exports = {
   JS_ASSET_PATTERN,
   SLIDER_PATCH_MARKER,
   applyCatalogPatch,
+  applyExistingChatOptimisticPatch,
   applyLocalComposerConfigPatch,
   applyLocalComposerResolverPatch,
   applySliderMinimumPatch,
@@ -806,6 +985,7 @@ module.exports = {
   codexLinuxModelPickerDefaultPresets,
   descriptors,
   normalizePresets,
+  existingChatOptimisticContract,
   localComposerConfig,
   localComposerConfigContract,
   localComposerResolverContract,

--- a/linux-features/model-picker-default-presets/test.js
+++ b/linux-features/model-picker-default-presets/test.js
@@ -14,18 +14,21 @@ const {
   CATALOG_PATCH_MARKER,
   CATALOG_PRESET_OPTIONS_KEY,
   EFFORT_TO_THINKING_EFFORT,
+  EXISTING_CHAT_OPTIMISTIC_MARKER,
   LOCAL_DEFAULT_PATCH_MARKER,
   LOCAL_COMPOSER_CONFIG_MARKER,
   LOCAL_COMPOSER_RESOLVER_MARKER,
   LOCAL_DRAFT_SELECTION_MARKER,
   SLIDER_PATCH_MARKER,
   applyCatalogPatch,
+  applyExistingChatOptimisticPatch,
   applyLocalComposerConfigPatch,
   applyLocalComposerResolverPatch,
   applySliderMinimumPatch,
   catalogAssetMatch,
   catalogPatchContract,
   codexLinuxModelPickerDefaultPresets,
+  existingChatOptimisticContract,
   normalizePresets,
   localComposerConfigContract,
   localComposerResolverContract,
@@ -100,6 +103,24 @@ function localComposerFixture(name = "LocalComposer") {
     "composer.mode.local.model.custom;let reset=zae(Ue,He==null?void 0:`${He.model}:${He.defaultReasoningEffort}`);",
     "render({onSelectDefault:reset});",
     "return{powerSelections:Ue,fallback:Ke,reset,selected}}",
+    "function Next(){}",
+  ].join("");
+}
+
+function existingChatStateFixture(cleanupName = "p6a", stateName = "q8a") {
+  return [
+    `function ${cleanupName}(e,t){e.get($1,t.target)===t.selection&&(e.set($1,t.target,null),e.get(Q1,t.target)===t.selection&&e.set(Q1,t.target,null),t.target[0]===\"default\"&&e.get(m6a)===t.selection&&e.set(m6a,null))}`,
+    `function ${stateName}(e,t,n){`,
+    "let i=e,host={authMethod:t??`chatgpt`},isChatGptAuth=host?.authMethod===`chatgpt`,",
+    "a=n??[`conversation`,`thread`],hasManagedNewThreadSettings=false,",
+    "setModelAndReasoningEffortForNextTurn=()=>true,",
+    "error=Error(`No conversation available for next-turn model update`),",
+    "G=()=>true,",
+    "de=(t,n,r)=>{let o=r?.serviceTier===void 0?void 0:r.serviceTier;",
+    "return d6a(i,a,{model:t,reasoningEffort:n,serviceTier:o},()=>G(t,n,`current`,o))};",
+    "return{hasManagedNewThreadSettings:hasManagedNewThreadSettings,",
+    "setModelAndReasoningEffortForNextTurn:setModelAndReasoningEffortForNextTurn,",
+    "setModelAndReasoningEffort:de,error}}",
     "function Next(){}",
   ].join("");
 }
@@ -602,6 +623,20 @@ test("local composer uses configured pairs and lowers only its config threshold"
   });
   assert.deepEqual(existingConversation.selections, []);
 
+  const existingConfiguredSelection = runComposer({
+    available: [
+      { id: "gpt-5.6-sol:high", model: "gpt-5.6-sol", reasoningEffort: "high" },
+    ],
+    conversationId: "existing",
+    manualSelection: true,
+  });
+  assert.deepEqual(existingConfiguredSelection.selections, [
+    {
+      effort: "high",
+      model: "gpt-5.6-sol",
+    },
+  ]);
+
   const lifecycleHooks = { refs: [] };
   const lifecycleAvailable = [
     { id: "gpt-5.6-sol:medium", model: "gpt-5.6-sol", reasoningEffort: "medium" },
@@ -632,6 +667,103 @@ test("local composer uses configured pairs and lowers only its config threshold"
       options: { persistAsDefault: false },
     },
   ]);
+});
+
+test("existing chats retain configured optimistic selections until another selection replaces them", () => {
+  const presets = context([
+    { model: "gpt-5.6-sol", effort: "medium", default: true },
+    { model: "gpt-5.6-sol", effort: "xhigh" },
+  ]);
+  const source = existingChatStateFixture();
+  assert.equal(existingChatOptimisticContract(source), "current");
+  const patched = applyExistingChatOptimisticPatch(source, presets);
+  assert.equal(existingChatOptimisticContract(patched), "applied");
+  assert.equal(applyExistingChatOptimisticPatch(patched, presets), patched);
+  assert.equal(
+    (patched.match(new RegExp(EXISTING_CHAT_OPTIMISTIC_MARKER, "g")) ?? []).length,
+    2,
+  );
+
+  const state = new Map();
+  const key = (_atom, target) => JSON.stringify(target);
+  const store = {
+    get(atom, target) {
+      return state.get(`${atom}:${key(atom, target)}`);
+    },
+    set(atom, target, value) {
+      state.set(`${atom}:${key(atom, target)}`, value);
+    },
+  };
+  const globals = {
+    $1: "pending",
+    Q1: "optimistic",
+    m6a: "default",
+    d6a: (_store, _target, selection) => selection,
+    store,
+  };
+  const configured = evaluate(
+    patched,
+    "q8a(store).setModelAndReasoningEffort('gpt-5.6-sol','xhigh')",
+    { ...globals },
+  );
+  const target = ["conversation", "thread"];
+  store.set("pending", target, configured);
+  store.set("optimistic", target, configured);
+  evaluate(patched, "p6a(store,{selection,target:['conversation','thread']})", {
+    ...globals,
+    selection: configured,
+  });
+  assert.equal(store.get("pending", target), null);
+  assert.strictEqual(store.get("optimistic", target), configured);
+
+  const translatedConfigured = evaluate(
+    patched,
+    "q8a(store).setModelAndReasoningEffort('gpt-5.6-sol','standard')",
+    { ...globals },
+  );
+  assert.equal(translatedConfigured.codexLinuxKeepOptimisticSelection, true);
+
+  const nonChatGptConfigured = evaluate(
+    patched,
+    "q8a(store,'api-key').setModelAndReasoningEffort('gpt-5.6-sol','xhigh')",
+    { ...globals },
+  );
+  assert.equal(nonChatGptConfigured.codexLinuxKeepOptimisticSelection, false);
+
+  const newThreadConfigured = evaluate(
+    patched,
+    "q8a(store,undefined,['default','local','/repo']).setModelAndReasoningEffort('gpt-5.6-sol','xhigh')",
+    { ...globals },
+  );
+  assert.equal(newThreadConfigured.codexLinuxKeepOptimisticSelection, false);
+
+  const manual = evaluate(
+    patched,
+    "q8a(store).setModelAndReasoningEffort('gpt-6-astra','standard')",
+    { ...globals },
+  );
+  store.set("pending", target, manual);
+  store.set("optimistic", target, manual);
+  evaluate(patched, "p6a(store,{selection,target:['conversation','thread']})", {
+    ...globals,
+    selection: manual,
+  });
+  assert.equal(store.get("optimistic", target), null);
+});
+
+test("existing-chat patch fails closed on drift, duplicate, and partial states", () => {
+  const presets = context([{ model: "gpt-5.6-sol", effort: "medium", default: true }]);
+  for (const source of [
+    "function unrelated(){}",
+    existingChatStateFixture("pOne", "qOne") + existingChatStateFixture("pTwo", "qTwo"),
+    `${EXISTING_CHAT_OPTIMISTIC_MARKER};${existingChatStateFixture()}`,
+  ]) {
+    const { result, warnings } = withCapturedWarnings(() =>
+      applyExistingChatOptimisticPatch(source, presets),
+    );
+    assert.equal(result, source);
+    assert.equal(warnings.length, 1);
+  }
 });
 
 test("local composer patches fail closed on drift, duplicate, and partial states", () => {
@@ -711,7 +843,7 @@ test("feature descriptors load alone and alongside ui-tweaks", () => {
       featuresRoot: root,
       featuresConfigPath: configPath,
     });
-    assert.equal(alone.length, 4);
+    assert.equal(alone.length, 5);
     assert.ok(alone.every(({ featureId }) => featureId === "model-picker-default-presets"));
     writeConfig(["model-picker-default-presets", "ui-tweaks"]);
     const together = loadLinuxFeaturePatchDescriptors({

--- a/linux-features/ui-tweaks/patches/ui-font-size.js
+++ b/linux-features/ui-tweaks/patches/ui-font-size.js
@@ -122,7 +122,7 @@ function fontSizeBundlePaths(extractedDir) {
   if (fs.existsSync(webviewAssetsDir)) {
     paths.push(
       ...fs.readdirSync(webviewAssetsDir, { withFileTypes: true })
-        .filter((entry) => entry.isFile() && /^app-initial-[^.]+\.js$/.test(entry.name))
+        .filter((entry) => entry.isFile() && /^src-[^.]+\.js$/.test(entry.name))
         .map((entry) => path.join(webviewAssetsDir, entry.name)),
     );
   }

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -191,12 +191,16 @@ function createUiFontSizeExtractedApp() {
   const targets = [
     path.join(buildDir, "src-fixture.js"),
     path.join(buildDir, "worker.js"),
-    path.join(webviewDir, "app-initial-fixture.js"),
+    path.join(webviewDir, "src-fixture.js"),
   ];
   for (const target of targets) {
     fs.writeFileSync(target, uiFontSizeBundleFixture());
   }
   fs.writeFileSync(path.join(buildDir, "unrelated.js"), "console.log('unrelated');");
+  fs.writeFileSync(
+    path.join(webviewDir, "app-initial-retired.js"),
+    uiFontSizeBundleFixture(),
+  );
   return { extractedDir, targets };
 }
 


### PR DESCRIPTION
## Summary

- retain configured Default model/effort pairs while stale metadata catches up in existing ChatGPT chats
- apply the retention in the shared model-settings state path so local, cloud, and TPP picker callers behave consistently
- keep new-draft behavior, manual non-preset selections, API-key/Copilot isolation, account gates, and upstream fallback unchanged
- follow the current signed Linux 26.908.31748 UI font-size bundle owner so the enabled local `ui-tweaks` configuration continues to build

## Tests

- `node --test linux-features/model-picker-default-presets/test.js linux-features/ui-tweaks/test.js`
- `node --test scripts/patch-linux-window-ui.test.js scripts/lib/linux-features.test.js linux-features/*/test.js`
- `node scripts/ci/verify-official-linux-features.js <26.908.31748 extracted app.asar>`
- feature-only patch build: 5/5 model picker descriptors applied
- combined local feature configuration: 27 patches applied, no enabled-feature failures
- `git diff --check`

## Notes

Configured selections remain an in-memory optimistic override for the active existing chat until another model/effort selection replaces them. The feature does not grant unavailable models or bypass workspace, Ultra, or XHigh gates.
