### PR TITLE
Keep authored messages visible after activity collapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ requirements, known limitations, configuration, and tests.
 | `api-key-model-visibility` | Show models reported by API-key authenticated compatible providers | [Docs](linux-features/api-key-model-visibility/README.md) |
 | `api-key-service-tier` | Fast/service-tier UI for API-key authenticated compatible providers | [Docs](linux-features/api-key-service-tier/README.md) |
 | `appshots` | Capture and crop the focused Linux window from the composer | [Docs](linux-features/appshots/README.md) |
+| `authored-message-visibility` | Keep assistant and user messages visible after tool activity collapses | [Docs](linux-features/authored-message-visibility/README.md) |
 | `authenticated-proxy` | Username/password support for HTTP proxies | [Docs](linux-features/authenticated-proxy/README.md) |
 | `automation-extensions` | Multi-time schedules and eager `automation_update` exposure | [Docs](linux-features/automation-extensions/README.md) |
 | `browser-proxy` | Pass explicit proxy settings to Browser Use network helpers | [Docs](linux-features/browser-proxy/README.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -201,6 +201,7 @@ Nix 用户应从 profile、Home Manager 配置或 NixOS module 中删除该包�
 | `api-key-model-visibility` | 显示 API-key compatible provider 返回的模型 | [文档](linux-features/api-key-model-visibility/README.md) |
 | `api-key-service-tier` | API-key compatible provider 的 Fast/service-tier UI | [文档](linux-features/api-key-service-tier/README.md) |
 | `appshots` | 从 composer 捕获并裁剪当前 Linux 窗口 | [文档](linux-features/appshots/README.md) |
+| `authored-message-visibility` | 工具活动折叠后，仍显示助手和用户消息 | [文档](linux-features/authored-message-visibility/README.md) |
 | `authenticated-proxy` | 带用户名和密码的 HTTP proxy | [文档](linux-features/authenticated-proxy/README.md) |
 | `automation-extensions` | 多时间调度和 eager `automation_update` | [文档](linux-features/automation-extensions/README.md) |
 | `browser-proxy` | 让 Browser Use 的网络辅助进程继承显式代理设置 | [文档](linux-features/browser-proxy/README.zh-CN.md) |

--- a/linux-features/authored-message-visibility/README.md
+++ b/linux-features/authored-message-visibility/README.md
@@ -1,0 +1,30 @@
+# Keep Authored Messages Visible
+
+The agent can mention useful information during a task, such as uncertainty about a result, and leave it out of the final answer.
+These messages get hidden when activity collapses, so you can miss that uncertainty unless you expand the activity and read through it.
+
+This feature keeps assistant commentary and user messages visible in their original order after the task finishes.
+Ordinary tool activity remains collapsible.
+
+This feature is disabled by default.
+Add `authored-message-visibility` to the `enabled` list in `linux-features/features.json`, then rebuild with `./install.sh` or your normal package build.
+Remove the ID and rebuild to disable it.
+
+The transcript becomes longer and can include commentary repeated by the final answer.
+
+The feature supports the current official Linux package on amd64 and arm64.
+An upstream update can prevent the patch from applying, causing the build to fail when this feature is enabled.
+Disable the feature and rebuild, or update the patch for the current package.
+
+## Validation
+
+```sh
+node --test linux-features/authored-message-visibility/test.js
+```
+
+Build with this feature alone against the signed official package. Check that
+commentary, an intervening tool, a steering message, and the final answer render
+in order after completion. Expand and collapse again: authored messages must not
+duplicate and ordinary tool activity must remain collapsible. Also check a turn
+without tools. Tests exercise the official partition/classifier and feature
+registration, idempotence, unique asset selection, and drift reporting.

--- a/linux-features/authored-message-visibility/feature.json
+++ b/linux-features/authored-message-visibility/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "authored-message-visibility",
+  "title": "Keep Authored Messages Visible",
+  "description": "Keep assistant and user messages visible when completed tool activity collapses.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/authored-message-visibility/patch.js
+++ b/linux-features/authored-message-visibility/patch.js
@@ -1,0 +1,37 @@
+"use strict";
+
+// Complete classifier template from official Linux 26.908.40834. Bind local
+// aliases; only the final message branch changes. Tool exceptions stay intact.
+const currentPattern = new RegExp("function\\ ([A-Za-z_$][\\w$]*)\\(\\{unit:([A-Za-z_$][\\w$]*),keepMcpAppEntriesPersistent:([A-Za-z_$][\\w$]*),mcpServerStatuses:([A-Za-z_$][\\w$]*),renderMcpApps:([A-Za-z_$][\\w$]*)\\}\\)\\{if\\(\\2\\.kind!==`standalone`\\)return!1;let\\ ([A-Za-z_$][\\w$]*)=\\2\\.item\\.item;return\\ \\6\\.type===`dynamic\\-tool\\-call`\\&\\&([A-Za-z_$][\\w$]*)\\(\\6\\)\\|\\|\\3\\&\\&\\5\\&\\&\\6\\.type===`mcp\\-tool\\-call`\\&\\&([A-Za-z_$][\\w$]*)\\(\\{item:\\6,mcpServerStatuses:\\4\\}\\)\\?!0:\\6\\.type===`user\\-message`\\&\\&\\(\\6\\.steeringStatus!=null\\|\\|\\6\\.hookFeedback===!0\\)\\}", "g");
+const patchedPattern = new RegExp("function\\ ([A-Za-z_$][\\w$]*)\\(\\{unit:([A-Za-z_$][\\w$]*),keepMcpAppEntriesPersistent:([A-Za-z_$][\\w$]*),mcpServerStatuses:([A-Za-z_$][\\w$]*),renderMcpApps:([A-Za-z_$][\\w$]*)\\}\\)\\{if\\(\\2\\.kind!==`standalone`\\)return!1;let\\ ([A-Za-z_$][\\w$]*)=\\2\\.item\\.item;return\\ \\6\\.type===`dynamic\\-tool\\-call`\\&\\&([A-Za-z_$][\\w$]*)\\(\\6\\)\\|\\|\\3\\&\\&\\5\\&\\&\\6\\.type===`mcp\\-tool\\-call`\\&\\&([A-Za-z_$][\\w$]*)\\(\\{item:\\6,mcpServerStatuses:\\4\\}\\)\\?!0:\\6\\.type===`assistant\\-message`\\|\\|\\6\\.type===`user\\-message`\\}", "g");
+const recovery = "Disable authored-message-visibility and rebuild, or update its patch for the current official package.";
+
+function applyAuthoredMessageVisibilityPatch(source) {
+  const current = [...source.matchAll(currentPattern)];
+  const patched = [...source.matchAll(patchedPattern)];
+  if (current.length === 0 && patched.length === 1) return source;
+  if (current.length !== 1 || patched.length !== 0) {
+    console.warn(`WARN: authored-message-visibility: expected one complete activity classifier, found ${current.length} original and ${patched.length} patched. ${recovery}`);
+    return source;
+  }
+  const match = current[0];
+  const item = match[6];
+  const before = `${item}.type===\`user-message\`&&(${item}.steeringStatus!=null||${item}.hookFeedback===!0)`;
+  const after = `${item}.type===\`assistant-message\`||${item}.type===\`user-message\``;
+  return source.slice(0, match.index) + match[0].replace(before, after) + source.slice(match.index + match[0].length);
+}
+
+module.exports = {
+  applyAuthoredMessageVisibilityPatch,
+  descriptors: [{
+    id: "persistent-messages",
+    phase: "webview-asset",
+    order: 20_740,
+    ciPolicy: "optional",
+    pattern: /^conversation-blocks-[A-Za-z0-9_-]+\.js$/,
+    assetMatch: (source) => source.includes("collapsibleUnits:") && source.includes("persistentUnits:"),
+    missingWarning: `WARN: authored-message-visibility: activity partition bundle missing. ${recovery}`,
+    ambiguousWarning: `WARN: authored-message-visibility: multiple activity partition bundles. ${recovery}`,
+    apply: applyAuthoredMessageVisibilityPatch,
+  }],
+};

--- a/linux-features/authored-message-visibility/test.js
+++ b/linux-features/authored-message-visibility/test.js
@@ -1,0 +1,87 @@
+"use strict";
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const vm = require("node:vm");
+const test = require("node:test");
+const { applyAuthoredMessageVisibilityPatch: apply, descriptors } = require("./patch.js");
+const { loadLinuxFeaturePatchDescriptors } = require("../../scripts/lib/linux-features.js");
+const { applyWebviewAssetPatchDescriptors } = require("../../scripts/patches/engine.js");
+const { createPatchReport, captureWarnings, enabledFeatureFailuresFromReport } = require("../../scripts/lib/patch-report.js");
+
+// Verbatim partition and classifier from signed official Linux 26.908.40834.
+const fixture = "function kG(e,{keepMcpAppEntriesPersistent:t=!1,mcpServerStatuses:n,renderMcpApps:r=!1}={}){let i=[],a=[],o=[],s=[],c=null;for(let l of e){if(l.kind===`standalone`&&l.item.item.type===`worked-for`){c=l.item.item;continue}if(l.kind===`standalone`&&l.item.item.type===`realtime-transcript`){a.length===0?s.push(l):(a.push(l),o.push(l));continue}a.push(l),AG({unit:l,keepMcpAppEntriesPersistent:t,mcpServerStatuses:n,renderMcpApps:r})?o.push(l):i.push(l)}return{collapsibleUnits:i,expandedUnits:a,persistentUnits:o,preToggleUnits:s,workedForItem:c}}function AG({unit:e,keepMcpAppEntriesPersistent:t,mcpServerStatuses:n,renderMcpApps:r}){if(e.kind!==`standalone`)return!1;let i=e.item.item;return i.type===`dynamic-tool-call`&&Mh(i)||t&&r&&i.type===`mcp-tool-call`&&jG({item:i,mcpServerStatuses:n})?!0:i.type===`user-message`&&(i.steeringStatus!=null||i.hookFeedback===!0)}";
+function partition(source, units, options) {
+  return vm.runInNewContext(source + ";kG", { Mh: item => item.interactive, jG: ({item}) => item.interactive })(units, options);
+}
+const unit = (type, id, extra = {}) => ({kind:"standalone",item:{item:{type,id,...extra}}});
+const ids = units => Array.from(units, unit => unit.item.item.id);
+
+test("commentary stays visible in order while tools collapse; expansion contains each item once", () => {
+  const units = [unit("assistant-message","c1"),unit("exec","tool"),unit("user-message","steering",{steeringStatus:"accepted"}),unit("assistant-message","c2"),unit("user-message","ordinary"),unit("user-message","hook",{hookFeedback:true})];
+  assert.deepEqual(ids(partition(fixture,units).persistentUnits), ["steering","hook"]);
+  const patched = apply(fixture);
+  assert.notEqual(patched, fixture);
+  for (let toggle = 0; toggle < 3; toggle++) {
+    const result = partition(patched, units);
+    assert.deepEqual(ids(result.persistentUnits), ["c1","steering","c2","ordinary","hook"]);
+    assert.deepEqual(ids(result.collapsibleUnits), ["tool"]);
+    assert.deepEqual(ids(result.expandedUnits), ids(units));
+  }
+  assert.equal(apply(patched), patched);
+});
+
+test("tool exceptions, grouped activity and worked-for handling remain upstream-owned", () => {
+  const tools = [unit("exec","exec"),unit("dynamic-tool-call","dynamic",{interactive:true}),unit("mcp-tool-call","mcp",{interactive:true}),unit("worked-for","duration")];
+  const options = {keepMcpAppEntriesPersistent:true,renderMcpApps:true};
+  assert.equal(JSON.stringify(partition(apply(fixture),tools,options)),JSON.stringify(partition(fixture,tools,options)));
+  const group = {kind:"group",items:[]};
+  assert.equal(partition(apply(fixture),[group]).collapsibleUnits[0],group);
+});
+
+test("missing, duplicate, mixed and changed classifiers remain byte-identical with actionable warnings", () => {
+  const patched = apply(fixture);
+  for (const source of ["",fixture+fixture,patched+patched,fixture+patched,fixture.replace("hookFeedback===!0","hookFeedback===!1"),fixture.replace("i=e.item.item","i=e.item.other")]) {
+    const result = captureWarnings(() => apply(source));
+    assert.equal(result.value,source);
+    assert.equal(result.warnings.length,1);
+    assert.match(result.warnings[0],/Disable authored-message-visibility and rebuild/);
+  }
+});
+
+test("classifier aliases can change without changing behavior", () => {
+  const source = fixture.replace(/\bi\b/g,"itemAlias");
+  assert.deepEqual(ids(partition(apply(source),[unit("assistant-message","c")] ).persistentUnits),["c"]);
+});
+
+test("feature registration, unique asset selection and enabled drift enforcement", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(),"authored-visibility-"));
+  try {
+    const config = path.join(temp,"features.json");
+    const assets = path.join(temp,"webview","assets");
+    fs.mkdirSync(assets,{recursive:true});
+    const options = {featuresRoot:path.join(__dirname,".."),featuresConfigPath:config};
+    fs.writeFileSync(config,JSON.stringify({enabled:[]}));
+    assert.deepEqual(loadLinuxFeaturePatchDescriptors(options),[]);
+    fs.writeFileSync(config,JSON.stringify({enabled:["authored-message-visibility"]}));
+    const loaded = loadLinuxFeaturePatchDescriptors(options);
+    assert.equal(loaded.length,1);
+    const file = path.join(assets,"conversation-blocks-newHash.js");
+    for (const scenario of ["valid","already","missing","drift","ambiguous"]) {
+      for (const name of fs.readdirSync(assets)) fs.unlinkSync(path.join(assets,name));
+      const source = scenario === "already" ? apply(fixture) : scenario === "drift" ? fixture.replace("hookFeedback===!0","hookFeedback===!1") : fixture;
+      if (scenario !== "missing") fs.writeFileSync(file,source);
+      if (scenario === "ambiguous") fs.writeFileSync(path.join(assets,"conversation-blocks-other.js"),source);
+      const report = createPatchReport(); report.enabledFeatures=["authored-message-visibility"];
+      captureWarnings(() => applyWebviewAssetPatchDescriptors(temp,loaded,{},report));
+      if (["valid","already"].includes(scenario)) {
+        assert.equal(enabledFeatureFailuresFromReport(report).length,0);
+        assert.equal(fs.readFileSync(file,"utf8"),apply(fixture));
+      } else {
+        assert.equal(enabledFeatureFailuresFromReport(report).length,1);
+        if (scenario !== "missing") assert.equal(fs.readFileSync(file,"utf8"),source);
+      }
+    }
+  } finally { fs.rmSync(temp,{recursive:true,force:true}); }
+});


### PR DESCRIPTION
## Summary

The agent sometimes puts useful information in progress messages, such as uncertainty about a result, and doesn't repeat it in the final answer.
The app hides those messages when activity collapses, so you can miss information that changes how you interpret the answer.
This feature keeps those messages visible after the task finishes.
Tool activity still collapses.

Before:
<img width="1719" height="306" alt="Screenshot from 2026-09-12 23-44-13" src="https://github.com/user-attachments/assets/e0093a5e-8499-49df-8614-5598689698e9" />
After:
<img width="1591" height="666" alt="Screenshot from 2026-09-12 23-43-25" src="https://github.com/user-attachments/assets/8335f2d6-6fa6-419d-adb0-1f4c60f8789d" />


The feature patches the complete activity classifier in the current official `conversation-blocks-*.js` bundle through the existing unique-asset descriptor path.
It preserves the existing renderer and collapse controls, supports repeated application, and leaves unknown or ambiguous source unchanged with an actionable warning.
Drift in an enabled feature rejects the build candidate under the existing framework policy.
Enable the feature in `linux-features/features.json` and rebuild.

## Validation

- `node --test linux-features/authored-message-visibility/test.js scripts/lib/linux-features.test.js scripts/patch-linux-window-ui.test.js`: 40 passed, including five new feature tests.
- Built signed official Linux `26.908.40834` for amd64 and arm64 with only this feature enabled: `applied`, no warnings.
- Compared packed amd64 ASAR entries with the official archive: only `conversation-blocks-9939301f934e.js` changed.
  Repeated application to the packaged asset is unchanged on both architectures.
- Built with all optional features disabled and compared ASAR with the official archive using `cmp`: byte-identical.
- Built the Nix package with this feature and checked its patch report.
- Built amd64 deb and RPM with the updater; checked the ASAR, enabled feature snapshot, and patch source in the package payload or file digests.
- Ran the supported pacman and AppImage staging modes and checked the staged ASAR and feature metadata, including the pacman update-builder.
- Compared user-provided collapsed and expanded UI screenshots with the corresponding rollout: commentary and final remain visible once, in order; the tool group appears between them when expanded.
- Manual UI and package testing, including AppImage, completed by the author.
- Checked new documentation links and added-line whitespace.

The tests exercise the official partition/classifier functions and do not simulate renderer transitions.
An independent Astra High implementation review found no confirmed defect in the current bundle.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [ ] If this fixes upstream drift, it targets only the latest signed stable OpenAI Linux package and removes obsolete fallback code and tests. (Not applicable: new optional feature.)
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
