### PR TITLE
Fix upstream renderer startup cycle by default

### DIFF
--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -103,7 +103,7 @@ jobs:
             throw new Error("invalid dispatched release identity");
           }
           NODE
-      - name: Build byte-identical clean baseline
+      - name: Build required default baseline
         env:
           CODEX_TARGET_ARCH: ${{ matrix.architecture }}
           CODEX_LINUX_FEATURES_CONFIG: ${{ github.workspace }}/linux-features/features.example.json
@@ -112,7 +112,29 @@ jobs:
           ./install.sh "${{ steps.upstream.outputs.package }}"
           upstream_root="$(mktemp -d)"
           dpkg-deb -x "${{ steps.upstream.outputs.package }}" "$upstream_root"
-          cmp "$upstream_root/usr/lib/chatgpt/resources/app.asar" "$CODEX_INSTALL_DIR/resources/app.asar"
+          if cmp -s "$upstream_root/usr/lib/chatgpt/resources/app.asar" "$CODEX_INSTALL_DIR/resources/app.asar"; then
+            echo "required renderer-cycle patch did not change app.asar" >&2
+            exit 1
+          fi
+          node - "$CODEX_INSTALL_DIR/.codex-linux/patch-report.json" <<'NODE'
+          const fs = require("node:fs");
+          const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const expected = [{
+            name: "upstream-renderer-cycle",
+            status: "applied",
+            ciPolicy: "required-upstream",
+            sourceKind: "core",
+          }];
+          const actual = report.patches.map(({ name, status, ciPolicy, sourceKind }) => ({
+            name,
+            status,
+            ciPolicy,
+            sourceKind,
+          }));
+          if (report.enabledFeatures.length !== 0 || JSON.stringify(actual) !== JSON.stringify(expected)) {
+            throw new Error(`unexpected default patch report: ${JSON.stringify(report)}`);
+          }
+          NODE
           test -x "$CODEX_INSTALL_DIR/ChatGPT"
           test -x "$CODEX_INSTALL_DIR/resources/codex"
       - name: Validate the Nix ELF contract against the official payload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Default builds now repair the renderer module cycle in signed stable Linux
+  `26.908.31748` that can leave the main window empty with
+  `Initial route prefetch failed: n is not a function`. The required core
+  patch is acceptance-gated and must be retired when upstream removes the
+  cycle.
 - Wayland sessions again start the app on a native Wayland surface. The
   launcher appends `--ozone-platform=wayland` when `WAYLAND_DISPLAY` names a
   live compositor socket, the session is not X11, and no command-line argument,

--- a/install.sh
+++ b/install.sh
@@ -102,10 +102,13 @@ stage_community_branding() {
 verify_clean_asar_preserved() {
     local upstream_asar="$1"
     local output_asar="$2"
-    local descriptor_count
-    descriptor_count="$(node "$SCRIPT_DIR/scripts/lib/linux-features.js" --patch-descriptor-count)"
-    [ "$descriptor_count" -ne 0 ] || cmp -s "$upstream_asar" "$output_asar" || \
-        error "Clean build changed resources/app.asar; refusing candidate"
+    local feature_descriptor_count
+    feature_descriptor_count="$(node "$SCRIPT_DIR/scripts/lib/linux-features.js" --patch-descriptor-count)"
+    [ "$feature_descriptor_count" -eq 0 ] || return 0
+    cmp -s "$upstream_asar" "$output_asar" && return 0
+    [ -n "${CODEX_PATCH_REPORT_RESOLVED:-}" ] &&
+        patch_report_has_only_required_core_changes "$CODEX_PATCH_REPORT_RESOLVED" && return 0
+    error "Default build changed resources/app.asar outside a required core patch; refusing candidate"
 }
 
 build_from_upstream_package() {

--- a/linux-features/filesystem-root-follow-ups/test.js
+++ b/linux-features/filesystem-root-follow-ups/test.js
@@ -100,7 +100,11 @@ function withApp(fn) {
   fs.mkdirSync(assets, { recursive: true });
   const config = path.join(dir, "features.json");
   fs.writeFileSync(config, JSON.stringify({ enabled: ["filesystem-root-follow-ups"] }));
-  const options = { featuresRoot: path.resolve(__dirname, ".."), featuresConfigPath: config };
+  const options = {
+    featuresRoot: path.resolve(__dirname, ".."),
+    featuresConfigPath: config,
+    corePatchRoot: path.join(dir, "empty-core"),
+  };
   try {
     fn({ dir, assets, config, options });
   } finally {

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -3273,7 +3273,8 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           syntheticAppMainActiveStatusBundle(),
         );
         const report = createPatchReport();
-        patchExtractedApp(tempApp, { report });
+        const patchOptions = { corePatchRoot: path.join(tempApp, "empty-core") };
+        patchExtractedApp(tempApp, { ...patchOptions, report });
 
         const patchedFile = fs.readFileSync(path.join(buildDir, "main.js"), "utf8");
         const patchedAppServerLaunchFile = fs.readFileSync(
@@ -3432,7 +3433,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         );
 
         const secondReport = createPatchReport();
-        patchExtractedApp(tempApp, { report: secondReport });
+        patchExtractedApp(tempApp, { ...patchOptions, report: secondReport });
         assert.ok(
           secondReport.patches.some((patch) =>
             patch.name === "feature:remote-mobile-control:linux-remote-terminal-status-recovery" &&

--- a/scripts/ci/github-actions-workflows.test.js
+++ b/scripts/ci/github-actions-workflows.test.js
@@ -55,6 +55,10 @@ test("official Linux validation runs fully on every pull request but not hourly"
   assert.match(workflow, /^      - \.github\/workflows\/upstream-build-app\.yml$/m);
   const signedBaseline = job(workflow, "signed-baseline");
   assert.match(signedBaseline, /architecture: \[amd64, arm64\]/);
+  assert.match(signedBaseline, /name: Build required default baseline/);
+  assert.match(signedBaseline, /name: "upstream-renderer-cycle"/);
+  assert.match(signedBaseline, /ciPolicy: "required-upstream"/);
+  assert.match(signedBaseline, /sourceKind: "core"/);
   assert.match(
     signedBaseline,
     /name: Validate the Nix ELF contract against the official payload[\s\S]*?env:\n          CODEX_INSTALL_DIR:.*matrix\.architecture[\s\S]*?nix\/elf-runtime\.cjs fix[\s\S]*?nix\/elf-runtime\.cjs audit/,

--- a/scripts/lib/asar-patch.sh
+++ b/scripts/lib/asar-patch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Apply enabled feature descriptors to the official Linux app.asar.
-# A clean build deliberately never extracts or repacks app.asar.
+# A build with no active descriptor never extracts or repacks app.asar.
 # Sourced by install.sh. Do not run directly.
 # shellcheck shell=bash
 
@@ -25,6 +25,18 @@ const [reportPath, helperPath] = process.argv.slice(2);
 const { reportHasPatchChanges } = require(helperPath);
 const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
 process.exit(reportHasPatchChanges(report) ? 0 : 1);
+NODE
+}
+
+patch_report_has_only_required_core_changes() {
+    local patch_report="$1"
+    node - "$patch_report" <<'NODE'
+const fs = require("node:fs");
+const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const changed = (report.patches ?? []).filter((patch) => patch.status === "applied");
+const valid = changed.length > 0 && changed.every((patch) =>
+  patch.sourceKind === "core" && patch.ciPolicy === "required-upstream");
+process.exit(valid ? 0 : 1);
 NODE
 }
 
@@ -67,11 +79,18 @@ patch_asar() {
     local app_asar="$resources_dir/app.asar"
     local patch_report_json="${CODEX_PATCH_REPORT_JSON:-$WORK_DIR/patch-report.json}"
     local descriptor_count
+    local core_descriptor_count
     local upstream_sha
     local patched_sha
 
     [ -f "$app_asar" ] || error "app.asar not found in $resources_dir"
+    core_descriptor_count="$(node - "$SCRIPT_DIR/scripts/patches/runner.js" <<'NODE'
+const { corePatchDescriptors } = require(process.argv[2]);
+process.stdout.write(String(corePatchDescriptors().length));
+NODE
+)"
     descriptor_count="$(node "$SCRIPT_DIR/scripts/lib/linux-features.js" --patch-descriptor-count)"
+    descriptor_count="$((descriptor_count + core_descriptor_count))"
     if [ "$descriptor_count" -eq 0 ]; then
         info "No ASAR feature descriptors enabled; preserving official app.asar byte-for-byte"
         write_empty_feature_patch_report "$patch_report_json" "$app_asar"
@@ -80,7 +99,7 @@ patch_asar() {
     fi
 
     upstream_sha="$(sha256sum "$app_asar" | awk '{print $1}')"
-    info "Extracting a temporary app.asar copy for $descriptor_count enabled feature descriptor(s)"
+    info "Extracting a temporary app.asar copy for $descriptor_count active descriptor(s)"
     npx --yes @electron/asar extract "$app_asar" "$WORK_DIR/app-extracted"
     if [ -d "$resources_dir/app.asar.unpacked" ]; then
         cp -a "$resources_dir/app.asar.unpacked/." "$WORK_DIR/app-extracted/"

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -48,14 +48,17 @@ test("best-effort feature drift stays non-fatal without hiding changed outputs",
   assert.equal(enabledFeatureFailuresFromReport(report).length, 1);
 });
 
-test("official Linux baseline has an empty core patch registry", () => {
-  assert.deepEqual(corePatchDescriptors(), []);
+test("official Linux baseline has one required renderer-cycle core patch", () => {
+  assert.deepEqual(
+    corePatchDescriptors().map(({ id, ciPolicy }) => ({ id, ciPolicy })),
+    [{ id: "upstream-renderer-cycle", ciPolicy: "required-upstream" }],
+  );
   assert.equal(featurePatchDescriptors({
     featuresConfigPath: path.join(__dirname, "..", "linux-features", "features.example.json"),
   }).length, 0);
 });
 
-test("empty registry leaves an extracted official-style app unchanged", (t) => {
+test("an explicitly empty registry leaves an extracted official-style app unchanged", (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-empty-patch-registry-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
   const buildDir = path.join(root, ".vite", "build");
@@ -73,6 +76,7 @@ test("empty registry leaves an extracted official-style app unchanged", (t) => {
   const report = createPatchReport();
   patchExtractedApp(root, {
     report,
+    corePatchRoot: path.join(root, "empty-core"),
     featuresConfigPath: path.join(__dirname, "..", "linux-features", "features.example.json"),
   });
   assert.deepEqual(report.patches, []);

--- a/scripts/patches/core/README.md
+++ b/scripts/patches/core/README.md
@@ -1,11 +1,17 @@
 # Core patch registry
 
-The core registry is intentionally empty. OpenAI's official Linux package is
-the compatibility baseline, and a default build must preserve `app.asar`
-byte-for-byte.
+OpenAI's official Linux package is the compatibility baseline. The registry
+contains only required compatibility patches for reproduced mandatory failures
+in the current signed stable package.
 
 Product extensions and measured workarounds belong in disabled-by-default
 `linux-features/<id>/` directories. A new core descriptor is allowed only when
 the current signed official package cannot pass a mandatory launch/work smoke
 test without it; the descriptor must include the reproduction evidence and a
 required regression test in the migration tracking record.
+
+Current required patch:
+
+- `upstream-renderer-cycle` defers the cyclic `authed-route` initializer in
+  signed stable `26.908.31748`; remove it when the next signed stable no longer
+  has that cycle.

--- a/scripts/patches/core/all-linux/extracted-app/upstream-renderer-cycle/patch.js
+++ b/scripts/patches/core/all-linux/extracted-app/upstream-renderer-cycle/patch.js
@@ -1,0 +1,182 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const IDENT = "[A-Za-z_$][\\w$]*";
+const AUTHED_ROUTE_ASSET_PATTERN = /^authed-route-[A-Za-z0-9_-]+\.js$/;
+const APP_PRIMARY_ASSET_PATTERN = /^app-primary-[A-Za-z0-9_-]+\.js$/;
+const ROUTE_INITIALIZER_PATTERN = new RegExp(
+  `(?:queueMicrotask\\(\\(\\)=>(${IDENT})\\(\\)\\)|(${IDENT})\\(\\));export\\{([^}]*)\\};`,
+  "gu",
+);
+const APP_PRIMARY_IMPORT_PATTERN = new RegExp(
+  `import\\{([^}]*)\\}from[\"']\\./(app-primary-[A-Za-z0-9_-]+\\.js)[\"'];`,
+  "gu",
+);
+const EXPORT_PATTERN = /export\{([^}]*)\};/gu;
+const WARNING =
+  "WARN: Could not uniquely identify the official app-primary/authed-route renderer cycle — skipping upstream renderer cycle fix";
+
+function specifierMappings(specifiers) {
+  return specifiers.split(",").map((specifier) => {
+    const names = specifier.trim().split(/\s+as\s+/u);
+    return { source: names[0], target: names[1] ?? names[0] };
+  });
+}
+
+function exportedNames(specifiers) {
+  return specifierMappings(specifiers).map(({ target }) => target);
+}
+
+function routeInitializerContracts(source) {
+  const imports = [...source.matchAll(APP_PRIMARY_IMPORT_PATTERN)];
+  const contracts = [];
+  for (const match of source.matchAll(ROUTE_INITIALIZER_PATTERN)) {
+    const initializer = match[1] ?? match[2];
+    const routeExports = exportedNames(match[3]);
+    if (!routeExports.includes("AuthedRoute") || !routeExports.includes("AppLayoutRoute")) {
+      continue;
+    }
+    const primaryImports = imports.flatMap((candidate) =>
+      specifierMappings(candidate[1])
+        .filter(({ target }) => target === initializer)
+        .map(({ source }) => ({ asset: candidate[2], exportedName: source })));
+    if (primaryImports.length !== 1) continue;
+    const call = match[1] == null
+      ? `${initializer}()`
+      : `queueMicrotask(()=>${initializer}())`;
+    contracts.push({
+      start: match.index,
+      end: match.index + call.length,
+      initializer,
+      primaryAsset: primaryImports[0].asset,
+      primaryExport: primaryImports[0].exportedName,
+      patched: match[1] != null,
+    });
+  }
+  return contracts;
+}
+
+function lateModuleInitializerContracts(source, exportedName) {
+  const exportedBindings = [...source.matchAll(EXPORT_PATTERN)]
+    .flatMap((match) => specifierMappings(match[1]))
+    .filter(({ target }) => target === exportedName);
+  if (exportedBindings.length !== 1) return [];
+
+  const localName = exportedBindings[0].source;
+  const escapedLocalName = localName.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  const assignmentPattern = new RegExp(
+    `(?:\\bvar\\s|,)${escapedLocalName}=(${IDENT})\\(\\(\\(\\)=>\\{`,
+    "gu",
+  );
+  return [...source.matchAll(assignmentPattern)].map((match) => ({
+    localName,
+    wrapperName: match[1],
+  }));
+}
+
+function hasReverseImport(source, authedRouteAsset) {
+  const escapedAsset = authedRouteAsset.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  return new RegExp(
+    `import\\{[^}]*\\}from[\"']\\./${escapedAsset}[\"'];`,
+    "u",
+  ).test(source);
+}
+
+function rendererCycleContracts(extractedDir) {
+  const assetsDir = path.join(extractedDir, "webview", "assets");
+  if (!fs.existsSync(assetsDir)) return [];
+
+  const contracts = [];
+  for (const authedRouteAsset of fs.readdirSync(assetsDir).sort()) {
+    if (!AUTHED_ROUTE_ASSET_PATTERN.test(authedRouteAsset)) continue;
+    const authedRoutePath = path.join(assetsDir, authedRouteAsset);
+    const source = fs.readFileSync(authedRoutePath, "utf8");
+    for (const contract of routeInitializerContracts(source)) {
+      if (!APP_PRIMARY_ASSET_PATTERN.test(contract.primaryAsset)) continue;
+      const primaryPath = path.join(assetsDir, contract.primaryAsset);
+      if (!fs.existsSync(primaryPath)) continue;
+      const primarySource = fs.readFileSync(primaryPath, "utf8");
+      if (!hasReverseImport(primarySource, authedRouteAsset)) continue;
+      const primaryInitializers = lateModuleInitializerContracts(
+        primarySource,
+        contract.primaryExport,
+      );
+      if (primaryInitializers.length !== 1) continue;
+      contracts.push({
+        ...contract,
+        authedRouteAsset,
+        authedRoutePath,
+        primaryInitializer: primaryInitializers[0].localName,
+        source,
+      });
+    }
+  }
+  return contracts;
+}
+
+function patchUpstreamRendererCycle(extractedDir) {
+  const contracts = rendererCycleContracts(extractedDir);
+  if (contracts.length !== 1) {
+    console.warn(WARNING);
+    return { matched: false, changed: 0, reason: WARNING };
+  }
+
+  const contract = contracts[0];
+  if (contract.patched) {
+    return {
+      matched: true,
+      changed: 0,
+      alreadyApplied: true,
+      assetName: contract.authedRouteAsset,
+    };
+  }
+
+  const patched =
+    contract.source.slice(0, contract.start) +
+    `queueMicrotask(()=>${contract.initializer}())` +
+    contract.source.slice(contract.end);
+  const verified = routeInitializerContracts(patched);
+  if (
+    verified.length !== 1 ||
+    !verified[0].patched ||
+    verified[0].primaryAsset !== contract.primaryAsset ||
+    verified[0].primaryExport !== contract.primaryExport
+  ) {
+    console.warn(WARNING);
+    return { matched: false, changed: 0, reason: WARNING };
+  }
+  fs.writeFileSync(contract.authedRoutePath, patched, "utf8");
+
+  return {
+    matched: true,
+    changed: 1,
+    alreadyApplied: false,
+    assetName: contract.authedRouteAsset,
+  };
+}
+
+module.exports = {
+  AUTHED_ROUTE_ASSET_PATTERN,
+  descriptors: [
+    {
+      id: "upstream-renderer-cycle",
+      phase: "extracted-app:post-webview",
+      order: 980,
+      ciPolicy: "required-upstream",
+      apply: patchUpstreamRendererCycle,
+      status: (result, warnings) => {
+        if (result?.matched !== true) {
+          return { status: "failed-required", reason: result?.reason ?? warnings[0] ?? null };
+        }
+        return result.changed > 0 ? "applied" : "already-applied";
+      },
+    },
+  ],
+  hasReverseImport,
+  lateModuleInitializerContracts,
+  patchUpstreamRendererCycle,
+  rendererCycleContracts,
+  routeInitializerContracts,
+};

--- a/scripts/patches/core/all-linux/extracted-app/upstream-renderer-cycle/patch.test.js
+++ b/scripts/patches/core/all-linux/extracted-app/upstream-renderer-cycle/patch.test.js
@@ -1,0 +1,255 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const childProcess = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { createPatchReport, criticalFailuresFromReport } = require("../../../../../lib/patch-report.js");
+const { patchExtractedApp } = require("../../../../runner.js");
+const patchModule = require("./patch.js");
+const {
+  lateModuleInitializerContracts,
+  patchUpstreamRendererCycle,
+  rendererCycleContracts,
+  routeInitializerContracts,
+} = patchModule;
+
+function fixtureRoot(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "upstream-renderer-cycle-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const assetsDir = path.join(root, "webview", "assets");
+  fs.mkdirSync(assetsDir, { recursive: true });
+  fs.writeFileSync(path.join(root, "package.json"), '{"type":"module"}\n');
+  return { root, assetsDir };
+}
+
+function authedRouteSource(primaryAsset = "app-primary-fixture.js", patched = false) {
+  const initializer = patched ? "queueMicrotask(()=>n())" : "n()";
+  return [
+    `import{Ac as t,jc as n,kc as r}from"./${primaryAsset}";`,
+    "var o={name:`smartphone-light-16`};",
+    `${initializer};export{r as AppLayoutRoute,t as AuthedRoute,o as n};`,
+  ].join("");
+}
+
+function appPrimarySource(
+  authedRouteAsset = "authed-route-fixture.js",
+  reverseImport = true,
+  initializerKind = "late",
+) {
+  return [
+    reverseImport ? `import{n as phone}from"./${authedRouteAsset}";` : "var phone={};",
+    "var initialized=false;",
+    initializerKind === "late"
+      ? "var initializer=moduleFactory((()=>{initialized=true}));function moduleFactory(factory){return()=>factory()}"
+      : "function initializer(){initialized=true}",
+    "var appLayout={},authed={};",
+    "export{authed as Ac,initializer as jc,appLayout as kc};",
+    "export function state(){return{initialized,phone:phone.name}}",
+  ].join("");
+}
+
+function writeCycleFixture(assetsDir, options = {}) {
+  const routeName = options.routeName ?? "authed-route-fixture.js";
+  const primaryName = options.primaryName ?? "app-primary-fixture.js";
+  fs.writeFileSync(
+    path.join(assetsDir, routeName),
+    authedRouteSource(primaryName, options.patched ?? false),
+  );
+  fs.writeFileSync(
+    path.join(assetsDir, primaryName),
+    appPrimarySource(
+      routeName,
+      options.reverseImport ?? true,
+      options.initializerKind ?? "late",
+    ),
+  );
+  return { routeName, primaryName };
+}
+
+function importPrimary(root, primaryName) {
+  const primaryUrl = new URL(
+    `./webview/assets/${primaryName}`,
+    `file://${root}/`,
+  ).href;
+  return childProcess.spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `const m=await import(${JSON.stringify(primaryUrl)});await new Promise(queueMicrotask);console.log(JSON.stringify(m.state()))`,
+    ],
+    { encoding: "utf8" },
+  );
+}
+
+test("renderer cycle repair is a required core descriptor", () => {
+  assert.deepEqual(
+    patchModule.descriptors.map(({ id, phase, ciPolicy }) => [id, phase, ciPolicy]),
+    [["upstream-renderer-cycle", "extracted-app:post-webview", "required-upstream"]],
+  );
+});
+
+test("renderer cycle patch defers the initializer and is idempotent", (t) => {
+  const { root, assetsDir } = fixtureRoot(t);
+  const { routeName } = writeCycleFixture(assetsDir);
+
+  const before = fs.readFileSync(path.join(assetsDir, routeName), "utf8");
+  const result = patchUpstreamRendererCycle(root);
+  const after = fs.readFileSync(path.join(assetsDir, routeName), "utf8");
+
+  assert.deepEqual(result, {
+    matched: true,
+    changed: 1,
+    alreadyApplied: false,
+    assetName: routeName,
+  });
+  assert.notEqual(after, before);
+  assert.equal(after, before.replace("n();export{", "queueMicrotask(()=>n());export{"));
+  assert.match(after, /queueMicrotask\(\(\)=>n\(\)\);export\{/u);
+  assert.equal(rendererCycleContracts(root).length, 1);
+  assert.equal(rendererCycleContracts(root)[0].patched, true);
+  assert.deepEqual(patchUpstreamRendererCycle(root), {
+    matched: true,
+    changed: 0,
+    alreadyApplied: true,
+    assetName: routeName,
+  });
+});
+
+test("deferred initializer repairs the executable module cycle", (t) => {
+  const { root, assetsDir } = fixtureRoot(t);
+  const { primaryName } = writeCycleFixture(assetsDir);
+
+  const failed = importPrimary(root, primaryName);
+  assert.notEqual(failed.status, 0);
+  assert.match(failed.stderr, /is not a function/u);
+
+  assert.equal(patchUpstreamRendererCycle(root).changed, 1);
+  const repaired = importPrimary(root, primaryName);
+  assert.equal(repaired.status, 0, repaired.stderr);
+  assert.deepEqual(JSON.parse(repaired.stdout), {
+    initialized: true,
+    phone: "smartphone-light-16",
+  });
+});
+
+test("patch runner reports the core cycle fix as applied then already applied", (t) => {
+  const { root, assetsDir } = fixtureRoot(t);
+  writeCycleFixture(assetsDir);
+  const firstReport = createPatchReport();
+  patchExtractedApp(root, { report: firstReport });
+  assert.deepEqual(
+    firstReport.patches.map(({ name, status, sourceKind, ciPolicy }) => ({
+      name,
+      status,
+      sourceKind,
+      ciPolicy,
+    })),
+    [{
+      name: "upstream-renderer-cycle",
+      status: "applied",
+      sourceKind: "core",
+      ciPolicy: "required-upstream",
+    }],
+  );
+  assert.deepEqual(criticalFailuresFromReport(firstReport), []);
+
+  const secondReport = createPatchReport();
+  patchExtractedApp(root, { report: secondReport });
+  assert.equal(secondReport.patches[0].status, "already-applied");
+  assert.deepEqual(criticalFailuresFromReport(secondReport), []);
+});
+
+test("historical one-way authed route import does not match issue 1465 payload shape", () => {
+  const source =
+    'import{oc as e,sc as t}from"./app-primary-old.js";t();export{e as AuthedRoute};';
+  assert.deepEqual(routeInitializerContracts(source), []);
+});
+
+test("safe hoisted app-primary initializer does not match", (t) => {
+  const { root, assetsDir } = fixtureRoot(t);
+  const { routeName, primaryName } = writeCycleFixture(assetsDir, {
+    initializerKind: "hoisted",
+  });
+  const routePath = path.join(assetsDir, routeName);
+  const primarySource = fs.readFileSync(path.join(assetsDir, primaryName), "utf8");
+  const before = fs.readFileSync(routePath, "utf8");
+
+  assert.deepEqual(lateModuleInitializerContracts(primarySource, "jc"), []);
+  assert.deepEqual(rendererCycleContracts(root), []);
+  assert.equal(patchUpstreamRendererCycle(root).matched, false);
+  assert.equal(fs.readFileSync(routePath, "utf8"), before);
+});
+
+test("missing reverse import fails closed without changing the route asset", (t) => {
+  const { root, assetsDir } = fixtureRoot(t);
+  const { routeName } = writeCycleFixture(assetsDir, { reverseImport: false });
+  const routePath = path.join(assetsDir, routeName);
+  const before = fs.readFileSync(routePath, "utf8");
+
+  const result = patchUpstreamRendererCycle(root);
+
+  assert.equal(result.matched, false);
+  assert.equal(result.changed, 0);
+  assert.equal(fs.readFileSync(routePath, "utf8"), before);
+});
+
+test("missing reverse import reports a required core failure", (t) => {
+  const { root, assetsDir } = fixtureRoot(t);
+  writeCycleFixture(assetsDir, { reverseImport: false });
+  const report = createPatchReport();
+
+  patchExtractedApp(root, { report });
+
+  assert.equal(report.patches[0].status, "failed-required");
+  assert.deepEqual(
+    criticalFailuresFromReport(report).map(({ name, status }) => ({ name, status })),
+    [{ name: "upstream-renderer-cycle", status: "failed-required" }],
+  );
+});
+
+test("ambiguous cycle contracts fail closed without changing either asset", (t) => {
+  const { root, assetsDir } = fixtureRoot(t);
+  const first = writeCycleFixture(assetsDir, {
+    routeName: "authed-route-first.js",
+    primaryName: "app-primary-first.js",
+  });
+  const second = writeCycleFixture(assetsDir, {
+    routeName: "authed-route-second.js",
+    primaryName: "app-primary-second.js",
+  });
+  const before = new Map(
+    [first.routeName, second.routeName].map((name) => [
+      name,
+      fs.readFileSync(path.join(assetsDir, name), "utf8"),
+    ]),
+  );
+
+  const result = patchUpstreamRendererCycle(root);
+
+  assert.equal(result.matched, false);
+  assert.equal(result.changed, 0);
+  for (const [name, source] of before) {
+    assert.equal(fs.readFileSync(path.join(assetsDir, name), "utf8"), source);
+  }
+});
+
+test("mixed current and patched contracts fail closed", (t) => {
+  const { root, assetsDir } = fixtureRoot(t);
+  const { routeName, primaryName } = writeCycleFixture(assetsDir);
+  const routePath = path.join(assetsDir, routeName);
+  const mixed =
+    authedRouteSource(primaryName, false) +
+    authedRouteSource(primaryName, true);
+  fs.writeFileSync(routePath, mixed, "utf8");
+
+  const result = patchUpstreamRendererCycle(root);
+
+  assert.equal(result.matched, false);
+  assert.equal(result.changed, 0);
+  assert.equal(fs.readFileSync(routePath, "utf8"), mixed);
+});

--- a/scripts/patches/runner.js
+++ b/scripts/patches/runner.js
@@ -20,6 +20,7 @@ const {
   applyExtractedAppPatchDescriptors,
   applyMainBundlePatchDescriptors,
   applyWebviewAssetPatchDescriptors,
+  discoverCorePatchDescriptors,
   normalizePatchDescriptors,
   recordUnavailablePhasePatchDescriptors,
 } = require("./engine.js");
@@ -37,8 +38,8 @@ const CORE_PATCH_ROOT = path.join(__dirname, "core");
 const CUSTOM_PATCH_POLICIES = [];
 
 function normalizeDiscoveredCorePatchDescriptors(options = {}) {
-  void options;
-  return [];
+  const root = options.corePatchRoot ?? CORE_PATCH_ROOT;
+  return normalizePatchDescriptors(discoverCorePatchDescriptors({ root }));
 }
 
 function corePatchDescriptors(options = {}) {
@@ -182,7 +183,7 @@ function patchExtractedApp(extractedDir, options = {}) {
     PHASE_EXTRACTED_APP_POST_WEBVIEW,
   );
 
-  console.log("Applied enabled Linux feature descriptors:", {
+  console.log("Applied Linux patch descriptors:", {
     target: main == null ? null : path.join(main.buildDir, main.mainBundle),
     mainBundle: main?.mainBundle ?? null,
     iconAsset,

--- a/scripts/patches/runner.test.js
+++ b/scripts/patches/runner.test.js
@@ -19,10 +19,19 @@ const {
 
 const emptyConfig = path.join(__dirname, "..", "..", "linux-features", "features.example.json");
 
-test("official baseline has no core descriptors or required patch policies", () => {
-  assert.deepEqual(corePatchDescriptors(), []);
-  assert.deepEqual(allPatchPolicies({ featuresConfigPath: emptyConfig }), []);
-  assert.deepEqual(requiredPatchNamesForProfile("upstream-build", { featuresConfigPath: emptyConfig }), []);
+test("official baseline requires the renderer-cycle core patch", () => {
+  assert.deepEqual(
+    corePatchDescriptors().map(({ id, ciPolicy }) => ({ id, ciPolicy })),
+    [{ id: "upstream-renderer-cycle", ciPolicy: "required-upstream" }],
+  );
+  assert.deepEqual(
+    allPatchPolicies({ featuresConfigPath: emptyConfig }).map(({ name, ciPolicy }) => ({ name, ciPolicy })),
+    [{ name: "upstream-renderer-cycle", ciPolicy: "required-upstream" }],
+  );
+  assert.deepEqual(
+    requiredPatchNamesForProfile("upstream-build", { featuresConfigPath: emptyConfig }),
+    ["upstream-renderer-cycle"],
+  );
 });
 
 test("runner context exposes enabled feature IDs", () => {
@@ -49,7 +58,11 @@ test("empty feature set leaves official extracted files byte-identical", () => {
     fs.writeFileSync(main, "official-main\n");
     fs.writeFileSync(webview, "official-webview\n");
     const report = createPatchReport();
-    patchExtractedApp(root, { report, featuresConfigPath: emptyConfig });
+    patchExtractedApp(root, {
+      report,
+      corePatchRoot: path.join(root, "empty-core"),
+      featuresConfigPath: emptyConfig,
+    });
     assert.equal(fs.readFileSync(main, "utf8"), "official-main\n");
     assert.equal(fs.readFileSync(webview, "utf8"), "official-webview\n");
     assert.deepEqual(report.patches, []);

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -87,9 +87,16 @@ if (report.upstreamAppAsar.sha256 !== "upstream-sha") throw new Error("bad upstr
 if (report.outputAppAsar.sha256 !== "output-sha") throw new Error("bad output hash");
 NODE
 
-if find scripts/patches/core -name patch.js -print -quit | grep -q .; then
-    fail "official baseline core registry must remain empty"
-fi
+assert_file scripts/patches/core/all-linux/extracted-app/upstream-renderer-cycle/patch.js
+node - <<'NODE'
+const { corePatchDescriptors } = require("./scripts/patches/runner.js");
+const descriptors = corePatchDescriptors();
+if (descriptors.length !== 1 ||
+    descriptors[0].id !== "upstream-renderer-cycle" ||
+    descriptors[0].ciPolicy !== "required-upstream") {
+  throw new Error("official baseline must require exactly the current renderer-cycle repair");
+}
+NODE
 
 node - <<'NODE'
 const fs = require("node:fs");


### PR DESCRIPTION
## Summary

- repair the current signed Linux renderer startup cycle in every default build
- register the repair as a required-upstream core descriptor; no feature flag or features.json entry is needed
- accept a default ASAR change only when the patch report proves that every change came from a required core descriptor

## Diagnosis

In official Linux 26.908.31748, app-primary imports authed-route while authed-route imports app-primary and eagerly calls its jc export. That export points at the late nzn module-initializer assignment, so cyclic evaluation reaches it while it is still undefined and renderer route prefetch fails with n is not a function.

The repair changes only that verified eager invocation to a queueMicrotask closure, allowing app-primary evaluation to finish before the initializer is read. If the exact current upstream contract is missing or ambiguous, the required patch fails the build and candidate promotion keeps the existing installation intact.

Issue #1465 describes a distinct native browser-process core dump in official 26.903 before any window appears. This PR does not close that issue.

## Validation

- focused core/runner tests: 18 passed
- default feature configuration: enabledFeatures is empty and the patch report records upstream-renderer-cycle as applied, required-upstream, sourceKind core
- default rebuild from the exact signed official 26.908.31748 amd64 package completed and promoted successfully
- the same renderer transformation was previously launched end to end: window ready, Codex CLI/app-server initialized, and thread hydration completed without the route-prefetch error
